### PR TITLE
Addresses Incorrect stock versus sales. #364

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock.php
@@ -249,8 +249,9 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
     /**
      * Set items out of stock basing on their quantities and config settings
      *
+     * @param array|null $productIds
      */
-    public function updateSetOutOfStock()
+    public function updateSetOutOfStock($productIds = null)
     {
         $this->_initConfig();
         $adapter = $this->_getWriteAdapter();
@@ -259,9 +260,15 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
             'stock_status_changed_auto'    => 1
         );
 
-        $select = $adapter->select()
-            ->from($this->getTable('catalog/product'), 'entity_id')
-            ->where('type_id IN(?)', $this->_configTypeIds);
+        if (!is_null($productIds) && is_array($productIds) && !empty($productIds)) {
+            $strProductIds = implode(', ', array_map('intval', $productIds));
+        } else {
+            $select = $adapter->select()
+                ->from($this->getTable('catalog/product'), 'entity_id')
+                ->where('type_id IN(?)', $this->_configTypeIds);
+
+            $strProductIds = $select->assemble();
+        }
 
         $where = sprintf('stock_id = %1$d'
             . ' AND is_in_stock = 1'
@@ -274,7 +281,7 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
             Mage_CatalogInventory_Model_Stock::BACKORDERS_NO,
             $this->_isConfigBackorders,
             $this->_configMinQty,
-            $select->assemble()
+            $strProductIds
         );
 
         $adapter->update($this->getTable('cataloginventory/stock_item'), $values, $where);
@@ -283,8 +290,9 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
     /**
      * Set items in stock basing on their quantities and config settings
      *
+     * @param array|null $productIds
      */
-    public function updateSetInStock()
+    public function updateSetInStock($productIds = null)
     {
         $this->_initConfig();
         $adapter = $this->_getWriteAdapter();
@@ -292,9 +300,15 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
             'is_in_stock'   => 1,
         );
 
-        $select = $adapter->select()
-            ->from($this->getTable('catalog/product'), 'entity_id')
-            ->where('type_id IN(?)', $this->_configTypeIds);
+        if (!is_null($productIds) && is_array($productIds) && !empty($productIds)) {
+            $strProductIds = implode(', ', array_map('intval', $productIds));
+        } else {
+            $select = $adapter->select()
+                ->from($this->getTable('catalog/product'), 'entity_id')
+                ->where('type_id IN(?)', $this->_configTypeIds);
+
+            $strProductIds = $select->assemble();
+        }
 
         $where = sprintf('stock_id = %1$d'
             . ' AND is_in_stock = 0'
@@ -305,7 +319,7 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
             $this->_stock->getId(),
             $this->_isConfigManageStock,
             $this->_configMinQty,
-            $select->assemble()
+            $strProductIds
         );
 
         $adapter->update($this->getTable('cataloginventory/stock_item'), $values, $where);
@@ -314,8 +328,9 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
     /**
      * Update items low stock date basing on their quantities and config settings
      *
+     * @param array|null $productIds
      */
-    public function updateLowStockDate()
+    public function updateLowStockDate($productIds = null)
     {
         $this->_initConfig();
 
@@ -329,16 +344,22 @@ class Mage_CatalogInventory_Model_Resource_Stock extends Mage_Core_Model_Resourc
             'low_stock_date' => new Zend_Db_Expr($conditionalDate),
         );
 
-        $select = $adapter->select()
-            ->from($this->getTable('catalog/product'), 'entity_id')
-            ->where('type_id IN(?)', $this->_configTypeIds);
+        if (!is_null($productIds) && is_array($productIds) && !empty($productIds)) {
+            $strProductIds = implode(', ', array_map('intval', $productIds));
+        } else {
+            $select = $adapter->select()
+                ->from($this->getTable('catalog/product'), 'entity_id')
+                ->where('type_id IN(?)', $this->_configTypeIds);
+
+            $strProductIds = $select->assemble();
+        }
 
         $where = sprintf('stock_id = %1$d'
             . ' AND ((use_config_manage_stock = 1 AND 1 = %2$d) OR (use_config_manage_stock = 0 AND manage_stock = 1))'
             . ' AND product_id IN (%3$s)',
             $this->_stock->getId(),
             $this->_isConfigManageStock,
-            $select->assemble()
+            $strProductIds
         );
 
         $adapter->update($this->getTable('cataloginventory/stock_item'), $value, $where);

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
@@ -728,11 +728,12 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
     }
 
     /**
-     * Before save prepare process
+     * Perform automatic data process on stock item
+     * Logic moved from _beforeSave()
      *
-     * @return Mage_CatalogInventory_Model_Stock_Item
+     * @return $this
      */
-    protected function _beforeSave()
+    public function processStockData()
     {
         // see if quantity is defined for this item type
         $typeId = $this->getTypeId();
@@ -763,6 +764,18 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
         } else {
             $this->setQty(0);
         }
+
+        return $this;
+    }
+
+    /**
+     * Before save prepare process
+     *
+     * @return Mage_CatalogInventory_Model_Stock_Item
+     */
+    protected function _beforeSave()
+    {
+        $this->processStockData();
 
         return $this;
     }


### PR DESCRIPTION
Solution taken from @bob2021 #189

Looking to address this issue I have implemented two solutions. This solution and #372. Each solution has there merits. I prefer the solution #372 with one of the biggest reasons being it's simplicity and staying closer to what was originally being done in Magento. 

This solution moves the update logic to a Sql query, the benefit is that it all stock item records are updated with a single query, the down side is that that event that gets fired `cataloginventory_stock_item_save_after` may have different information to that that is in the database.
