### PR TITLE
Add quotes to numeric incrementIds - The Sequel

### DIFF
--- a/app/code/core/Mage/Sales/Model/Resource/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote.php
@@ -163,9 +163,7 @@ class Mage_Sales_Model_Resource_Quote extends Mage_Sales_Model_Resource_Abstract
     public function isOrderIncrementIdUsed($orderIncrementId)
     {
         $adapter   = $this->_getReadAdapter();
-        $fields    = $adapter->describeTable($this->getMainTable());
-        $orderIncrementId = $adapter->prepareColumnValue($fields['increment_id'], $orderIncrementId);
-        $bind      = array(':increment_id' => $orderIncrementId);
+        $bind      = array(':increment_id' => (string)$orderIncrementId);
         $select    = $adapter->select();
         $select->from($this->getTable('sales/order'), 'entity_id')
             ->where('increment_id = :increment_id');

--- a/app/code/core/Mage/Sales/Model/Resource/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote.php
@@ -169,7 +169,8 @@ class Mage_Sales_Model_Resource_Quote extends Mage_Sales_Model_Resource_Abstract
         $select = $adapter->select()
             ->from($this->getTable('sales/order'), 'entity_id')
             ->where('increment_id = :increment_id');
-        if ($adapter->fetchOne($select, array(':increment_id' => $orderIncrementId)) > 0) {
+        $entity_id = $adapter->fetchOne($select, array(':increment_id' => $orderIncrementId));
+        if ($entity_id > 0) {
             return true;
         }
 

--- a/app/code/core/Mage/Sales/Model/Resource/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote.php
@@ -162,11 +162,13 @@ class Mage_Sales_Model_Resource_Quote extends Mage_Sales_Model_Resource_Abstract
      */
     public function isOrderIncrementIdUsed($orderIncrementId)
     {
+        $adapter   = $this->_getReadAdapter();
         $orderIncrementId = $adapter->prepareColumnValue($fields['increment_id'], $orderIncrementId);
-        $select = $adapter->select()
-            ->from($this->getTable('sales/order'), 'entity_id')
+        $bind      = array(':increment_id' => $orderIncrementId);
+        $select    = $adapter->select();
+        $select->from($this->getTable('sales/order'), 'entity_id')
             ->where('increment_id = :increment_id');
-        $entity_id = $adapter->fetchOne($select, array(':increment_id' => $orderIncrementId));
+        $entity_id = $adapter->fetchOne($select, $bind);
         if ($entity_id > 0) {
             return true;
         }

--- a/app/code/core/Mage/Sales/Model/Resource/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote.php
@@ -156,22 +156,20 @@ class Mage_Sales_Model_Resource_Quote extends Mage_Sales_Model_Resource_Abstract
     /**
      * Check is order increment id use in sales/order table
      *
-     * @param string $orderIncrementId
+     * @param string|integer $orderIncrementId
+     *
      * @return boolean
      */
     public function isOrderIncrementIdUsed($orderIncrementId)
     {
-        $fields = $this->_getReadAdapter()->describeTable($this->getTable('sales/order'));
-        if(isset($fields['increment_id']['DATA_TYPE']))   {
-            $orderIncrementId  = $this->_getReadAdapter()->prepareColumnValue($fields['increment_id'], $orderIncrementId);
-        }
-        $adapter   = $this->_getReadAdapter();
-        $bind      = array(':increment_id' => $orderIncrementId);
-        $select    = $adapter->select();
-        $select->from($this->getTable('sales/order'), 'entity_id')
+
+        $adapter = $this->_getReadAdapter();
+        $fields = $adapter->describeTable($this->getTable('sales/order'));
+        $orderIncrementId = $adapter->prepareColumnValue($fields['increment_id'], $orderIncrementId);
+        $select = $adapter->select()
+            ->from($this->getTable('sales/order'), 'entity_id')
             ->where('increment_id = :increment_id');
-        $entity_id = $adapter->fetchOne($select, $bind);
-        if ($entity_id > 0) {
+        if ($adapter->fetchOne($select, array(':increment_id' => $orderIncrementId)) > 0) {
             return true;
         }
 

--- a/app/code/core/Mage/Sales/Model/Resource/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote.php
@@ -161,6 +161,10 @@ class Mage_Sales_Model_Resource_Quote extends Mage_Sales_Model_Resource_Abstract
      */
     public function isOrderIncrementIdUsed($orderIncrementId)
     {
+        $fields = $this->_getReadAdapter()->describeTable($this->getTable('sales/order'));
+        if(isset($fields['increment_id']['DATA_TYPE']))   {
+            $orderIncrementId  = $this->_getReadAdapter()->prepareColumnValue($fields['increment_id'], $orderIncrementId);
+        }
         $adapter   = $this->_getReadAdapter();
         $bind      = array(':increment_id' => $orderIncrementId);
         $select    = $adapter->select();

--- a/app/code/core/Mage/Sales/Model/Resource/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote.php
@@ -163,6 +163,7 @@ class Mage_Sales_Model_Resource_Quote extends Mage_Sales_Model_Resource_Abstract
     public function isOrderIncrementIdUsed($orderIncrementId)
     {
         $adapter   = $this->_getReadAdapter();
+        $fields    = $adapter->describeTable($this->getMainTable());
         $orderIncrementId = $adapter->prepareColumnValue($fields['increment_id'], $orderIncrementId);
         $bind      = array(':increment_id' => $orderIncrementId);
         $select    = $adapter->select();

--- a/app/code/core/Mage/Sales/Model/Resource/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote.php
@@ -162,9 +162,6 @@ class Mage_Sales_Model_Resource_Quote extends Mage_Sales_Model_Resource_Abstract
      */
     public function isOrderIncrementIdUsed($orderIncrementId)
     {
-
-        $adapter = $this->_getReadAdapter();
-        $fields = $adapter->describeTable($this->getTable('sales/order'));
         $orderIncrementId = $adapter->prepareColumnValue($fields['increment_id'], $orderIncrementId);
         $select = $adapter->select()
             ->from($this->getTable('sales/order'), 'entity_id')


### PR DESCRIPTION
Here's the second location where queries were built without quotes around increment_id if it was numeric.