### PR TITLE
SUPEE-3941 - Addresses extension-related issues

### DIFF
--- a/downloader/Maged/Model/Connect.php
+++ b/downloader/Maged/Model/Connect.php
@@ -486,6 +486,9 @@ class Maged_Model_Connect extends Maged_Model
      */
     public function checkExtensionKey($id, &$match)
     {
-        return preg_match('#^([^ ]+)\/([^-]+)(-.+)?$#', $id, $match);
+        if (preg_match('#^(.+)\/(.+)-([\.\d]+)$#', $id, $match)) {
+            return $match;
+        }
+        return preg_match('#^(.+)\/(.+)$#', $id, $match);
     }
 }

--- a/downloader/lib/Mage/Connect/Backup.php
+++ b/downloader/lib/Mage/Connect/Backup.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magentocommerce.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magentocommerce.com for more information.
+ *
+ * @category    Mage
+ * @package     Mage_Connect
+ * @copyright   Copyright (c) 2014 Magento Inc. (http://www.magentocommerce.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Class to backup files before extension installation
+ *
+ * @category    Mage
+ * @package     Mage_Connect
+ * @author      Magento Core Team <core@magentocommerce.com>
+ */
+class Mage_Connect_Backup
+{
+    /**
+     * Prefix for backuped files
+     *
+     * @var string
+     */
+    protected $_prefix = '_backup_';
+
+    /**
+     * Array of available to overwrite type of files
+     *
+     * @var array
+     */
+    protected $_fileTypes = array();
+
+    /**
+     * List of files to backup files
+     *
+     * @var array
+     */
+    protected $_fileList = array();
+
+    /**
+     * Get available file types for backup
+     *
+     * @return array
+     */
+    public function getFileTypes()
+    {
+        return $this->_fileTypes;
+    }
+
+    /**
+     * Set available file types for backup
+     *
+     * @param array $types
+     */
+    public function setFileTypes(array $types)
+    {
+        foreach ($types as $type) {
+            $this->_fileTypes[] = $type;
+        }
+    }
+
+    /**
+     * Add file to files list for backup
+     *
+     * @param string $file
+     * @param string $rootPath
+     * @return void
+     */
+    public function addFile($file, $rootPath)
+    {
+        $dest = $rootPath . DS . $file;
+        $type = $this->getFileType($file);
+        if (file_exists($dest) && in_array($type, $this->getFileTypes())) {
+            $this->_fileList[] = $file;
+        }
+    }
+
+    /**
+     * Get count of files
+     *
+     * @return int
+     */
+    public function getFilesCount()
+    {
+        return count($this->_fileList);
+    }
+
+    /**
+     * Clear list of files
+     *
+     * @return void
+     */
+    public function unsetAllFiles()
+    {
+        $this->_fileList = array();
+    }
+
+    /**
+     * Get list of files
+     *
+     * @return array
+     */
+    public function getAllFiles()
+    {
+       return $this->_fileList;
+    }
+
+    /**
+     * Run backup process
+     *
+     * @param boolean $cleanUpQueue
+     * @return void
+     */
+    public function run($cleanUpQueue = false)
+    {
+        if ($this->getFilesCount() > 0) {
+            $fileList = $this->getAllFiles();
+            foreach($fileList as $file) {
+                $this->_backupFile($file);
+            }
+            if ($cleanUpQueue) {
+                $this->unsetAllFiles();
+            }
+        }
+    }
+
+    /**
+     * Get File type
+     *
+     * @param string $file
+     * @return string
+     */
+    public function getFileType($file)
+    {
+        return pathinfo($file, PATHINFO_EXTENSION);
+    }
+
+    /**
+     * Backup file
+     *
+     * @param string $file
+     * @return void
+     */
+    private function _backupFile($file)
+    {
+        $type = $this->getFileType($file);
+        if ($type && $type != '') {
+            $newName = $this->_prefix . time() . '.' . $type;
+            @rename($file, str_replace('.' . $type, $newName, $file));
+        }
+    }
+}

--- a/downloader/lib/Mage/Connect/Command.php
+++ b/downloader/lib/Mage/Connect/Command.php
@@ -64,6 +64,13 @@ class Mage_Connect_Command
     protected static $_validator = null;
 
     /**
+     * Backup instance
+     *
+     * @var Mage_Connect_Backup
+     */
+    protected static $_backup = null;
+
+    /**
      * Rest instance
      *
      * @var Mage_Connect_Rest
@@ -249,6 +256,19 @@ class Mage_Connect_Command
     }
 
     /**
+     * Get backup object
+     *
+     * @return Mage_Connect_Backup
+     */
+    public function backup()
+    {
+        if(is_null(self::$_backup)) {
+            self::$_backup = new Mage_Connect_Backup();
+        }
+        return self::$_backup;
+    }
+
+    /**
      * Get rest object
      *
      * @return Mage_Connect_Rest
@@ -422,8 +442,8 @@ class Mage_Connect_Command
             return;
         }
         if(preg_match("@([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)@ims", $params[0], $subs)) {
-           $params[0] = $subs[2];
-           array_unshift($params, $subs[1]);
+            $params[0] = $subs[2];
+            array_unshift($params, $subs[1]);
         }
     }
 

--- a/downloader/lib/Mage/Connect/Command/Install.php
+++ b/downloader/lib/Mage/Connect/Command/Install.php
@@ -90,15 +90,15 @@ final class Mage_Connect_Command_Install extends Mage_Connect_Command
                 @mkdir($config->magento_root . $dirTmp,0777,true);
                 @mkdir($config->magento_root . $dirMedia,0777,true);
                 $isWritable = is_writable($config->magento_root)
-                              && is_writable($config->magento_root . DIRECTORY_SEPARATOR . $config->downloader_path)
-                              && is_writable($config->magento_root . $dirCache)
-                              && is_writable($config->magento_root . $dirTmp)
-                              && is_writable($config->magento_root . $dirMedia);
+                    && is_writable($config->magento_root . DIRECTORY_SEPARATOR . $config->downloader_path)
+                    && is_writable($config->magento_root . $dirCache)
+                    && is_writable($config->magento_root . $dirTmp)
+                    && is_writable($config->magento_root . $dirMedia);
                 $err = "Please check for sufficient write file permissions.";
             }
             $isWritable = $isWritable && is_writable($config->magento_root . $dirMedia)
-                          && is_writable($config->magento_root . $dirCache)
-                          && is_writable($config->magento_root . $dirTmp);
+                && is_writable($config->magento_root . $dirCache)
+                && is_writable($config->magento_root . $dirTmp);
             if (!$isWritable) {
                 $this->doError($command, $err);
                 throw new Exception(
@@ -316,7 +316,7 @@ final class Mage_Connect_Command_Install extends Mage_Connect_Command
                     if ($ftp) {
                         $cwd=$ftpObj->getcwd();
                         $dir=$cwd . DIRECTORY_SEPARATOR .$config->downloader_path . DIRECTORY_SEPARATOR
-                             . Mage_Connect_Config::DEFAULT_CACHE_PATH . DIRECTORY_SEPARATOR . trim( $pChan, "\\/");
+                            . Mage_Connect_Config::DEFAULT_CACHE_PATH . DIRECTORY_SEPARATOR . trim( $pChan, "\\/");
                         $ftpObj->mkdirRecursive($dir,0777);
                         $ftpObj->chdir($cwd);
                     } else {
@@ -346,10 +346,32 @@ final class Mage_Connect_Command_Install extends Mage_Connect_Command
 
                     $package = new Mage_Connect_Package($file);
                     if ($clearInstallMode && $pInstallState != 'upgrade' && !$installAll) {
-                        $this->validator()->validateContents($package->getContents(), $config);
+                        $contents = $package->getContents();
+                        $this->backup()->setFileTypes(array('csv', 'html'));
+                        $typesToBackup = $this->backup()->getFileTypes();
+                        $this->validator()->validateContents($contents, $config, $typesToBackup);
                         $errors = $this->validator()->getErrors();
                         if (count($errors)) {
                             throw new Exception("Package '{$pName}' is invalid\n" . implode("\n", $errors));
+                        }
+
+                        $targetPath = rtrim($config->magento_root, "\\/");
+                        foreach ($contents as $filePath) {
+                            $this->backup()->addFile($filePath, $targetPath);
+                        }
+
+                        if ($this->backup()->getFilesCount() > 0) {
+                            $this->ui()->output('<br/>');
+                            $this->ui()->output('Backup of following files will be created :');
+                            $this->ui()->output('<br/>');
+                            $this->backup()->run();
+                            $this->ui()->output(implode('<br/>', $this->backup()->getAllFiles()));
+                            $this->ui()->output('<br/>');
+                            $this->ui()->output(
+                                $this->backup()->getFilesCount() . ' files was overwritten by installed extension.'
+                            );
+                            $this->ui()->output('<br/>');
+                            $this->backup()->unsetAllFiles();
                         }
                     }
 

--- a/downloader/lib/Mage/Connect/Rest.php
+++ b/downloader/lib/Mage/Connect/Rest.php
@@ -82,17 +82,14 @@ class Mage_Connect_Rest
      *
      * @param string $protocol
      */
-    public function __construct($protocol="http")
+    public function __construct($protocol="https")
     {
         switch ($protocol) {
-            case 'ftp':
-                $this->_protocol = 'ftp';
-                break;
             case 'http':
                 $this->_protocol = 'http';
                 break;
             default:
-                $this->_protocol = 'http';
+                $this->_protocol = 'https';
                 break;
         }
     }

--- a/downloader/lib/Mage/Connect/Singleconfig.php
+++ b/downloader/lib/Mage/Connect/Singleconfig.php
@@ -136,7 +136,6 @@ class Mage_Connect_Singleconfig
         $uri = rtrim($uri, "/");
         $uri = str_replace("http://", '', $uri);
         $uri = str_replace("https://", '', $uri);
-        $uri = str_replace("ftp://", '', $uri);
         return $uri;
     }
 

