### PR TITLE
Fix Coupon Removal Failure When Shipping/Tax Is Applied To Quote

### DIFF
--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -620,6 +620,7 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
                 }
             } else {
                 $this->_getSession()->addSuccess($this->__('Coupon code was canceled.'));
+                $this->_getSession()->setCartCouponCode($couponCode);
             }
 
         } catch (Mage_Core_Exception $e) {


### PR DESCRIPTION
This pull request is based on Issue #508 

In the Shopping Cart, when you use the estimate shipping/tax feature, apply the estimations to the order, add a coupon code to the order, and then remove the coupon, the Shopping Cart returns the "Coupon code was canceled." messages, however, the coupon remains attached to the quote/sale.
If you do not use the estimate shipping/tax feature, the coupon can be added and then removed without issue.

LAMP Stack
Linux: Ubuntu 16.04.10 (AWS Ubuntu 16.04 AMI)
Apache: Apache/2.4.18 (Ubuntu)
MySQL: Ver 15.1 Distrib 10.1.35-MariaDB, for debian-linux-gnu (x86_64) using readline 5.2
PHP: PHP 7.0.30-0ubuntu0.16.04.1 (cli)

Magento CE Version: 1.9.3.9

Modules Active In Local Pool:

Inchoo_PHP7
Modules Active In Community Pool:

Cm_RedisSession
Active Theme: base/default