### PR TITLE
Suggesting to change default font to HELVETICA in pdf & reduce PDF fi…

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
@@ -790,8 +790,9 @@ abstract class Mage_Sales_Model_Order_Pdf_Abstract extends Varien_Object
      */
     protected function _setFontRegular($object, $size = 7)
     {
-        $font = Zend_Pdf_Font::fontWithPath(Mage::getBaseDir() . '/lib/LinLibertineFont/LinLibertine_Re-4.4.1.ttf');
-        $object->setFont($font, $size);
+        //$font = Zend_Pdf_Font::fontWithPath(Mage::getBaseDir() . '/lib/LinLibertineFont/LinLibertine_Re-4.4.1.ttf');
+        $font = Zend_Pdf_Font::fontWithName(Zend_Pdf_Font::FONT_HELVETICA);
+		$object->setFont($font, $size);
         return $font;
     }
 
@@ -804,7 +805,8 @@ abstract class Mage_Sales_Model_Order_Pdf_Abstract extends Varien_Object
      */
     protected function _setFontBold($object, $size = 7)
     {
-        $font = Zend_Pdf_Font::fontWithPath(Mage::getBaseDir() . '/lib/LinLibertineFont/LinLibertine_Bd-2.8.1.ttf');
+        // $font = Zend_Pdf_Font::fontWithPath(Mage::getBaseDir() . '/lib/LinLibertineFont/LinLibertine_Bd-2.8.1.ttf');
+		$font = Zend_Pdf_Font::fontWithName(Zend_Pdf_Font::FONT_HELVETICA_BOLD);
         $object->setFont($font, $size);
         return $font;
     }
@@ -818,8 +820,9 @@ abstract class Mage_Sales_Model_Order_Pdf_Abstract extends Varien_Object
      */
     protected function _setFontItalic($object, $size = 7)
     {
-        $font = Zend_Pdf_Font::fontWithPath(Mage::getBaseDir() . '/lib/LinLibertineFont/LinLibertine_It-2.8.2.ttf');
-        $object->setFont($font, $size);
+        //$font = Zend_Pdf_Font::fontWithPath(Mage::getBaseDir() . '/lib/LinLibertineFont/LinLibertine_It-2.8.2.ttf');
+        $font = Zend_Pdf_Font::fontWithName(Zend_Pdf_Font::FONT_HELVETICA_OBLIQUE);
+		$object->setFont($font, $size);
         return $font;
     }
 


### PR DESCRIPTION
…lesize

Suggesting to change default font to HELVETICA in pdf & reduce PDF filesize

We have seen LinLibertine Pdf files ranging from 1.5 = 2 MB files .... per file whereas the same PDF in Helvetica is 40Kb ... 

This is not the end solution as I can imagine "just changing" the font has too much impact - maybe ... 

A suggestion would be to add a FONT selector in the backend? Maybe populated from Font.php? https://github.com/colinmollenhour/magento-zend/blob/master/Pdf/Font.php

This is a recording of the fix we execute every time after an upgrade

Feedback welcome on how to tackle something like this; without breaking BC