### PR TITLE
splitted union queries for eav entities to simpler queries

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -1117,9 +1117,6 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
             }
             unset($values);
             unset($storeValues);
-            #foreach ($values as $value) {
-            #    $this->_setItemAttributeValue($value);
-            #}
         }
 
         return $this;


### PR DESCRIPTION
This is a follow up to the past PR #347.

This pull requests converts EAV - based queries for $model->load() and $collection->load() queries. Affected Entities are catalog_product catalog_categories customers. The idea behind is to convert the SQL - Queries to simpler one which reduces the load on the database and don't create tmp-tables and also depending on the configuration tmp-tables on disc. Instead of having one HUGE query with UNION ALL for the eav tables each table is queried separatly. Another improfement is that the if expression is gone and the order by store_id is happening in PHP which reduces the overall load on the database. Another improfement is the static sorted attribute cache to avoid double sort of attributes when 2 products whinin an listing have the same attribute set.

@seansan @colinmollenhour @tmotyl @partounian the other PR is closed 