### PR TITLE
Sort categories returned by  "getChildren" by position

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category.php
@@ -727,8 +727,8 @@ class Mage_Catalog_Model_Resource_Category extends Mage_Catalog_Model_Resource_A
                 'c.attribute_id = :attribute_id AND c.store_id = :store_id AND c.entity_id = m.entity_id',
                 array()
             )
-            ->where($checkSql . ' = :scope');
-        $select->order("m.position ASC");
+            ->where($checkSql . ' = :scope')
+            ->order("m.position ASC");
 
         return $adapter->fetchCol($select, $bind);
     }

--- a/app/code/core/Mage/Catalog/Model/Resource/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category.php
@@ -728,6 +728,7 @@ class Mage_Catalog_Model_Resource_Category extends Mage_Catalog_Model_Resource_A
                 array()
             )
             ->where($checkSql . ' = :scope');
+        $select->order("m.position ASC");
 
         return $adapter->fetchCol($select, $bind);
     }

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
@@ -1311,8 +1311,9 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
      */
     public function getChildren($category, $recursive = true, $isActive = true)
     {
+        $maintable = $this->getMainStoreTable($category->getStoreId());
         $select = $this->_getReadAdapter()->select()
-            ->from($this->getMainStoreTable($category->getStoreId()), 'entity_id')
+            ->from($maintable, 'entity_id')
             ->where('path LIKE ?', "{$category->getPath()}/%");
         if (!$recursive) {
             $select->where('level <= ?', $category->getLevel() + 1);
@@ -1320,7 +1321,6 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
         if ($isActive) {
             $select->where('is_active = ?', '1');
         }
-        $maintable = $this->getMainStoreTable($category->getStoreId());
         $select->order($maintable.".position ASC");
         $_categories = $this->_getReadAdapter()->fetchAll($select);
         $categoriesIds = array();

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
@@ -1314,14 +1314,15 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
         $maintable = $this->getMainStoreTable($category->getStoreId());
         $select = $this->_getReadAdapter()->select()
             ->from($maintable, 'entity_id')
-            ->where('path LIKE ?', "{$category->getPath()}/%");
+            ->where('path LIKE ?', "{$category->getPath()}/%")
+            ->order($maintable.".position ASC");
         if (!$recursive) {
             $select->where('level <= ?', $category->getLevel() + 1);
         }
         if ($isActive) {
             $select->where('is_active = ?', '1');
         }
-        $select->order($maintable.".position ASC");
+
         $_categories = $this->_getReadAdapter()->fetchAll($select);
         $categoriesIds = array();
         foreach ($_categories as $_category) {

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
@@ -1320,6 +1320,8 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
         if ($isActive) {
             $select->where('is_active = ?', '1');
         }
+        $maintable = $this->getMainStoreTable($category->getStoreId());
+        $select->order($maintable.".position ASC");
         $_categories = $this->_getReadAdapter()->fetchAll($select);
         $categoriesIds = array();
         foreach ($_categories as $_category) {


### PR DESCRIPTION
Change "getChildren" category method to return categories sorted by position.
Fixes issue https://github.com/OpenMage/magento-lts/issues/350