### PR TITLE
Add custom source for multiselect product attributes

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
@@ -182,6 +182,21 @@ class Mage_Catalog_Model_Resource_Product_Indexer_Eav_Source extends Mage_Catalo
             $options[$row['attribute_id']][$row['option_id']] = true;
         }
 
+        foreach ($attrIds as $attId) {
+            $attribute = Mage::getResourceSingleton('catalog/product')->getAttribute($attId);
+            if ($attribute->getSourceModel() != 'eav/entity_attribute_source_table') {
+                unset($options[$attId]);
+                $sourceOptions = $attribute->getSource()->getAllOptions();
+                if ($sourceOptions) {
+                    foreach ($sourceOptions as $sourceOption) {
+                        if (isset($sourceOption['value'])) {
+                            $options[$attId][$sourceOption['value']] = true;
+                        }
+                    }
+                }
+            }
+        }
+
         // prepare get multiselect values query
         $productValueExpression = $adapter->getCheckSql('pvs.value_id > 0', 'pvs.value', 'pvd.value');
         $select = $adapter->select()


### PR DESCRIPTION
When you create your own multiselect product attribute with a custom source model, this attribute is not displayed on the layered navigation.

Thanks to this fix, you can show your attribute on the filter. In first time I browse all `attribute_id` and if the attribute have a custom source model I set all custom values on `options` array.

(Inspirated by : http://stackoverflow.com/questions/7597448/multi-select-filter-in-layered-navigation)
