### PR TITLE
Disable `DISABLE KEYS` statements

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Abstract.php
@@ -99,9 +99,7 @@ abstract class Mage_Catalog_Model_Resource_Product_Indexer_Eav_Abstract
             $adapter->delete($this->getMainTable(), $where);
 
             // insert new index
-            $this->useDisableKeys(false);
             $this->insertFromTable($this->getIdxTable(), $this->getMainTable());
-            $this->useDisableKeys(true);
 
             $adapter->commit();
         } catch (Exception $e) {

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price.php
@@ -131,9 +131,7 @@ class Mage_Catalog_Model_Resource_Product_Indexer_Price extends Mage_Index_Model
             $write->delete($this->getIdxTable(), $where);
 
             // insert new index
-            $this->useDisableKeys(false);
             $this->insertFromTable($this->getIdxTable(), $this->getMainTable());
-            $this->useDisableKeys(true);
 
             $this->commit();
         } catch (Exception $e) {

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Default.php
@@ -136,11 +136,9 @@ class Mage_Catalog_Model_Resource_Product_Indexer_Price_Default
      */
     public function reindexEntity($entityIds)
     {
-        $this->useDisableKeys(false);
         $this->_prepareFinalPriceData($entityIds);
         $this->_applyCustomOption();
         $this->_movePriceDataToIndexTable();
-        $this->useDisableKeys(true);
 
         return $this;
     }

--- a/app/code/core/Mage/Index/Model/Indexer/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Indexer/Abstract.php
@@ -191,7 +191,6 @@ abstract class Mage_Index_Model_Indexer_Abstract extends Mage_Core_Model_Abstrac
 
         $resourceModel = $this->getResource();
         if ($resourceModel instanceof Mage_Index_Model_Resource_Abstract) {
-            $resourceModel->useDisableKeys(true);
             $resourceModel->disableTableKeys();
         }
 
@@ -211,7 +210,6 @@ abstract class Mage_Index_Model_Indexer_Abstract extends Mage_Core_Model_Abstrac
 
         $resourceModel = $this->getResource();
         if ($resourceModel instanceof Mage_Index_Model_Resource_Abstract) {
-            $resourceModel->useDisableKeys(true);
             $resourceModel->enableTableKeys();
         }
 

--- a/app/code/core/Mage/Index/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Resource/Abstract.php
@@ -48,7 +48,7 @@ abstract class Mage_Index_Model_Resource_Abstract extends Mage_Core_Model_Resour
      *
      * @var bool
      */
-    protected $_isDisableKeys = true;
+    protected $_isDisableKeys = false;
 
     /**
      * Whether table changes are allowed


### PR DESCRIPTION
This is part of a group of PRs containing the changes discussed in issue #152

Indexers that extend `Mage_Index_Model_Resource_Abstract` run an `ALTER TABLE ... DISABLE|ENABLE KEYS` statement before and after inserting data.  

The statement is only supported by MyISAM tables so it is useless for modern magento installations, but it still requires a table metadata lock even if MyISAM is not used.

The catalogsearch index does still use MyISAM, but it doesn't extend `Mage_Index_Model_Resource_Abstract` so it isn't affected.

This PR disables the statements by default, but leaves the functionality in place if still required.  

It also removes calls to `Mage_Index_Model_Resource_Abstract::useDisableKeys`.  In most cases it was called by mistake and had no effect (it should have been `Mage_Index_Model_Resource_Abstract::disableTableKeys`), but now they aren't required at all.