### PR TITLE
Hide inactive categories from sitemap

### DIFF
--- a/app/design/frontend/base/default/template/catalog/seo/tree.phtml
+++ b/app/design/frontend/base/default/template/catalog/seo/tree.phtml
@@ -33,7 +33,9 @@
 <?php if($_items->getSize()): ?>
     <ul class="sitemap">
         <?php foreach ($_items as $_item): ?>
-            <li class="level-<?php echo $this->getLevel($_item) ?>" <?php echo $this->getLevel($_item)?'style="padding-left:' . $this->getLevel($_item, 2) . '0px;"':'' ?>><a href="<?php echo $this->getItemUrl($_item) ?>"><?php echo $_item->name ?></a></li>
+            <?php if ($_item->getIsActive()): ?>
+                <li class="level-<?php echo $this->getLevel($_item) ?>" <?php echo $this->getLevel($_item)?'style="padding-left:' . $this->getLevel($_item, 2) . '0px;"':'' ?>><a href="<?php echo $this->getItemUrl($_item) ?>"><?php echo $_item->name ?></a></li>
+            <?php endif; ?>
         <?php endforeach; ?>
     </ul>
 <?php else: ?>


### PR DESCRIPTION
# Why?
because https://github.com/OpenMage/magento-lts/pull/59 does not appear to do the trick.

# What?
Hide inactive categories from web-based sitemap at `/catalog/seo_sitemap/category/` and `/catalog/seo_sitemap/category/tree/`

# Weird?
Both layouts (`catalog_seo_sitemap_category` and `catalog_seo_sitemap_category_tree`) end up using `template="catalog/seo/tree.phtml"` regardless of the reference in `catalog_seo_sitemap_category` to use `template="catalog/seo/sitemap.phtml"`.
That last one is used when viewing  products per `catalog_seo_sitemap_product`.