### PR TITLE
Adds product before add to cart event

### DIFF
--- a/app/code/core/Mage/Checkout/Model/Cart.php
+++ b/app/code/core/Mage/Checkout/Model/Cart.php
@@ -244,6 +244,8 @@ class Mage_Checkout_Model_Cart extends Varien_Object implements Mage_Checkout_Mo
         $product = $this->_getProduct($productInfo);
         $request = $this->_getProductRequest($requestInfo);
 
+        Mage::dispatchEvent('checkout_cart_product_add_before', array('request' => $request', product' => $product));
+
         /** @var Mage_Catalog_Helper_Product $helper */
         $helper  = Mage::helper('catalog/product');
 


### PR DESCRIPTION
Add an event before product is added to cart. Guess this will help when trying to prevent adding item to cart or want to manipulate product data ...

At the moment you just can use `checkout_cart_product_add_after` and do something like this ...

    $quote      = $observer->getQuote();
    $product    = $observer->getProduct();
    
    if ($something) {
        foreach ($quote->getAllItems() as $item) {
            if ($something == $item->getProduct()->getData('abc')) {
                $quote->removeItem($quote->getId());
                Mage::throwException(
                    Mage::helper('sales')->__('You cannot add that product to your cart.')
                );
            }
        }
    }