### PR TITLE
Fix _addUrlRewrite() ignoring collection store scope.

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
@@ -1178,7 +1178,7 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
             }
 
             $select = $this->_factory->getProductUrlRewriteHelper()
-                ->getTableSelect($productIds, $this->_urlRewriteCategory, Mage::app()->getStore()->getId());
+                ->getTableSelect($productIds, $this->_urlRewriteCategory, Mage::app()->getStore($this->getStoreId())->getId());
 
             $urlRewrites = array();
             foreach ($this->getConnection()->fetchAll($select) as $row) {


### PR DESCRIPTION
While `Mage_Catalog_Model_Resource_Product_Collection::addUrlRewrite()` [respects](https://github.com/OpenMage/magento-lts/blob/1.9.3.x/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php#L1143) any set `storeId` on the collection it's helper that does the actual work is hard-coded to the current active store. So the following will not work as expected when, for example, called from a script:

```php
Mage::getResourceModel('catalog/product_collection')
    ->setStore($someStoreId)
    ->addUrlRewrite();
```

`Mage::getSingleton('core/app_emulation')->startEnvironmentEmulation($someStoreId);` could be used to work around the problem, but this looks like a bug to me plus it's fairly annoying to debug if you are not aware.

The fix (ab)uses the fact that `Mage::app()->getStore($this->getStoreId())` will fall back to the current active store if there is no `storeId` set on the current collection, so there should be no BC issues. Happy to amend if something less cute is prefered, i.e.:

```php
$storeId = $this->getStoreId();
if (!$storeId)
    $storeId = Mage::app()->getStore()->getId();

$select = $this->_factory->getProductUrlRewriteHelper()
    ->getTableSelect($productIds, $this->_urlRewriteCategory, $storeId);
```


