### PR TITLE
Standardize toOptionArray() method

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
@@ -160,7 +160,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Crosssell extends Mage_Admin
             'width'     => 100,
             'index'     => 'type_id',
             'type'      => 'options',
-            'options'   => Mage::getSingleton('catalog/product_type')->getOptionArray(),
+            'options'   => Mage::getSingleton('catalog/product_type')->toOptionArray(),
         ));
 
         $sets = Mage::getResourceModel('eav/entity_attribute_set_collection')
@@ -181,7 +181,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Crosssell extends Mage_Admin
             'width'     => 90,
             'index'     => 'status',
             'type'      => 'options',
-            'options'   => Mage::getSingleton('catalog/product_status')->getOptionArray(),
+            'options'   => Mage::getSingleton('catalog/product_status')->toOptionArray(),
         ));
 
         $this->addColumn('visibility', array(
@@ -189,7 +189,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Crosssell extends Mage_Admin
             'width'     => 90,
             'index'     => 'visibility',
             'type'      => 'options',
-            'options'   => Mage::getSingleton('catalog/product_visibility')->getOptionArray(),
+            'options'   => Mage::getSingleton('catalog/product_visibility')->toOptionArray(),
         ));
 
         $this->addColumn('sku', array(

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
@@ -157,7 +157,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Related extends Mage_Adminht
             'width'     => 100,
             'index'     => 'type_id',
             'type'      => 'options',
-            'options'   => Mage::getSingleton('catalog/product_type')->getOptionArray(),
+            'options'   => Mage::getSingleton('catalog/product_type')->toOptionArray(),
         ));
 
         $sets = Mage::getResourceModel('eav/entity_attribute_set_collection')
@@ -178,7 +178,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Related extends Mage_Adminht
             'width'     => 90,
             'index'     => 'status',
             'type'      => 'options',
-            'options'   => Mage::getSingleton('catalog/product_status')->getOptionArray(),
+            'options'   => Mage::getSingleton('catalog/product_status')->toOptionArray(),
         ));
 
         $this->addColumn('visibility', array(
@@ -186,7 +186,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Related extends Mage_Adminht
             'width'     => 90,
             'index'     => 'visibility',
             'type'      => 'options',
-            'options'   => Mage::getSingleton('catalog/product_visibility')->getOptionArray(),
+            'options'   => Mage::getSingleton('catalog/product_visibility')->toOptionArray(),
         ));
 
         $this->addColumn('sku', array(

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Settings.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Settings.php
@@ -69,7 +69,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Settings extends Mage_Adminh
             'title' => Mage::helper('catalog')->__('Product Type'),
             'name'  => 'type',
             'value' => '',
-            'values'=> Mage::getModel('catalog/product_type')->getOptionArray()
+            'values'=> Mage::getModel('catalog/product_type')->toOptionArray()
         ));
 
         $fieldset->addField('continue_button', 'note', array(

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
@@ -157,7 +157,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Upsell extends Mage_Adminhtm
             'width'     => 100,
             'index'     => 'type_id',
             'type'      => 'options',
-            'options'   => Mage::getSingleton('catalog/product_type')->getOptionArray(),
+            'options'   => Mage::getSingleton('catalog/product_type')->toOptionArray(),
         ));
 
         $sets = Mage::getResourceModel('eav/entity_attribute_set_collection')
@@ -178,7 +178,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Upsell extends Mage_Adminhtm
             'width'     => 90,
             'index'     => 'status',
             'type'      => 'options',
-            'options'   => Mage::getSingleton('catalog/product_status')->getOptionArray(),
+            'options'   => Mage::getSingleton('catalog/product_status')->toOptionArray(),
         ));
 
         $this->addColumn('visibility', array(
@@ -186,7 +186,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Upsell extends Mage_Adminhtm
             'width'     => 90,
             'index'     => 'visibility',
             'type'      => 'options',
-            'options'   => Mage::getSingleton('catalog/product_visibility')->getOptionArray(),
+            'options'   => Mage::getSingleton('catalog/product_visibility')->toOptionArray(),
         ));
 
         $this->addColumn('sku', array(

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
@@ -172,7 +172,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
                 'width' => '60px',
                 'index' => 'type_id',
                 'type'  => 'options',
-                'options' => Mage::getSingleton('catalog/product_type')->getOptionArray(),
+                'options' => Mage::getSingleton('catalog/product_type')->toOptionArray(),
         ));
 
         $sets = Mage::getResourceModel('eav/entity_attribute_set_collection')
@@ -221,7 +221,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
                 'width' => '70px',
                 'index' => 'visibility',
                 'type'  => 'options',
