### PR TITLE
Fix typo in sales/order model _afterSave() method

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -2203,7 +2203,7 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
             }
 
             $shippingAddress = $this->getShippingAddress();
-            if ($shippingAddress && $this->getShippigAddressId() != $shippingAddress->getId()) {
+            if ($shippingAddress && $this->getShippingAddressId() != $shippingAddress->getId()) {
                 $this->setShippingAddressId($shippingAddress->getId());
                 $attributesForSave[] = 'shipping_address_id';
             }


### PR DESCRIPTION
Getter in if statement has a typo which causes it to attempt to grab the wrong attribute. Since result is null, the comparison always fails, and shipping_address_id attribute is always flagged for update when Order model is saved. 