### PR TITLE
Don't print HTML markup when running on CLI

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -893,8 +893,8 @@ final class Mage
      */
     public static function printException(Exception $e, $extra = '')
     {
-        if (self::$_isDeveloperMode) {
-            print '<pre>';
+        if (self::$_isDeveloperMode || PHP_SAPI == "cli") {
+            PHP_SAPI == "cli" or print '<pre>';
 
             if (!empty($extra)) {
                 print $extra . "\n\n";
@@ -902,7 +902,7 @@ final class Mage
 
             print $e->getMessage() . "\n\n";
             print $e->getTraceAsString();
-            print '</pre>';
+            PHP_SAPI == "cli" or print '</pre>';
         } else {
 
             $reportData = array(


### PR DESCRIPTION
The `printException` method is used in several places including `cron.php`. It doesn't make sense to print HTML markup for CLI mode so this skips it.