### PR TITLE
Fixed ability to save config by a user with limited access

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/Config/Data.php
+++ b/app/code/core/Mage/Adminhtml/Model/Config/Data.php
@@ -168,7 +168,8 @@ class Mage_Adminhtml_Model_Config_Data extends Varien_Object
                 if (is_object($fieldConfig)) {
                     $configPath = (string)$fieldConfig->config_path;
                     if (!empty($configPath) && strrpos($configPath, '/') > 0) {
-                        if (!Mage::getSingleton('admin/session')->isAllowed($configPath)) {
+                        $parts = explode('/', $configPath);
+                        if (!$this->_isSectionAllowed($parts[0])) {
                             Mage::throwException('Access denied.');
                         }
                         // Extend old data with specified section group
@@ -242,6 +243,30 @@ class Mage_Adminhtml_Model_Config_Data extends Varien_Object
             return $oldConfig + $extended;
         }
         return $extended;
+    }
+
+    /**
+     * Check if specified section allowed in ACL
+     *
+     * Taken from Mage_Adminhtml_System_ConfigController::_isSectionAllowed
+     *
+     * @param string $section
+     * @return bool
+     */
+    protected function _isSectionAllowed($section)
+    {
+        try {
+            $session = Mage::getSingleton('admin/session');
+            $resourceLookup = "admin/system/config/{$section}";
+            if ($session->getData('acl') instanceof Mage_Admin_Model_Acl) {
+                return $session->isAllowed(
+                    $session->getData('acl')->get($resourceLookup)->getResourceId()
+                );
+            }
+        } catch (Exception $e) {
+            return false;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Related to configs that use `config_path` parameter - Paypal config section for example.

### Steps to reproduce

 1. Create new Admin Role at _System > Permission > Roles_ with access to "Payment Methods Section" and "PayPal Section" configurations.
 2. Create a new Admin User with this Role at _System > Permission > Users_
 3. Login by this user and try to save config.
 4. "Access denied" message will be shown

p.s. Solution is taken from https://github.com/OpenMage/magento-lts/blob/1.9.3.x/app/code/core/Mage/Adminhtml/controllers/System/ConfigController.php#L280-L288