### PR TITLE
Fix to allow for always reorder

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -775,7 +775,7 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
      */
     public function canReorder()
     {
-        return $this->_canReorder(false);
+        return $this->_canReorder(true);
     }
 
     /**
@@ -796,7 +796,7 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
      */
     protected function _canReorder($ignoreSalable = false)
     {
-        if ($this->canUnhold() || $this->isPaymentReview() || !$this->getCustomerId()) {
+        if ($this->canUnhold() || $this->isPaymentReview()) {
             return false;
         }
 


### PR DESCRIPTION
Fix to allow for always reorder

Works on backend. Tested on frontend. Maybe not all cases. 

Rationale
- if you want to reorder Magento should at least try
- if there is no stock: then we see this in admin order entry; can remove product or change: why block even trying?
- customerid check seems to work even with anonymous checkout

In short. Reorder is something you "want" so if you click it you are performing an action where the user "wants" to reorder
Currently there are all these safeguards in the code protecting against what? Magento should at least "try" to reorder. And the reorder screen or cart is a perfect place to do corrections (out of stock etc) if necessary: in short => there is a flow to highlight and correct potentials low stock or missing info anyways. Dont understand why this is so heavily blocked. 
Another option would be to offer a new config setting under sales->reorder but I think the current setting is already clear enough: we want the ability to reorder!

![image](https://user-images.githubusercontent.com/652395/44518516-bbd98700-a6ca-11e8-8ea6-ef43dabbc4d1.png)
