### PR TITLE
[BUG] Fix memory leaks during image upload

### DIFF
--- a/app/code/core/Mage/Catalog/Helper/Image.php
+++ b/app/code/core/Mage/Catalog/Helper/Image.php
@@ -639,7 +639,13 @@ class Mage_Catalog_Helper_Image extends Mage_Core_Helper_Abstract
         }
 
         $_processor = new Varien_Image($filePath);
-        return $_processor->getMimeType() !== null;
+        $result = $_processor->getMimeType() !== null;
+
+        // free resources to prevent memory leaks
+        $_processor->close();
+        unset($_processor);
+
+        return $result;
     }
 
 }

--- a/lib/Varien/Image.php
+++ b/lib/Varien/Image.php
@@ -85,8 +85,9 @@ class Varien_Image
      * @return void
      */
     public function close() {
-        if ($this->_fileName) {
-            $this->_getAdapter()->destruct();
+        $adapter = $this->_getAdapter();
+        if ($this->_fileName && method_exists($adapter, 'destruct')) {
+            $adapter->destruct();
         }
     }
 

--- a/lib/Varien/Image.php
+++ b/lib/Varien/Image.php
@@ -54,6 +54,15 @@ class Varien_Image
     }
 
     /**
+     * Class destructor
+     * @return void
+     */
+    function __destruct()
+    {
+        $this->close();
+    }
+
+    /**
      * Opens an image and creates image handle
      *
      * @access public
@@ -68,6 +77,17 @@ class Varien_Image
         }
 
         $this->_getAdapter()->open($this->_fileName);
+    }
+
+    /**
+     * Free resources
+     *
+     * @return void
+     */
+    public function close() {
+        if ($this->_fileName) {
+            $this->_getAdapter()->destruct();
+        }
     }
 
     /**

--- a/lib/Varien/Image/Adapter/Abstract.php
+++ b/lib/Varien/Image/Adapter/Abstract.php
@@ -65,6 +65,8 @@ abstract class Varien_Image_Adapter_Abstract
 
     abstract public function open($fileName);
 
+    abstract public function destruct();
+
     abstract public function save($destination=null, $newName=null);
 
     abstract public function display();

--- a/lib/Varien/Image/Adapter/Abstract.php
+++ b/lib/Varien/Image/Adapter/Abstract.php
@@ -65,8 +65,6 @@ abstract class Varien_Image_Adapter_Abstract
 
     abstract public function open($fileName);
 
-    abstract public function destruct();
-
     abstract public function save($destination=null, $newName=null);
 
     abstract public function display();


### PR DESCRIPTION
The image upload - especially during mass imports - leads to memory leaks due to consumed memory of the image adapter.

The fix frees the consumed image resources.