### PR TITLE
added php7 htaccess settings

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -26,6 +26,9 @@
 
     DirectoryIndex index.php
 
+############################################
+## php5 settings
+
 <IfModule mod_php5.c>
 
 ############################################
@@ -61,6 +64,21 @@
 
     php_flag zend.ze1_compatibility_mode Off
 
+</IfModule>
+
+############################################
+## php7 settings
+## see above for php_flag descriptions
+
+<IfModule mod_php7.c>
+    #php_value memory_limit 64M
+    php_value memory_limit 256M
+    php_value max_execution_time 18000
+    php_flag magic_quotes_gpc off
+    php_flag session.auto_start off
+    #php_flag zlib.output_compression on
+    php_flag suhosin.session.cryptua off
+    php_flag zend.ze1_compatibility_mode Off
 </IfModule>
 
 <IfModule mod_security.c>

--- a/media/.htaccess
+++ b/media/.htaccess
@@ -2,6 +2,9 @@ Options All -Indexes
 <IfModule mod_php5.c>
 php_flag engine 0
 </IfModule>
+<IfModule mod_php7.c>
+php_flag engine 0
+</IfModule>
 
 AddHandler cgi-script .php .pl .py .jsp .asp .htm .shtml .sh .cgi
 Options -ExecCGI


### PR DESCRIPTION
Since there seems to be no way to have shared settings for both mod_php5 and mod_php7, the PR simply duplicates the directives in .htaccess for both. While not ideal, it will save headaches from people who run on php7 and haven't manually edited .htaccess.