### PR TITLE
Addresses Incorrect stock versus sales. #364

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -744,7 +744,7 @@ class Mage_CatalogInventory_Model_Observer
         // Reindex previously remembered items
         $productIds = array();
         foreach ($this->_itemsForReindex as $item) {
-            $item->save();
+            $item->updateStockStatus();
             $productIds[] = $item->getProductId();
         }
         Mage::getResourceSingleton('catalog/product_indexer_price')->reindexProductIds($productIds);

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Item.php
@@ -126,4 +126,22 @@ class Mage_CatalogInventory_Model_Resource_Stock_Item extends Mage_Core_Model_Re
         }
         return $data;
     }
+
+    /**
+     * Update specific fields of a single row.
+     *
+     * @param int $itemId Item id of the row being updated
+     * @param mixed[] $data Array structure of fields being updated
+     *
+     * @return $this
+     */
+    public function updateRecord($itemId, $data)
+    {
+        $adapter = $this->_getWriteAdapter();
+
+        $where = array('item_id = ?' => $itemId);
+
+        $adapter->update($this->getMainTable(), $data, $where);
+        return $this;
+    }
 }

--- a/app/code/core/Mage/CatalogInventory/Model/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock.php
@@ -139,7 +139,7 @@ class Mage_CatalogInventory_Model_Stock extends Mage_Core_Model_Abstract
             $stockInfo = $this->_getResource()->getProductsStock($this, array_keys($qtys), true);
             $fullSaveItems = array();
             foreach ($stockInfo as $itemInfo) {
-                $item->setData($itemInfo);
+                $item->setData($itemInfo)->setOrigData();
                 if (!$item->checkQty($qtys[$item->getProductId()])) {
                     Mage::throwException(Mage::helper('cataloginventory')->__('Not all products are available in the requested quantity'));
                 }

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
@@ -392,7 +392,7 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
         return $this->_qtyIncrements;
     }
 
-     /**
+    /**
      * Retrieve Default Quantity Increments data wrapper
      *
      * @deprecated since 1.7.0.0
@@ -556,8 +556,8 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
             $qty = intval($qty);
 
             /**
-              * Adding stock data to quote item
-              */
+             * Adding stock data to quote item
+             */
             $result->setItemQty($qty);
 
             if (!is_numeric($qty)) {
@@ -762,6 +762,41 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
             }
         } else {
             $this->setQty(0);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Update Stock Status and low stock date as if $this->save() has been
+     * called, keeping the update query very light, by only touching those
+     * fields of interest
+     *
+     * @return $this
+     */
+    public function updateStockStatus()
+    {
+        $this->setOrigData()->setDataChanges(false);
+        $this->_beforeSave();
+
+        if ($this->hasDataChanges()) {
+
+            $updatedFields = array(
+                'is_in_stock' => $this->getIsInStock(),
+                'stock_status_changed_auto' => $this->getStockStatusChangedAutomatically(),
+                'low_stock_date' => $this->getLowStockDate()
+            );
+
+            $this->getResource()
+                ->updateRecord($this->getId(), $updatedFields);
+
+            Mage::dispatchEvent(
+                'cataloginventory_stock_item_save_after',
+                array(
+                    'item' => $this,
+                    'data_object' => $this,
+                )
+            );
         }
 
         return $this;


### PR DESCRIPTION
Looking to address this issue I have implemented two solutions. This solution and #372 where a lot of work from taken from #189. Each solution has there merits. I prefer this solution with one of the biggest reasons being it's simplicity and staying closer to what was originally being done in Magento. 

The second solution moves the update logic to a Sql query, the benefit is that it all stock item records are updated with a single query, the down side is that that event that gets fired `cataloginventory_stock_item_save_after` may have different information to that that is in the database.