### PR TITLE
Fix missing customer email address on api created order

### DIFF
--- a/app/code/core/Mage/Checkout/Model/Cart/Customer/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Customer/Api.php
@@ -146,9 +146,12 @@ class Mage_Checkout_Model_Cart_Customer_Api extends Mage_Checkout_Model_Api_Reso
                 $this->_fault('customer_address_invalid', implode(PHP_EOL, $validateRes));
             }
 
+            if (!$address->getEmail() && $quote->getCustomerEmail()) {
+                $address->setEmail($quote->getCustomerEmail());
+            }
+
             switch($addressMode) {
             case self::ADDRESS_BILLING:
-                $address->setEmail($quote->getCustomer()->getEmail());
 
                 if (!$quote->isVirtual()) {
                     $usingCase = isset($addressItem['use_for_shipping']) ? (int)$addressItem['use_for_shipping'] : 0;


### PR DESCRIPTION
Solves Issue #476

I used the logic from the Onepage Checkout
```php
//app/code/core/Mage/Checkout/Model/Type/Onepage.php:309

// set email for newly created user
if (!$address->getEmail() && $this->getQuote()->getCustomerEmail()) {
    $address->setEmail($this->getQuote()->getCustomerEmail());
}
```

My debug script for testing this PR:
[https://gist.github.com/spinsch/eba8eacc7e84f5d7209bb7992cd5a842](https://gist.github.com/spinsch/eba8eacc7e84f5d7209bb7992cd5a842)
