### PR TITLE
Make Mage registry related methods consistent

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -473,7 +473,7 @@ final class Mage
     public static function getSingleton($modelClass='', array $arguments=array())
     {
         $registryKey = '_singleton/'.$modelClass;
-        if (!self::registry($registryKey)) {
+        if (!isset(self::$_registry[$registryKey]) {
             self::register($registryKey, self::getModel($modelClass, $arguments));
         }
         return self::registry($registryKey);
@@ -515,7 +515,7 @@ final class Mage
     public static function getResourceSingleton($modelClass = '', array $arguments = array())
     {
         $registryKey = '_resource_singleton/'.$modelClass;
-        if (!self::registry($registryKey)) {
+        if (!isset(self::$_registry[$registryKey]) {
             self::register($registryKey, self::getResourceModel($modelClass, $arguments));
         }
         return self::registry($registryKey);
@@ -542,7 +542,7 @@ final class Mage
     public static function helper($name)
     {
         $registryKey = '_helper/' . $name;
-        if (!self::registry($registryKey)) {
+        if (!isset(self::$_registry[$registryKey]) {
             $helperClass = self::getConfig()->getHelperClassName($name);
             self::register($registryKey, new $helperClass);
         }
@@ -558,7 +558,7 @@ final class Mage
     public static function getResourceHelper($moduleName)
     {
         $registryKey = '_resource_helper/' . $moduleName;
-        if (!self::registry($registryKey)) {
+        if (!isset(self::$_registry[$registryKey]) {
             $helperClass = self::getConfig()->getResourceHelper($moduleName);
             self::register($registryKey, $helperClass);
         }

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -473,7 +473,7 @@ final class Mage
     public static function getSingleton($modelClass='', array $arguments=array())
     {
         $registryKey = '_singleton/'.$modelClass;
-        if (!isset(self::$_registry[$registryKey]) {
+        if (!isset(self::$_registry[$registryKey])) {
             self::register($registryKey, self::getModel($modelClass, $arguments));
         }
         return self::registry($registryKey);
@@ -515,7 +515,7 @@ final class Mage
     public static function getResourceSingleton($modelClass = '', array $arguments = array())
     {
         $registryKey = '_resource_singleton/'.$modelClass;
-        if (!isset(self::$_registry[$registryKey]) {
+        if (!isset(self::$_registry[$registryKey])) {
             self::register($registryKey, self::getResourceModel($modelClass, $arguments));
         }
         return self::registry($registryKey);
@@ -542,7 +542,7 @@ final class Mage
     public static function helper($name)
     {
         $registryKey = '_helper/' . $name;
-        if (!isset(self::$_registry[$registryKey]) {
+        if (!isset(self::$_registry[$registryKey])) {
             $helperClass = self::getConfig()->getHelperClassName($name);
             self::register($registryKey, new $helperClass);
         }
@@ -558,7 +558,7 @@ final class Mage
     public static function getResourceHelper($moduleName)
     {
         $registryKey = '_resource_helper/' . $moduleName;
-        if (!isset(self::$_registry[$registryKey]) {
+        if (!isset(self::$_registry[$registryKey])) {
             $helperClass = self::getConfig()->getResourceHelper($moduleName);
             self::register($registryKey, $helperClass);
         }


### PR DESCRIPTION
The current behavior of the registry related methods (```getSingleton```, ```getResourceSingleton```, ```getResourceHelper```, and ```helper```) is inconsistent. The check done in those methods differs from the check done in ```register``` and ```unregister```. This PR simply unifies the checking to always use ```isset``` on the registry array. This was chosen since the default return when ```registry``` is called and the key does not exist is ```null```. Every other value should technically be storable in the registry, including ```false``` and ```0```.

See #367 