### PR TITLE
Fix backgroundColor() "getting"

### DIFF
--- a/lib/Varien/Image/Adapter/Abstract.php
+++ b/lib/Varien/Image/Adapter/Abstract.php
@@ -244,8 +244,9 @@ abstract class Varien_Image_Adapter_Abstract
                     return;
                 }
             }
+            $this->_backgroundColor = $value;
         }
-        $this->_backgroundColor = $value;
+        
         return $this->_backgroundColor;
     }
 


### PR DESCRIPTION
Method backgroundColor() should behave as a setter/getter. If no parameters are provided, it should return the image's current background color. However, due to the location of the line that does the setting ($this->_backgroundColor = $value), the image's background color is set regardless of whether or not a parameter was provided to the method.