### PR TITLE
[FIX] set email as sent only if customer notified

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
@@ -791,8 +791,11 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
             )
         );
         $mailer->send();
-        $this->setEmailSent(true);
-        $this->_getResource()->saveAttribute($this, 'email_sent');
+
+        if ($notifyCustomer) {
+            $this->setEmailSent(true);
+            $this->_getResource()->saveAttribute($this, 'email_sent');
+        }
 
         return $this;
     }

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -844,8 +844,11 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
             )
         );
         $mailer->send();
-        $this->setEmailSent(true);
-        $this->_getResource()->saveAttribute($this, 'email_sent');
+
+        if ($notifyCustomer) {
+            $this->setEmailSent(true);
+            $this->_getResource()->saveAttribute($this, 'email_sent');
+        }
 
         return $this;
     }


### PR DESCRIPTION
In all other places where a "email" flag is used, email_sent is only set if the flag is true.

PS:
In my opinion, the $notifiyCustomer condition is a better solution than assigning $notifiyCustomer directly to "email_sent". One can send invoices/creditmemos multiple times. Just a second run could make it look like an email was never sent (even though it was sent in the first run).