### PR TITLE
fix jsonDecode() PHP7 compatibility

### DIFF
--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -656,6 +656,14 @@ XML;
      */
     public function jsonDecode($encodedValue, $objectDecodeType = Zend_Json::TYPE_ARRAY)
     {
+        switch (true) {
+            case (null === $encodedValue)  : $encodedValue = 'null'; break;
+            case (true === $encodedValue)  : $encodedValue = 'true'; break;
+            case (false === $encodedValue) : $encodedValue = 'false'; break;
+            case ('' === $encodedValue)    : $encodedValue = '""'; break;
+            default    : // do nothing
+        }
+        
         return Zend_Json::decode($encodedValue, $objectDecodeType);
     }
 


### PR DESCRIPTION
When saving a customer in the admin panel, Magento always throws an error regarding `jsonDecode` - `Exception message: Decoding failed: Syntax error`.

I think `jsonDecode` should be changed to the one in the Inchoo_PHP7 extension [here](https://github.com/Inchoo/Inchoo_PHP7/blob/master/app/code/local/Inchoo/PHP7/Helper/Data.php) instead, which looks like this and has that switch statement added:

    public function jsonDecode($encodedValue, $objectDecodeType = Zend_Json::TYPE_ARRAY) {
        switch (true) {
            case (null === $encodedValue)  : $encodedValue = 'null'; break;
            case (true === $encodedValue)  : $encodedValue = 'true'; break;
            case (false === $encodedValue) : $encodedValue = 'false'; break;
            case ('' === $encodedValue)    : $encodedValue = '""'; break;
            default    : // do nothing
        }
        return Zend_Json::decode($encodedValue, $objectDecodeType);
    }