### PR TITLE
shipping_as_billing is 0

### DIFF
--- a/js/mage/adminhtml/sales.js
+++ b/js/mage/adminhtml/sales.js
@@ -350,6 +350,7 @@ AdminOrder.prototype = {
     setShippingMethod : function(method){
         var data = {};
         data['order[shipping_method]'] = method;
+        data['shipping_as_billing'] = this.shippingAsBilling ? 1 : 0;
         this.loadArea(['shipping_method', 'totals', 'billing_method'], true, data);
     },
 


### PR DESCRIPTION
issue: https://github.com/OpenMage/magento-lts/issues/305

'data' is sends via ajax to `Mage_Adminhtml_Sales_Order_CreateController`. In  `_processActionData` method there is a check for `$syncFlag = $this->getRequest()->getPost('shipping_as_billing');` and in this case `(int)$syncFlag == 0`. So we need to send data['shipping_as_billing'] via post request to save the right information