### PR TITLE
creditmemo bundle inventory calculation error

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -778,7 +778,7 @@ class Mage_CatalogInventory_Model_Observer
                 $parentOrderId = $item->getOrderItem()->getParentItemId();
                 /* @var $parentItem Mage_Sales_Model_Order_Creditmemo_Item */
                 $parentItem = $parentOrderId ? $creditmemo->getItemByOrderId($parentOrderId) : false;
-                $qty = $parentItem ? ($parentItem->getQty() * $item->getQty()) : $item->getQty();
+                $qty = $item->getQty();
                 if (isset($items[$item->getProductId()])) {
                     $items[$item->getProductId()]['qty'] += $qty;
                 } else {


### PR DESCRIPTION
This bug was present beginning in 1.7.0.2 and is still present in 1.9.3.3. This patch has been running in production for about 4 years without any issues.

Code was mis-calcuating the qty of simple items to put back in stock for bundle (and configurable) products.

For example if you had a Bundle X that contained 10 Widgets and the customer ordered 10 of the Bundle X (thus they ordered 100 Widgets), the code previously would multiply twice when issuing a credit memo: When calling $item->getQty() on the Widget product Magento would return 100, since that's how many exist in the order. It would then multiply that by the number of Bundle X in the order (10), and would return 1000 items to the inventory for the Widget, instead of just 100.