### PR TITLE
implemented fastcgi_finish_request

### DIFF
--- a/app/code/core/Mage/Core/Controller/Varien/Front.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Front.php
@@ -182,6 +182,12 @@ class Mage_Core_Controller_Varien_Front extends Varien_Object
         Mage::dispatchEvent('controller_front_send_response_before', array('front'=>$this));
         Varien_Profiler::start('mage::app::dispatch::send_response');
         $this->getResponse()->sendResponse();
+        //This function flushes all response data to the client and finishes the request.
+        // This allows for time consuming tasks to be performed without leaving the connection
+        // to the client open.
+        if(php_sapi_name() == 'fpm-fcgi' && true === function_exists('fastcgi_finish_request')){
+            fastcgi_finish_request();
+        }
         Varien_Profiler::stop('mage::app::dispatch::send_response');
         Mage::dispatchEvent('controller_front_send_response_after', array('front'=>$this));
         return $this;


### PR DESCRIPTION
Implemented [fastcgi_finish_request()](http://php.net/manual/de/function.fastcgi-finish-request.php) to send response to the client as early as possible.
This function flushes all response data to the client and finishes the request. This allows for time consuming tasks to be performed without leaving the connection to the client open.
