### PR TITLE
Magento order status updated to “Processing” even when PayPal payment fails

### DIFF
--- a/app/code/core/Mage/Paypal/Model/Ipn.php
+++ b/app/code/core/Mage/Paypal/Model/Ipn.php
@@ -532,6 +532,10 @@ class Mage_Paypal_Model_Ipn
     protected function _registerPaymentFailure()
     {
         $this->_importPaymentInformation();
+        // paypal bug, must remove invoice before order cancel 
+        foreach ($this->_order->getInvoiceCollection() as $invoice){
+            $invoice->cancel()->save();
+        }
         $this->_order
             ->registerCancellation($this->_createIpnComment(''), false)
             ->save();


### PR DESCRIPTION
Must remove invoices before cancel, otherwise order cancel will fail and status will go to go to processing