### PR TITLE
cloudflare reset current path in file manager

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Cms/Wysiwyg/ImagesController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/Wysiwyg/ImagesController.php
@@ -218,9 +218,11 @@ class Mage_Adminhtml_Cms_Wysiwyg_ImagesController extends Mage_Adminhtml_Control
      */
     protected function _saveSessionCurrentPath()
     {
-        $this->getStorage()
-            ->getSession()
-            ->setCurrentPath(Mage::helper('cms/wysiwyg_images')->getCurrentPath());
+        if ($this->getRequest()->isPost()) {
+            $this->getStorage()
+                ->getSession()
+                ->setCurrentPath(Mage::helper('cms/wysiwyg_images')->getCurrentPath());
+        }
         return $this;
     }
 


### PR DESCRIPTION
check also if is post request on set current path because i've got an issue with cloudflare that make a PURGE request like this:
[REQUEST_METHOD] => PURGE
[CONTENT_TYPE] => application/x-www-form-urlencoded; charset=UTF-8
[CONTENT_LENGTH] =>
[SCRIPT_NAME] => /index.php
[REQUEST_URI] => /index.php/gestione/cms_wysiwyg_images/contents/type/image/key/e0b288aa6c56c42688c45a7f0ef4340e/?isAjax=true
without POST parameters and reset current path on file manager to the root / and with the result of we are unable to upload or delete a file.

this resolve issues with cloudflare at application level but you can fix problem at server level by limit methods on nginix to request uri
contains *cms_wysiwyg_images*
for examples (not tested):

location ~ cms_wysiwyg_images {
    limit_except POST {
        deny all;
    }
}