### PR TITLE
Ensure index events of type `mass_action` are cleaned

### DIFF
--- a/app/code/core/Mage/Index/Model/Event.php
+++ b/app/code/core/Mage/Index/Model/Event.php
@@ -216,7 +216,7 @@ class Mage_Index_Model_Event extends Mage_Core_Model_Abstract
 
         $newData = $this->getNewData(false);
         foreach ($processIds as $processId => $processStatus) {
-            if ($processStatus == Mage_Index_Model_Process::EVENT_STATUS_DONE) {
+            if (is_null($processStatus) || $processStatus == Mage_Index_Model_Process::EVENT_STATUS_DONE) {
                 $process = Mage::getSingleton('index/indexer')->getProcessById($processId);
                 if ($process) {
                     $namespace = get_class($process->getIndexer());

--- a/app/code/core/Mage/Index/Model/Process.php
+++ b/app/code/core/Mage/Index/Model/Process.php
@@ -208,6 +208,10 @@ class Mage_Index_Model_Process extends Mage_Core_Model_Abstract
                 }
             } else {
                 //Update existing events since we'll do reindexAll
+                foreach ($eventsCollection->getItemsByColumnValue('type', Mage_Index_Model_Event::TYPE_MASS_ACTION) as $event) {
+                    $event->addProcessId($this->getId(), self::EVENT_STATUS_DONE)
+                        ->save();
+                }
                 $eventResource->updateProcessEvents($this);
                 $this->getIndexer()->reindexAll();
             }


### PR DESCRIPTION
This is part of a group of PRs containing the changes discussed in issue #152

If indexers are set to manual mode, mass_action events aren't cleaned after they are processed.

This PR makes sure that the data is cleaned.