### PR TITLE
Fix creditmemo tax calculation bug when using multiple discounts

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
@@ -324,9 +324,25 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
      *
      * @return Mage_Sales_Model_Order_Creditmemo
      */
-    public function collectTotals()
+     public function collectTotals()
     {
-        foreach ($this->getConfig()->getTotalModels() as $model) {
+        $models = $this->getConfig()->getTotalModels();
+        $res = array();
+        $i=0;
+        $discount = 0;
+        foreach ($models as $name =>$model) {
+            if ($name=='discount') $discount = $i;
+            if ($name=='tax') {
+                //array_splice( $res, $discount, 0, array($models[$name]) );
+            } else {
+                $res[] = $model;
+            }
+
+            $i++;
+        }
+
+
+        foreach ($res as $model) {
             $model->collect($this);
         }
         return $this;

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Subtotal.php
@@ -58,8 +58,8 @@ class Mage_Sales_Model_Order_Creditmemo_Total_Subtotal extends Mage_Sales_Model_
         $creditmemo->setSubtotalInclTax($subtotalInclTax );
         $creditmemo->setBaseSubtotalInclTax($baseSubtotalInclTax);
 
-        $creditmemo->setGrandTotal($creditmemo->getGrandTotal() + $subtotal);
-        $creditmemo->setBaseGrandTotal($creditmemo->getBaseGrandTotal() + $baseSubtotal);
+        $creditmemo->setGrandTotal($creditmemo->getGrandTotal() + $subtotalInclTax);
+        $creditmemo->setBaseGrandTotal($creditmemo->getBaseGrandTotal() + $baseSubtotalInclTax);
 
         return $this;
     }


### PR DESCRIPTION
Fix creditmemo tax calculation bug when using multiple discounts

Needs code review and additional testing

But this has been tested in production and solved our errors with creditmemo calculation missing value
