### PR TITLE
Fix user logged out after `reload_acl_flag` updated.

### DIFF
--- a/app/code/core/Mage/Admin/Model/Resource/User.php
+++ b/app/code/core/Mage/Admin/Model/Resource/User.php
@@ -459,6 +459,26 @@ class Mage_Admin_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstrac
     }
 
     /**
+     * Set reload ACL flag
+     *
+     * @param Mage_Core_Model_Abstract $object
+     * @param int $flag
+     * @return Mage_Admin_Model_Resource_User
+     */
+    public function saveReloadAclFlag($object, $flag)
+    {
+        if ($object->getId()) {
+            $this->_getWriteAdapter()->update(
+                $this->getMainTable(),
+                array('reload_acl_flag' => $flag),
+                array('user_id = ?' => (int) $object->getId())
+            );
+        }
+
+        return $this;
+    }
+
+    /**
      * Unserializes user extra data
      *
      * @param Mage_Core_Model_Abstract $user

--- a/app/code/core/Mage/Admin/Model/Session.php
+++ b/app/code/core/Mage/Admin/Model/Session.php
@@ -31,6 +31,11 @@
  * @category    Mage
  * @package     Mage_Admin
  * @author      Magento Core Team <core@magentocommerce.com>
+ *
+ * @method Mage_Admin_Model_User getUser()
+ * @method $this setUser(Mage_Admin_Model_User $user)
+ * @method Mage_Admin_Model_Acl getAcl()
+ * @method $this setAcl(Mage_Admin_Model_Acl $acl)
  */
 class Mage_Admin_Model_Session extends Mage_Core_Model_Session_Abstract
 {
@@ -186,7 +191,7 @@ class Mage_Admin_Model_Session extends Mage_Core_Model_Session_Abstract
             $this->setAcl(Mage::getResourceModel('admin/acl')->loadAcl());
         }
         if ($user->getReloadAclFlag()) {
-            $user->getResource()->save($user->setReloadAclFlag('0'));
+            $user->getResource()->saveReloadAclFlag($user, 0);
         }
         return $this;
     }

--- a/app/code/core/Mage/Admin/Model/Session.php
+++ b/app/code/core/Mage/Admin/Model/Session.php
@@ -186,8 +186,7 @@ class Mage_Admin_Model_Session extends Mage_Core_Model_Session_Abstract
             $this->setAcl(Mage::getResourceModel('admin/acl')->loadAcl());
         }
         if ($user->getReloadAclFlag()) {
-            $user->unsetData('password');
-            $user->setReloadAclFlag('0')->save();
+            $user->getResource()->save($user->setReloadAclFlag('0'));
         }
         return $this;
     }


### PR DESCRIPTION
When the `reload_acl_flag` is set to 1  the `refreshAcl` method is setting the flag value back to 0. However, it also unsets the password and in doing so causes the `reload` method of the User model to fail the password check. The id is then set to NULL and this gets saved in the users session so the *next* page load results in the user being effectively logged out based on how it is checking in the `isLoggedIn` method.

I personally always reset this flag to 1 when deploying code updates so that the ACL is refreshed in case any changes were made to the ACL itself. Magento core code only uses this flag when roles are updated (`_updateRoleUsersAcl`) but in either case it is not necessary to actually log the user out and I don't think it was the intention of the original author to log the user out but rather simply refresh the ACL as the method is called.