### PR TITLE
Add username to order comments

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -1083,6 +1083,12 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
         } else {
             $this->setStatus($status);
         }
+        
+         //get username and append
+        $session = Mage::getSingleton('admin/session');
+        $username = $session->getUser()->getUsername();
+        $comment .= ($username) ? " ({$username})" : ' (system)';       
+        
         $history = Mage::getModel('sales/order_status_history')
             ->setStatus($status)
             ->setComment($comment)


### PR DESCRIPTION
Add username to order comments (we we know who actually did it ;) - Lets make it a pull to discuss because there are some caveats ... 

Improvements
- Can add system setting to turn on / off 

Problems
- When we check "Visible on frontend" then the customer could potentially see the username / dont know how to circumvent this
- this message can be shown in transactional emails
- Solution would be to maybe only capture backend history comments by real users (not system/default processes) 

Cleaner solution is
- https://stackoverflow.com/questions/6219620/add-username-to-order-comment-history