### PR TITLE
Fixed the CSS merging data uri bug

### DIFF
--- a/app/code/core/Mage/Core/Model/Design/Package.php
+++ b/app/code/core/Mage/Core/Model/Design/Package.php
@@ -781,7 +781,7 @@ class Mage_Core_Model_Design_Package
        $cssImport = '/@import\\s+([\'"])(.*?)[\'"]/';
        $contents = preg_replace_callback($cssImport, array($this, '_cssMergerImportCallback'), $contents);
 
-       $cssUrl = '/url\\(\\s*(?!data:)([^\\)\\s]+)\\s*\\)?/';
+       $cssUrl = '/url\\(\\s*(?![\\\'\\"]?data:)([^\\)\\s]+)\\s*\\)?/';
        $contents = preg_replace_callback($cssUrl, array($this, '_cssMergerUrlCallback'), $contents);
 
        return $contents;


### PR DESCRIPTION
See: https://github.com/just-better/magento1-css-merge-data-uri-fix

As requested here: https://github.com/just-better/magento1-css-merge-data-uri-fix/issues/1

Currently only for 1.9.3.1, but this patch should be applied to all versions @seansan.