### PR TITLE
Account Edit: Magento requests current password, even when you don't change it

### DIFF
--- a/app/code/core/Mage/Customer/controllers/AccountController.php
+++ b/app/code/core/Mage/Customer/controllers/AccountController.php
@@ -964,10 +964,6 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
                 $customerForm->compactData($customerData);
                 $errors = array();
 
-                if (!$customer->validatePassword($this->getRequest()->getPost('current_password'))) {
-                    $errors[] = $this->__('Invalid current password');
-                }
-
                 // If email change was requested then set flag
                 $isChangeEmail = ($customer->getOldEmail() != $customer->getEmail()) ? true : false;
                 $customer->setIsChangeEmail($isChangeEmail);
@@ -976,6 +972,10 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
                 $customer->setIsChangePassword($this->getRequest()->getParam('change_password'));
 
                 if ($customer->getIsChangePassword()) {
+                    if (!$customer->validatePassword($this->getRequest()->getPost('current_password'))) {
+                        $errors[] = $this->__('Invalid current password');
+                    }
+
                     $newPass    = $this->getRequest()->getPost('password');
                     $confPass   = $this->getRequest()->getPost('confirmation');
 


### PR DESCRIPTION
Just copied from https://magento.com/tech-resources/bug-tracking/issue/index/id/1525/

> Steps to reproduce:
With the update to version 1.9.3.0 or 1.9.3.1 Magento displays the error message "Invalid current password" and don't save any changes when you try to edit your account data without setting a new password.

> the problem is introduced in 1.9.3.0 and is caused by the fact that the password is always being validated even though the users has not checked the "Change password" combobox.