### PR TITLE
Fix undefined var in Mage_Core_Model_Url_Rewrite::removeTag()

### DIFF
--- a/app/code/core/Mage/Core/Model/Url/Rewrite.php
+++ b/app/code/core/Mage/Core/Model/Url/Rewrite.php
@@ -171,7 +171,7 @@ class Mage_Core_Model_Url_Rewrite extends Mage_Core_Model_Abstract implements Ma
 
         $removeTags = is_array($tags) ? $tags : explode(',', $tags);
 
-        foreach ($removeTags as $t) {
+        foreach ($removeTags as $k=>$t) {
             if (!is_numeric($k)) {
                 $t = $k.'='.$t;
             }


### PR DESCRIPTION
`$k` is referenced but never defined.

refs #416