### PR TITLE
is_readabe fix

### DIFF
--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -525,7 +525,7 @@ class Varien_Io_File extends Varien_Io_Abstract
     protected function _checkSrcIsFile($src)
     {
         $result = false;
-        if (is_string($src) && is_readable($src) && is_file($src)) {
+        if (is_string($src) && @is_readable($src) && is_file($src)) {
             $result = true;
         }
 


### PR DESCRIPTION
Added @ on ``is_readable`` to suppress warning thrown if ``$src`` is file content, not a path (e.g. when image is updated through the REST API) to prevent failure when the PHP server is set to stop on warning like on development server