### PR TITLE
Remove empty JS file

### DIFF
--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
@@ -118,7 +118,7 @@ class Mage_ConfigurableSwatches_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Get swatches product javascript
      *
-     * @return string
+     * @return string | null
      */
     public function getSwatchesProductJs()
     {
@@ -135,6 +135,6 @@ class Mage_ConfigurableSwatches_Helper_Data extends Mage_Core_Helper_Abstract
                 }
             }
         }
-        return '';
+        return null;
     }
 }


### PR DESCRIPTION
Method use for add swatches JS on product page
(call: PRODUCT_TYPE_configurable Handle, rwd/default/layout/configurableswatches.xml)
But if the condition is false, this method return an empty string AND include empty js.
http://storage3.static.itmages.com/i/18/0228/h_1519839970_6082466_fdd17a4d7d.png