### PR TITLE
Add Customer Email unsubscribe option to credit memo

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
@@ -295,6 +295,16 @@ class Mage_Adminhtml_Sales_Order_CreditmemoController extends Mage_Adminhtml_Con
                     }
                 }
 
+                $succesubscribemsg = '';
+                if (isset($data['newsletter_customer_unsubscribe'])) {
+                    $order = $creditmemo->getOrder();
+                    $email = (string)$order->getBillingAddress()->getEmail();
+                    if (!$email) $email = $order->getCustomerEmail();
+                    if (Mage::getModel('newsletter/subscriber')->loadByEmail($email)->unsubscribe()) {
+                        $succesubscribemsg = $this->__(' Newsletter unsubscribe success (%s).', $email);
+                    }
+                }                
+                
                 if (isset($data['do_refund'])) {
                     $creditmemo->setRefundRequested(true);
                 }
@@ -310,7 +320,7 @@ class Mage_Adminhtml_Sales_Order_CreditmemoController extends Mage_Adminhtml_Con
                 $creditmemo->getOrder()->setCustomerNoteNotify(!empty($data['send_email']));
                 $this->_saveCreditmemo($creditmemo);
                 $creditmemo->sendEmail(!empty($data['send_email']), $comment);
-                $this->_getSession()->addSuccess($this->__('The credit memo has been created.'));
+                $this->_getSession()->addSuccess($this->__('The credit memo has been created.') . $succesubscribemsg);
                 Mage::getSingleton('adminhtml/session')->getCommentText(true);
                 $this->_redirect('*/sales_order/view', array('order_id' => $creditmemo->getOrderId()));
                 return;

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
@@ -301,7 +301,7 @@ class Mage_Adminhtml_Sales_Order_CreditmemoController extends Mage_Adminhtml_Con
                     $email = (string)$order->getBillingAddress()->getEmail();
                     if (!$email) $email = $order->getCustomerEmail();
                     if (Mage::getModel('newsletter/subscriber')->loadByEmail($email)->unsubscribe()) {
-                        $succesubscribemsg = $this->__(' Newsletter unsubscribe success (%s).', $email);
+                        $this->_getSession()->addSuccess($this->__('Newsletter unsubscription success'));
                     }
                 }                
                 
@@ -320,7 +320,7 @@ class Mage_Adminhtml_Sales_Order_CreditmemoController extends Mage_Adminhtml_Con
                 $creditmemo->getOrder()->setCustomerNoteNotify(!empty($data['send_email']));
                 $this->_saveCreditmemo($creditmemo);
                 $creditmemo->sendEmail(!empty($data['send_email']), $comment);
-                $this->_getSession()->addSuccess($this->__('The credit memo has been created.') . $succesubscribemsg);
+                $this->_getSession()->addSuccess($this->__('The credit memo has been created.'));
                 Mage::getSingleton('adminhtml/session')->getCommentText(true);
                 $this->_redirect('*/sales_order/view', array('order_id' => $creditmemo->getOrderId()));
                 return;

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
@@ -300,8 +300,11 @@ class Mage_Adminhtml_Sales_Order_CreditmemoController extends Mage_Adminhtml_Con
                     $order = $creditmemo->getOrder();
                     $email = (string)$order->getBillingAddress()->getEmail();
                     if (!$email) $email = $order->getCustomerEmail();
-                    if (Mage::getModel('newsletter/subscriber')->loadByEmail($email)->unsubscribe()) {
-                        $this->_getSession()->addSuccess($this->__('Newsletter unsubscription success'));
+                    if (!empty($email)) { 
+                        if ($unsubscriber = Mage::getModel('newsletter/subscriber')->loadByEmail($email)) {
+                            $unsubscriber->unsubscribe();
+                            $this->_getSession()->addSuccess($this->__('Newsletter unsubscription success'));
+                        }
                     }
                 }                
                 

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items.phtml
@@ -104,6 +104,10 @@
               <label class="normal" for="notify_customer"><?php echo Mage::helper('sales')->__('Append Comments') ?></label>
               <input id="notify_customer" name="creditmemo[comment_customer_notify]" value="1" type="checkbox" />
           </p>
+          <p>
+              <label class="normal" for="newsletterunsubscribe_customer"><?php echo Mage::helper('sales')->__('Unsubscribe from Newsletter') ?></label>
+              <input id="newsletterunsubscribe_customer" name="creditmemo[newsletter_customer_unsubscribe]" value="" type="checkbox" />
+          </p>
           <?php if ($this->canSendCreditmemoEmail()):?>
           <p>
               <label class="normal" for="send_email"><?php echo Mage::helper('sales')->__('Email Copy of Credit Memo') ?></label>


### PR DESCRIPTION
Add Customer Email unsubscribe option to credit memo

**The rationale**

- email subscriber management is becoming increasingly important (esp email sender credability)
- it is a given that customers sometimes cancel orders, make returns, buy products twice with both you and the competitor and return 1, are (structurally) unhappy .. no problem, daily business ;)
- however we have seen that this niche customer group is a very large contributor to email unsubscribes (even marking it as spam, when they did subscribe themselves)
- for years we have focussed on OPTIN and list growth, now the time has come for email OPT OUT

So our backoffice team has made the request to add an option during credit memo process to more easily unsubscribe customers in the above situation ... (the workaround is via account etc etc)

**Coding**

I have added a simple update that does not break anything (so it seems). I did not manage to add it into the test scripts where I can see it also exists. But see this as logic to be improved by a more senior programmer. I am no PHP developer. 

I think it would be nice/good to have this ... again it does not break anything either

Hope it helps





 



 