### PR TITLE
Added "image" attribute to flat tables

### DIFF
--- a/app/code/core/Mage/Catalog/etc/config.xml
+++ b/app/code/core/Mage/Catalog/etc/config.xml
@@ -758,6 +758,7 @@
                     <special_from_date/>
                     <special_to_date/>
                     <short_description/>
+                    <image/>
                     <thumbnail/>
                     <small_image/>
                     <image_label/>


### PR DESCRIPTION
Fixes a bug that drives me crazy since ages ... 

If "Flat Product Tables" are enabled, you'll find ...

- thumbnail
- small_image
- thumbnail_label
- small_image_label

... even ...

- image_label

... but not the `image` attribute itself.