### PR TITLE
don't escape console redirection in cron.php

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -63,8 +63,8 @@ try {
             $fileName = escapeshellarg(basename(__FILE__));
             $cronPath = escapeshellarg(dirname(__FILE__) . '/cron.sh');
 
-            shell_exec(escapeshellcmd("/bin/sh $cronPath $fileName -mdefault 1 > /dev/null 2>&1 &"));
-            shell_exec(escapeshellcmd("/bin/sh $cronPath $fileName -malways 1 > /dev/null 2>&1 &"));
+            shell_exec(escapeshellcmd("/bin/sh $cronPath $fileName -mdefault 1") . ' > /dev/null 2>&1 &');
+            shell_exec(escapeshellcmd("/bin/sh $cronPath $fileName -malways 1") . ' > /dev/null 2>&1 &');
             exit;
         }
     }


### PR DESCRIPTION
Since SUPEE 6788, the `shell_exec` commands in cron.php have been escaped.  

But escaping the console redirection part `> /dev/null 2>&1 &` will stop the redirection & detach from working, so the commands end up running sequentially instead of in parallel