### PR TITLE
fix paypal IPN postback response parsing

### DIFF
--- a/app/code/core/Mage/Paypal/Model/Ipn.php
+++ b/app/code/core/Mage/Paypal/Model/Ipn.php
@@ -166,8 +166,8 @@ class Mage_Paypal_Model_Ipn
             throw new Mage_Paypal_UnavailableException($reason);
         }
 
-        $response = preg_split('/^\r?$/m', $postbackResult, 2);
-        $response = trim($response[1]);
+        $response = preg_split('/^\r?$/m', $postbackResult);
+        $response = trim(end($response));
         if ($response != 'VERIFIED') {
             $this->_debugData['postback'] = $postbackQuery;
             $this->_debugData['postback_result'] = $postbackResult;


### PR DESCRIPTION
I'm not sure where this fix first came from, I've seen it posted on a few different blogs and forums.

The IPN class always expects a status code to be on the second line of the response, but curl sometimes adds extra HTTP headers, so it is better to look for the status code on the last line of the response instead.