### PR TITLE
Improve post-checkout indexing

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -783,7 +783,7 @@ class Mage_CatalogInventory_Model_Observer
         }
 
         // price indexer is responsible for hiding out of stock products
-        if ($stockStatusProductIds) {
+        if ($stockStatusProductIds && !Mage::helper('cataloginventory')->isShowOutOfStock()) {
             $priceIndexProcess = Mage::getModel('index/process')->load('catalog_product_price', 'indexer_code');
             if ($priceIndexProcess->getMode() === Mage_Index_Model_Process::MODE_REAL_TIME) {
                 $priceIndexProcess->lock();

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock.php
@@ -245,7 +245,7 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
      * Set items out of stock basing on their quantities and config settings
      *
      */
-    public function updateSetOutOfStock()
+    public function updateSetOutOfStock($productIds = array())
     {
         $this->_initConfig();
         $adapter = $this->_getWriteAdapter();
@@ -254,9 +254,14 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
             'stock_status_changed_auto'    => 1
         );
 
-        $select = $adapter->select()
-            ->from($this->getTable('catalog/product'), 'entity_id')
-            ->where('type_id IN(?)', $this->_configTypeIds);
+        if ($productIds) {
+            $productIdsCondition = implode(', ', array_map('intval', $productIds));
+        } else {
+            $productIdsCondition = $adapter->select()
+                ->from($this->getTable('catalog/product'), 'entity_id')
+                ->where('type_id IN(?)', $this->_configTypeIds)
+                ->assemble();
+        }
 
         $where = sprintf('stock_id = %1$d'
             . ' AND is_in_stock = 1'
@@ -269,7 +274,7 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
             Mage_CatalogInventory_Model_Stock::BACKORDERS_NO,
             $this->_isConfigBackorders,
             $this->_configMinQty,
-            $select->assemble()
+            $productIdsCondition
         );
 
         $adapter->update($this->getTable('cataloginventory/stock_item'), $values, $where);
@@ -279,7 +284,7 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
      * Set items in stock basing on their quantities and config settings
      *
      */
-    public function updateSetInStock()
+    public function updateSetInStock($productIds = array())
     {
         $this->_initConfig();
         $adapter = $this->_getWriteAdapter();
@@ -287,9 +292,14 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
             'is_in_stock'   => 1,
         );
 
-        $select = $adapter->select()
-            ->from($this->getTable('catalog/product'), 'entity_id')
-            ->where('type_id IN(?)', $this->_configTypeIds);
+        if ($productIds) {
+            $productIdsCondition = implode(', ', array_map('intval', $productIds));
+        } else {
+            $productIdsCondition = $adapter->select()
+                ->from($this->getTable('catalog/product'), 'entity_id')
+                ->where('type_id IN(?)', $this->_configTypeIds)
+                ->assemble();
+        }
 
         $where = sprintf('stock_id = %1$d'
             . ' AND is_in_stock = 0'
@@ -300,7 +310,7 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
             $this->_stock->getId(),
             $this->_isConfigManageStock,
             $this->_configMinQty,
-            $select->assemble()
+            $productIdsCondition
         );
 
         $adapter->update($this->getTable('cataloginventory/stock_item'), $values, $where);
@@ -310,7 +320,7 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
      * Update items low stock date basing on their quantities and config settings
      *
      */
-    public function updateLowStockDate()
+    public function updateLowStockDate($productIds = array())
     {
         $this->_initConfig();
 
@@ -324,16 +334,21 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
             'low_stock_date' => new Zend_Db_Expr($conditionalDate),
         );
 
-        $select = $adapter->select()
-            ->from($this->getTable('catalog/product'), 'entity_id')
-            ->where('type_id IN(?)', $this->_configTypeIds);
+        if ($productIds) {
+            $productIdsCondition = implode(', ', array_map('intval', $productIds));
+        } else {
+            $productIdsCondition = $adapter->select()
+                ->from($this->getTable('catalog/product'), 'entity_id')
+                ->where('type_id IN(?)', $this->_configTypeIds)
+                ->assemble();
+        }
 
         $where = sprintf('stock_id = %1$d'
             . ' AND ((use_config_manage_stock = 1 AND 1 = %2$d) OR (use_config_manage_stock = 0 AND manage_stock = 1))'
             . ' AND product_id IN (%3$s)',
             $this->_stock->getId(),
             $this->_isConfigManageStock,
-            $select->assemble()
+            $productIdsCondition
         );
 
         $adapter->update($this->getTable('cataloginventory/stock_item'), $value, $where);


### PR DESCRIPTION
This is part of a group of PRs containing the changes discussed in issue #152

There are a few issues with `Mage_CatalogInventory_Model_Observer::reindexQuoteInventory()`:

- Exceptions aren't caught
  - ~~Throwing an exception here will roll back the inventory, but it is too late as the order has already been placed.~~ EDIT: No longer true as #187 has been merged
  - Creates a poor user experience - it makes no difference to the customer if indexing failed

- Stock & price indexer resource models are accessed directly
  - No locking - causes duplicate insert errors
  - No mode check - the indexers run even if in manual mode

- Stock item models are saved for low/OOS stock items
  - Stock data is loaded before quote conversion - if a payment authorisation takes 5 seconds, then the inventory data being saved is at least 5 seconds old.
  - Triggers re-indexing that isn't always necessary
  - Can cause a deadlock on index_* tables

This PR:
- Catches & logs exceptions
- Adds indexer locking
- Adds indexer mode check
- Only runs indexers when necessary
- Updates inventory data using `Mage_CatalogInventory_Model_Resource_Stock`

Possible breaking changes:
- Stock item model is not saved, so the related events are not fired
- These indexers no longer run: catalog_product_attribute, catalogsearch_fulltext
  - To hide an OOS product on the frontend it only needs to be removed from the price index.  The other indexes will be cleaned up when saving the stock item model or running a full reindex.

I don't really like the way this solution duplicates the logic from the stock item model and accesses so many resource methods, but it gives maximum control over the indexing that occurs, and ensures the inventory data is kept consistent.