### PR TITLE
fix ssl version

### DIFF
--- a/downloader/lib/Mage/HTTP/Client/Curl.php
+++ b/downloader/lib/Mage/HTTP/Client/Curl.php
@@ -374,13 +374,7 @@ implements Mage_HTTP_IClient
         $this->_ch = curl_init();
         $this->curlOption(CURLOPT_URL, $uriModified);
         $this->curlOption(CURLOPT_SSL_VERIFYPEER, true);
-        /**
-         * Use value from CURL_SSLVERSION_TLSv1 (available since PHP 5.5)
-         *
-         * @link http://php.net/manual/ru/function.curl-setopt.php
-         */
-
-        $this->curlOption(CURLOPT_SSLVERSION, 1);
+       
         $this->getCurlMethodSettings($method, $params, $isAuthorizationRequired);
 
         if(count($this->_headers)) {


### PR DESCRIPTION
./mage list-upgrades
Error:
list-upgrades: TCP connection reset by peer

remove specific ssl version, first because version specified TLS v1 is not supported by connect20.magentocommerce.com
https://www.ssllabs.com/ssltest/analyze.html?d=connect20.magentocommerce.com&s=52.3.167.65

and second because server can choise right version byself
tested on centos
PHP 5.5.38 (cli) (built: Feb 18 2017 08:04:56)
curl 7.54.1 (x86_64-redhat-linux-gnu) libcurl/7.54.1 NSS/3.28.4 zlib/1.2.7 libpsl/0.7.0 (+libicu/50.1.2) libssh2/1.8.0 nghttp2/1.21.1