### PR TITLE
Improve layout cache efficiency by de-duplicating XML strings.

### DIFF
--- a/app/code/core/Mage/Core/Model/Layout/Update.php
+++ b/app/code/core/Mage/Core/Model/Layout/Update.php
@@ -33,6 +33,11 @@ class Mage_Core_Model_Layout_Update
     const LAYOUT_GENERAL_CACHE_TAG = 'LAYOUT_GENERAL_CACHE_TAG';
 
     /**
+     * Prefix used for actual XML storage (unprefixed is just the sha1 hash)
+     */
+    const XML_KEY_PREFIX = 'XML_';
+
+    /**
      * Layout Update Simplexml Element Class Name
      *
      * @var string
@@ -182,6 +187,13 @@ class Mage_Core_Model_Layout_Update
             return false;
         }
 
+        // The cache key is just a hash of the real content to de-duplicate the often large XML strings
+        if (strlen($result) === 40) { // sha1
+            if (!$result = Mage::app()->loadCache(self::XML_KEY_PREFIX . $result)) {
+                return false;
+            }
+        }
+
         $this->addUpdate($result);
 
         return true;
@@ -194,8 +206,17 @@ class Mage_Core_Model_Layout_Update
         }
         $str = $this->asString();
         $tags = $this->getHandles();
+
+        // Cache key is sha1 hash of actual XML string
+        $hash = sha1($str);
         $tags[] = self::LAYOUT_GENERAL_CACHE_TAG;
-        return Mage::app()->saveCache($str, $this->getCacheId(), $tags, null);
+        Mage::app()->saveCache($hash, $this->getCacheId(), $tags, null);
+
+        // Only save actual XML to cache if it doesn't already exist
+        if ( ! Mage::app()->getCache()->test(self::XML_KEY_PREFIX . $hash)) {
+            Mage::app()->saveCache($str, self::XML_KEY_PREFIX . $hash, $tags, null);
+        }
+        return TRUE;
     }
 
     /**


### PR DESCRIPTION
As announced a while back and made public first here: https://gist.github.com/colinmollenhour/14ed23d029e5b991a3e31ad1fe0841d4

I've been using this in production for months now with no issues. Massive cache storage savings.