### PR TITLE
Fixes catalog pricerule with date attributes in conditions, closes #433

### DIFF
--- a/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Product.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Product.php
@@ -115,7 +115,10 @@ class Mage_CatalogRule_Model_Rule_Condition_Product extends Mage_Rule_Model_Cond
     {
         $attribute = $object->getResource()->getAttribute($this->getAttribute());
         if ($attribute && $attribute->getBackendType() == 'datetime') {
-            $value = strtotime($value);
+            $this->setValue(strtotime($this->getValue()));
+            if (is_scalar($value)) {
+                $value = strtotime($value);
+            }
         }
         return $value;
     }


### PR DESCRIPTION
Fixes a bug where a string is compared to a timestamp when trying to apply prices rules that use `datetime` product attributes.

See: https://magento.stackexchange.com/questions/210006/catalog-price-rules-with-date-as-conditions-cannot-possibly-work-due-to-strtotim