### PR TITLE
[DRAFT] Added some event prefixes, see #92

### DIFF
--- a/app/code/core/Mage/Admin/Model/Block.php
+++ b/app/code/core/Mage/Admin/Model/Block.php
@@ -34,6 +34,13 @@
 class Mage_Admin_Model_Block extends Mage_Core_Model_Abstract
 {
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'admin_block';
+
+    /**
      * Initialize variable model
      */
     protected function _construct()

--- a/app/code/core/Mage/Admin/Model/Block.php
+++ b/app/code/core/Mage/Admin/Model/Block.php
@@ -36,6 +36,7 @@ class Mage_Admin_Model_Block extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'admin_block';

--- a/app/code/core/Mage/Admin/Model/Variable.php
+++ b/app/code/core/Mage/Admin/Model/Variable.php
@@ -30,6 +30,13 @@
 class Mage_Admin_Model_Variable extends Mage_Core_Model_Abstract
 {
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'admin_variable';
+
+    /**
      * Initialize variable model
      */
     protected function _construct()

--- a/app/code/core/Mage/Admin/Model/Variable.php
+++ b/app/code/core/Mage/Admin/Model/Variable.php
@@ -32,6 +32,7 @@ class Mage_Admin_Model_Variable extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'admin_variable';

--- a/app/code/core/Mage/AdminNotification/Model/Inbox.php
+++ b/app/code/core/Mage/AdminNotification/Model/Inbox.php
@@ -59,6 +59,7 @@ class Mage_AdminNotification_Model_Inbox extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'adminnotification_inbox';

--- a/app/code/core/Mage/AdminNotification/Model/Inbox.php
+++ b/app/code/core/Mage/AdminNotification/Model/Inbox.php
@@ -56,6 +56,13 @@ class Mage_AdminNotification_Model_Inbox extends Mage_Core_Model_Abstract
     const SEVERITY_MINOR    = 3;
     const SEVERITY_NOTICE   = 4;
 
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'adminnotification_inbox';
+
     protected function _construct()
     {
         $this->_init('adminnotification/inbox');

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
@@ -34,6 +34,13 @@
 class Mage_Adminhtml_Block_Customer_Edit_Tab_Account extends Mage_Adminhtml_Block_Widget_Form
 {
     /**
+     * Block event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'adminhtml_customer_edit_tab_account';
+
+    /**
      * Initialize block
      */
     public function __construct()

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
@@ -34,13 +34,6 @@
 class Mage_Adminhtml_Block_Customer_Edit_Tab_Account extends Mage_Adminhtml_Block_Widget_Form
 {
     /**
-     * Block event prefix
-     *
-     * @var string
-     */
-    protected $_eventPrefix = 'adminhtml_customer_edit_tab_account';
-
-    /**
      * Initialize block
      */
     public function __construct()

--- a/app/code/core/Mage/Adminhtml/Block/Page.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page.php
@@ -34,13 +34,6 @@
 class Mage_Adminhtml_Block_Page extends Mage_Adminhtml_Block_Template
 {
     /**
-     * Block event prefix
-     *
-     * @var string
-     */
-    protected $_eventPrefix = 'adminhtml_page';
-
-    /**
      * Class constructor
      *
      */

--- a/app/code/core/Mage/Adminhtml/Block/Page.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page.php
@@ -33,6 +33,12 @@
  */
 class Mage_Adminhtml_Block_Page extends Mage_Adminhtml_Block_Template
 {
+    /**
+     * Block event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'adminhtml_page';
 
     /**
      * Class constructor

--- a/app/code/core/Mage/Adminhtml/Block/Page/Header.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Header.php
@@ -33,6 +33,13 @@
  */
 class Mage_Adminhtml_Block_Page_Header extends Mage_Adminhtml_Block_Template
 {
+    /**
+     * Block event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'adminhtml_page_header';
+
     public function __construct()
     {
         parent::__construct();

--- a/app/code/core/Mage/Adminhtml/Block/Page/Header.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Header.php
@@ -33,13 +33,6 @@
  */
 class Mage_Adminhtml_Block_Page_Header extends Mage_Adminhtml_Block_Template
 {
-    /**
-     * Block event prefix
-     *
-     * @var string
-     */
-    protected $_eventPrefix = 'adminhtml_page_header';
-
     public function __construct()
     {
         parent::__construct();

--- a/app/code/core/Mage/Adminhtml/Block/Page/Notices.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Notices.php
@@ -33,6 +33,12 @@
  */
 class Mage_Adminhtml_Block_Page_Notices extends Mage_Adminhtml_Block_Template
 {
+    /**
+     * Block event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'adminhtml_page_notices';
 
     /**
      * Check if noscript notice should be displayed

--- a/app/code/core/Mage/Adminhtml/Block/Page/Notices.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Notices.php
@@ -34,13 +34,6 @@
 class Mage_Adminhtml_Block_Page_Notices extends Mage_Adminhtml_Block_Template
 {
     /**
-     * Block event prefix
-     *
-     * @var string
-     */
-    protected $_eventPrefix = 'adminhtml_page_notices';
-
-    /**
      * Check if noscript notice should be displayed
      *
      * @return boolean

--- a/app/code/core/Mage/Adminhtml/Block/Template.php
+++ b/app/code/core/Mage/Adminhtml/Block/Template.php
@@ -36,9 +36,10 @@ class Mage_Adminhtml_Block_Template extends Mage_Core_Block_Template
     /**
      * Block event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'adminhtml_template';
+    protected $_eventPrefix = 'adminhtml';
 
     /**
      * Enter description here...
@@ -85,9 +86,6 @@ class Mage_Adminhtml_Block_Template extends Mage_Core_Block_Template
     protected function _toHtml()
     {
         Mage::dispatchEvent('adminhtml_block_html_before', array('block' => $this));
-        if ($this->_eventPrefix !== 'adminhtml') {
-            Mage::dispatchEvent($this->_eventPrefix . '_block_html_before', array('block' => $this));
-        }
         return parent::_toHtml();
     }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Template.php
+++ b/app/code/core/Mage/Adminhtml/Block/Template.php
@@ -34,6 +34,13 @@
 class Mage_Adminhtml_Block_Template extends Mage_Core_Block_Template
 {
     /**
+     * Block event prefix
+     *
+     * @var string
+     */
+    $_eventPrefix = 'adminhtml';
+
+    /**
      * Enter description here...
      *
      * @return string
@@ -78,6 +85,9 @@ class Mage_Adminhtml_Block_Template extends Mage_Core_Block_Template
     protected function _toHtml()
     {
         Mage::dispatchEvent('adminhtml_block_html_before', array('block' => $this));
+        if ($this->_eventPrefix !== 'adminhtml') {
+            Mage::dispatchEvent($this->_eventPrefix . '_block_html_before', array('block' => $this));
+        }
         return parent::_toHtml();
     }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Template.php
+++ b/app/code/core/Mage/Adminhtml/Block/Template.php
@@ -38,7 +38,7 @@ class Mage_Adminhtml_Block_Template extends Mage_Core_Block_Template
      *
      * @var string
      */
-    $_eventPrefix = 'adminhtml';
+    protected $_eventPrefix = 'adminhtml_template';
 
     /**
      * Enter description here...

--- a/app/code/core/Mage/Adminhtml/Model/Email/Template.php
+++ b/app/code/core/Mage/Adminhtml/Model/Email/Template.php
@@ -41,6 +41,13 @@ class Mage_Adminhtml_Model_Email_Template extends Mage_Core_Model_Email_Template
     const XML_PATH_TEMPLATE_EMAIL = '//sections/*/groups/*/fields/*[source_model="adminhtml/system_config_source_email_template"]';
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'adminhtml_email_template';
+
+    /**
      * Collect all system config pathes where current template is used as default
      *
      * @return array

--- a/app/code/core/Mage/Adminhtml/Model/Email/Template.php
+++ b/app/code/core/Mage/Adminhtml/Model/Email/Template.php
@@ -43,6 +43,7 @@ class Mage_Adminhtml_Model_Email_Template extends Mage_Core_Model_Email_Template
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'adminhtml_email_template';

--- a/app/code/core/Mage/Api/Model/Roles.php
+++ b/app/code/core/Mage/Api/Model/Roles.php
@@ -57,6 +57,12 @@ class Mage_Api_Model_Roles extends Mage_Core_Model_Abstract
      */
     protected $_filters;
 
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'api_roles';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Api/Model/Rules.php
+++ b/app/code/core/Mage/Api/Model/Rules.php
@@ -48,6 +48,13 @@
  */
 class Mage_Api_Model_Rules extends Mage_Core_Model_Abstract
 {
+    /**
+     * Prefix of model events names
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'api_rules';
+
     protected function _construct()
     {
         $this->_init('api/rules');

--- a/app/code/core/Mage/Api/Model/Rules.php
+++ b/app/code/core/Mage/Api/Model/Rules.php
@@ -51,6 +51,7 @@ class Mage_Api_Model_Rules extends Mage_Core_Model_Abstract
     /**
      * Prefix of model events names
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'api_rules';

--- a/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute.php
@@ -53,6 +53,13 @@ class Mage_Api2_Model_Acl_Filter_Attribute extends Mage_Core_Model_Abstract
     protected $_permissionModel;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'api2_acl_filter_attribute';
+
+    /**
      * Initialize resource model
      *
      * @return void

--- a/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute.php
@@ -55,6 +55,7 @@ class Mage_Api2_Model_Acl_Filter_Attribute extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'api2_acl_filter_attribute';

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Role.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Role.php
@@ -68,6 +68,7 @@ class Mage_Api2_Model_Acl_Global_Role extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'api2_acl_global_role';

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Role.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Role.php
@@ -66,6 +66,13 @@ class Mage_Api2_Model_Acl_Global_Role extends Mage_Core_Model_Abstract
     protected $_permissionModel;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'api2_acl_global_role';
+
+    /**
      * Initialize resource model
      *
      * @return void

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule.php
@@ -56,6 +56,7 @@ class Mage_Api2_Model_Acl_Global_Rule extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'api2_acl_global_rule';

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule.php
@@ -54,6 +54,13 @@ class Mage_Api2_Model_Acl_Global_Rule extends Mage_Core_Model_Abstract
     const RESOURCE_ALL = 'all';
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'api2_acl_global_rule';
+
+    /**
      * Initialize resource model
      *
      * @return void

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Tree.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Tree.php
@@ -114,6 +114,13 @@ class Mage_Api2_Model_Acl_Global_Rule_Tree extends Mage_Core_Helper_Abstract
     protected $_hasEntityOnlyAttributes = false;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'api2_acl_global_rule_tree';
+
+    /**
      * Constructor
      *
      * In the constructor should be set tree type: attributes or privileges.

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Tree.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Tree.php
@@ -116,6 +116,7 @@ class Mage_Api2_Model_Acl_Global_Rule_Tree extends Mage_Core_Helper_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'api2_acl_global_rule_tree';

--- a/app/code/core/Mage/Bundle/Model/Option.php
+++ b/app/code/core/Mage/Bundle/Model/Option.php
@@ -52,6 +52,13 @@ class Mage_Bundle_Model_Option extends Mage_Core_Model_Abstract
     protected $_defaultSelection = null;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'bundle_option';
+
+    /**
      * Initialize resource model
      *
      */

--- a/app/code/core/Mage/Bundle/Model/Option.php
+++ b/app/code/core/Mage/Bundle/Model/Option.php
@@ -54,6 +54,7 @@ class Mage_Bundle_Model_Option extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'bundle_option';

--- a/app/code/core/Mage/Bundle/Model/Selection.php
+++ b/app/code/core/Mage/Bundle/Model/Selection.php
@@ -55,6 +55,13 @@
 class Mage_Bundle_Model_Selection extends Mage_Core_Model_Abstract
 {
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'bundle_selection';
+
+    /**
      * Initialize resource model
      */
     protected function _construct()

--- a/app/code/core/Mage/Bundle/Model/Selection.php
+++ b/app/code/core/Mage/Bundle/Model/Selection.php
@@ -57,6 +57,7 @@ class Mage_Bundle_Model_Selection extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'bundle_selection';

--- a/app/code/core/Mage/Catalog/Model/Product/Flat/Flag.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Flat/Flag.php
@@ -44,6 +44,7 @@ class Mage_Catalog_Model_Product_Flat_Flag extends Mage_Core_Model_Flag
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'catalog_product_flat_flag';

--- a/app/code/core/Mage/Catalog/Model/Product/Flat/Flag.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Flat/Flag.php
@@ -42,6 +42,13 @@ class Mage_Catalog_Model_Product_Flat_Flag extends Mage_Core_Model_Flag
     protected $_flagCode = 'catalog_product_flat';
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'catalog_product_flat_flag';
+
+    /**
      * Retrieve flag data array
      *
      * @return array

--- a/app/code/core/Mage/Catalog/Model/Product/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option.php
@@ -155,6 +155,7 @@ class Mage_Catalog_Model_Product_Option extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'catalog_product_option';

--- a/app/code/core/Mage/Catalog/Model/Product/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option.php
@@ -153,6 +153,13 @@ class Mage_Catalog_Model_Product_Option extends Mage_Core_Model_Abstract
     protected $_values = array();
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'catalog_product_option';
+
+    /**
      * Constructor
      */
     protected function _construct()

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Value.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Value.php
@@ -51,6 +51,7 @@ class Mage_Catalog_Model_Product_Option_Value extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'catalog_product_option_value';

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Value.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Value.php
@@ -48,6 +48,13 @@ class Mage_Catalog_Model_Product_Option_Value extends Mage_Core_Model_Abstract
 
     protected $_option;
 
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'catalog_product_option_value';
+
     protected function _construct()
     {
         $this->_init('catalog/product_option_value');

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Attribute.php
@@ -44,6 +44,13 @@
 class Mage_Catalog_Model_Product_Type_Configurable_Attribute extends Mage_Core_Model_Abstract
 {
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'catalog_product_type_configurable_attribute';
+
+    /**
      * Initialize resource model
      *
      */

--- a/app/code/core/Mage/Catalog/Model/Resource/Collection/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Collection/Abstract.php
@@ -36,6 +36,13 @@
 class Mage_Catalog_Model_Resource_Collection_Abstract extends Mage_Eav_Model_Entity_Collection_Abstract
 {
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_catalog_collection_abstract';
+
+    /**
      * Current scope (store Id)
      *
      * @var int

--- a/app/code/core/Mage/Catalog/Model/Resource/Collection/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Collection/Abstract.php
@@ -40,7 +40,7 @@ class Mage_Catalog_Model_Resource_Collection_Abstract extends Mage_Eav_Model_Ent
      *
      * @var string
      */
-    protected $_eventPrefix = 'eav_catalog_collection_abstract';
+    protected $_eventPrefix = 'catalog_resource_collection_abstract';
 
     /**
      * Current scope (store Id)

--- a/app/code/core/Mage/CatalogRule/Model/Flag.php
+++ b/app/code/core/Mage/CatalogRule/Model/Flag.php
@@ -39,4 +39,11 @@ class Mage_CatalogRule_Model_Flag extends Mage_Core_Model_Flag
      * @var string
      */
     protected $_flagCode = 'catalog_rules_dirty';
+
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'catalogrule_flag';
 }

--- a/app/code/core/Mage/CatalogRule/Model/Flag.php
+++ b/app/code/core/Mage/CatalogRule/Model/Flag.php
@@ -43,6 +43,7 @@ class Mage_CatalogRule_Model_Flag extends Mage_Core_Model_Flag
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'catalogrule_flag';

--- a/app/code/core/Mage/Checkout/Model/Agreement.php
+++ b/app/code/core/Mage/Checkout/Model/Agreement.php
@@ -51,6 +51,7 @@ class Mage_Checkout_Model_Agreement extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'checkout_agreement';

--- a/app/code/core/Mage/Checkout/Model/Agreement.php
+++ b/app/code/core/Mage/Checkout/Model/Agreement.php
@@ -48,6 +48,13 @@
  */
 class Mage_Checkout_Model_Agreement extends Mage_Core_Model_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'checkout_agreement';
+
     protected function _construct()
     {
         $this->_init('checkout/agreement');

--- a/app/code/core/Mage/Cms/Model/Block.php
+++ b/app/code/core/Mage/Cms/Model/Block.php
@@ -55,6 +55,7 @@ class Mage_Cms_Model_Block extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'cms_block';

--- a/app/code/core/Mage/Cms/Model/Block.php
+++ b/app/code/core/Mage/Cms/Model/Block.php
@@ -52,6 +52,13 @@ class Mage_Cms_Model_Block extends Mage_Core_Model_Abstract
     const CACHE_TAG     = 'cms_block';
     protected $_cacheTag= 'cms_block';
 
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'cms_block';
+
     protected function _construct()
     {
         $this->_init('cms/block');

--- a/app/code/core/Mage/Core/Model/Design.php
+++ b/app/code/core/Mage/Core/Model/Design.php
@@ -48,6 +48,7 @@ class Mage_Core_Model_Design extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'core_design';

--- a/app/code/core/Mage/Core/Model/Design.php
+++ b/app/code/core/Mage/Core/Model/Design.php
@@ -45,6 +45,13 @@
  */
 class Mage_Core_Model_Design extends Mage_Core_Model_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'core_design';
+
     protected function _construct()
     {
         $this->_init('core/design');

--- a/app/code/core/Mage/Core/Model/Email/Queue.php
+++ b/app/code/core/Mage/Core/Model/Email/Queue.php
@@ -67,6 +67,13 @@ class Mage_Core_Model_Email_Queue extends Mage_Core_Model_Abstract
     protected $_recipients = array();
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'core_email_queue';
+
+    /**
      * Initialize object
      */
     protected function _construct()

--- a/app/code/core/Mage/Core/Model/Email/Queue.php
+++ b/app/code/core/Mage/Core/Model/Email/Queue.php
@@ -69,6 +69,7 @@ class Mage_Core_Model_Email_Queue extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'core_email_queue';

--- a/app/code/core/Mage/Core/Model/File/Storage/Flag.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Flag.php
@@ -64,6 +64,13 @@ class Mage_Core_Model_File_Storage_Flag extends Mage_Core_Model_Flag
     protected $_flagCode    = 'synchronize';
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'core_file_storage_flag';
+
+    /**
      * Pass error to flag
      *
      * @param Exception $e

--- a/app/code/core/Mage/Core/Model/File/Storage/Flag.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Flag.php
@@ -66,6 +66,7 @@ class Mage_Core_Model_File_Storage_Flag extends Mage_Core_Model_Flag
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'core_file_storage_flag';

--- a/app/code/core/Mage/Core/Model/Flag.php
+++ b/app/code/core/Mage/Core/Model/Flag.php
@@ -53,6 +53,7 @@ class Mage_Core_Model_Flag extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'core_flag';

--- a/app/code/core/Mage/Core/Model/Flag.php
+++ b/app/code/core/Mage/Core/Model/Flag.php
@@ -51,6 +51,13 @@ class Mage_Core_Model_Flag extends Mage_Core_Model_Abstract
     protected $_flagCode = null;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'core_flag';
+
+    /**
      * Init resource model
      * Set flag_code if it is specified in arguments
      *

--- a/app/code/core/Mage/Core/Model/Resource/Store/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Store/Collection.php
@@ -43,6 +43,22 @@ class Mage_Core_Model_Resource_Store_Collection extends Mage_Core_Model_Resource
     protected $_loadDefault    = false;
 
     /**
+     * Event object prefix
+     *
+     * @see Mage_Core_Model_Resource_Store_Collection::$_eventPrefix
+     * @var string
+     */
+    protected $_eventPrefix = 'core_store_collection';
+
+    /**
+     * Event object prefix
+     *
+     * @see Mage_Core_Model_Resource_Store_Collection::$_eventObject
+     * @var string
+     */
+    protected $_eventObject = 'store_collection';
+
+    /**
      *  Define resource model
      *
      */

--- a/app/code/core/Mage/Core/Model/Resource/Website/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Website/Collection.php
@@ -47,6 +47,22 @@ class Mage_Core_Model_Resource_Website_Collection extends Mage_Core_Model_Resour
     protected $_map = array('fields' => array('website_id' => 'main_table.website_id'));
 
     /**
+     * Event object prefix
+     *
+     * @see Mage_Core_Model_Resource_Store_Collection::$_eventPrefix
+     * @var string
+     */
+    protected $_eventPrefix = 'core_website_collection';
+
+    /**
+     * Event object prefix
+     *
+     * @see Mage_Core_Model_Resource_Store_Collection::$_eventObject
+     * @var string
+     */
+    protected $_eventObject = 'website_collection';
+
+    /**
      * Define resource model
      *
      */

--- a/app/code/core/Mage/Core/Model/Url/Rewrite.php
+++ b/app/code/core/Mage/Core/Model/Url/Rewrite.php
@@ -69,6 +69,7 @@ class Mage_Core_Model_Url_Rewrite extends Mage_Core_Model_Abstract implements Ma
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'core_url_rewrite';

--- a/app/code/core/Mage/Core/Model/Url/Rewrite.php
+++ b/app/code/core/Mage/Core/Model/Url/Rewrite.php
@@ -66,6 +66,13 @@ class Mage_Core_Model_Url_Rewrite extends Mage_Core_Model_Abstract implements Ma
      */
     protected $_cacheTag = false;
 
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'core_url_rewrite';
+
     protected function _construct()
     {
         $this->_init('core/url_rewrite');

--- a/app/code/core/Mage/Core/Model/Variable.php
+++ b/app/code/core/Mage/Core/Model/Variable.php
@@ -48,6 +48,7 @@ class Mage_Core_Model_Variable extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'core_variable';

--- a/app/code/core/Mage/Core/Model/Variable.php
+++ b/app/code/core/Mage/Core/Model/Variable.php
@@ -46,6 +46,13 @@ class Mage_Core_Model_Variable extends Mage_Core_Model_Abstract
     protected $_storeId = 0;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'core_variable';
+
+    /**
      * Internal Constructor
      */
     protected function _construct()

--- a/app/code/core/Mage/Customer/Model/Flowpassword.php
+++ b/app/code/core/Mage/Customer/Model/Flowpassword.php
@@ -34,6 +34,13 @@
  */
 class Mage_Customer_Model_Flowpassword extends Mage_Core_Model_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'customer_flowpassword';
+
     protected function _construct()
     {
         $this->_init('customer/flowpassword');

--- a/app/code/core/Mage/Customer/Model/Flowpassword.php
+++ b/app/code/core/Mage/Customer/Model/Flowpassword.php
@@ -37,6 +37,7 @@ class Mage_Customer_Model_Flowpassword extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'customer_flowpassword';

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Collection.php
@@ -35,6 +35,13 @@
 class Mage_Customer_Model_Resource_Address_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_customer_address_collection';
+
+    /**
      * Resource initialization
      */
     protected function _construct()

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Collection.php
@@ -37,9 +37,10 @@ class Mage_Customer_Model_Resource_Address_Collection extends Mage_Eav_Model_Ent
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_customer_address_collection';
+    protected $_eventPrefix = 'customer_resource_address_collection';
 
     /**
      * Resource initialization

--- a/app/code/core/Mage/Customer/Model/Resource/Customer/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Customer/Collection.php
@@ -35,6 +35,13 @@
 class Mage_Customer_Model_Resource_Customer_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_customer_customer_collection';
+
+    /**
      * Resource initialization
      */
     protected function _construct()

--- a/app/code/core/Mage/Customer/Model/Resource/Customer/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Customer/Collection.php
@@ -37,9 +37,10 @@ class Mage_Customer_Model_Resource_Customer_Collection extends Mage_Eav_Model_En
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_customer_customer_collection';
+    protected $_eventPrefix = 'customer_resource_customer_collection';
 
     /**
      * Resource initialization

--- a/app/code/core/Mage/Customer/Model/Resource/Wishlist/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Wishlist/Collection.php
@@ -35,6 +35,13 @@
 class Mage_Customer_Model_Resource_Wishlist_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_customer_wishlist_collection';
+
+    /**
      * Set entity
      */
     protected function _construct()

--- a/app/code/core/Mage/Customer/Model/Resource/Wishlist/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Wishlist/Collection.php
@@ -37,9 +37,10 @@ class Mage_Customer_Model_Resource_Wishlist_Collection extends Mage_Eav_Model_En
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_customer_wishlist_collection';
+    protected $_eventPrefix = 'customer_resource_wishlist_collection';
 
     /**
      * Set entity

--- a/app/code/core/Mage/Dataflow/Model/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Profile.php
@@ -60,6 +60,7 @@ class Mage_Dataflow_Model_Profile extends Mage_Core_Model_Abstract
     /**
      * Prefix of model events names
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'dataflow_profile';

--- a/app/code/core/Mage/Dataflow/Model/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Profile.php
@@ -57,6 +57,13 @@ class Mage_Dataflow_Model_Profile extends Mage_Core_Model_Abstract
     const DEFAULT_EXPORT_PATH = 'var/export';
     const DEFAULT_EXPORT_FILENAME = 'export_';
 
+    /**
+     * Prefix of model events names
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'dataflow_profile';
+
     protected function _construct()
     {
         $this->_init('dataflow/profile');

--- a/app/code/core/Mage/Dataflow/Model/Profile/History.php
+++ b/app/code/core/Mage/Dataflow/Model/Profile/History.php
@@ -44,6 +44,13 @@
  */
 class Mage_Dataflow_Model_Profile_History extends Mage_Core_Model_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'dataflow_profile_history';
+
     protected function _construct()
     {
         $this->_init('dataflow/profile_history');

--- a/app/code/core/Mage/Dataflow/Model/Profile/History.php
+++ b/app/code/core/Mage/Dataflow/Model/Profile/History.php
@@ -47,6 +47,7 @@ class Mage_Dataflow_Model_Profile_History extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'dataflow_profile_history';

--- a/app/code/core/Mage/Directory/Model/Country.php
+++ b/app/code/core/Mage/Directory/Model/Country.php
@@ -47,6 +47,7 @@ class Mage_Directory_Model_Country extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'directory_country';

--- a/app/code/core/Mage/Directory/Model/Country.php
+++ b/app/code/core/Mage/Directory/Model/Country.php
@@ -44,6 +44,13 @@ class Mage_Directory_Model_Country extends Mage_Core_Model_Abstract
 {
     static public $_format = array();
 
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'directory_country';
+
     protected function _construct()
     {
         $this->_init('directory/country');

--- a/app/code/core/Mage/Directory/Model/Region.php
+++ b/app/code/core/Mage/Directory/Model/Region.php
@@ -42,6 +42,13 @@
  */
 class Mage_Directory_Model_Region extends Mage_Core_Model_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'directory_region';
+
     protected function _construct()
     {
         $this->_init('directory/region');

--- a/app/code/core/Mage/Directory/Model/Region.php
+++ b/app/code/core/Mage/Directory/Model/Region.php
@@ -45,6 +45,7 @@ class Mage_Directory_Model_Region extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'directory_region';

--- a/app/code/core/Mage/Downloadable/Model/Link.php
+++ b/app/code/core/Mage/Downloadable/Model/Link.php
@@ -68,6 +68,7 @@ class Mage_Downloadable_Model_Link extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'downloadable_link';

--- a/app/code/core/Mage/Downloadable/Model/Link.php
+++ b/app/code/core/Mage/Downloadable/Model/Link.php
@@ -66,6 +66,13 @@ class Mage_Downloadable_Model_Link extends Mage_Core_Model_Abstract
     const LINK_SHAREABLE_CONFIG = 2;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'downloadable_link';
+
+    /**
      * Initialize resource model
      *
      */

--- a/app/code/core/Mage/Downloadable/Model/Link/Purchased.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Purchased.php
@@ -57,6 +57,7 @@ class Mage_Downloadable_Model_Link_Purchased extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'downloadable_link_purchased';

--- a/app/code/core/Mage/Downloadable/Model/Link/Purchased.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Purchased.php
@@ -55,7 +55,14 @@
 class Mage_Downloadable_Model_Link_Purchased extends Mage_Core_Model_Abstract
 {
     /**
-     * Enter description here...
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'downloadable_link_purchased';
+
+    /**
+     * Initialize resource model
      *
      */
     protected function _construct()

--- a/app/code/core/Mage/Downloadable/Model/Link/Purchased/Item.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Purchased/Item.php
@@ -77,6 +77,7 @@ class Mage_Downloadable_Model_Link_Purchased_Item extends Mage_Core_Model_Abstra
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'downloadable_link_purchased_item';

--- a/app/code/core/Mage/Downloadable/Model/Link/Purchased/Item.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Purchased/Item.php
@@ -75,7 +75,14 @@ class Mage_Downloadable_Model_Link_Purchased_Item extends Mage_Core_Model_Abstra
     const LINK_STATUS_PAYMENT_REVIEW = 'payment_review';
 
     /**
-     * Enter description here...
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'downloadable_link_purchased_item';
+
+    /**
+     * Initialize resource model
      *
      */
     protected function _construct()

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Group.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Group.php
@@ -48,6 +48,7 @@ class Mage_Eav_Model_Entity_Attribute_Group extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'eav_entity_attribute_group';

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Group.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Group.php
@@ -46,6 +46,13 @@
 class Mage_Eav_Model_Entity_Attribute_Group extends Mage_Core_Model_Abstract
 {
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_entity_attribute_group';
+
+    /**
      * Resource initialization
      */
     protected function _construct()

--- a/app/code/core/Mage/Eav/Model/Entity/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection.php
@@ -29,6 +29,7 @@ class Mage_Eav_Model_Entity_Collection extends Mage_Eav_Model_Entity_Collection_
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'eav_entity_collection';

--- a/app/code/core/Mage/Eav/Model/Entity/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection.php
@@ -27,6 +27,13 @@
 class Mage_Eav_Model_Entity_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_entity_collection';
+
+    /**
      * Initialize resource
      */
     public function __construct()

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -116,6 +116,10 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
     /**
      * Model event prefix
      *
+     * This fits default event prefix and is
+     * just to prevent to fire events two time
+     *
+     * @see load()
      * @var string
      */
     protected $_eventPrefix = 'eav_collection_abstract';

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -114,6 +114,13 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
     );
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_collection_abstract';
+
+    /**
      * Collection constructor
      *
      * @param Mage_Core_Model_Resource_Abstract $resource
@@ -861,6 +868,11 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
         }
         Varien_Profiler::start('__EAV_COLLECTION_BEFORE_LOAD__');
         Mage::dispatchEvent('eav_collection_abstract_load_before', array('collection' => $this));
+
+        if ($this->_eventPrefix !== 'eav_collection_abstract') {
+            Mage::dispatchEvent($this->_eventPrefix . '_load_before', array('collection' => $this));
+        }
+
         $this->_beforeLoad();
         Varien_Profiler::stop('__EAV_COLLECTION_BEFORE_LOAD__');
 

--- a/app/code/core/Mage/Eav/Model/Entity/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Store.php
@@ -46,6 +46,13 @@
 class Mage_Eav_Model_Entity_Store extends Mage_Core_Model_Abstract
 {
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_entity_store';
+
+    /**
      * Resource initialization
      */
     protected function _construct()

--- a/app/code/core/Mage/Eav/Model/Entity/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Store.php
@@ -48,6 +48,7 @@ class Mage_Eav_Model_Entity_Store extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'eav_entity_store';

--- a/app/code/core/Mage/Eav/Model/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Type.php
@@ -82,6 +82,14 @@ class Mage_Eav_Model_Entity_Type extends Mage_Core_Model_Abstract
     protected $_sets;
 
     /**
+     * Model event prefix
+     *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_entity_type';
+
+    /**
      * Resource initialization
      */
     protected function _construct()

--- a/app/code/core/Mage/GiftMessage/Model/Message.php
+++ b/app/code/core/Mage/GiftMessage/Model/Message.php
@@ -63,6 +63,7 @@ class Mage_GiftMessage_Model_Message extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'giftmessage_message';

--- a/app/code/core/Mage/GiftMessage/Model/Message.php
+++ b/app/code/core/Mage/GiftMessage/Model/Message.php
@@ -60,6 +60,13 @@ class Mage_GiftMessage_Model_Message extends Mage_Core_Model_Abstract
         'quote_address_item' => 'sales/quote_address_item'
     );
 
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'giftmessage_message';
+
     protected function _construct()
     {
         $this->_init('giftmessage/message');

--- a/app/code/core/Mage/Index/Model/Event.php
+++ b/app/code/core/Mage/Index/Model/Event.php
@@ -72,6 +72,13 @@ class Mage_Index_Model_Event extends Mage_Core_Model_Abstract
     protected $_process = null;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'index_event';
+
+    /**
      * Initialize resource
      */
     protected function _construct()

--- a/app/code/core/Mage/Index/Model/Event.php
+++ b/app/code/core/Mage/Index/Model/Event.php
@@ -74,6 +74,7 @@ class Mage_Index_Model_Event extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'index_event';

--- a/app/code/core/Mage/Index/Model/Process.php
+++ b/app/code/core/Mage/Index/Model/Process.php
@@ -94,6 +94,13 @@ class Mage_Index_Model_Process extends Mage_Core_Model_Abstract
     protected $_allowTableChanges = true;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'index_process';
+
+    /**
      * Initialize resource
      */
     protected function _construct()

--- a/app/code/core/Mage/Index/Model/Process.php
+++ b/app/code/core/Mage/Index/Model/Process.php
@@ -96,6 +96,7 @@ class Mage_Index_Model_Process extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'index_process';

--- a/app/code/core/Mage/Log/Model/Customer.php
+++ b/app/code/core/Mage/Log/Model/Customer.php
@@ -49,6 +49,7 @@ class Mage_Log_Model_Customer extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'log_customer';

--- a/app/code/core/Mage/Log/Model/Customer.php
+++ b/app/code/core/Mage/Log/Model/Customer.php
@@ -47,6 +47,13 @@
 class Mage_Log_Model_Customer extends Mage_Core_Model_Abstract
 {
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'log_customer';
+
+    /**
      * Define resource model
      *
      */

--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -73,6 +73,7 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'log_visitor';

--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -70,6 +70,13 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
      */
     protected $_session;
 
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'log_visitor';
+
     public function __construct(array $data = array())
     {
         $this->_httpHelper = !empty($data['http_helper']) ? $data['http_helper'] : Mage::helper('core/http');

--- a/app/code/core/Mage/Newsletter/Model/Template.php
+++ b/app/code/core/Mage/Newsletter/Model/Template.php
@@ -73,6 +73,7 @@ class Mage_Newsletter_Model_Template extends Mage_Core_Model_Email_Template_Abst
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'newsletter_template';

--- a/app/code/core/Mage/Newsletter/Model/Template.php
+++ b/app/code/core/Mage/Newsletter/Model/Template.php
@@ -71,6 +71,13 @@ class Mage_Newsletter_Model_Template extends Mage_Core_Model_Email_Template_Abst
     protected $_mail;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'newsletter_template';
+
+    /**
      * Initialize resource model
      *
      */

--- a/app/code/core/Mage/Oauth/Model/Consumer.php
+++ b/app/code/core/Mage/Oauth/Model/Consumer.php
@@ -64,6 +64,7 @@ class Mage_Oauth_Model_Consumer extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'oauth_consumer';

--- a/app/code/core/Mage/Oauth/Model/Consumer.php
+++ b/app/code/core/Mage/Oauth/Model/Consumer.php
@@ -62,6 +62,13 @@ class Mage_Oauth_Model_Consumer extends Mage_Core_Model_Abstract
     const SECRET_LENGTH = 32;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'oauth_consumer';
+
+    /**
      * Initialize resource model
      *
      * @return void

--- a/app/code/core/Mage/Persistent/Model/Session.php
+++ b/app/code/core/Mage/Persistent/Model/Session.php
@@ -52,6 +52,14 @@ class Mage_Persistent_Model_Session extends Mage_Core_Model_Abstract
     protected $_loadExpired = false;
 
     /**
+     * Model event prefix
+     *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
+     * @var string
+     */
+    protected $_eventPrefix = 'persistent_session';
+
+    /**
      * Define resource model
      */
     protected function _construct()

--- a/app/code/core/Mage/Poll/Model/Poll.php
+++ b/app/code/core/Mage/Poll/Model/Poll.php
@@ -58,6 +58,13 @@ class Mage_Poll_Model_Poll extends Mage_Core_Model_Abstract
     protected $_answersCollection   = array();
     protected $_storeCollection     = array();
 
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'poll_poll';
+
     protected function _construct()
     {
         $this->_init('poll/poll');

--- a/app/code/core/Mage/Poll/Model/Poll.php
+++ b/app/code/core/Mage/Poll/Model/Poll.php
@@ -61,6 +61,7 @@ class Mage_Poll_Model_Poll extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'poll_poll';

--- a/app/code/core/Mage/Poll/Model/Poll/Answer.php
+++ b/app/code/core/Mage/Poll/Model/Poll/Answer.php
@@ -45,6 +45,13 @@
 
 class Mage_Poll_Model_Poll_Answer extends Mage_Core_Model_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'poll_poll_answer';
+
     protected function _construct()
     {
         $this->_init('poll/poll_answer');

--- a/app/code/core/Mage/Poll/Model/Poll/Answer.php
+++ b/app/code/core/Mage/Poll/Model/Poll/Answer.php
@@ -48,6 +48,7 @@ class Mage_Poll_Model_Poll_Answer extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'poll_poll_answer';

--- a/app/code/core/Mage/Poll/Model/Poll/Vote.php
+++ b/app/code/core/Mage/Poll/Model/Poll/Vote.php
@@ -49,6 +49,7 @@ class Mage_Poll_Model_Poll_Vote extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'poll_poll_vote';

--- a/app/code/core/Mage/Poll/Model/Poll/Vote.php
+++ b/app/code/core/Mage/Poll/Model/Poll/Vote.php
@@ -46,6 +46,13 @@
  */
 class Mage_Poll_Model_Poll_Vote extends Mage_Core_Model_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'poll_poll_vote';
+
     protected function _construct()
     {
         $this->_init('poll/poll_vote');

--- a/app/code/core/Mage/Poll/Model/Resource/Poll/Answer/Collection.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll/Answer/Collection.php
@@ -35,6 +35,22 @@
 class Mage_Poll_Model_Resource_Poll_Answer_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {
     /**
+     * Event object prefix
+     *
+     * @see Mage_Core_Model_Resource_Store_Collection::$_eventPrefix
+     * @var string
+     */
+    protected $_eventPrefix = 'poll_poll_answer_collection';
+
+    /**
+     * Event object prefix
+     *
+     * @see Mage_Core_Model_Resource_Store_Collection::$_eventObject
+     * @var string
+     */
+    protected $_eventObject = 'poll_answer_collection';
+
+    /**
      * Initialize collection
      *
      */

--- a/app/code/core/Mage/Reports/Model/Event.php
+++ b/app/code/core/Mage/Reports/Model/Event.php
@@ -56,6 +56,13 @@ class Mage_Reports_Model_Event extends Mage_Core_Model_Abstract
     const EVENT_WISHLIST_SHARE  = 6;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'reports_event';
+
+    /**
      * Initialize resource
      *
      */

--- a/app/code/core/Mage/Reports/Model/Event.php
+++ b/app/code/core/Mage/Reports/Model/Event.php
@@ -58,6 +58,7 @@ class Mage_Reports_Model_Event extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'reports_event';

--- a/app/code/core/Mage/Reports/Model/Flag.php
+++ b/app/code/core/Mage/Reports/Model/Flag.php
@@ -44,6 +44,13 @@ class Mage_Reports_Model_Flag extends Mage_Core_Model_Flag
     const REPORT_PRODUCT_VIEWED_FLAG_CODE = 'report_product_viewed_aggregated';
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'reports_flag';
+
+    /**
      * Setter for flag code
      *
      * @param string $code

--- a/app/code/core/Mage/Reports/Model/Flag.php
+++ b/app/code/core/Mage/Reports/Model/Flag.php
@@ -46,6 +46,7 @@ class Mage_Reports_Model_Flag extends Mage_Core_Model_Flag
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'reports_flag';

--- a/app/code/core/Mage/Reports/Model/Product/Index/Compared.php
+++ b/app/code/core/Mage/Reports/Model/Product/Index/Compared.php
@@ -52,6 +52,13 @@ class Mage_Reports_Model_Product_Index_Compared extends Mage_Reports_Model_Produ
     protected $_countCacheKey   = 'product_index_compared_count';
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'reports_product_index_compared';
+
+    /**
      * Initialize resource model
      *
      */

--- a/app/code/core/Mage/Reports/Model/Product/Index/Compared.php
+++ b/app/code/core/Mage/Reports/Model/Product/Index/Compared.php
@@ -54,6 +54,7 @@ class Mage_Reports_Model_Product_Index_Compared extends Mage_Reports_Model_Produ
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'reports_product_index_compared';

--- a/app/code/core/Mage/Reports/Model/Product/Index/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Product/Index/Viewed.php
@@ -52,6 +52,13 @@ class Mage_Reports_Model_Product_Index_Viewed extends Mage_Reports_Model_Product
     protected $_countCacheKey   = 'product_index_viewed_count';
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'reports_product_index_viewed';
+
+    /**
      * Initialize resource model
      *
      */

--- a/app/code/core/Mage/Reports/Model/Product/Index/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Product/Index/Viewed.php
@@ -54,6 +54,7 @@ class Mage_Reports_Model_Product_Index_Viewed extends Mage_Reports_Model_Product
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'reports_product_index_viewed';

--- a/app/code/core/Mage/Review/Model/Review/Summary.php
+++ b/app/code/core/Mage/Review/Model/Review/Summary.php
@@ -37,6 +37,7 @@ class Mage_Review_Model_Review_Summary extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'review_review_summary';

--- a/app/code/core/Mage/Review/Model/Review/Summary.php
+++ b/app/code/core/Mage/Review/Model/Review/Summary.php
@@ -34,6 +34,12 @@
 
 class Mage_Review_Model_Review_Summary extends Mage_Core_Model_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'review_review_summary';
 
     public function __construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Address/Collection.php
@@ -34,6 +34,12 @@
 
 class Mage_Sales_Model_Entity_Order_Address_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_order_address_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Address/Collection.php
@@ -37,9 +37,10 @@ class Mage_Sales_Model_Entity_Order_Address_Collection extends Mage_Eav_Model_En
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_order_address_collection';
+    protected $_eventPrefix = 'sales_entity_order_address_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Collection.php
@@ -37,9 +37,10 @@ class Mage_Sales_Model_Entity_Order_Collection extends Mage_Eav_Model_Entity_Col
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_order_collection';
+    protected $_eventPrefix = 'sales_entity_order_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Collection.php
@@ -34,6 +34,13 @@
 
 class Mage_Sales_Model_Entity_Order_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_order_collection';
+
     protected function _construct()
     {
         $this->_init('sales/order');

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Collection.php
@@ -34,6 +34,13 @@
 
 class Mage_Sales_Model_Entity_Order_Creditmemo_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_order_creditmemo_collection';
+
     protected function _construct()
     {
         $this->_init('sales/order_creditmemo');

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Collection.php
@@ -37,9 +37,10 @@ class Mage_Sales_Model_Entity_Order_Creditmemo_Collection extends Mage_Eav_Model
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_order_creditmemo_collection';
+    protected $_eventPrefix = 'sales_entity_order_creditmemo_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment/Collection.php
@@ -34,6 +34,13 @@
  */
 class Mage_Sales_Model_Entity_Order_Creditmemo_Comment_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_order_creditmemo_comment_collection';
+
     protected function _construct()
     {
         $this->_init('sales/order_creditmemo_comment');

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment/Collection.php
@@ -37,9 +37,10 @@ class Mage_Sales_Model_Entity_Order_Creditmemo_Comment_Collection extends Mage_E
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_order_creditmemo_comment_collection';
+    protected $_eventPrefix = 'sales_entity_order_creditmemo_comment_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item/Collection.php
@@ -35,6 +35,13 @@
 
 class Mage_Sales_Model_Entity_Order_Creditmemo_Item_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_order_creditmemo_item_collection';
+
     protected function _construct()
     {
         $this->_init('sales/order_creditmemo_item');

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item/Collection.php
@@ -38,9 +38,10 @@ class Mage_Sales_Model_Entity_Order_Creditmemo_Item_Collection extends Mage_Eav_
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_order_creditmemo_item_collection';
+    protected $_eventPrefix = 'sales_entity_order_creditmemo_item_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Collection.php
@@ -34,6 +34,13 @@
 
 class Mage_Sales_Model_Entity_Order_Invoice_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_order_invoice_collection';
+
     protected function _construct()
     {
         $this->_init('sales/order_invoice');

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Collection.php
@@ -37,9 +37,10 @@ class Mage_Sales_Model_Entity_Order_Invoice_Collection extends Mage_Eav_Model_En
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_order_invoice_collection';
+    protected $_eventPrefix = 'sales_entity_order_invoice_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment/Collection.php
@@ -34,6 +34,13 @@
  */
 class Mage_Sales_Model_Entity_Order_Invoice_Comment_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_order_invoice_comment_collection';
+
     protected function _construct()
     {
         $this->_init('sales/order_invoice_comment');

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment/Collection.php
@@ -37,9 +37,10 @@ class Mage_Sales_Model_Entity_Order_Invoice_Comment_Collection extends Mage_Eav_
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_order_invoice_comment_collection';
+    protected $_eventPrefix = 'sales_entity_order_invoice_comment_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item/Collection.php
@@ -37,9 +37,10 @@ class Mage_Sales_Model_Entity_Order_Invoice_Item_Collection extends Mage_Eav_Mod
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_order_invoice_item_collection';
+    protected $_eventPrefix = 'sales_entity_order_invoice_item_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item/Collection.php
@@ -34,6 +34,13 @@
  */
 class Mage_Sales_Model_Entity_Order_Invoice_Item_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_order_invoice_item_collection';
+
     protected function _construct()
     {
         $this->_init('sales/order_invoice_item');

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Item/Collection.php
@@ -33,6 +33,13 @@
  */
 class Mage_Sales_Model_Entity_Order_Item_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_order_item_collection';
+
     public function _construct()
     {
         $this->_init('sales/order_item');

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Item/Collection.php
@@ -36,9 +36,10 @@ class Mage_Sales_Model_Entity_Order_Item_Collection extends Mage_Eav_Model_Entit
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_order_item_collection';
+    protected $_eventPrefix = 'sales_entity_order_item_collection';
 
     public function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Payment/Collection.php
@@ -33,6 +33,13 @@
  */
 class Mage_Sales_Model_Entity_Order_Payment_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_order_payment_collection';
+
     protected function _construct()
     {
         $this->_init('sales/order_payment');

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Payment/Collection.php
@@ -36,9 +36,10 @@ class Mage_Sales_Model_Entity_Order_Payment_Collection extends Mage_Eav_Model_En
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_order_payment_collection';
+    protected $_eventPrefix = 'sales_entity_order_payment_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Collection.php
@@ -34,6 +34,13 @@
 
 class Mage_Sales_Model_Entity_Order_Shipment_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_order_shipment_collection';
+
     protected function _construct()
     {
         $this->_init('sales/order_shipment');

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Collection.php
@@ -37,9 +37,10 @@ class Mage_Sales_Model_Entity_Order_Shipment_Collection extends Mage_Eav_Model_E
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_order_shipment_collection';
+    protected $_eventPrefix = 'sales_entity_order_shipment_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment/Collection.php
@@ -37,9 +37,10 @@ class Mage_Sales_Model_Entity_Order_Shipment_Comment_Collection extends Mage_Eav
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_order_shipment_comment_collection';
+    protected $_eventPrefix = 'sales_entity_order_shipment_comment_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment/Collection.php
@@ -34,6 +34,13 @@
  */
 class Mage_Sales_Model_Entity_Order_Shipment_Comment_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_order_shipment_comment_collection';
+
     protected function _construct()
     {
         $this->_init('sales/order_shipment_comment');

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item/Collection.php
@@ -38,9 +38,10 @@ class Mage_Sales_Model_Entity_Order_Shipment_Item_Collection extends Mage_Eav_Mo
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_order_shipment_item_collection';
+    protected $_eventPrefix = 'sales_entity_order_shipment_item_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item/Collection.php
@@ -35,6 +35,13 @@
 
 class Mage_Sales_Model_Entity_Order_Shipment_Item_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_order_shipment_item_collection';
+
     protected function _construct()
     {
         $this->_init('sales/order_shipment_item');

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track/Collection.php
@@ -35,6 +35,13 @@
 
 class Mage_Sales_Model_Entity_Order_Shipment_Track_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_order_shipment_track_collection';
+
     public function _construct()
     {
         $this->_init('sales/order_shipment_track');

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track/Collection.php
@@ -38,9 +38,10 @@ class Mage_Sales_Model_Entity_Order_Shipment_Track_Collection extends Mage_Eav_M
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_order_shipment_track_collection';
+    protected $_eventPrefix = 'sales_entity_order_shipment_track_collection';
 
     public function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Status/History/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Status/History/Collection.php
@@ -34,6 +34,12 @@
 
 class Mage_Sales_Model_Entity_Order_Status_History_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_order_status_history_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Status/History/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Status/History/Collection.php
@@ -37,9 +37,10 @@ class Mage_Sales_Model_Entity_Order_Status_History_Collection extends Mage_Eav_M
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_order_status_history_collection';
+    protected $_eventPrefix = 'sales_entity_order_status_history_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Collection.php
@@ -35,6 +35,13 @@
 
 class Mage_Sales_Model_Entity_Quote_Address_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_quote_address_collection';
+
     protected function _construct()
     {
         $this->_init('sales/quote_address');

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Collection.php
@@ -38,9 +38,10 @@ class Mage_Sales_Model_Entity_Quote_Address_Collection extends Mage_Eav_Model_En
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_quote_address_collection';
+    protected $_eventPrefix = 'sales_entity_quote_address_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item/Collection.php
@@ -35,6 +35,13 @@
 
 class Mage_Sales_Model_Entity_Quote_Address_Item_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_quote_address_item_collection';
+
     protected function _construct()
     {
         $this->_init('sales/quote_address_item');

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item/Collection.php
@@ -38,9 +38,10 @@ class Mage_Sales_Model_Entity_Quote_Address_Item_Collection extends Mage_Eav_Mod
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_quote_address_item_collection';
+    protected $_eventPrefix = 'sales_entity_quote_address_item_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate/Collection.php
@@ -35,6 +35,13 @@
 
 class Mage_Sales_Model_Entity_Quote_Address_Rate_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_quote_address_rate_collection';
+
     protected function _construct()
     {
         $this->_init('sales/quote_address_rate');

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate/Collection.php
@@ -38,9 +38,10 @@ class Mage_Sales_Model_Entity_Quote_Address_Rate_Collection extends Mage_Eav_Mod
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_quote_address_rate_collection';
+    protected $_eventPrefix = 'sales_entity_quote_address_rate_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Collection.php
@@ -36,9 +36,10 @@ class Mage_Sales_Model_Entity_Quote_Collection extends Mage_Eav_Model_Entity_Col
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_quote_collection';
+    protected $_eventPrefix = 'sales_entity_quote_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Collection.php
@@ -33,6 +33,13 @@
  */
 class Mage_Sales_Model_Entity_Quote_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_quote_collection';
+
     protected function _construct()
     {
         $this->_init('sales/quote');

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Item/Collection.php
@@ -42,6 +42,13 @@ class Mage_Sales_Model_Entity_Quote_Item_Collection extends Mage_Eav_Model_Entit
      */
     protected $_quote;
 
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_quote_item_collection';
+
     protected function _construct()
     {
         $this->_init('sales/quote_item');

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Item/Collection.php
@@ -45,9 +45,10 @@ class Mage_Sales_Model_Entity_Quote_Item_Collection extends Mage_Eav_Model_Entit
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_quote_item_collection';
+    protected $_eventPrefix = 'sales_entity_quote_item_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Payment/Collection.php
@@ -35,6 +35,13 @@
 
 class Mage_Sales_Model_Entity_Quote_Payment_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'eav_sales_quote_payment_collection';
+
     protected function _construct()
     {
         $this->_init('sales/quote_payment');

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Payment/Collection.php
@@ -38,9 +38,10 @@ class Mage_Sales_Model_Entity_Quote_Payment_Collection extends Mage_Eav_Model_En
     /**
      * Model event prefix
      *
+     * @see Mage_Eav_Model_Entity_Collection_Abstract::$_eventPrefix
      * @var string
      */
-    protected $_eventPrefix = 'eav_sales_quote_payment_collection';
+    protected $_eventPrefix = 'sales_entity_quote_payment_collection';
 
     protected function _construct()
     {

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Comment.php
@@ -57,6 +57,7 @@ class Mage_Sales_Model_Order_Creditmemo_Comment extends Mage_Sales_Model_Abstrac
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'sales_order_creditmemo_comment';

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Comment.php
@@ -55,6 +55,13 @@ class Mage_Sales_Model_Order_Creditmemo_Comment extends Mage_Sales_Model_Abstrac
     protected $_creditmemo;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'sales_order_creditmemo_comment';
+
+    /**
      * Initialize resource model
      */
     protected function _construct()

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Comment.php
@@ -57,6 +57,7 @@ class Mage_Sales_Model_Order_Invoice_Comment extends Mage_Sales_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'sales_order_invoice_comment';

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Comment.php
@@ -55,6 +55,13 @@ class Mage_Sales_Model_Order_Invoice_Comment extends Mage_Sales_Model_Abstract
     protected $_invoice;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'sales_order_invoice_comment';
+
+    /**
      * Initialize resource model
      */
     protected function _construct()

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Comment.php
@@ -50,6 +50,7 @@ class Mage_Sales_Model_Order_Shipment_Comment extends Mage_Sales_Model_Abstract
     /**
      * Shipment instance
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var Mage_Sales_Model_Order_Shipment
      */
     protected $_shipment;

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Comment.php
@@ -55,6 +55,13 @@ class Mage_Sales_Model_Order_Shipment_Comment extends Mage_Sales_Model_Abstract
     protected $_shipment;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'sales_order_shipment_comment';
+
+    /**
      * Initialize resource model
      */
     protected function _construct()

--- a/app/code/core/Mage/Sales/Model/Order/Status.php
+++ b/app/code/core/Mage/Sales/Model/Order/Status.php
@@ -30,11 +30,12 @@ class Mage_Sales_Model_Order_Status extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'sales_order_status';
 
-     protected function _construct()
+    protected function _construct()
     {
         $this->_init('sales/order_status');
     }

--- a/app/code/core/Mage/Sales/Model/Order/Status.php
+++ b/app/code/core/Mage/Sales/Model/Order/Status.php
@@ -27,8 +27,14 @@
 
 class Mage_Sales_Model_Order_Status extends Mage_Core_Model_Abstract
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'sales_order_status';
 
-    protected function _construct()
+     protected function _construct()
     {
         $this->_init('sales/order_status');
     }

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Rate.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Rate.php
@@ -61,6 +61,13 @@ class Mage_Sales_Model_Quote_Address_Rate extends Mage_Shipping_Model_Rate_Abstr
 {
     protected $_address;
 
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'sales_quote_address_rate';
+
     protected function _construct()
     {
         $this->_init('sales/quote_address_rate');

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Rate.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Rate.php
@@ -64,6 +64,7 @@ class Mage_Sales_Model_Quote_Address_Rate extends Mage_Shipping_Model_Rate_Abstr
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'sales_quote_address_rate';

--- a/app/code/core/Mage/Sales/Model/Quote/Item/Option.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item/Option.php
@@ -49,6 +49,13 @@ class Mage_Sales_Model_Quote_Item_Option extends Mage_Core_Model_Abstract
     protected $_product;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'sales_quote_item_option';
+
+    /**
      * Initialize resource model
      */
     protected function _construct()

--- a/app/code/core/Mage/Sales/Model/Quote/Item/Option.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item/Option.php
@@ -51,6 +51,7 @@ class Mage_Sales_Model_Quote_Item_Option extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'sales_quote_item_option';

--- a/app/code/core/Mage/SalesRule/Model/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Model/Coupon.php
@@ -60,6 +60,13 @@ class Mage_SalesRule_Model_Coupon extends Mage_Core_Model_Abstract
      */
     protected $_rule;
 
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'salesrule_coupon';
+
     protected function _construct()
     {
         parent::_construct();

--- a/app/code/core/Mage/SalesRule/Model/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Model/Coupon.php
@@ -63,6 +63,7 @@ class Mage_SalesRule_Model_Coupon extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'salesrule_coupon';

--- a/app/code/core/Mage/SalesRule/Model/Rule/Customer.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Customer.php
@@ -43,6 +43,13 @@
  */
 class Mage_SalesRule_Model_Rule_Customer extends Mage_Core_Model_Abstract 
 {
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'salesrule_rule_customer';
+
     protected function _construct()
     {
         parent::_construct();

--- a/app/code/core/Mage/SalesRule/Model/Rule/Customer.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Customer.php
@@ -46,6 +46,7 @@ class Mage_SalesRule_Model_Rule_Customer extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'salesrule_rule_customer';

--- a/app/code/core/Mage/Sitemap/Model/Sitemap.php
+++ b/app/code/core/Mage/Sitemap/Model/Sitemap.php
@@ -57,6 +57,7 @@ class Mage_Sitemap_Model_Sitemap extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'sitemap_sitemap';

--- a/app/code/core/Mage/Sitemap/Model/Sitemap.php
+++ b/app/code/core/Mage/Sitemap/Model/Sitemap.php
@@ -55,6 +55,13 @@ class Mage_Sitemap_Model_Sitemap extends Mage_Core_Model_Abstract
     protected $_filePath;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'sitemap_sitemap';
+
+    /**
      * Init model
      */
     protected function _construct()

--- a/app/code/core/Mage/Tag/Model/Resource/Popular/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Popular/Collection.php
@@ -35,6 +35,22 @@
 class Mage_Tag_Model_Resource_Popular_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {
     /**
+     * Event object prefix
+     *
+     * @see Mage_Core_Model_Resource_Store_Collection::$_eventPrefix
+     * @var string
+     */
+    protected $_eventPrefix = 'tag_popular_collection';
+
+    /**
+     * Event object prefix
+     *
+     * @see Mage_Core_Model_Resource_Store_Collection::$_eventObject
+     * @var string
+     */
+    protected $_eventObject = 'popular_collection';
+
+    /**
      * Defines resource model and model
      *
      */

--- a/app/code/core/Mage/Tag/Model/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Tag/Relation.php
@@ -62,6 +62,13 @@ class Mage_Tag_Model_Tag_Relation extends Mage_Core_Model_Abstract
     const ENTITY = 'tag_relation';
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'tag_tag_relation';
+
+    /**
      * Initialize resource model
      *
      */

--- a/app/code/core/Mage/Tag/Model/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Tag/Relation.php
@@ -64,6 +64,7 @@ class Mage_Tag_Model_Tag_Relation extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'tag_tag_relation';

--- a/app/code/core/Mage/Tax/Model/Calculation.php
+++ b/app/code/core/Mage/Tax/Model/Calculation.php
@@ -120,6 +120,7 @@ class Mage_Tax_Model_Calculation extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'tax_calculation';

--- a/app/code/core/Mage/Tax/Model/Calculation.php
+++ b/app/code/core/Mage/Tax/Model/Calculation.php
@@ -118,6 +118,13 @@ class Mage_Tax_Model_Calculation extends Mage_Core_Model_Abstract
     protected $_taxHelper;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'tax_calculation';
+
+    /**
      * Constructor
      */
     protected function _construct()

--- a/app/code/core/Mage/Tax/Model/Calculation/Rate.php
+++ b/app/code/core/Mage/Tax/Model/Calculation/Rate.php
@@ -69,6 +69,7 @@ class Mage_Tax_Model_Calculation_Rate extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'tax_calculation_rate';

--- a/app/code/core/Mage/Tax/Model/Calculation/Rate.php
+++ b/app/code/core/Mage/Tax/Model/Calculation/Rate.php
@@ -67,6 +67,13 @@ class Mage_Tax_Model_Calculation_Rate extends Mage_Core_Model_Abstract
     protected $_titleModel = null;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'tax_calculation_rate';
+
+    /**
      * Varien model constructor
      */
     protected function _construct()

--- a/app/code/core/Mage/Tax/Model/Calculation/Rule.php
+++ b/app/code/core/Mage/Tax/Model/Calculation/Rule.php
@@ -92,6 +92,13 @@ class Mage_Tax_Model_Calculation_Rule extends Mage_Core_Model_Abstract
     protected $_calculationModel    = null;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'tax_calculation_rule';
+
+    /**
      * Varien model constructor
      */
     protected function _construct()

--- a/app/code/core/Mage/Tax/Model/Calculation/Rule.php
+++ b/app/code/core/Mage/Tax/Model/Calculation/Rule.php
@@ -94,6 +94,7 @@ class Mage_Tax_Model_Calculation_Rule extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'tax_calculation_rule';

--- a/app/code/core/Mage/Tax/Model/Class.php
+++ b/app/code/core/Mage/Tax/Model/Class.php
@@ -47,6 +47,7 @@ class Mage_Tax_Model_Class extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'tax_class';

--- a/app/code/core/Mage/Tax/Model/Class.php
+++ b/app/code/core/Mage/Tax/Model/Class.php
@@ -44,6 +44,13 @@ class Mage_Tax_Model_Class extends Mage_Core_Model_Abstract
     const TAX_CLASS_TYPE_CUSTOMER   = 'CUSTOMER';
     const TAX_CLASS_TYPE_PRODUCT    = 'PRODUCT';
 
+    /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'tax_class';
+
     public function _construct()
     {
         $this->_init('tax/class');

--- a/app/code/core/Mage/Wishlist/Model/Item/Option.php
+++ b/app/code/core/Mage/Wishlist/Model/Item/Option.php
@@ -38,6 +38,13 @@ class Mage_Wishlist_Model_Item_Option extends Mage_Core_Model_Abstract
     protected $_product;
 
     /**
+     * Model event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'wishlist_item_option';
+
+    /**
      * Initialize resource model
      */
     protected function _construct()

--- a/app/code/core/Mage/Wishlist/Model/Item/Option.php
+++ b/app/code/core/Mage/Wishlist/Model/Item/Option.php
@@ -40,6 +40,7 @@ class Mage_Wishlist_Model_Item_Option extends Mage_Core_Model_Abstract
     /**
      * Model event prefix
      *
+     * @see Mage_Core_Model_Abstract::$_eventPrefix
      * @var string
      */
     protected $_eventPrefix = 'wishlist_item_option';


### PR DESCRIPTION
Just added some event prefixed for models that can be triggered in frontend/backend:

**Models**
- Mage_Admin_Model_Block
- Mage_Admin_Model_Variable
- Mage_Adminhtml_Model_Email_Template
- Mage_AdminNotification_Model_Inbox
- Mage_Api_Model_Roles
- Mage_Api2_Model_Acl_Filter_Attribute
- Mage_Api2_Model_Acl_Global_Role
- Mage_Api2_Model_Acl_Global_Rule
- Mage_Bundle_Model_Option
- Mage_Bundle_Model_Selection
- Mage_Catalog_Model_Product_Flat_Flag
- Mage_Catalog_Model_Product_Option
- Mage_Catalog_Model_Product_Option_Value
- Mage_Catalog_Model_Product_Type_Configurable_Attribute
- Mage_CatalogRule_Model_Flag
- Mage_Checkout_Model_Agreement
- Mage_Cms_Model_Block
- Mage_Core_Model_Design
- Mage_Core_Model_Flag
- Mage_Core_Model_File_Storage_Flag
- Mage_Core_Model_Email_Queue
- Mage_Core_Model_Url_Rewrite
- Mage_Core_Model_Variable
- Mage_Customer_Model_Flowpassword
- Mage_Dataflow_Model_Profile
- Mage_Dataflow_Model_Profile_History
- Mage_Directory_Model_Country
- Mage_Directory_Model_Region
- Mage_Downloadable_Model_Link
- Mage_Downloadable_Model_Link_Purchased
- Mage_Downloadable_Model_Link_Purchased_Item
- Mage_Eav_Model_Entity_Attribute_Group
- Mage_Eav_Model_Entity_Store
- Mage_GiftMessage_Model_Message
- Mage_Index_Model_Event
- Mage_Index_Model_Process
- Mage_Log_Model_Customer
- Mage_Log_Model_Visitor
- Mage_Oauth_Model_Consumer
- Mage_Poll_Model_Poll
- Mage_Poll_Model_Poll_Answer
- Mage_Poll_Model_Poll_Vote
- Mage_Reports_Model_Event
- Mage_Reports_Model_Flag
- Mage_Reports_Model_Product_Index_Compared
- Mage_Reports_Model_Product_Index_Viewed
- Mage_Review_Model_Review_Summary
- Mage_Sales_Model_Order_Creditmemo_Comment
- Mage_Sales_Model_Order_Invoice_Comment
- Mage_Sales_Model_Order_Shipment_Comment
- Mage_Sales_Model_Order_Status
- Mage_Sales_Model_Quote_Address_Rate
- Mage_Sales_Model_Quote_Item_Option
- Mage_SalesRule_Model_Coupon
- Mage_SalesRule_Model_Rule_Customer
- Mage_Sitemap_Model_Sitemap
- Mage_Tag_Model_Tag_Relation
- Mage_Tax_Model_Class
- Mage_Tax_Model_Calculation
- Mage_Tax_Model_Calculation_Rate
- Mage_Tax_Model_Calculation_Rule
- Mage_Wishlist_Model_Item_Option
- Mage_Wishlist_Model_Wishlist

**Collections**
- Mage_Catalog_Model_Resource_Collection_Abstract
- Mage_Customer_Model_Resource_Address_Collection
- Mage_Customer_Model_Resource_Customer_Collection
- Mage_Customer_Model_Resource_Wishlist_Collection
- Mage_Eav_Model_Entity_Collection
- Mage_Sales_Model_Entity_Order_Collection
- Mage_Sales_Model_Entity_Order_Address_Collection
- Mage_Sales_Model_Entity_Order_Creditmemo_Collection
- Mage_Sales_Model_Entity_Order_Creditmemo_Comment_Collection
- Mage_Sales_Model_Entity_Order_Creditmemo_Item_Collection
- Mage_Sales_Model_Entity_Order_Invoice_Collection
- Mage_Sales_Model_Entity_Order_Invoice_Comment_Collection
- Mage_Sales_Model_Entity_Order_Invoice_Item_Collection
- Mage_Sales_Model_Entity_Order_Item_Collection
- Mage_Sales_Model_Entity_Order_Payment_Collection
- Mage_Sales_Model_Entity_Order_Shipment_Collection
- Mage_Sales_Model_Entity_Order_Shipment_Comment_Collection
- Mage_Sales_Model_Entity_Order_Shipment_Item_Collection
- Mage_Sales_Model_Entity_Order_Shipment_Track_Collection
- Mage_Sales_Model_Entity_Order_Status_History_Collection
- Mage_Sales_Model_Entity_Quote_Collection
- Mage_Sales_Model_Entity_Quote_Address_Collection
- Mage_Sales_Model_Entity_Quote_Address_Item_Collection
- Mage_Sales_Model_Entity_Quote_Address_Rate_Collection
- Mage_Sales_Model_Entity_Quote_Item_Collection
- Mage_Sales_Model_Entity_Quote_Payment_Collection

In, but optional:
- event prefixex for adminblocks
- event prefixex for load collections

To add more you can use https://github.com/sreichel/sr-debug  to log models w/o prefix.