### PR TITLE
If add qty field is empty set a default vallue of 1

### DIFF
--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/qty.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/qty.phtml
@@ -34,3 +34,13 @@
         </dl>
     </div>
 </div>
+
+<script type="text/javascript">
+    //<![CDATA[
+    var input = document.getElementById('product_composite_configure_input_qty');
+    if(input.value.length == 0) { 
+        input.value = "1";
+    }
+    //]]>
+</script>
+


### PR DESCRIPTION
If add qty field is empty set a default vallue of 1

Solution is maybe not the most elegant but makes sure we don't overwrite existing values. Only oly if the fields is empty set a default value. A an improvement one could get the value from the mimimal_order_qty settings in settings (this is the way you set a default order qty value in frontend instead of leaving it empty)

please imagine use entering orders every day via adminhtml and every every time this fields is empty

a starting value of 1 already solves 95% of these cases

Major improvement for us, please accept
