### PR TITLE
Optimized EAV Cache

### DIFF
--- a/app/code/core/Mage/Catalog/Helper/Data.php
+++ b/app/code/core/Mage/Catalog/Helper/Data.php
@@ -422,8 +422,7 @@ class Mage_Catalog_Helper_Data extends Mage_Core_Helper_Abstract
     {
         if($this->_mapApplyToProductType === null) {
             /** @var $attribute Mage_Catalog_Model_Resource_Eav_Attribute */
-            $attribute = Mage::getModel('catalog/resource_eav_attribute')
-                ->loadByCode(Mage_Catalog_Model_Product::ENTITY, 'msrp_enabled');
+            $attribute = Mage::getSingleton('eav/config')->getAttribute(Mage_Catalog_Model_Product::ENTITY,'msrp_enabled');
             $this->_mapApplyToProductType = $attribute->getApplyTo();
         }
         return empty($this->_mapApplyToProductType) || in_array($product->getTypeId(), $this->_mapApplyToProductType);

--- a/app/code/core/Mage/Catalog/Model/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Config.php
@@ -256,8 +256,8 @@ class Mage_Catalog_Model_Config extends Mage_Eav_Model_Config
      */
     public function getProductAttributes()
     {
-        if (is_null($this->_productAttributes)) {
-            $this->_productAttributes = array_keys($this->getAttributesUsedInProductListing());
+        if (null === $this->_usedInProductListing) {
+            $this->_usedInProductListing = Mage::getSingleton('eav/config')->getAttributesUsedInProductListing();
         }
         return $this->_productAttributes;
     }

--- a/app/code/core/Mage/Catalog/Model/Layer.php
+++ b/app/code/core/Mage/Catalog/Model/Layer.php
@@ -214,24 +214,19 @@ class Mage_Catalog_Model_Layer extends Varien_Object
      */
     public function getFilterableAttributes()
     {
-//        $entity = Mage::getSingleton('eav/config')
-//            ->getEntityType('catalog_product');
-
         $setIds = $this->_getSetIds();
-        if (!$setIds) {
+        if (false === is_array($setIds) || count($setIds) === 0) {
             return array();
         }
-        /** @var $collection Mage_Catalog_Model_Resource_Product_Attribute_Collection */
-        $collection = Mage::getResourceModel('catalog/product_attribute_collection');
-        $collection
-            ->setItemObjectClass('catalog/resource_eav_attribute')
-            ->setAttributeSetFilter($setIds)
-            ->addStoreLabel(Mage::app()->getStore()->getId())
-            ->setOrder('position', 'ASC');
-        $collection = $this->_prepareAttributeCollection($collection);
-        $collection->load();
-
-        return $collection;
+        /** @var Mage_Eav_Model_Config $eavConfig */
+        $attributes = Mage::getSingleton('eav/config')->getFilterableProductAttributesUsedInSets($setIds);
+        usort($attributes, function ($attributeA, $attributeB){
+            if ((int)$attributeA->getPosition() == (int)$attributeB->getPosition()) {
+                return 0;
+            }
+            return ((int)$attributeA->getPosition() < (int)$attributeB->getPosition()) ? -1 : 1;
+        });
+        return $attributes;
     }
 
     /**

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Media.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Media.php
@@ -270,8 +270,7 @@ class Mage_Catalog_Model_Resource_Product_Attribute_Backend_Media extends Mage_C
      */
     protected function _getAttributeId() {
         if(is_null($this->_attributeId)) {
-            $attribute = Mage::getModel('eav/entity_attribute')
-                ->loadByCode(Mage_Catalog_Model_Product::ENTITY, 'media_gallery');
+            $attribute = Mage::getSingleton('eav/config')->getAttribute(Mage_Catalog_Model_Product::ENTITY, 'media_gallery');
 
             $this->_attributeId = $attribute->getId();
         }

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Minimalprice.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Minimalprice.php
@@ -65,7 +65,7 @@ class Mage_CatalogIndex_Model_Indexer_Minimalprice extends Mage_CatalogIndex_Mod
     {
         $data = $this->getData('tier_price_attribute');
         if (is_null($data)) {
-            $data = Mage::getModel('eav/entity_attribute')->loadByCode(Mage_Catalog_Model_Product::ENTITY, 'tier_price');
+            $data = Mage::getSingleton('eav/config')->getAttribute(Mage_Catalog_Model_Product::ENTITY, 'tier_price');
             $this->setData('tier_price_attribute', $data);
         }
         return $data;
@@ -75,7 +75,7 @@ class Mage_CatalogIndex_Model_Indexer_Minimalprice extends Mage_CatalogIndex_Mod
     {
         $data = $this->getData('price_attribute');
         if (is_null($data)) {
-            $data = Mage::getModel('eav/entity_attribute')->loadByCode(Mage_Catalog_Model_Product::ENTITY, 'price');
+            $data = Mage::getSingleton('eav/config')->getAttribute(Mage_Catalog_Model_Product::ENTITY, 'price');
             $this->setData('price_attribute', $data);
         }
         return $data;

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -73,8 +73,7 @@ class Mage_Downloadable_Block_Adminhtml_Catalog_Product_Edit_Tab_Downloadable_Li
         if (is_null($this->_purchasedSeparatelyAttribute)) {
             $_attributeCode = 'links_purchased_separately';
 
-            $this->_purchasedSeparatelyAttribute = Mage::getModel('eav/entity_attribute')
-                ->loadByCode(Mage_Catalog_Model_Product::ENTITY, $_attributeCode);
+            $this->_purchasedSeparatelyAttribute = Mage::getSingleton('eav/config')->getAttribute(Mage_Catalog_Model_Product::ENTITY, $_attributeCode);
         }
 
         return $this->_purchasedSeparatelyAttribute;

--- a/app/code/core/Mage/Eav/Model/Entity/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Abstract.php
@@ -35,6 +35,14 @@
 abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_Abstract
     implements Mage_Eav_Model_Entity_Interface
 {
+
+    /**
+     * sorted attributes by attribute Set Id (static cache)
+     *
+     * @var array
+     */
+    protected static $_sortedAttributesByAttributeSetId = array();
+
     /**
      * Read connection
      *
@@ -540,6 +548,9 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
      */
     public function getSortedAttributes($setId = null)
     {
+        if (null !== $setId && true === isset(self::$_sortedAttributesByAttributeSetId[$setId])) {
+            return self::$_sortedAttributesByAttributeSetId[$setId];
+        }
         $attributes = $this->getAttributesByCode();
         if ($setId === null) {
             $setId = $this->getEntityType()->getDefaultAttributeSetId();
@@ -558,6 +569,9 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
 
         $this->_sortingSetId = $setId;
         uasort($attributes, array($this, 'attributesCompare'));
+        if (null !== $setId) {
+            self::$_sortedAttributesByAttributeSetId[$setId] = $attributes;
+        }
         return $attributes;
     }
 

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute.php
@@ -310,7 +310,7 @@ class Mage_Eav_Model_Entity_Attribute extends Mage_Eav_Model_Entity_Attribute_Ab
      */
     public function getStoreLabels()
     {
-        if (!$this->getData('store_labels')) {
+        if (false === is_array($this->getData('store_labels'))) {
             $storeLabel = $this->getResource()->getStoreLabelsByAttributeId($this->getId());
             $this->setData('store_labels', $storeLabel);
         }

--- a/app/code/core/Mage/Tax/Helper/Data.php
+++ b/app/code/core/Mage/Tax/Helper/Data.php
@@ -871,8 +871,7 @@ class Mage_Tax_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function joinTaxClass($select, $storeId, $priceTable = 'main_table')
     {
-        $taxClassAttribute = Mage::getModel('eav/entity_attribute')
-            ->loadByCode(Mage_Catalog_Model_Product::ENTITY, 'tax_class_id');
+        $taxClassAttribute = Mage::getSingleton('eav/config')->getAttribute(Mage_Catalog_Model_Product::ENTITY, 'tax_class_id');
         $joinConditionD = implode(' AND ', array(
             "tax_class_d.entity_id = {$priceTable}.entity_id",
             $select->getAdapter()->quoteInto('tax_class_d.attribute_id = ?', (int)$taxClassAttribute->getId()),


### PR DESCRIPTION
This pull requests extends the eav cache to preload the entities and also cache them and reduce the amount of queries send to the Databases. In my Environment we reduced the amount of queries from 70 to 40. Also EAV Tags are added to cache entries to evict them on Attribute Save or Attribute set save etc. Also the Peak Memory usage gets lowered. 

Here some Queries which gets executed once and cached. 

```sql
SELECT `catalog_eav_attribute`.* FROM `catalog_eav_attribute` WHERE (attribute_id = :attribute_id);
SELECT `eav_entity_type`.`additional_attribute_table` FROM `eav_entity_type` WHERE (entity_type_id = :entity_type_id);
SELECT `eav_entity_type`.* FROM `eav_entity_type` WHERE (`eav_entity_type`.`entity_type_code`='catalog_product');

```