### PR TITLE
Fixes wrong usage of getSelect()->order() method

### DIFF
--- a/app/code/core/Mage/Cron/Model/Resource/Schedule/Collection.php
+++ b/app/code/core/Mage/Cron/Model/Resource/Schedule/Collection.php
@@ -51,7 +51,7 @@ class Mage_Cron_Model_Resource_Schedule_Collection extends Mage_Core_Model_Resou
      */
     public function orderByScheduledAt($dir = self::SORT_ORDER_ASC)
     {
-        $this->getSelect()->order('scheduled_at', $dir);
+        $this->getSelect()->order('scheduled_at ' . $dir);
         return $this;
     }
 }

--- a/app/code/core/Mage/Reports/Model/Resource/Order/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Order/Collection.php
@@ -174,7 +174,7 @@ class Mage_Reports_Model_Resource_Order_Collection extends Mage_Sales_Model_Reso
                 Mage_Sales_Model_Order::STATE_PENDING_PAYMENT,
                 Mage_Sales_Model_Order::STATE_NEW)
             )
-            ->order('range', Zend_Db_Select::SQL_ASC)
+            ->order('range ' . Zend_Db_Select::SQL_ASC)
             ->group($tzRangeOffsetExpression);
 
         $this->addFieldToFilter('created_at', $dateRange);

--- a/app/code/core/Mage/XmlConnect/Model/Resource/Images.php
+++ b/app/code/core/Mage/XmlConnect/Model/Resource/Images.php
@@ -54,7 +54,7 @@ class Mage_XmlConnect_Model_Resource_Images extends Mage_Core_Model_Resource_Db_
 
         $select = $this->_getWriteAdapter()->select()->from($this->getMainTable(), array('image_id'))
             ->where('application_id=:application_id AND image_type=:image_type')
-            ->order('order', Varien_Data_Collection::SORT_ORDER_ASC);
+            ->order('order ' . Varien_Data_Collection::SORT_ORDER_ASC);
 
         $result = $this->_getWriteAdapter()->fetchCol($select, $bind);
         $imageModel = Mage::getModel('xmlconnect/images');


### PR DESCRIPTION
Fixed `order()` methods where direction is used as (non-existing) second parameter.

https://github.com/OpenMage/magento-lts/blob/1.9.3.x/lib/Zend/Db/Select.php#L577-L587

    /**
     * Adds a row order to the query.
     *
     * @param mixed $spec The column(s) and direction to order by.
     * @return Zend_Db_Select This Zend_Db_Select object.
     */
    public function order($spec)
    {
        if (!is_array($spec)) {
            $spec = array($spec);
        }

Used `$ grep -rn "order('[a-z_]*'," ./app/code/core/Mage/` ... so that should be all.