-                'options' => Mage::getModel('catalog/product_visibility')->getOptionArray(),
+                'options' => Mage::getModel('catalog/product_visibility')->toOptionArray(),
         ));
 
         $this->addColumn('status',
@@ -230,7 +230,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
                 'width' => '70px',
                 'index' => 'status',
                 'type'  => 'options',
-                'options' => Mage::getSingleton('catalog/product_status')->getOptionArray(),
+                'options' => Mage::getSingleton('catalog/product_status')->toOptionArray(),
         ));
 
         if (!Mage::app()->isSingleStoreMode()) {
@@ -284,7 +284,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
              'confirm' => Mage::helper('catalog')->__('Are you sure?')
         ));
 
-        $statuses = Mage::getSingleton('catalog/product_status')->getOptionArray();
+        $statuses = Mage::getSingleton('catalog/product_status')->toOptionArray();
 
         array_unshift($statuses, array('label'=>'', 'value'=>''));
         $this->getMassactionBlock()->addItem('status', array(

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Sku.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Sku.php
@@ -129,7 +129,7 @@ class Mage_Adminhtml_Block_Promo_Widget_Chooser_Sku extends Mage_Adminhtml_Block
                 'width' => '60px',
                 'index' => 'type_id',
                 'type'  => 'options',
-                'options' => Mage::getSingleton('catalog/product_type')->getOptionArray(),
+                'options' => Mage::getSingleton('catalog/product_type')->toOptionArray(),
         ));
 
         $sets = Mage::getResourceModel('eav/entity_attribute_set_collection')

--- a/app/code/core/Mage/Adminhtml/Block/Review/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Product/Grid.php
@@ -86,7 +86,7 @@ class Mage_Adminhtml_Block_Review_Product_Grid extends Mage_Adminhtml_Block_Cata
                 'index'     => 'status',
                 'type'      => 'options',
                 'source'    => 'catalog/product_status',
-                'options'   => Mage::getSingleton('catalog/product_status')->getOptionArray(),
+                'options'   => Mage::getSingleton('catalog/product_status')->toOptionArray(),
         ));
 
         /**

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Wizard.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Wizard.php
@@ -125,7 +125,7 @@ class Mage_Adminhtml_Block_System_Convert_Gui_Edit_Tab_Wizard extends Mage_Admin
 
     public function getProductTypeFilterOptions()
     {
-        $options = Mage::getSingleton('catalog/product_type')->getOptionArray();
+        $options = Mage::getSingleton('catalog/product_type')->toOptionArray();
         array_splice($options, 0, 0, array(''=>$this->__('Any Type')));
         return $options;
     }
@@ -148,7 +148,7 @@ class Mage_Adminhtml_Block_System_Convert_Gui_Edit_Tab_Wizard extends Mage_Admin
 
     public function getProductVisibilityFilterOptions()
     {
-        $options = Mage::getSingleton('catalog/product_visibility')->getOptionArray();
+        $options = Mage::getSingleton('catalog/product_visibility')->toOptionArray();
 
         array_splice($options, 0, 0, array(''=>$this->__('Any Visibility')));
         return $options;
@@ -156,7 +156,7 @@ class Mage_Adminhtml_Block_System_Convert_Gui_Edit_Tab_Wizard extends Mage_Admin
 
     public function getProductStatusFilterOptions()
     {
-        $options = Mage::getSingleton('catalog/product_status')->getOptionArray();
+        $options = Mage::getSingleton('catalog/product_status')->toOptionArray();
 
         array_splice($options, 0, 0, array(''=>$this->__('Any Status')));
         return $options;

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Assigned/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Assigned/Grid.php
@@ -185,7 +185,7 @@ class Mage_Adminhtml_Block_Tag_Assigned_Grid extends Mage_Adminhtml_Block_Widget
                 'width'     => 100,
                 'index'     => 'type_id',
                 'type'      => 'options',
-                'options'   => Mage::getSingleton('catalog/product_type')->getOptionArray(),
+                'options'   => Mage::getSingleton('catalog/product_type')->toOptionArray(),
         ));
 
         $sets = Mage::getResourceModel('eav/entity_attribute_set_collection')
@@ -224,7 +224,7 @@ class Mage_Adminhtml_Block_Tag_Assigned_Grid extends Mage_Adminhtml_Block_Widget
                 'width'     => 100,
                 'index'     => 'visibility',
                 'type'      => 'options',
-                'options'   => Mage::getModel('catalog/product_visibility')->getOptionArray(),
+                'options'   => Mage::getModel('catalog/product_visibility')->toOptionArray(),
         ));
 
         $this->addColumn('status',
@@ -233,7 +233,7 @@ class Mage_Adminhtml_Block_Tag_Assigned_Grid extends Mage_Adminhtml_Block_Widget
                 'width'     => 70,
                 'index'     => 'status',
                 'type'      => 'options',
-                'options'   => Mage::getSingleton('catalog/product_status')->getOptionArray(),
+                'options'   => Mage::getSingleton('catalog/product_status')->toOptionArray(),
         ));
 
         return parent::_prepareColumns();

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Product/Grid.php
@@ -75,7 +75,7 @@ class Mage_Adminhtml_Block_Urlrewrite_Product_Grid extends Mage_Adminhtml_Block_
                 'width' => 50,
                 'index' => 'status',
                 'type'  => 'options',
-                'options' => Mage::getSingleton('catalog/product_status')->getOptionArray(),
+                'options' => Mage::getSingleton('catalog/product_status')->toOptionArray(),
         ));
         return $this;
     }

--- a/app/code/core/Mage/Catalog/Model/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Config.php
@@ -203,7 +203,7 @@ class Mage_Catalog_Model_Config extends Mage_Eav_Model_Config
             ->load();
         */
         $productTypeCollection = Mage::getModel('catalog/product_type')
