### PR TITLE
Fix minimum cart subtotal not working in salesrule (based on ex vat i…

### DIFF
--- a/app/code/core/Mage/SalesRule/etc/config.xml
+++ b/app/code/core/Mage/SalesRule/etc/config.xml
@@ -139,7 +139,7 @@
                     </freeshipping>
                     <discount>
                         <class>salesrule/quote_discount</class>
-                        <after>subtotal,shipping</after>
+                        <after>subtotal,tax_subtotal,shipping</after>
                         <before>grand_total</before>
                     </discount>
                 </totals>


### PR DESCRIPTION
…nstead of incl vat)

Bug? magento upgrade to 1.9.3.1 cart discount subtotal rule applies on value EXCL VAT (instead of INCL tax)

* SalesRule exists that has subtotal cart minimum > 50
* Add product with price inlc tax 50.01 to cart
* Result: discount is not applied
* Expected result: discount is applied because subtotal minimum > 50 (and used to work before the upgrade from 1.9.2.4)

Thix fix solved it for our store. Not sure about possible side effects. BUt I have come to understand that this error also existed with the freeshipping rule that was missing tax_subtotal and solved by Digital Pianism fix ..... then I realized it was also missing for the "normal" coupon based variant ... so changed it also: and fixed our problem

For youor reference this is how freeshipping buf was fixed: https://github.com/digitalpianism/bugfixes/commit/a77b7616f7c9113a7c472f3fa208aebb803abeb0

I thought adding    tax_subtotal to after was solution                     <after>subtotal,tax_subtotal,shipping</after>

Maybe someone can confirm/verify?

Also may be related: http://magento.stackexchange.com/questions/92783/magento-grand-total-without-taxes-in-1-9-with-php7
