### PR TITLE
Duplicate addPriceData() function call

### DIFF
--- a/app/code/core/Mage/Bundle/Model/Observer.php
+++ b/app/code/core/Mage/Bundle/Model/Observer.php
@@ -119,8 +119,7 @@ class Mage_Bundle_Model_Observer
         $bundleCollection = $product->getCollection()
             ->addAttributeToSelect(Mage::getSingleton('catalog/config')->getProductAttributes())
             ->addStoreFilter()
-            ->addMinimalPrice()
-            ->addFinalPrice()
+            ->addPriceData()
             ->addTaxPercents();
 
         Mage::getSingleton('catalog/product_visibility')

--- a/app/code/core/Mage/Catalog/Block/Product/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Abstract.php
@@ -490,8 +490,7 @@ abstract class Mage_Catalog_Block_Product_Abstract extends Mage_Core_Block_Templ
     protected function _addProductAttributesAndPrices(Mage_Catalog_Model_Resource_Product_Collection $collection)
     {
         return $collection
-            ->addMinimalPrice()
-            ->addFinalPrice()
+            ->addPriceData()
             ->addTaxPercents()
             ->addAttributeToSelect(Mage::getSingleton('catalog/config')->getProductAttributes())
             ->addUrlRewrite();

--- a/app/code/core/Mage/Catalog/Model/Layer.php
+++ b/app/code/core/Mage/Catalog/Model/Layer.php
@@ -117,8 +117,7 @@ class Mage_Catalog_Model_Layer extends Varien_Object
     {
         $collection
             ->addAttributeToSelect(Mage::getSingleton('catalog/config')->getProductAttributes())
-            ->addMinimalPrice()
-            ->addFinalPrice()
+            ->addPriceData()
             ->addTaxPercents()
             ->addUrlRewrite($this->getCurrentCategory()->getId());
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
@@ -1212,6 +1212,9 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
     /**
      * Add minimal price data to result
      *
+     * @deprecated use addPriceData
+     * @see Mage_Catalog_Model_Resource_Product_Collection::addPriceData
+     *
      * @return Mage_Catalog_Model_Resource_Product_Collection
      */
     public function addMinimalPrice()
@@ -1234,6 +1237,9 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
 
     /**
      * Add price data for calculate final price
+     *
+     * @deprecated use addPriceData
+     * @see Mage_Catalog_Model_Resource_Product_Collection::addPriceData
      *
      * @return Mage_Catalog_Model_Resource_Product_Collection
      */

--- a/app/code/core/Mage/CatalogSearch/Model/Layer.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Layer.php
@@ -57,8 +57,7 @@ class Mage_CatalogSearch_Model_Layer extends Mage_Catalog_Model_Layer
             ->addAttributeToSelect(Mage::getSingleton('catalog/config')->getProductAttributes())
             ->addSearchFilter(Mage::helper('catalogsearch')->getQuery()->getQueryText())
             ->setStore(Mage::app()->getStore())
-            ->addMinimalPrice()
-            ->addFinalPrice()
+            ->addPriceData()
             ->addTaxPercents()
             ->addStoreFilter()
             ->addUrlRewrite();


### PR DESCRIPTION
In 
```
Mage_Bundle_Model_Observer::appendUpsellProducts
Mage_Catalog_Block_Product_Abstract::_addProductAttributesAndPrices
Mage_Catalog_Model_Layer::prepareProductCollection
Mage_CatalogSearch_Model_Layer::prepareProductCollection

```
Magento call function 
`Mage_Catalog_Model_Resource_Product_Collection::addFinalPrice`
And
`Mage_Catalog_Model_Resource_Product_Collection::addMinimalPrice`
But there functions make the same think and just call the function "addPriceData"

So I remove this duplicate call, I directly call addPriceData and I've add deprecated comment on addFinalPrice and addMinimalPrice