### PR TITLE
Fix for Mage_Core_Controller_Varien_Exception::prepareRedirect

### DIFF
--- a/app/code/core/Mage/Core/Controller/Varien/Exception.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Exception.php
@@ -67,7 +67,7 @@ class Mage_Core_Controller_Varien_Exception extends Exception
     public function prepareRedirect($path, $arguments = array())
     {
         $this->_resultCallback = self::RESULT_REDIRECT;
-        $this->_resultCallbackParams($path, $arguments);
+        $this->_resultCallbackParams = array($path, $arguments);
         return $this;
     }
 


### PR DESCRIPTION
The Mage_Core_Controller_Varien_Exception::prepareRedirect method has been broken since the class was introduced in 1.3.2.

Details:
https://gist.github.com/LeeSaferite/2311574
https://stuntcoders.com/snippets/magento-redirect-action-from-pre-dispatch-hook/