### PR TITLE
Add SUPEE-4814

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Subselect.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Subselect.php
@@ -114,7 +114,7 @@ class Mage_SalesRule_Model_Rule_Condition_Product_Subselect
         $attr = $this->getAttribute();
         $total = 0;
         foreach ($object->getQuote()->getAllVisibleItems() as $item) {
-            if (parent::validate($item)) {
+            if (Mage_Rule_Model_Condition_Combine::validate($item)) {
                 $total += $item->getData($attr);
             }
         }


### PR DESCRIPTION
This fixes an infinite recursion loop when validating a "Products subselect" cart price rule.
Apparently the patch only got released for EE, but CE suffers from the same problem. :/

To reproduce the issue create a new cart price rule and add a "Products subselect" condition with a constraint on manufacturer or any other product attribute. Then try to apply the coupon in the frontend.

source: https://gist.github.com/piotrekkaminski/54529dadb0bc01a62a2d
