### PR TITLE
Fixes Magento bug 648

### DIFF
--- a/app/code/core/Mage/Shipping/Model/Carrier/Tablerate.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Tablerate.php
@@ -103,8 +103,8 @@ class Mage_Shipping_Model_Carrier_Tablerate
 
         // Free shipping by qty
         $freeQty = 0;
+        $freePackageValue = 0;
         if ($request->getAllItems()) {
-            $freePackageValue = 0;
             foreach ($request->getAllItems() as $item) {
                 if ($item->getProduct()->isVirtual() || $item->getParentItem()) {
                     continue;


### PR DESCRIPTION
Read here
http://magento.stackexchange.com/questions/60743/undefined-variable-freepackagevalue-in-tablerate-php-on-line-130/60779#6077
and here
https://www.magentocommerce.com/bug-tracking/issue/index/id/648