### PR TITLE
Change minimal passwd req from >5 to 7> (8 min chars)

### DIFF
--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Password.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Password.php
@@ -43,8 +43,8 @@ class Mage_Customer_Model_Customer_Attribute_Backend_Password extends Mage_Eav_M
         $password = trim($object->getPassword());
         $len = Mage::helper('core/string')->strlen($password);
         if ($len) {
-             if ($len < 6) {
-                Mage::throwException(Mage::helper('customer')->__('The password must have at least 6 characters. Leading or trailing spaces will be ignored.'));
+             if ($len < 8) {
+                Mage::throwException(Mage::helper('customer')->__('The password must have at least 8 characters. Leading or trailing spaces will be ignored.'));
             }
             $object->setPasswordHash($object->hashPassword($password));
         }


### PR DESCRIPTION
Change minimal passwd req from >5 to 7> (8 min chars)

not saying 8 is ideal but most systems default to 8

(for example: we interface with external system where users cannnot be created because their passwd is too short)