### PR TITLE
Improve extensibility of get.php file

### DIFF
--- a/get.php
+++ b/get.php
@@ -143,11 +143,13 @@ if (0 !== stripos($pathInfo, $mediaDirectory . '/')) {
 }
 
 try {
-    $databaseFileSotrage = Mage::getModel('core/file_storage_database');
-    $databaseFileSotrage->loadByFilename($relativeFilename);
+    /** @var Mage_Core_Helper_File_Storage_Database $databaseFileStorageHelper */
+    $databaseFileStorageHelper = Mage::helper('core/file_storage_database');
+    $databaseFileStorage = $databaseFileStorageHelper->getStorageDatabaseModel();
+    $databaseFileStorage->loadByFilename($relativeFilename);
 } catch (Exception $e) {
 }
-if ($databaseFileSotrage->getId()) {
+if ($databaseFileStorage->getId()) {
     $directory = dirname($filePath);
     if (!is_dir($directory)) {
         mkdir($directory, 0777, true);
@@ -156,7 +158,7 @@ if ($databaseFileSotrage->getId()) {
     $fp = fopen($filePath, 'w');
     if (flock($fp, LOCK_EX | LOCK_NB)) {
         ftruncate($fp, 0);
-        fwrite($fp, $databaseFileSotrage->getContent());
+        fwrite($fp, $databaseFileStorage->getContent());
     }
     flock($fp, LOCK_UN);
     fclose($fp);


### PR DESCRIPTION
Rather than directly calling the database storage model, we use the storage helper to call it instead. This makes it easier to customise how the file storage system works.