### PR TITLE
Sitemap dispatch event to add custom data

### DIFF
--- a/app/code/core/Mage/Sitemap/Model/Sitemap.php
+++ b/app/code/core/Mage/Sitemap/Model/Sitemap.php
@@ -221,6 +221,13 @@ class Mage_Sitemap_Model_Sitemap extends Mage_Core_Model_Abstract
         }
         unset($collection);
 
+        Mage::dispatchEvent('sitemap_generate_before', array(
+            'file'      => $io ,
+            'base_url'  => $baseUrl ,
+            'date'      => $date,
+            'store_id'  => $storeId
+        ));
+
         $io->streamWrite('</urlset>');
         $io->streamClose();
 


### PR DESCRIPTION
Create new Dispatch event before end of generate xml function for the sitemap.

Perfect to add your custom link on the sitemap.
Use exemple :
```
/**
     * Add brand url to sitemap
     *
     * @event sitemap_generate_before
     * @param Varien_Event_Observer $observer
     */
    public function addBrandToSitemap(Varien_Event_Observer $observer)
    {
        $io               = $observer->getEvent()->getFile();
        $baseUrl    = $observer->getEvent()->getBaseUrl();
        $date         = $observer->getEvent()->getDate();
        $storeId    = $observer->getEvent()->getStoreId();

        $changefreq = (string)Mage::getStoreConfig('sitemap/brand/changefreq', $storeId);
        $priority   = (string)Mage::getStoreConfig('sitemap/brand/priority', $storeId);

        $collection = Mage::getResourceModel('brand/brand_collection')
            ->addActiveFilter()
        ;


        foreach ($collection as $brand) {
            $url = htmlspecialchars($baseUrl . Mage::helper('brand')->getBrandUrl($brand));

            if (Mage::getStoreConfig('web/seo/trailingslash'))
            {
                if (!preg_match('/\\.(rss|html|htm|xml|php?)$/', strtolower($url)) && substr($url, -1) != '/')
                {
                    $url .= '/';
                }
            }

            $xml = sprintf('<url><loc>%s</loc><lastmod>%s</lastmod><changefreq>%s</changefreq><priority>%.1f</priority></url>',
                $url,
                $date,
                $changefreq,
                $priority
            );
            $io->streamWrite($xml);
        }
        unset($collection);

    }
```