### PR TITLE
Fix rounding bug? Supposed to be solved in 1.9.3.1

### DIFF
--- a/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
+++ b/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
@@ -459,7 +459,7 @@ class Mage_CatalogRule_Model_Action_Index_Refresh
                     )
                 )
             ),
-            '@price := @price'
+            '@price'
         );
     }
 


### PR DESCRIPTION
https://magento.stackexchange.com/questions/108570/1-9-2-catalogue-price-rules-rounding-when-more-then-one-rule-applied-with-stop

Might be that this bug was fixed elsewhere - or not? 

please cancel the pull if wrong (we are seeing this rounding bug in our stores now and on 1.9.3.x)