### PR TITLE
Fix $this->setMassactionIdField('id_here') in custom/all grids

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -611,9 +611,10 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
     protected function _prepareMassactionColumn()
     {
         $columnId = 'massaction';
+        $_MassactionIdField = $this->getMassactionIdField();
         $massactionColumn = $this->getLayout()->createBlock('adminhtml/widget_grid_column')
                 ->setData(array(
-                    'index'        => $this->getMassactionIdField(),
+                    'index'        => $_MassactionIdField,
                     'filter_index' => $this->getMassactionIdFilter(),
                     'type'         => 'massaction',
                     'name'         => $this->getMassactionBlock()->getFormFieldName(),
@@ -625,6 +626,10 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
             $massactionColumn->setData('filter', false);
         }
 
+        if (!empty($_MassactionIdField)) {
+            $massactionColumn->setData('use_index', true);
+        }        
+        
         $massactionColumn->setSelected($this->getMassactionBlock()->getSelected())
             ->setGrid($this)
             ->setId($columnId);
@@ -632,7 +637,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
         $oldColumns = $this->_columns;
         $this->_columns = array();
         $this->_columns[$columnId] = $massactionColumn;
-        $this->_columns = array_merge($this->_columns, $oldColumns);
+        $this->_columns = array_merge($oldColumns,$this->_columns);
         return $this;
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Checkbox.php
@@ -76,7 +76,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Checkbox
 
         $this->setDisabled($disabled);
 
-        if ($this->getNoObjectId() || $this->getColumn()->getUseIndex()){
+        if ($this->getColumn()->getUseIndex()){
             $v = $value;
         } else {
             $v = ($row->getId() != "") ? $row->getId():$value;


### PR DESCRIPTION
I could not get setMassactionIdField to work in a custom grid and stumbled on I think what is an error in th code. setMassactionIdField  is never being respected is seems .... (please comfirm)

What I did
- Add use_index to massaction checkbox data array
- Remove check for getNoObjectId
- Fix reversal of merge (better other way around)

Needs logic confirmation
Also there are only a handfull of grids that use setMassactionIdField if they actually start working that may break something again
