### PR TITLE
Replace font LinLibertineFont with FONT_HELVETICA: reduces PDf filesi…

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Abstract.php
@@ -317,7 +317,8 @@ abstract class Mage_Sales_Model_Order_Pdf_Items_Abstract extends Mage_Core_Model
      */
     protected function _setFontRegular($size = 7)
     {
-        $font = Zend_Pdf_Font::fontWithPath(Mage::getBaseDir() . '/lib/LinLibertineFont/LinLibertine_Re-4.4.1.ttf');
+        // $font = Zend_Pdf_Font::fontWithPath(Mage::getBaseDir() . '/lib/LinLibertineFont/LinLibertine_It-2.8.2.ttf');
+        $font = Zend_Pdf_Font::fontWithName(Zend_Pdf_Font::FONT_HELVETICA);
         $this->getPage()->setFont($font, $size);
         return $font;
     }
@@ -330,7 +331,8 @@ abstract class Mage_Sales_Model_Order_Pdf_Items_Abstract extends Mage_Core_Model
      */
     protected function _setFontBold($size = 7)
     {
-        $font = Zend_Pdf_Font::fontWithPath(Mage::getBaseDir() . '/lib/LinLibertineFont/LinLibertine_Bd-2.8.1.ttf');
+        // $font = Zend_Pdf_Font::fontWithPath(Mage::getBaseDir() . '/lib/LinLibertineFont/LinLibertine_Bd-2.8.1.ttf');
+        $font = Zend_Pdf_Font::fontWithName(Zend_Pdf_Font::FONT_HELVETICA);
         $this->getPage()->setFont($font, $size);
         return $font;
     }
@@ -343,7 +345,8 @@ abstract class Mage_Sales_Model_Order_Pdf_Items_Abstract extends Mage_Core_Model
      */
     protected function _setFontItalic($size = 7)
     {
-        $font = Zend_Pdf_Font::fontWithPath(Mage::getBaseDir() . '/lib/LinLibertineFont/LinLibertine_It-2.8.2.ttf');
+        // $font = Zend_Pdf_Font::fontWithPath(Mage::getBaseDir() . '/lib/LinLibertineFont/LinLibertine_It-2.8.2.ttf');
+        $font = Zend_Pdf_Font::fontWithName(Zend_Pdf_Font::FONT_HELVETICA);
         $this->getPage()->setFont($font, $size);
         return $font;
     }


### PR DESCRIPTION
…zes almost 20x fold

Replace font LinLibertineFont with FONT_HELVETICA: reduces PDf filesizes almost 20x fold

Also officialy logged in Magento 1.9x stream

Also HELVETICA is a standard font (instead of loading a lib file)

$font = Zend_Pdf_Font::fontWithName(Zend_Pdf_Font::FONT_HELVETICA);
