### PR TITLE
Added functionality for $after paramenter in addCrumbs() method

### DIFF
--- a/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
+++ b/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
@@ -67,7 +67,12 @@ class Mage_Page_Block_Html_Breadcrumbs extends Mage_Core_Block_Template
     {
         $this->_prepareArray($crumbInfo, array('label', 'title', 'link', 'first', 'last', 'readonly'));
         if ((!isset($this->_crumbs[$crumbName])) || (!$this->_crumbs[$crumbName]['readonly'])) {
-           $this->_crumbs[$crumbName] = $crumbInfo;
+            if ($after && isset($this->_crumbs[$after])) {
+                $offset = array_search($after, array_keys($this->_crumbs)) + 1;
+                $this->_crumbs = array_slice($this->_crumbs, 0, $offset, true) + array($crumbName => $crumbInfo) + array_slice($this->_crumbs, $offset, null, true);
+            } else {
+                $this->_crumbs[$crumbName] = $crumbInfo;
+            }
         }
         return $this;
     }

--- a/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
+++ b/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
@@ -77,6 +77,30 @@ class Mage_Page_Block_Html_Breadcrumbs extends Mage_Core_Block_Template
         return $this;
     }
 
+    public function addCrumbBefore($crumbName, $crumbInfo, $before = false)
+    {
+        if ($before && isset($this->_crumbs[$before])) {
+            $keys = array_keys($this->_crumbs);
+            $offset = array_search($before, $keys);
+            # add before first
+            if (!$offset) {
+                $this->_prepareArray($crumbInfo, array('label', 'title', 'link', 'first', 'last', 'readonly'));
+                $this->_crumbs = array($crumbName => $crumbInfo) + $this->_crumbs;
+            } else {
+                $this->addCrumb($crumbName, $crumbInfo, $keys[$offset-1]);
+            }
+        } else {
+            $this->addCrumb($crumbName, $crumbInfo);
+        }
+    }
+
+    public function removeCrumb($crumbName)
+    {
+        if (isset($this->_crumbs[$crumbName])) {
+            unset($this->_crumbs[$crumbName]);
+        }
+    }
+
     /**
      * Get cache key informative items
      *


### PR DESCRIPTION
In `Mage_Page_Block_Html_Breadcrumbs::addCrumb()` third parameter `$after` is ignored/has no affect ...

This should work correctly now ...

     $block->addCrumb('my_crumb', array(
         'label'    => label,
         'title'    => title,
     ), 'home');
