### PR TITLE
prevent HEADERS ALREADY SENT error

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Cms/Wysiwyg/ImagesController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/Wysiwyg/ImagesController.php
@@ -186,9 +186,12 @@ class Mage_Adminhtml_Cms_Wysiwyg_ImagesController extends Mage_Adminhtml_Control
         $file = Mage::helper('cms/wysiwyg_images')->idDecode($file);
         $thumb = $this->getStorage()->resizeOnTheFly($file);
         if ($thumb !== false) {
+            ob_start();
             $image = Varien_Image_Adapter::factory('GD2');
             $image->open($thumb);
             $image->display();
+            $this->getResponse()->setHeader('Content-type', $image->getMimeType(), true);
+            $this->getResponse()->setBody(ob_get_clean());
         } else {
             // todo: genearte some placeholder
         }

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
@@ -43,6 +43,7 @@ class Mage_Adminhtml_Cms_WysiwygController extends Mage_Adminhtml_Controller_Act
         $directive = $this->getRequest()->getParam('___directive');
         $directive = Mage::helper('core')->urlDecode($directive);
         $url = Mage::getModel('cms/adminhtml_template_filter')->filter($directive);
+        ob_start();
         try {
             $image = Varien_Image_Adapter::factory('GD2');
             $image->open($url);
@@ -62,5 +63,8 @@ class Mage_Adminhtml_Cms_WysiwygController extends Mage_Adminhtml_Controller_Act
             imagedestroy($image);
             */
         }
+        $this->getResponse()->setHeader('Content-type', $image->getMimeType(), true);
+        $this->getResponse()->setBody(ob_get_contents());
+        ob_get_clean();
     }
 }

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
@@ -64,7 +64,6 @@ class Mage_Adminhtml_Cms_WysiwygController extends Mage_Adminhtml_Controller_Act
             */
         }
         $this->getResponse()->setHeader('Content-type', $image->getMimeType(), true);
-        $this->getResponse()->setBody(ob_get_contents());
-        ob_get_clean();
+        $this->getResponse()->setBody(ob_get_clean());
     }
 }


### PR DESCRIPTION
$image->display() directly outputs the image together with the mimeType header,
causing the Mage_Core_Controller_Varien_Front->dispatch() to log an 
Headers already sent error on sending the actual Response object


The error occurs if magento tries to display an image in the cms wysiwyg editor mode.
The error occurs only in log, it seems to not affect the output of the image.