--- a/downloader/lib/Mage/Connect/Validator.php
+++ b/downloader/lib/Mage/Connect/Validator.php
@@ -459,9 +459,10 @@ class Mage_Connect_Validator
      *
      * @param array $contents
      * @param Mage_Connect_Config $config
+     * @param array $typesToBackup
      * @return bool
      */
-    public function validateContents(array $contents, $config)
+    public function validateContents(array $contents, $config, $typesToBackup = array())
     {
         if (!count($contents)) {
             $this->addError('Empty package contents section');
@@ -471,7 +472,8 @@ class Mage_Connect_Validator
         $targetPath = rtrim($config->magento_root, "\\/");
         foreach ($contents as $file) {
             $dest = $targetPath . DS . $file;
-            if (file_exists($dest)) {
+            $type = pathinfo($file, PATHINFO_EXTENSION);
+            if (file_exists($dest) && !in_array($type, $typesToBackup)) {
                 $this->addError("'{$file}' already exists");
                 return false;
             }

--- a/downloader/template/settings.phtml
+++ b/downloader/template/settings.phtml
@@ -63,8 +63,8 @@ function changeDeploymentType (element)
                     <td class="label">Magento Connect Channel Protocol:</td>
                     <td class="value">
                         <select id="protocol" name="protocol">
+                            <option value="https" <?php if ($this->get('protocol')=='https'):?>selected="selected"<?php endif ?>>Https</option>
                             <option value="http" <?php if ($this->get('protocol')=='http'):?>selected="selected"<?php endif ?>>Http</option>
-                            <option value="ftp" <?php if ($this->get('protocol')=='ftp'):?>selected="selected"<?php endif ?>>Ftp</option>
                         </select>
                     </td>
                 </tr>


### PR DESCRIPTION
This is an official Magento patch.
- When you install a community-created translation package,
  the translation provided by the package overwrites any existing
  translations for the same items. This enables you to more easily
  install packages with translations.
- To improve security, Magento Connect now uses HTTPS by default
  to download extensions, rather than FTP.
- Extension developers can now create an extensions with a dash
  character in the name. Merchants can install those extensions without issues.
- Magento administrators who attempt to install an extension
  with insufficient file system privileges are now informed.
  Typically, the Magento Admin Panel runs as the web server user.
  If this user has insufficient privileges to the your Magento
  install dir/app/code/community directory structure, the Magento
  administrator sees an error message in the Magento Connect Manager.
  To set file system permissions appropriately, see
  http://www.magentocommerce.com/knowledge-base/entry/install-privs-after#extensions
