### PR TITLE
Added "System"-Tab to product attribute edit page

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/System.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/System.php
@@ -58,7 +58,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Attribute_Edit_Tab_System extends Mag
                 'label' => Mage::helper('catalog')->__('Yes')
             ));
 
-        /*$fieldset->addField('attribute_model', 'text', array(
+        $fieldset->addField('attribute_model', 'text', array(
             'name' => 'attribute_model',
             'label' => Mage::helper('catalog')->__('Attribute Model'),
             'title' => Mage::helper('catalog')->__('Attribute Model'),
@@ -68,7 +68,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Attribute_Edit_Tab_System extends Mag
             'name' => 'backend_model',
             'label' => Mage::helper('catalog')->__('Backend Model'),
             'title' => Mage::helper('catalog')->__('Backend Model'),
-        ));*/
+        ));
 
         $fieldset->addField('backend_type', 'select', array(
             'name' => 'backend_type',
@@ -84,7 +84,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Attribute_Edit_Tab_System extends Mag
             ),
         ));
 
-        /*$fieldset->addField('backend_table', 'text', array(
+        $fieldset->addField('backend_table', 'text', array(
             'name' => 'backend_table',
             'label' => Mage::helper('catalog')->__('Backend Table'),
             'title' => Mage::helper('catalog')->__('Backend Table Title'),
@@ -94,20 +94,40 @@ class Mage_Adminhtml_Block_Catalog_Product_Attribute_Edit_Tab_System extends Mag
             'name' => 'frontend_model',
             'label' => Mage::helper('catalog')->__('Frontend Model'),
             'title' => Mage::helper('catalog')->__('Frontend Model'),
-        ));*/
+        ));
 
-        /*$fieldset->addField('is_visible', 'select', array(
+        $fieldset->addField('frontend_class', 'text', array(
+            'name' => 'frontend_class',
+            'label' => Mage::helper('catalog')->__('Frontend Class'),
+            'title' => Mage::helper('catalog')->__('Frontend Class'),
+        ));
+
+        $fieldset->addField('frontend_input_renderer', 'text', array(
+            'name' => 'frontend_input_renderer',
+            'label' => Mage::helper('catalog')->__('Frontend Renderer'),
+            'title' => Mage::helper('catalog')->__('Frontend Renderer'),
+        ));
+
+        $fieldset->addField('note', 'text', array(
+            'name' => 'note',
+            'label' => Mage::helper('catalog')->__('Note'),
+            'title' => Mage::helper('catalog')->__('Note'),
+        ));
+
+        $fieldset->addField('is_visible', 'select', array(
             'name' => 'is_visible',
             'label' => Mage::helper('catalog')->__('Visible'),
             'title' => Mage::helper('catalog')->__('Visible'),
             'values' => $yesno,
-        ));*/
+        ));
 
-        /*$fieldset->addField('source_model', 'text', array(
-            'name' => 'source_model',
-            'label' => Mage::helper('catalog')->__('Source Model'),
-            'title' => Mage::helper('catalog')->__('Source Model'),
-        ));*/
+        if (in_array($model->getFrontendInput(), array('select', 'multiselect', 'boolean'))) {
+            $fieldset->addField('source_model', 'text', array(
+                'name' => 'source_model',
+                'label' => Mage::helper('catalog')->__('Source Model'),
+                'title' => Mage::helper('catalog')->__('Source Model'),
+            ));
+        }
 
         $fieldset->addField('is_global', 'select', array(
             'name'  => 'is_global',

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tabs.php
@@ -58,6 +58,14 @@ class Mage_Adminhtml_Block_Catalog_Product_Attribute_Edit_Tabs extends Mage_Admi
             'title'     => Mage::helper('catalog')->__('Manage Label / Options'),
             'content'   => $this->getLayout()->createBlock('adminhtml/catalog_product_attribute_edit_tab_options')->toHtml(),
         ));
