### PR TITLE
composer.json type value

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "openmage/magento-lts",
   "license": "OSL-3.0",
-  "type": "magento-source",
+  "type": "magento-core",
   "require": {
     "php": ">=5.2.13",
     "magento-hackathon/magento-composer-installer": "*"


### PR DESCRIPTION
Change the composer.json type value from `magento-source` to `magento-core` to enable composer installers like https://github.com/AydinHassan/magento-core-composer-installer 

See issue #24