### PR TITLE
Fix date selection when current date is disabled

### DIFF
--- a/js/calendar/calendar.js
+++ b/js/calendar/calendar.js
@@ -1246,6 +1246,8 @@ Calendar.prototype._init = function (firstDayOfWeek, date) {
                 }
                 if (weekend.indexOf(wday.toString()) != -1)
                     cell.className += cell.otherMonth ? " oweekend" : " weekend";
+            } else {
+                this.currentDateEl = cell;
             }
         }
         if (!(hasdays || this.showsOtherMonths))


### PR DESCRIPTION
When working with `calendar.js` (utilized in admin grid filtering and other date selector functions) in a recent project, I came across a bug that this PR resolves.

Using the `disableFunc` property within the `Calendar.setup` method, if the current date is disabled selection of other dates will not work properly. In full disclosure, I discovered this fix via [this Stackoverflow answer](https://stackoverflow.com/a/28073450/1412625), but it works quite well and has no sides effects that I've noticed during testing.