### PR TITLE
Better log msg when template file doesn't exist.

### DIFF
--- a/app/code/core/Mage/Core/Block/Template.php
+++ b/app/code/core/Mage/Core/Block/Template.php
@@ -237,10 +237,10 @@ HTML;
 
         try {
             $includeFilePath = realpath($this->_viewDir . DS . $fileName);
-            if (strpos($includeFilePath, realpath($this->_viewDir)) === 0 || $this->_getAllowSymlinks()) {
+            if ($includeFilePath != '' && (strpos($includeFilePath, realpath($this->_viewDir)) === 0 || $this->_getAllowSymlinks())) {
                 include $includeFilePath;
             } else {
-                Mage::log('Not valid template file:'.$fileName, Zend_Log::CRIT, null, null, true);
+                Mage::log('Not valid template file:'.$fileName, Zend_Log::CRIT, null, true);
             }
 
         } catch (Exception $e) {


### PR DESCRIPTION
Before, if Magento was not able to locate a file, and error like this was logged:
2015-06-09T11:32:35+00:00 ERR (3): Warning: include(): Filename cannot be empty  in app/code/core/Mage/Core/Block/Template.php on line 241

Which is not very helpful. 
This change makes Magento log a filename and also fixes the one parameter too much in the Mage::log call.