### PR TITLE
Fixed removeAccents method for german umlauts

### DIFF
--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -317,9 +317,9 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
 
             if ($german) {
                 // umlauts
-                $subst = array_merge($subst, array(
+                $subst = array(
                     196=>'Ae', 228=>'ae', 214=>'Oe', 246=>'oe', 220=>'Ue', 252=>'ue'
-                ));
+                ) + $subst;
             }
 
             $replacements[$german] = array();


### PR DESCRIPTION
If setting 2nd parameter to yes in `removeAccents($string, $german=false)` german umlauts should be translated from `ä` to 'ae' ...

    $str = 'Ae-Ä Oe-Ö Ue-Ü ae-ä oe-ö ue-ü';
    echo Mage::helper('core')->removeAccents($str, true);

    
**Expected:**
`Ae-Ae Oe-Oe Ue-Ue ae-ae oe-oe ue-ue`

**Current:**
`DnnÄaSnnÖaZnnÜalnnäaznnöassnnü` 