### PR TITLE
Fix backend creationdate bug

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
@@ -78,8 +78,12 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_View
      */
     public function getCreateDate()
     {
-        return $this->_getCoreHelper()->formatDate($this->getCustomer()->getCreatedAt(),
-            Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true);
+        $date = Mage::app()->getLocale()->storeDate(
+        $this->getCustomer()->getStoreId(),
+        $this->getCustomer()->getCreatedAtTimestamp(),
+        true
+    );
+    return $this->formatDate($date, Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true);
     }
 
     public function getStoreCreateDate()


### PR DESCRIPTION
We dont want system time in backend. 

https://magento.stackexchange.com/questions/38143/customer-created-logged-in-timestamps-in-admin

Discovered whilst testing for GDPR: when customer asks "when" did I subscribe our data is always 1 hour off