### PR TITLE
Clean model cache after commit instead of after save to avoid stale c…

### DIFF
--- a/app/code/core/Mage/Core/Model/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Abstract.php
@@ -340,6 +340,7 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
      */
     public function afterCommitCallback()
     {
+        $this->cleanModelCache();
         Mage::dispatchEvent('model_save_commit_after', array('object'=>$this));
         Mage::dispatchEvent($this->_eventPrefix.'_save_commit_after', $this->_getEventData());
         return $this;
@@ -461,7 +462,6 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
      */
     protected function _afterSave()
     {
-        $this->cleanModelCache();
         Mage::dispatchEvent('model_save_after', array('object'=>$this));
         Mage::dispatchEvent($this->_eventPrefix.'_save_after', $this->_getEventData());
         return $this;


### PR DESCRIPTION
There exists a race condition between a model save being committed to the database and another process (re)populating a cleaned cache record. Example:

- Process1: Start transaction, save one or more models, _afterSave cleans cache records
- Process2: Cache miss, load data, save new cache record
- Process1: Complete other work inside transaction, commit transaction
- Process3: Load stale cache record created by Process2

With this patch it goes like this:

- Process1: Start transaction, save one or more models
- Process2: Cache hit since cache record was not yet cleaned
- Process1: Complete other work inside transaction, commit transaction, clean cache records
- Process3: Cache miss, load fresh data, save new cache record