### PR TITLE
Fix bug with wrong shipping cost

### DIFF
--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -957,14 +957,6 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
                 if ($this->getShippingMethod() == $rate->getCode()) {
                     if ($item) {
                         $item->setBaseShippingAmount($rate->getPrice());
-                    } else {
-                        /**
-                         * possible bug: this should be setBaseShippingAmount(),
-                         * see Mage_Sales_Model_Quote_Address_Total_Shipping::collect()
-                         * where this value is set again from the current specified rate price
-                         * (looks like a workaround for this bug)
-                         */
-                        $this->setShippingAmount($rate->getPrice());
                     }
 
                     $found = true;


### PR DESCRIPTION
I have confirmed this to be a bug, as assumed in the original comment:
```
                    } else {
                        /**
                         * possible bug: this should be setBaseShippingAmount(),
                         * see Mage_Sales_Model_Quote_Address_Total_Shipping::collect()
                         * where this value is set again from the current specified rate price
                         * (looks like a workaround for this bug)
                         */
                        $this->setShippingAmount($rate->getPrice());
```
It caused the wrong shipping cost appear in the shopping cart - including tax instead of excluding tax as configured. The bug is fixed by using BaseShippingAmoun.