+
+        if ($this->_isAllowed()) {
+            $this->addTab('system_section', array(
+                'label'     => Mage::helper('catalog')->__('System'),
+                'title'     => Mage::helper('catalog')->__('System'),
+                'content'   => $this->getLayout()->createBlock('adminhtml/catalog_product_attribute_edit_tab_system')->toHtml(),
+            ));
+        }
         
         /*if ('select' == $model->getFrontendInput()) {
             $this->addTab('options_section', array(
@@ -70,4 +78,14 @@ class Mage_Adminhtml_Block_Catalog_Product_Attribute_Edit_Tabs extends Mage_Admi
         return parent::_beforeToHtml();
     }
 
+    /**
+     * Check admin permissions.
+     * This allows a user to change the attribute system settings if they are allowed to.
+     *
+     * @return bool
+     */
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('catalog/attributes/system_attributes');
+    }
 }

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
@@ -232,6 +232,61 @@ class Mage_Adminhtml_Catalog_Product_AttributeController extends Mage_Adminhtml_
                 }
             }
 
+            //validate attribute model
+            if (isset($data['attribute_model']) && !empty($data['attribute_model'])) {
+                $class = Mage::getSingleton($data['attribute_model']);
+                if (!is_callable(array($class, '_init'))) {
+                    $session->addError(
+                        Mage::helper('catalog')->__('%s is no valid attribute model', $data['attribute_model']));
+                    $this->_redirect('*/*/edit', array('attribute_id' => $id, '_current' => true));
+                    return;
+                }
+            }
+
+            //validate frontend model
+            if (isset($data['frontend_model']) && !empty($data['frontend_model'])) {
+                $class = Mage::getSingleton($data['frontend_model']);
+                if (!is_callable(array($class, 'getValue'))) {
+                    $session->addError(
+                        Mage::helper('catalog')->__('%s is no valid frontend model', $data['frontend_model']));
+                    $this->_redirect('*/*/edit', array('attribute_id' => $id, '_current' => true));
+                    return;
+                }
+            }
+
+            //validate frontend input renderer
+            if (isset($data['frontend_input_renderer']) && !empty($data['frontend_input_renderer'])) {
+                $class = Mage::getBlockSingleton($data['frontend_input_renderer']);
+                if (!is_callable(array($class, 'getElementHtml'))) {
+                    $session->addError(
+                        Mage::helper('catalog')->__('%s is no valid frontend input renderer', $data['frontend_input_renderer']));
+                    $this->_redirect('*/*/edit', array('attribute_id' => $id, '_current' => true));
+                    return;
+                }
+            }
+
+            //validate backend model
+            if (isset($data['backend_model']) && !empty($data['backend_model'])) {
+                $class = Mage::getSingleton($data['backend_model']);
+                if (!is_callable(array($class, 'getAllOptions'))) {
+                    $session->addError(
+                        Mage::helper('catalog')->__('%s is no valid backend model', $data['backend_model']));
+                    $this->_redirect('*/*/edit', array('attribute_id' => $id, '_current' => true));
+                    return;
+                }
+            }
+
+            //validate source model
+            if (isset($data['source_model']) && !empty($data['source_model'])) {
+                $class = Mage::getSingleton($data['source_model']);
+                if (!is_callable(array($class, 'getAllOptions'))) {
+                    $session->addError(
+                        Mage::helper('catalog')->__('%s is no valid source model', $data['attribute_model']));
+                    $this->_redirect('*/*/edit', array('attribute_id' => $id, '_current' => true));
+                    return;
+                }
+            }
+
             if ($id) {
                 $model->load($id);
 

--- a/app/code/core/Mage/Catalog/etc/adminhtml.xml
+++ b/app/code/core/Mage/Catalog/etc/adminhtml.xml
@@ -92,6 +92,9 @@
                                     <attributes translate="title">
                                         <title>Manage Attributes</title>
                                     </attributes>
+                                    <system_attributes translate="title">
+                                        <title>Manage System Attributes</title>
+                                    </system_attributes>
                                     <sets translate="title">
                                         <title>Manage Attribute Sets</title>
                                     </sets>


### PR DESCRIPTION
This PR adds a new tab to product attribute edit page where you can change :

- attribute model
- backend model
- backend table (used for??)
- frontend model
- input renderer
- note
- visibility
- source model

System tab was already in core code, it was just not visible. I've just added ...

- some fields
- ACL option
- field validation

All tests were fine so far, but please check field validation.