### PR TITLE
Sitemap dispatch event to add custom data // Rename dispatch event

### DIFF
--- a/app/code/core/Mage/Sitemap/Model/Sitemap.php
+++ b/app/code/core/Mage/Sitemap/Model/Sitemap.php
@@ -221,7 +221,7 @@ class Mage_Sitemap_Model_Sitemap extends Mage_Core_Model_Abstract
         }
         unset($collection);
 
-        Mage::dispatchEvent('sitemap_generate_before', array(
+        Mage::dispatchEvent('sitemap_urlset_generating_before', array(
             'file'      => $io ,
             'base_url'  => $baseUrl ,
             'date'      => $date,


### PR DESCRIPTION
For understand this PR, see https://github.com/OpenMage/magento-lts/pull/248 :)
I update 'use exemple' : 

```
     /**
     * Add brand url to sitemap
     *
     * @event sitemap_urlset_generating_before
     * @param Varien_Event_Observer $observer
     */
    public function addBrandToSitemap(Varien_Event_Observer $observer)
    {
        $io               = $observer->getEvent()->getFile();
        $baseUrl    = $observer->getEvent()->getBaseUrl();
        $date         = $observer->getEvent()->getDate();
        $storeId    = $observer->getEvent()->getStoreId();

        $changefreq = (string)Mage::getStoreConfig('sitemap/brand/changefreq', $storeId);
        $priority   = (string)Mage::getStoreConfig('sitemap/brand/priority', $storeId);

        $collection = Mage::getResourceModel('brand/brand_collection')
            ->addActiveFilter()
        ;


        foreach ($collection as $brand) {
            $url = htmlspecialchars($baseUrl . Mage::helper('brand')->getBrandUrl($brand));

            if (Mage::getStoreConfig('web/seo/trailingslash'))
            {
                if (!preg_match('/\\.(rss|html|htm|xml|php?)$/', strtolower($url)) && substr($url, -1) != '/')
                {
                    $url .= '/';
                }
            }

            $xml = sprintf('<url><loc>%s</loc><lastmod>%s</lastmod><changefreq>%s</changefreq><priority>%.1f</priority></url>',
                $url,
                $date,
                $changefreq,
                $priority
            );
            $io->streamWrite($xml);
        }
        unset($collection);

    }

```