### PR TITLE
Escape strings in admin grids by default. Fixes #375

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Longtext.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Longtext.php
@@ -54,7 +54,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Longtext
             $truncateLength = $this->getColumn()->getTruncate();
         }
         $text = Mage::helper('core/string')->truncate(parent::_getValue($row), $truncateLength);
-        if ($this->getColumn()->getEscape()) {
+        if ($this->getColumn()->getEscape() !== FALSE) {
             $text = $this->escapeHtml($text);
         }
         if ($this->getColumn()->getNl2br()) {


### PR DESCRIPTION
Escape should be the default.