### PR TITLE
Escape values in formatted grid columns. Refs #375

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Text.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Text.php
@@ -62,7 +62,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Text
             // Parsing of format string
             $formattedString = $format;
             foreach ($matches[0] as $matchIndex=>$match) {
-                $value = $row->getData($matches[1][$matchIndex]);
+                $value = $this->escapeHtml($row->getData($matches[1][$matchIndex]));
                 $formattedString = str_replace($match, $value, $formattedString);
             }
             return $formattedString;


### PR DESCRIPTION
Similar to #376 there is a case in the Text renderer where values can be rendered un-escaped.