### PR TITLE
fix: admin group_prices: disable is_percent input

### DIFF
--- a/app/design/adminhtml/default/default/template/catalog/product/edit/price/group.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/price/group.phtml
@@ -124,7 +124,7 @@ var groupPriceControl = {
         <?php endif;?>
 
         if (data.readOnly == '1') {
-            ['website', 'cust_group', 'price', 'delete'].each(function(element_suffix) {
+            ['website', 'cust_group', 'price', 'delete', 'is_percent'].each(function(element_suffix) {
                 $('group_price_row_' + data.index + '_' + element_suffix).disabled = true;
             });
             $('group_price_row_' + data.index + '_delete_button').hide();


### PR DESCRIPTION
When modifying product group prices in admin, is_percent inputs were not disabled as the other inputs leading to a wrong validation error "Duplicate website group price customer group".

It may be related to : https://community.magento.com/t5/Technical-Issues/Can-t-save-product-Duplicate-website-group-price-customer-group/td-p/51039