### PR TITLE
Fix "Store View" field value empty when reloading form after failed save.

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Cms/PageController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/PageController.php
@@ -102,6 +102,7 @@ class Mage_Adminhtml_Cms_PageController extends Mage_Adminhtml_Controller_Action
         // 3. Set entered data if was error when we do save
         $data = Mage::getSingleton('adminhtml/session')->getFormData(true);
         if (! empty($data)) {
+            $data['store_id'] = $data['stores'];
             $model->setData($data);
         }
 


### PR DESCRIPTION
The form uses 'store_id' as the element id but 'stores[]' as the input name since the model after save uses `getStores` for the new store ids. Without this change the store_id is empty and so the Store View field values get wiped when the form is reloaded.