### PR TITLE
opcheckout.js should  iterate over elements, not functions

### DIFF
--- a/skin/frontend/base/default/js/opcheckout.js
+++ b/skin/frontend/base/default/js/opcheckout.js
@@ -90,9 +90,9 @@ Checkout.prototype = {
 
     _disableEnableAll: function(element, isDisabled) {
         var descendants = element.descendants();
-        for (var k in descendants) {
-            descendants[k].disabled = isDisabled;
-        }
+        descendants.each(function(descendant) {
+            descendant.disabled = isDisabled;
+        });
         element.disabled = isDisabled;
     },
 


### PR DESCRIPTION
This patch make use of the prototype's ``each`` function
to iterate over dom elements instead of all object properties and functions.

fixes https://github.com/OpenMage/magento-lts/issues/42