### PR TITLE
Fix tax calculation bug in credit memo

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Subtotal.php
@@ -58,8 +58,8 @@ class Mage_Sales_Model_Order_Creditmemo_Total_Subtotal extends Mage_Sales_Model_
         $creditmemo->setSubtotalInclTax($subtotalInclTax );
         $creditmemo->setBaseSubtotalInclTax($baseSubtotalInclTax);
 
-        $creditmemo->setGrandTotal($creditmemo->getGrandTotal() + $subtotal);
-        $creditmemo->setBaseGrandTotal($creditmemo->getBaseGrandTotal() + $baseSubtotal);
+        $creditmemo->setGrandTotal($creditmemo->getGrandTotal() + $subtotalInclTax);
+        $creditmemo->setBaseGrandTotal($creditmemo->getBaseGrandTotal() + $baseSubtotalInclTax);
 
         return $this;
     }


### PR DESCRIPTION
Replace

        $creditmemo->setGrandTotal($creditmemo->getGrandTotal() + $subtotal);
        $creditmemo->setBaseGrandTotal($creditmemo->getBaseGrandTotal() + $baseSubtotal);

with 

        $creditmemo->setGrandTotal($creditmemo->getGrandTotal() + $subtotalInclTax);
        $creditmemo->setBaseGrandTotal($creditmemo->getBaseGrandTotal() + $baseSubtotalInclTax);