### PR TITLE
Fixes empty dataflow profile history, closes #285

### DIFF
--- a/app/code/core/Mage/Dataflow/Model/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Profile.php
@@ -142,7 +142,7 @@ class Mage_Dataflow_Model_Profile extends Mage_Core_Model_Abstract
 
         $profileHistory = Mage::getModel('dataflow/profile_history');
 
-        $adminUserId = $this->getAdminUserId();
+        $adminUserId = Mage::getSingleton('admin/session')->getUser()->getId();
         if($adminUserId) {
             $profileHistory->setUserId($adminUserId);
         }
@@ -192,6 +192,7 @@ class Mage_Dataflow_Model_Profile extends Mage_Core_Model_Abstract
         Mage::getModel('dataflow/profile_history')
             ->setProfileId($this->getId())
             ->setActionCode('run')
+            ->setUserId(Mage::getSingleton('admin/session')->getUser()->getId())
             ->save();
 
         /**


### PR DESCRIPTION
**Before** ... profile history is always empty (see: https://magento.stackexchange.com/questions/170468/magento-1-is-not-showing-dataflow-profile-history)

**After** ... create|run|update dataflow profile is logged