### PR TITLE
Fix in ACL checking for newsletter subscription

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/CustomerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/CustomerController.php
@@ -317,7 +317,7 @@ class Mage_Adminhtml_CustomerController extends Mage_Adminhtml_Controller_Action
                 }
             }
 
-            if (Mage::getSingleton('admin/session')->isAllowed('newsletter/subscription')
+            if (Mage::getSingleton('admin/session')->isAllowed('newsletter/subscriber')
                 && !$customer->getConfirmation()
             ) {
                 $customer->setIsSubscribed(isset($data['subscription']));

--- a/app/code/core/Mage/Adminhtml/controllers/CustomerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/CustomerController.php
@@ -317,7 +317,7 @@ class Mage_Adminhtml_CustomerController extends Mage_Adminhtml_Controller_Action
                 }
             }
 
-            if (Mage::getSingleton('admin/session')->isAllowed('customer/newsletter')
+            if (Mage::getSingleton('admin/session')->isAllowed('newsletter/subscription')
                 && !$customer->getConfirmation()
             ) {
                 $customer->setIsSubscribed(isset($data['subscription']));


### PR DESCRIPTION
1. The checked ACL identifier (`customer/newsletter`) does not exist, so any restricted admin user cannot manage subscriptions.
2. It should check the same identifier that the customer edit page uses to detemine if the tab with checkbox should be visible (see https://github.com/OpenMage/magento-lts/blob/1.9.3.x/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tabs.php#L92).