### PR TITLE
Added stock update event to registerProductsSale + revertProductsSale

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock.php
@@ -162,7 +162,6 @@ class Mage_CatalogInventory_Model_Stock extends Mage_Core_Model_Abstract
         Mage::dispatchEvent(self::EVENT_CORRECT_STOCK_ITEMS_QTY_AFTER, array(
         'stock'          => $this,
         'items'          => $items,
-        'fullsave_items' => $result,
         'operator'       => '+'
         ));
         
@@ -185,7 +184,6 @@ class Mage_CatalogInventory_Model_Stock extends Mage_Core_Model_Abstract
         Mage::dispatchEvent(self::EVENT_CORRECT_STOCK_ITEMS_QTY_BEFORE, array(
         'stock'          => $this,
         'items'          => $items,
-        'fullsave_items' => $result,
         'operator'       => '-'
         ));
         return $this;

--- a/app/code/core/Mage/CatalogInventory/Model/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock.php
@@ -50,6 +50,9 @@ class Mage_CatalogInventory_Model_Stock extends Mage_Core_Model_Abstract
     const STOCK_IN_STOCK            = 1;
 
     const DEFAULT_STOCK_ID          = 1;
+    
+    const EVENT_CORRECT_STOCK_ITEMS_QTY_BEFORE = 'cataloginventory_stock_item_correct_qty_before';
+    const EVENT_CORRECT_STOCK_ITEMS_QTY_AFTER = 'cataloginventory_stock_item_correct_qty_after';
 
     protected function _construct()
     {
@@ -132,6 +135,11 @@ class Mage_CatalogInventory_Model_Stock extends Mage_Core_Model_Abstract
      */
     public function registerProductsSale($items)
     {
+        Mage::dispatchEvent(self::EVENT_CORRECT_STOCK_ITEMS_QTY_BEFORE, array(
+        'stock'     => $this,
+        'items_obj' => (object)array('items' => &$items),
+        'operator'  => '+'
+        ));
         $qtys = $this->_prepareProductQtys($items);
         $item = Mage::getModel('cataloginventory/stock_item');
         $this->_getResource()->beginTransaction();
@@ -150,6 +158,14 @@ class Mage_CatalogInventory_Model_Stock extends Mage_Core_Model_Abstract
         }
         $this->_getResource()->correctItemsQty($this, $qtys, '-');
         $this->_getResource()->commit();
+        
+        Mage::dispatchEvent(self::EVENT_CORRECT_STOCK_ITEMS_QTY_AFTER, array(
+        'stock'          => $this,
+        'items'          => $items,
+        'fullsave_items' => $result,
+        'operator'       => '+'
+        ));
+        
         return $fullSaveItems;
     }
 
@@ -159,8 +175,19 @@ class Mage_CatalogInventory_Model_Stock extends Mage_Core_Model_Abstract
      */
     public function revertProductsSale($items)
     {
+        Mage::dispatchEvent(self::EVENT_CORRECT_STOCK_ITEMS_QTY_BEFORE, array(
+        'stock'     => $this,
+        'items_obj' => (object)array('items' => &$items),
+        'operator'  => '-'
+        ));
         $qtys = $this->_prepareProductQtys($items);
         $this->_getResource()->correctItemsQty($this, $qtys, '+');
+        Mage::dispatchEvent(self::EVENT_CORRECT_STOCK_ITEMS_QTY_BEFORE, array(
+        'stock'          => $this,
+        'items'          => $items,
+        'fullsave_items' => $result,
+        'operator'       => '-'
+        ));
         return $this;
     }
 


### PR DESCRIPTION
Added stock update event to registerProductsSale + revertProductsSale - much needed event to solve complex stock event capture methods. Suggestion is made here bij Fabian: http://magento.stackexchange.com/questions/25207/detect-inventory-change

Maybe the event prefix which is defined elsewhere should be use, but for now just added event name as CONST

Breaks nothing, adds cool stuff

Please verify + upvote if you like it
