### PR TITLE
Color swatches work with disparate product IDs

### DIFF
--- a/skin/frontend/rwd/default/js/configurableswatches/product-media.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/product-media.js
@@ -28,23 +28,9 @@ var ConfigurableMediaImages = {
     productImages: {},
     imageObjects: {},
 
+    // deprecated - use Array.prototype.intersect instead
     arrayIntersect: function(a, b) {
-        var ai=0, bi=0;
-        var result = new Array();
-
-        while( ai < a.length && bi < b.length )
-        {
-            if      (a[ai] < b[bi] ){ ai++; }
-            else if (a[ai] > b[bi] ){ bi++; }
-            else /* they're equal */
-            {
-                result.push(a[ai]);
-                ai++;
-                bi++;
-            }
-        }
-
-        return result;
+        return a.intersect(b);
     },
 
     getCompatibleProductImages: function(productFallback, selectedLabels) {


### PR DESCRIPTION
There is a bug in ConfigurableSwatches module where product IDs are sorted numerically then compared alphabetically.
For example, "2" is less than "10" numerically, but "2" is greater than "10" because it is also greater than "1" alphabetically.
This led to cases where a child product with a shorter ID than it's siblings would break swatch switching for those parent products only.
The bug was identified in https://magento.com/tech-resources/bug-tracking/issue/index/id/1305/ @ 2/15/2016

This fix removes the buggy `ConfigurableMediaImages.arrayIntersect` method in favour of Prototype's `Array#intersect`