### PR TITLE
Fix for #443, catalog pricerules start and end date not respected (co…

### DIFF
--- a/app/code/core/Mage/CatalogRule/Model/Resource/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Resource/Rule.php
@@ -213,7 +213,7 @@ class Mage_CatalogRule_Model_Resource_Rule extends Mage_Rule_Model_Resource_Abst
         $toTime = (int) Mage::getModel('core/date')->gmtTimestamp(strtotime($rule->getToDate()));
         $toTime = $toTime ? ($toTime + self::SECONDS_IN_DAY - 1) : 0;
 
-        $timestamp = Mage::app()->getLocale()->date(null, null, null, true)->get(Zend_Date::TIMESTAMP);
+        $timestamp = time();
         if ($fromTime > $timestamp
             || ($toTime && $toTime < $timestamp)
         ) {

--- a/app/code/core/Mage/CatalogRule/Model/Resource/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Resource/Rule.php
@@ -209,13 +209,11 @@ class Mage_CatalogRule_Model_Resource_Rule extends Mage_Rule_Model_Resource_Abst
 
         $customerGroupIds = $rule->getCustomerGroupIds();
 
-        $fromTime = (int) strtotime($rule->getFromDate());
-        $toTime = (int) strtotime($rule->getToDate());
+        $fromTime = (int) Mage::getModel('core/date')->gmtTimestamp(strtotime($rule->getFromDate()));
+        $toTime = (int) Mage::getModel('core/date')->gmtTimestamp(strtotime($rule->getToDate()));
         $toTime = $toTime ? ($toTime + self::SECONDS_IN_DAY - 1) : 0;
 
-        /** @var Mage_Core_Model_Date $coreDate */
-        $coreDate  = $this->_factory->getModel('core/date');
-        $timestamp = $coreDate->gmtTimestamp('Today');
+        $timestamp = Mage::app()->getLocale()->date(null, null, null, true)->get(Zend_Date::TIMESTAMP);
         if ($fromTime > $timestamp
             || ($toTime && $toTime < $timestamp)
         ) {


### PR DESCRIPTION
…rrect)

Fix for #443, catalog pricerules start and end date not respected (correct)

Please validate my logic. 

1. Fromtime and totime are now measured in GMT
2. And compared to GMT time (now) in $timestamp

This way (if and) when the CRON runs the rules at that specific time are checked and activated (or disabled) - as this cron job runs per default at 2 AM as I understand. This would mean that all rules enabled and disable are in effect turned ON and OFF at 2AM during the night the rule is activated (1st day) and de-activated after the end date 2 hours after midnight. 

Reference 1: https://magento.stackexchange.com/questions/61045/catalog-price-rule-from-today-does-not-apply
Reference 2: (under catalog rules) http://jokiruiz.com/magento/magento-timezones-timestamps/

Test data:
- for a rule with start date 10 dec 2017 and end date 30 jan 2018
- we see the following comparison on Thu 1 feb 2018 @ 14:28 GMT

TIMESTAMP: Thu, 01 Feb 2018 14:28:03 GMT
START; Sat, 09 Dec 2017 23:00:00 GMT
END: Tue, 30 Jan 2018 22:59:59 GMT

So rule in this case is turned OFF

Please confirm