### PR TITLE
Fixes "wrong" array key type

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Price/Algorithm.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Price/Algorithm.php
@@ -179,7 +179,7 @@ class Mage_Catalog_Model_Layer_Filter_Price_Algorithm
         }
 
         $separator = floor(($limits[0] + $limits[1]) / 2);
-        if ($this->_prices[$separator] < $value) {
+        if ($this->_prices[(int)$separator] < $value) {
             $limits[0] = $separator + 1;
         } else {
             $limits[1] = $separator;
@@ -487,7 +487,7 @@ class Mage_Catalog_Model_Layer_Filter_Price_Algorithm
                 if ($roundPrices) {
                     $index = round($roundingFactorCoefficient
                         / Mage_Catalog_Model_Resource_Layer_Filter_Price::MIN_POSSIBLE_PRICE);
-                    $result[$index] = $roundPrices;
+                    $result[(int)$index] = $roundPrices;
                 }
             }
             $tenPower /= 10;


### PR DESCRIPTION
Not really a bug, but still worth to fix?

PHP interally casts `float` values key to `int`, but I think it should be better done before ...

    $arr = array();
    $arr[1.4] = '1st';
    $arr[1.1] = '2nd';
    var_dump($arr);

    array (size=1)
      1 => string '2nd' (length=3)