### PR TITLE
Fixed abandoned cart report

### DIFF
--- a/app/code/core/Mage/Reports/Model/Resource/Quote/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Quote/Collection.php
@@ -206,7 +206,7 @@ class Mage_Reports_Model_Resource_Quote_Collection extends Mage_Sales_Model_Reso
                 )),
                 array('firstname' => 'cust_fname.value')
             )
-            ->joinLeft(
+            ->joinInner(
                 array('cust_mname' => $attrMiddlenameTableName),
                 implode(' AND ', array(
                     'cust_mname.entity_id = main_table.customer_id',

--- a/app/code/core/Mage/Reports/Model/Resource/Quote/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Quote/Collection.php
@@ -215,14 +215,6 @@ class Mage_Reports_Model_Resource_Quote_Collection extends Mage_Sales_Model_Reso
                 array('middlename' => 'cust_mname.value')
             )
             ->joinInner(
-                array('cust_mname' => $attrMiddlenameTableName),
-                implode(' AND ', array(
-                    'cust_mname.entity_id = main_table.customer_id',
-                    $adapter->quoteInto('cust_mname.attribute_id = ?', (int) $attrMiddlenameId),
-                )),
-                array('middlename' => 'cust_mname.value')
-            )
-            ->joinInner(
                 array('cust_lname' => $attrLastnameTableName),
                 implode(' AND ', array(
                     'cust_lname.entity_id = main_table.customer_id',


### PR DESCRIPTION
Fix for 1.9.3.1/1.9.3.x

```
`a:5:{i:0;s:64:"You cannot define a correlation name 'cust_mname' more than once";i:1;s:5216:"#0 /var/www/html/magento-1.9.1.0/lib/Varien/Db/Select.php(281): Zend_Db_Select->_join('inner join', Array, 'cust_mname.enti...', Array, NULL)
#1 /var/www/html/magento-1.9.1.0/app/code/core/Zend/Db/Select.php(352): Varien_Db_Select->_join('inner join', Array, 'cust_mname.enti...', Array, NULL)
#2 /var/www/html/magento-1.9.1.0/app/code/core/Mage/Reports/Model/Resource/Quote/Collection.php(224): Zend_Db_Select->joinInner(Array, 'cust_mname.enti...', Array)
#3 /var/www/html/magento-1.9.1.0/app/code/core/Mage/Reports/Model/Resource/Quote/Collection.php(90): Mage_Reports_Model_Resource_Quote_Collection->addCustomerData(NULL)
```