### PR TITLE
Add translation to note in product edition

### DIFF
--- a/app/design/adminhtml/default/default/template/catalog/form/renderer/fieldset/element.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/form/renderer/fieldset/element.phtml
@@ -46,7 +46,7 @@
     <td class="value">
         <?php echo trim($this->getElementHtml()) ?>
         <?php if ($_element->getNote()) : ?>
-            <p class="note"><?php echo $_element->getNote() ?></p>
+            <p class="note"><?php echo $this->__($_element->getNote()); ?></p>
         <?php endif; ?>
     </td>
     <td class="scope-label"><span class="nobr"><?php echo $this->getScopeLabel() ?></span></td>


### PR DESCRIPTION
When we create a product attribute like this : 

```php
 $installer->addAttribute(Mage_Catalog_Model_Product::ENTITY, "my-attribute", [
       // [...]
        'note'                       => 'My Note',
       // [...]
    ]);
```

The note is not translated even if the translation exists.
So this change call the translation for the note information.