### PR TITLE
Fix cms breadcrumb issue in 1.9.3.0

### DIFF
--- a/app/code/core/Mage/Cms/Block/Page.php
+++ b/app/code/core/Mage/Cms/Block/Page.php
@@ -64,6 +64,7 @@ class Mage_Cms_Block_Page extends Mage_Core_Block_Abstract
     {
         $page = $this->getPage();
         $breadcrumbsArray = array();
+        $breadcrumbs = null;
 
         // show breadcrumbs
         if (Mage::getStoreConfig('web/default/show_cms_breadcrumbs')
@@ -104,8 +105,10 @@ class Mage_Cms_Block_Page extends Mage_Core_Block_Abstract
 
         Mage::dispatchEvent('cms_generate_breadcrumbs', array('breadcrumbs' => $breadcrumbsObject));
 
-        foreach ($breadcrumbsObject->getCrumbs() as $breadcrumbsItem) {
-            $breadcrumbs->addCrumb($breadcrumbsItem['crumbName'], $breadcrumbsItem['crumbInfo']);
+        if ($breadcrumbs instanceof Mage_Page_Block_Html_Breadcrumbs) {
+            foreach ($breadcrumbsObject->getCrumbs() as $breadcrumbsItem) {
+               $breadcrumbs->addCrumb($breadcrumbsItem['crumbName'], $breadcrumbsItem['crumbInfo']);
+            }
         }
         return parent::_prepareLayout();
     }


### PR DESCRIPTION
$breadcrumbs is not always defined and should have at least _some_ checking.  Results in fatal exception on frontend in some cases.
