### PR TITLE
[BUG] Fix memory leaks during image upload

### DIFF
--- a/lib/Varien/Image.php
+++ b/lib/Varien/Image.php
@@ -54,6 +54,19 @@ class Varien_Image
     }
 
     /**
+     * Destructor
+     */
+    public function __destruct()
+    {
+        if (
+            $this->_adapter instanceof Varien_Image_Adapter_Abstract
+            && method_exists($this->_adapter, 'destruct')
+        ) {
+            $this->_adapter->destruct();
+        }
+    }
+
+    /**
      * Opens an image and creates image handle
      *
      * @access public


### PR DESCRIPTION
The image upload - especially during mass imports - leads to memory leaks
 due to consumed memory of the image adapter.

The fix frees the consumed image resources on destruction by calling the
destruct() method on the image adapter.

Note: The root cause is in Varien_Image_Adapter_Gd2, a class that keeps
every created instance in memory until the PHP script exits. This root-
cause remains unfixed with this commit.