### PR TITLE
Add visibility and qty in stock to product selection grid in backend order creation

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid.php
@@ -101,6 +101,7 @@ class Mage_Adminhtml_Block_Sales_Order_Create_Search_Grid extends Mage_Adminhtml
             ->setStore($this->getStore())
             ->addAttributeToSelect($attributes)
             ->addAttributeToSelect('sku')
+            ->addAttributeToSelect('visibility')            
             ->addStoreFilter()
             ->addAttributeToFilter('type_id', array_keys(
                 Mage::getConfig()->getNode('adminhtml/sales/order/create/available_product_types')->asArray()
@@ -108,7 +109,16 @@ class Mage_Adminhtml_Block_Sales_Order_Create_Search_Grid extends Mage_Adminhtml
             ->addAttributeToSelect('gift_message_available');
 
         Mage::getSingleton('catalog/product_status')->addSaleableFilterToCollection($collection);
-
+        
+        if (Mage::helper('catalog')->isModuleEnabled('Mage_CatalogInventory')) {
+        $collection->joinField('inv_qty',
+            'cataloginventory/stock_item',
+            'qty',
+            'product_id=entity_id',
+            '{{table}}.stock_id=1',
+            'left');
+        }
+        
         $this->setCollection($collection);
         return parent::_prepareCollection();
     }
@@ -136,6 +146,7 @@ class Mage_Adminhtml_Block_Sales_Order_Create_Search_Grid extends Mage_Adminhtml
             'width'     => '80',
             'index'     => 'sku'
         ));
+        
         $this->addColumn('price', array(
             'header'    => Mage::helper('sales')->__('Price'),
             'column_css_class' => 'price',


### PR DESCRIPTION
Add new fields to collection

doesnt break anything just makes more logic to be able to filter your grid based on stock or visibility. FOr instance one could choose to show only visibility=4 so we see the same products as in the frontend

See also here: http://magento.stackexchange.com/questions/17566/magento-add-stock-qty-in-backend-new-order-creation/17898#17898

Optionally we could add the column per default to the grid: although I think this is quite logic and should be in core. Others would maybe not agree. So I will leave that up to you.

```
    if (Mage::helper('catalog')->isModuleEnabled('Mage_CatalogInventory')) {
        $this->addColumn('inv_qty',
        array(
        'header'=> Mage::helper('catalog')->__('Qty'),
        'width' => '30px',
        'type'  => 'number',
        'index' => 'inv_qty',
        ));
    }
```
