### PR TITLE
Fix query which creates significant deadlock potential.

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock.php
@@ -131,11 +131,24 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
         $productTable = $this->getTable('catalog/product');
         $select = $this->_getWriteAdapter()->select()
             ->from(array('si' => $itemTable))
-            ->join(array('p' => $productTable), 'p.entity_id=si.product_id', array('type_id'))
             ->where('stock_id=?', $stock->getId())
             ->where('product_id IN(?)', $productIds)
             ->forUpdate($lockRows);
-        return $this->_getWriteAdapter()->fetchAll($select);
+        $rows = $this->_getWriteAdapter()->fetchAll($select);
+
+        // Add type_id to result using separate select without FOR UPDATE instead
+        // of a join which causes only an S lock on catalog_product_entity rather
+        // than an X lock. An X lock on a table causes an S lock on all foreign keys
+        // so using a separate query here significantly reduces the number of
+        // unnecessarily locked rows in other tables, thereby avoiding deadlocks.
+        $select = $this->_getWriteAdapter()->select()
+            ->from($productTable, ['entity_id', 'type_id'])
+            ->where('entity_id IN(?)', $productIds);
+        $typeIds = $this->_getWriteAdapter()->fetchPairs($select);
+        foreach ($rows as $row) {
+            $row['type_id'] = $typeIds[$row['product_id']];
+        }
+        return $rows;
     }
 
     /**


### PR DESCRIPTION
While doing some database performance testing with Magento (e.g. 16 processes simultaneously creating 100 orders each) I noticed a significant number of deadlocks occurring, especially with newer and more optimized versions of MySQL (5.7 & MariaDb 10.1). By inspecting the general query log and `show engine innodb status` I determined that the issue was that the `SELECT si.*, p.type_id ... FOR UPDATE` query used by `registerProductsForSale()` method was the culprit. When `FOR UPDATE` is used an X lock is taken on all matching rows *and* an S lock is taken on all rows linked by foreign keys. This applies also to joined tables, so joining `catalog_product_entity` in this `FOR UPDATE` is causing an X lock on `catalog_product_entity` which I don't see as being at all necessary, and it also causes an S lock to be taken on all rows linked to `cpe` by a foreign key (`eav_attribute_set` and `eav_entity_type`).

Here is an example deadlock:

```
------------------------
LATEST DETECTED DEADLOCK
------------------------
2016-09-28 20:59:17 7f46bb7e7700
*** (1) TRANSACTION:
TRANSACTION 453781, ACTIVE 11 sec starting index read
mysql tables in use 1, locked 1
LOCK WAIT 16 lock struct(s), heap size 2936, 12 row lock(s), undo log entries 13
MySQL thread id 273, OS thread handle 0x7f46bb754700, query id 2689415 10.0.1.5 root statistics
SELECT `eav_entity_store`.* FROM `eav_entity_store` WHERE (entity_type_id = '11') AND (store_id = '3') FOR UPDATE
*** (1) WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 255 page no 4 n bits 120 index `entity_type_id_store_id` of table `magento`.`eav_entity_store` trx
table locks 9 total table locks 6  trx id 453781 lock_mode X locks rec but not gap waiting lock hold time 4 wait time before grant 0
*** (2) TRANSACTION:
TRANSACTION 453786, ACTIVE 9 sec starting index read, thread declared inside InnoDB 4998
mysql tables in use 2, locked 2
115 lock struct(s), heap size 30248, 1767 row lock(s), undo log entries 2417
MySQL thread id 271, OS thread handle 0x7f46bb7e7700, query id 2693906 10.0.1.5 root Sending data
SELECT `si`.*, `p`.`type_id` FROM `cataloginventory_stock_item` AS `si`
 INNER JOIN `catalog_product_entity` AS `p` ON p.entity_id=si.product_id WHERE (stock_id=1) AND (product_id IN(1454, 274, 842, 464, 2
87, 826)) FOR UPDATE
*** (2) HOLDS THE LOCK(S):
RECORD LOCKS space id 255 page no 4 n bits 120 index `entity_type_id_store_id` of table `magento`.`eav_entity_store` trx
table locks 20 total table locks 6  trx id 453786 lock_mode X locks rec but not gap lock hold time 4 wait time before grant 0
*** (2) WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 84 page no 8 n bits 304 index `PRIMARY` of table `magento`.`catalog_product_entity` trx table locks
 20 total table locks 3  trx id 453786 lock_mode X locks rec but not gap waiting lock hold time 0 wait time before grant 0
*** WE ROLL BACK TRANSACTION (1)
```

Notice how txn 2 has `115 lock struct(s), heap size 30248, 1767 row lock(s), undo log entries 2417` even though it is only locking 6 stock items. By separating the `SELECT ... JOIN ... FOR UPDATE` into two separate selects with only the one on `cataloginventory_stock_item` using `FOR UPDATE` the lock still ensures correct inventory updates but will no longer create an X lock on `cpe` or a massive number of S locks on a bunch of other tables.

Note, there is also room for improvement in reducing lock contention on fetchNewIncrementId which I have fixed years ago but I will open a separate PR for that issue or perhaps add it to this one. In short, add unique key on `eav_entity_store (entity_type_id, store_id)` and drop foreign keys and indexes on entity_type_id and store_id. The unique key fixes a bug where there can be two conflicting rows and also allows innodb to lock only a single row and removing the foreign keys gets rid of unnecessary S locks on other tables.

What should the version numbering be for database upgrade scripts to avoid conflicts with future upstream upgrade scripts?