### PR TITLE
Fixed another bug where it was not possible to retrieve payment child transactions

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Payment/Transaction.php
+++ b/app/code/core/Mage/Sales/Model/Order/Payment/Transaction.php
@@ -284,7 +284,7 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
                 }
             }
             // return transaction only if type matches
-            if (!$transaction || $types && !in_array($transaction->getType(), $types, true)) {
+            if (!$transaction || $types && !in_array($transaction->getTxnType(), $types, true)) {
                 return;
             }
             return $transaction;
@@ -293,7 +293,7 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
         // filter transactions by types
         $result = array();
         foreach ($this->_children as $child) {
-            if (in_array($child->getType(), $types, true)) {
+            if (in_array($child->getTxnType(), $types, true)) {
                 $result[$child->getId()] = $child;
             }
         }


### PR DESCRIPTION
As it can be seen everywhere around this class, the correct way to get the transaction type is:
->getTxnType() no ->getType()

Without this fix, its not possible to retrieve child transaction of a transaction f.e getting the child VOID transaction of an AUTH transaction
