### PR TITLE
PHP 7.2 fixes (method signature)

### DIFF
--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Group.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Group.php
@@ -33,7 +33,7 @@
  */
 class Mage_Customer_Model_Customer_Attribute_Source_Group extends Mage_Eav_Model_Entity_Attribute_Source_Table
 {
-    public function getAllOptions()
+    public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if (!$this->_options) {
             $this->_options = Mage::getResourceModel('customer/group_collection')

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Group.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Group.php
@@ -33,6 +33,13 @@
  */
 class Mage_Customer_Model_Customer_Attribute_Source_Group extends Mage_Eav_Model_Entity_Attribute_Source_Table
 {
+    /**
+     * Retrieve Full Option values array
+     *
+     * @param bool $withEmpty       Argument has no effect, included for PHP 7.2 method signature compatibility
+     * @param bool $defaultValues   Argument has no effect, included for PHP 7.2 method signature compatibility
+     * @return array
+     */
     public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if (!$this->_options) {

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Store.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Store.php
@@ -33,7 +33,7 @@
  */
 class Mage_Customer_Model_Customer_Attribute_Source_Store extends Mage_Eav_Model_Entity_Attribute_Source_Table
 {
-    public function getAllOptions()
+    public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if (!$this->_options) {
             $collection = Mage::getResourceModel('core/store_collection');

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Store.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Store.php
@@ -33,6 +33,13 @@
  */
 class Mage_Customer_Model_Customer_Attribute_Source_Store extends Mage_Eav_Model_Entity_Attribute_Source_Table
 {
+    /**
+     * Retrieve Full Option values array
+     *
+     * @param bool $withEmpty       Argument has no effect, included for PHP 7.2 method signature compatibility
+     * @param bool $defaultValues   Argument has no effect, included for PHP 7.2 method signature compatibility
+     * @return array
+     */
     public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if (!$this->_options) {

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Website.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Website.php
@@ -33,7 +33,7 @@
  */
 class Mage_Customer_Model_Customer_Attribute_Source_Website extends Mage_Eav_Model_Entity_Attribute_Source_Table
 {
-    public function getAllOptions()
+    public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if (!$this->_options) {
             $this->_options = Mage::getSingleton('adminhtml/system_store')->getWebsiteValuesForForm(true, true);

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Website.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Website.php
@@ -33,6 +33,13 @@
  */
 class Mage_Customer_Model_Customer_Attribute_Source_Website extends Mage_Eav_Model_Entity_Attribute_Source_Table
 {
+    /**
+     * Retrieve Full Option values array
+     *
+     * @param bool $withEmpty       Argument has no effect, included for PHP 7.2 method signature compatibility
+     * @param bool $defaultValues   Argument has no effect, included for PHP 7.2 method signature compatibility
+     * @return array
+     */
     public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if (!$this->_options) {

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Country.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Country.php
@@ -56,7 +56,7 @@ class Mage_Customer_Model_Entity_Address_Attribute_Source_Country
      *
      * @return array
      */
-    public function getAllOptions()
+    public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if (!$this->_options) {
             $this->_options = $this->_factory->getResourceModel('directory/country_collection')

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Country.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Country.php
@@ -54,6 +54,8 @@ class Mage_Customer_Model_Entity_Address_Attribute_Source_Country
     /**
      * Retrieve all options
      *
+     * @param bool $withEmpty       Argument has no effect, included for PHP 7.2 method signature compatibility
+     * @param bool $defaultValues   Argument has no effect, included for PHP 7.2 method signature compatibility
      * @return array
      */
     public function getAllOptions($withEmpty = true, $defaultValues = false)

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Country.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Country.php
@@ -39,7 +39,7 @@ class Mage_Customer_Model_Resource_Address_Attribute_Source_Country extends Mage
      *
      * @return array
      */
-    public function getAllOptions()
+    public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if (!$this->_options) {
             $this->_options = Mage::getResourceModel('directory/country_collection')

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Country.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Country.php
@@ -37,6 +37,8 @@ class Mage_Customer_Model_Resource_Address_Attribute_Source_Country extends Mage
     /**
      * Retreive all options
      *
+     * @param bool $withEmpty       Argument has no effect, included for PHP 7.2 method signature compatibility
+     * @param bool $defaultValues   Argument has no effect, included for PHP 7.2 method signature compatibility
      * @return array
      */
     public function getAllOptions($withEmpty = true, $defaultValues = false)

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Region.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Region.php
@@ -39,7 +39,7 @@ class Mage_Customer_Model_Resource_Address_Attribute_Source_Region extends Mage_
      *
      * @return array
      */
-    public function getAllOptions()
+    public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if (!$this->_options) {
             $this->_options = Mage::getResourceModel('directory/region_collection')->load()->toOptionArray();

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Region.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Region.php
@@ -37,6 +37,8 @@ class Mage_Customer_Model_Resource_Address_Attribute_Source_Region extends Mage_
     /**
      * Retreive all region options
      *
+     * @param bool $withEmpty       Argument has no effect, included for PHP 7.2 method signature compatibility
+     * @param bool $defaultValues   Argument has no effect, included for PHP 7.2 method signature compatibility
      * @return array
      */
     public function getAllOptions($withEmpty = true, $defaultValues = false)

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Store.php
@@ -38,7 +38,7 @@ class Mage_Eav_Model_Entity_Attribute_Source_Store extends Mage_Eav_Model_Entity
      *
      * @return array
      */
-    public function getAllOptions()
+    public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if ($this->_options === null) {
             $this->_options = Mage::getResourceModel('core/store_collection')->load()->toOptionArray();

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Store.php
@@ -36,6 +36,8 @@ class Mage_Eav_Model_Entity_Attribute_Source_Store extends Mage_Eav_Model_Entity
     /**
      * Retrieve Full Option values array
      *
+     * @param bool $withEmpty       Argument has no effect, included for PHP 7.2 method signature compatibility
+     * @param bool $defaultValues   Argument has no effect, included for PHP 7.2 method signature compatibility
      * @return array
      */
     public function getAllOptions($withEmpty = true, $defaultValues = false)


### PR DESCRIPTION
PHP 7.2 requires method signatures to match when a class overrides a method from the parent. This PR fixes the getAllOptions method in classes that extend Mage_Eav_Model_Entity_Attribute_Source_Table.

In each instance, the child method used no parameters, thus including them will not break anything. There may be other places where this is a problem, and I will fix as I come across them.