### PR TITLE
Fix issue #472 /// empty billing and ship details after cancel payment @ PSP

### DIFF
--- a/app/code/core/Mage/Checkout/Block/Onepage/Billing.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Billing.php
@@ -102,20 +102,7 @@ class Mage_Checkout_Block_Onepage_Billing extends Mage_Checkout_Block_Onepage_Ab
     public function getAddress()
     {
         if (is_null($this->_address)) {
-            if ($this->isCustomerLoggedIn()) {
-                $this->_address = $this->getQuote()->getBillingAddress();
-                if (!$this->_address->getFirstname()) {
-                    $this->_address->setFirstname($this->getQuote()->getCustomer()->getFirstname());
-                }
-                if (!$this->_address->getMiddlename()) {
-                    $this->_address->setMiddlename($this->getQuote()->getCustomer()->getMiddlename());
-                }
-                if (!$this->_address->getLastname()) {
-                    $this->_address->setLastname($this->getQuote()->getCustomer()->getLastname());
-                }
-            } else {
-                $this->_address = Mage::getModel('sales/quote_address');
-            }
+            $this->_address = $this->getQuote()->getBillingAddress();
         }
 
         return $this->_address;

--- a/app/code/core/Mage/Checkout/Block/Onepage/Shipping.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Shipping.php
@@ -69,11 +69,7 @@ class Mage_Checkout_Block_Onepage_Shipping extends Mage_Checkout_Block_Onepage_A
     public function getAddress()
     {
         if (is_null($this->_address)) {
-            if ($this->isCustomerLoggedIn()) {
-                $this->_address = $this->getQuote()->getShippingAddress();
-            } else {
-                $this->_address = Mage::getModel('sales/quote_address');
-            }
+            $this->_address = $this->getQuote()->getShippingAddress();
         }
 
         return $this->_address;


### PR DESCRIPTION

Fixes issue: https://github.com/OpenMage/magento-lts/issues/472

From what I hear this is a long standing bug/unexpected behavior

If a user cancels his order at the PSP, they are redirected to the cart, if they then proceed back to the checkout: guess what? all billing information is empty and they have to re-enter all

so whatever the final fix: we should consider the customer experience. If you cancel your payment at the PSP and return to cart and continue: you expect your data to still be there



