### PR TITLE
Fix Missing Mage_Api_Model_Server_V2_Handler in SOAP v2 WSDL.

### DIFF
--- a/app/code/core/Mage/Api/Model/Server/V2/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/V2/Adapter/Soap.php
@@ -41,8 +41,6 @@ class Mage_Api_Model_Server_V2_Adapter_Soap extends Mage_Api_Model_Server_Adapte
     protected function _getWsdlConfig()
     {
         $wsdlConfig = Mage::getModel('api/wsdl_config');
-        $wsdlConfig->setHandler($this->getHandler())
-            ->init();
         return $wsdlConfig;
     }
 
@@ -57,6 +55,9 @@ class Mage_Api_Model_Server_V2_Adapter_Soap extends Mage_Api_Model_Server_Adapte
         $apiConfigCharset = Mage::getStoreConfig("api/config/charset");
 
         if ($this->getController()->getRequest()->getParam('wsdl') !== null) {
+            $this->wsdlConfig->setHandler($this->getHandler())
+                ->init();
+            
             $this->getController()->getResponse()
                 ->clearHeaders()
                 ->setHeader('Content-Type','text/xml; charset='.$apiConfigCharset)


### PR DESCRIPTION
Hey Guys,

this is a quick fix for the missing Handler in WSDL of SOAP API v2. Handler was always null, because the correct Handler was set after Model Instantiation. 

