### PR TITLE
fix paypal settlement report parsing

### DIFF
--- a/app/code/core/Mage/Paypal/Model/Report/Settlement.php
+++ b/app/code/core/Mage/Paypal/Model/Report/Settlement.php
@@ -269,6 +269,14 @@ class Mage_Paypal_Model_Report_Settlement extends Mage_Core_Model_Abstract
 
         $flippedSectionColumns = array_flip($sectionColumns);
         $fp = fopen($localCsv, 'r');
+
+        // skip BOM if present
+        $bom = pack("CCC", 0xef, 0xbb, 0xbf);
+        $test = fread($fp, 3);
+        if (strncmp($test, $bom, 3) !== 0) {
+            fseek($fp, 0);
+        }
+
         while($line = fgetcsv($fp)) {
             if (empty($line)) { // The line was empty, so skip it.
                 continue;
@@ -298,7 +306,9 @@ class Mage_Paypal_Model_Report_Settlement extends Mage_Core_Model_Abstract
                 case 'SB': // Section body.
                     $bodyItem = array();
                     for($i = 1; $i < count($line); $i++) {
-                        $bodyItem[$rowMap[$flippedSectionColumns[$i]]] = $line[$i];
+                        if (isset($rowMap[$flippedSectionColumns[$i]]) && $rowMap[$flippedSectionColumns[$i]]) {
+                            $bodyItem[$rowMap[$flippedSectionColumns[$i]]] = $line[$i];
+                        }
                     }
                     $this->_rows[] = $bodyItem;
                     break;

--- a/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement.php
@@ -75,9 +75,9 @@ class Mage_Paypal_Model_Resource_Report_Settlement extends Mage_Core_Model_Resou
                     /*
                      * Converting dates
                      */
-                    $completionDate = new Zend_Date($rows[$key]['transaction_completion_date']);
+                    $completionDate = new Zend_Date($rows[$key]['transaction_completion_date'], 'yyyy/MM/dd HH:mm:ss Z');
                     $rows[$key]['transaction_completion_date'] = $date->date(null, $completionDate->getTimestamp());
-                    $initiationDate = new Zend_Date($rows[$key]['transaction_initiation_date']);
+                    $initiationDate = new Zend_Date($rows[$key]['transaction_initiation_date'], 'yyyy/MM/dd HH:mm:ss Z');
                     $rows[$key]['transaction_initiation_date'] = $date->date(null, $initiationDate->getTimestamp());
                     /*
                      * Converting numeric


### PR DESCRIPTION
These are the changes I had to make to get paypal settlement reports to parse correctly

I'm not sure if its a regional issue (I'm in the UK), but these fixes shouldn't change any previous behaviour.  

The only exception might be if the date format used in reports varies between regions, but that seems unlikely as the format used is not regional (`yyyy/MM/dd HH:mm:ss Z`)