-            ->getOptionArray();
+            ->toOptionArray();
 
         $this->_productTypesById = array();
         $this->_productTypesByName = array();

--- a/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
@@ -264,7 +264,7 @@ class Mage_Catalog_Model_Convert_Adapter_Product
         if (is_null($this->_productTypes)) {
             $this->_productTypes = array();
             $options = Mage::getModel('catalog/product_type')
-                ->getOptionArray();
+                ->toOptionArray();
             foreach ($options as $k => $v) {
                 $this->_productTypes[$k] = $k;
             }

--- a/app/code/core/Mage/Catalog/Model/Convert/Parser/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Parser/Product.php
@@ -127,7 +127,7 @@ class Mage_Catalog_Model_Convert_Parser_Product
     {
         if (is_null($this->_productTypes)) {
             $this->_productTypes = Mage::getSingleton('catalog/product_type')
-                ->getOptionArray();
+                ->toOptionArray();
         }
         return $this->_productTypes;
     }

--- a/app/code/core/Mage/Catalog/Model/Product/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Api.php
@@ -442,7 +442,7 @@ class Mage_Catalog_Model_Product_Api extends Mage_Catalog_Model_Api_Resource
      */
     protected function _checkProductTypeExists($productType)
     {
-        if (!in_array($productType, array_keys(Mage::getModel('catalog/product_type')->getOptionArray()))) {
+        if (!in_array($productType, array_keys(Mage::getModel('catalog/product_type')->toOptionArray()))) {
             $this->_fault('product_type_not_exists');
         }
     }

--- a/app/code/core/Mage/Catalog/Model/Product/Status.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Status.php
@@ -135,7 +135,7 @@ class Mage_Catalog_Model_Product_Status extends Mage_Core_Model_Abstract
      *
      * @return array
      */
-    static public function getOptionArray()
+    static public function toOptionArray()
     {
         return array(
             self::STATUS_ENABLED    => Mage::helper('catalog')->__('Enabled'),
@@ -150,7 +150,7 @@ class Mage_Catalog_Model_Product_Status extends Mage_Core_Model_Abstract
      */
     static public function getAllOption()
     {
-        $options = self::getOptionArray();
+        $options = self::toOptionArray();
         array_unshift($options, array('value'=>'', 'label'=>''));
         return $options;
     }
@@ -168,7 +168,7 @@ class Mage_Catalog_Model_Product_Status extends Mage_Core_Model_Abstract
                 'label' => Mage::helper('catalog')->__('-- Please Select --')
             )
         );
-        foreach (self::getOptionArray() as $index => $value) {
+        foreach (self::toOptionArray() as $index => $value) {
             $res[] = array(
                'value' => $index,
                'label' => $value
@@ -185,7 +185,7 @@ class Mage_Catalog_Model_Product_Status extends Mage_Core_Model_Abstract
      */
     static public function getOptionText($optionId)
     {
-        $options = self::getOptionArray();
+        $options = self::toOptionArray();
         return isset($options[$optionId]) ? $options[$optionId] : null;
     }
 

--- a/app/code/core/Mage/Catalog/Model/Product/Type.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type.php
@@ -105,7 +105,7 @@ class Mage_Catalog_Model_Product_Type
         return self::$_priceModels[$productType];
     }
 
-    static public function getOptionArray()
+    static public function toOptionArray()
     {
         $options = array();
         foreach(self::getTypes() as $typeId=>$type) {
@@ -117,7 +117,7 @@ class Mage_Catalog_Model_Product_Type
 
     static public function getAllOption()
     {
-        $options = self::getOptionArray();
+        $options = self::toOptionArray();
         array_unshift($options, array('value'=>'', 'label'=>''));
         return $options;
     }
@@ -126,7 +126,7 @@ class Mage_Catalog_Model_Product_Type
     {
         $res = array();
         $res[] = array('value'=>'', 'label'=>'');
-        foreach (self::getOptionArray() as $index => $value) {
+        foreach (self::toOptionArray() as $index => $value) {
             $res[] = array(
                'value' => $index,
                'label' => $value
@@ -138,7 +138,7 @@ class Mage_Catalog_Model_Product_Type
     static public function getOptions()
     {
         $res = array();
-        foreach (self::getOptionArray() as $index => $value) {
+        foreach (self::toOptionArray() as $index => $value) {
             $res[] = array(
                'value' => $index,
                'label' => $value
@@ -149,7 +149,7 @@ class Mage_Catalog_Model_Product_Type
 
     static public function getOptionText($optionId)
     {
-        $options = self::getOptionArray();
+        $options = self::toOptionArray();
         return isset($options[$optionId]) ? $options[$optionId] : null;
     }
 

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Api.php
@@ -42,7 +42,7 @@ class Mage_Catalog_Model_Product_Type_Api extends Mage_Api_Model_Resource_Abstra
     {
         $result = array();
 
-        foreach (Mage_Catalog_Model_Product_Type::getOptionArray() as $type=>$label) {
+        foreach (Mage_Catalog_Model_Product_Type::toOptionArray() as $type=>$label) {
             $result[] = array(
                 'type'  => $type,
                 'label' => $label

--- a/app/code/core/Mage/Catalog/Model/Product/Visibility.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Visibility.php
@@ -133,7 +133,7 @@ class Mage_Catalog_Model_Product_Visibility extends Varien_Object
      *
      * @return array
      */
-    static public function getOptionArray()
+    static public function toOptionArray()
     {
         return array(
             self::VISIBILITY_NOT_VISIBLE=> Mage::helper('catalog')->__('Not Visible Individually'),
@@ -150,7 +150,7 @@ class Mage_Catalog_Model_Product_Visibility extends Varien_Object
      */
     static public function getAllOption()
     {
-        $options = self::getOptionArray();
+        $options = self::toOptionArray();
         array_unshift($options, array('value'=>'', 'label'=>''));
         return $options;
     }
@@ -164,7 +164,7 @@ class Mage_Catalog_Model_Product_Visibility extends Varien_Object
     {
         $res = array();
         $res[] = array('value'=>'', 'label'=> Mage::helper('catalog')->__('-- Please Select --'));
-        foreach (self::getOptionArray() as $index => $value) {
+        foreach (self::toOptionArray() as $index => $value) {
             $res[] = array(
                'value' => $index,
                'label' => $value
@@ -181,7 +181,7 @@ class Mage_Catalog_Model_Product_Visibility extends Varien_Object
      */
     static public function getOptionText($optionId)
     {
-        $options = self::getOptionArray();
+        $options = self::toOptionArray();
         return isset($options[$optionId]) ? $options[$optionId] : null;
     }
 

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Boolean.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Boolean.php
@@ -61,7 +61,7 @@ class Mage_Eav_Model_Entity_Attribute_Source_Boolean extends Mage_Eav_Model_Enti
      *
      * @return array
      */
-    public function getOptionArray()
+    public function toOptionArray()
     {
         $_options = array();
         foreach ($this->getAllOptions() as $option) {

--- a/app/code/core/Mage/GoogleBase/Block/Adminhtml/Items/Product.php
+++ b/app/code/core/Mage/GoogleBase/Block/Adminhtml/Items/Product.php
@@ -101,7 +101,7 @@ class Mage_GoogleBase_Block_Adminhtml_Items_Product extends Mage_Adminhtml_Block
                 'width' => '60px',
                 'index' => 'type_id',
                 'type'  => 'options',
-                'options' => Mage::getSingleton('catalog/product_type')->getOptionArray(),
+                'options' => Mage::getSingleton('catalog/product_type')->toOptionArray(),
         ));
 
         $this->addColumn('set_name',


### PR DESCRIPTION
There are some models that use `getOptionArray()` instead of `toOptionArray()` making it impossible to define a source model in system.xml like `<source_model>catalog/product_visibility</source_model>`