### PR TITLE
Fix comment history with % sign.

### DIFF
--- a/app/code/core/Mage/Adminhtml/Helper/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Sales.php
@@ -121,6 +121,7 @@ class Mage_Adminhtml_Helper_Sales extends Mage_Core_Helper_Abstract
     public function escapeHtmlWithLinks($data, $allowedTags = null)
     {
         if (is_string($data) && is_array($allowedTags) && in_array('a', $allowedTags)) {
+            $data = str_replace('%', '%%', $data);
             $links = array();
             $i = 1;
             $regexp = '@(<a[^>]*>(?:[^<]|<[^/]|</[^a]|</a[^>])*</a>)@';


### PR DESCRIPTION
The issue will be solved in the upcomming 1.9.2 release of magento.
See the issues below:
http://www.magentocommerce.com/bug-tracking/issue/index/id/697
http://www.magentocommerce.com/bug-tracking/issue/index/id/519

Steps to reproduce:
Add comment to order in 'Comments History' containing '%' symbol

Expected Result:
Comment should be displayed after being saved

Actual Result:
Comment without message content is being displayed