### PR TITLE
Ensure StockId is set before saving cataloginventory/stock_item

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
@@ -764,6 +764,10 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
             $this->setQty(0);
         }
 
+        if (!$this->hasData('stock_id')) {
+            $this->setStockId($this->getStockId());
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
This fixes mainly a regression introduced in Magento 1.8:

The `catalogInventoryStockItemUpdate` api method does not call
`product->save()` anymore, which until then ensured the stock_item model
had a `StockId` before saving. As a consequence the `stock_item->save()`
fails due to a fkey constraint on `stock_id`, rendering the api
method defunc.

Initially I hot-fixed this directly in `Mage_CatalogInventory_Model_Stock_Item_Api_V2::update()`, but might as well fix the problem at the root I guess.

Another solution would be to update the db schema default value for `stock_id` given that it's practically static anyways:

`Mage_CatalogInventory_Model_Stock_Item`
```
    public function getStockId()
    {
        return 1;
    }
```

`Mage::getModel('catalogInventory/stock_item')->setStockId(33)->getStockId();` 💩 

