### PR TITLE
Use secure cookie if unsecure base url is actually secure.

### DIFF
--- a/app/code/core/Mage/Core/Model/Cookie.php
+++ b/app/code/core/Mage/Core/Model/Cookie.php
@@ -186,6 +186,10 @@ class Mage_Core_Model_Cookie
         if ($this->getStore()->isAdmin()) {
             return $this->_getRequest()->isSecure();
         }
+        // Use secure cookie if unsecure base url is actually secure
+        if (preg_match('/^https:/', $this->getStore()->getBaseUrl(Mage_Core_Model_Store::URL_TYPE_LINK, false))) {
+            return true;
+        }
         return false;
     }
 


### PR DESCRIPTION
As the web is moving to always-https sites more and more I believe it makes sense to just set the "frontend" cookie Secure flag rather than have an unsecure "frontend" and a corresponding "frontend_cid" cookie.  This patch sets the Secure flag when the Magento store *unsecure* base url starts with https. The result is the "frontend" cookie gets the Secure flag and there is no "frontend_cid" cookie necessary.