### PR TITLE
admin panel customer address form fixes

### DIFF
--- a/app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
@@ -106,7 +106,7 @@
             <?php foreach ($addressCollection as $_address): ?>
             <div id="form_address_item_<?php echo $_address->getId() ?>" style="display:none">
             <?php
-                    $this->getForm()->addValues($_address->getData())
+                    $this->getForm()->setValues($_address->getData())
                             ->setHtmlIdPrefix("_item{$_address->getId()}")
                             ->setFieldNameSuffix('address['.$_address->getId().']');
                     $this->addValuesToNamePrefixElement($_address->getPrefix())

--- a/js/mage/adminhtml/sales.js
+++ b/js/mage/adminhtml/sales.js
@@ -281,7 +281,7 @@ AdminOrder.prototype = {
             }
 
             if (fields[i].changeUpdater) fields[i].changeUpdater();
-            if (name == 'region' && data['region_id'] && !data['region']){
+            if (name == 'region' && data['region_id'] > 0 && !data['region']){
                 fields[i].value = data['region_id'];
             }
         }


### PR DESCRIPTION
Switching between saved customer addresses when creating an order in the admin panel can sometimes result in a '0' being set for the region field.

Also, when editing customer addresses in the admin panel, the same form instance is reused for each address, but it isn't reset properly for each iteration, so data can leak between addresses.

eg. address1 has a postcode set, but address2 has a null value for postcode.  Because `addValues()` is used instead of `setValues()`, the postcode field wont get cleared for address2 (it will still have address1's postcode)
