### PR TITLE
don't save index events for indexers in manual mode

### DIFF
--- a/app/code/core/Mage/Index/Model/Event.php
+++ b/app/code/core/Mage/Index/Model/Event.php
@@ -216,7 +216,7 @@ class Mage_Index_Model_Event extends Mage_Core_Model_Abstract
 
         $newData = $this->getNewData(false);
         foreach ($processIds as $processId => $processStatus) {
-            if ($processStatus == Mage_Index_Model_Process::EVENT_STATUS_DONE) {
+            if (is_null($processStatus) || $processStatus == Mage_Index_Model_Process::EVENT_STATUS_DONE) {
                 $process = Mage::getSingleton('index/indexer')->getProcessById($processId);
                 if ($process) {
                     $namespace = get_class($process->getIndexer());

--- a/app/code/core/Mage/Index/Model/Process.php
+++ b/app/code/core/Mage/Index/Model/Process.php
@@ -137,13 +137,14 @@ class Mage_Index_Model_Process extends Mage_Core_Model_Abstract
     public function register(Mage_Index_Model_Event $event)
     {
         if ($this->matchEvent($event)) {
+            if ($this->getMode() == self::MODE_MANUAL) {
+                $this->_getResource()->updateStatus($this, self::STATUS_REQUIRE_REINDEX);
+                return $this;
+            }
             $this->_setEventNamespace($event);
             $this->getIndexer()->register($event);
             $event->addProcessId($this->getId());
             $this->_resetEventNamespace($event);
-            if ($this->getMode() == self::MODE_MANUAL) {
-                $this->_getResource()->updateStatus($this, self::STATUS_REQUIRE_REINDEX);
-            }
         }
         return $this;
 


### PR DESCRIPTION
This is part of a group of PRs containing the changes discussed in issue #152

If an indexer is in manual mode, there is no need to save an index event as it will never be processed - manual mode indexes can only be updated using a full reindex.

Index event data can grow very large (megabytes) for mass_action events.  It is not cleaned properly after processing and new data is often appended without deduplication.

This PR prevents index events from registering with an indexer if it is in manual mode.  It also ensures that index data is cleaned during a partial 'full' reindex.