### PR TITLE
send PayPal new account mail in correct language

### DIFF
--- a/app/code/core/Mage/Paypal/Model/Express/Checkout.php
+++ b/app/code/core/Mage/Paypal/Model/Express/Checkout.php
@@ -1042,13 +1042,13 @@ class Mage_Paypal_Model_Express_Checkout
     {
         $customer = $this->_quote->getCustomer();
         if ($customer->isConfirmationRequired()) {
-            $customer->sendNewAccountEmail('confirmation');
+            $customer->sendNewAccountEmail('confirmation', '', $this->_quote->getStoreId());
             $url = Mage::helper('customer')->getEmailConfirmationUrl($customer->getEmail());
             $this->getCustomerSession()->addSuccess(
                 Mage::helper('customer')->__('Account confirmation is required. Please, check your e-mail for confirmation link. To resend confirmation email please <a href="%s">click here</a>.', $url)
             );
         } else {
-            $customer->sendNewAccountEmail();
+            $customer->sendNewAccountEmail('registered', '', $this->_quote->getStoreId());
             $this->getCustomerSession()->loginById($customer->getId());
         }
         return $this;


### PR DESCRIPTION
If no store ID is given to the method `Mage_Customer_Model_Customer::sendNewAccountEmail`, the first store ID of the current website is used:

https://github.com/OpenMage/magento-mirror/blob/577122d5a50acb7ae585a817fa50faee848c9673/app/code/core/Mage/Customer/Model/Customer.php#L615-L617

This can lead to wrong languages in new account mails.