### PR TITLE
Add URI info to log files.

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -838,7 +838,7 @@ final class Mage
                 }
                 $writer->setFormatter($formatter);
                 $loggers[$file] = new Zend_Log($writer);
-                $loggers[$file]->setEventItem('uri', $_SERVER["REQUEST_URI"]);
+                $loggers[$file]->setEventItem('uri', isset($_SERVER["REQUEST_URI"]) ? $_SERVER["REQUEST_URI"] : 'No URI');
             }
 
             if (is_array($message) || is_object($message)) {

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -827,7 +827,7 @@ final class Mage
                     chmod($logFile, 0640);
                 }
 
-                $format = '%timestamp% %priorityName% (%priority%): %message%' . PHP_EOL;
+                $format = '%timestamp% %priorityName% (%priority%) [%uri%]: %message%' . PHP_EOL;
                 $formatter = new Zend_Log_Formatter_Simple($format);
                 $writerModel = (string)self::getConfig()->getNode('global/log/core/writer_model');
                 if (!self::$_app || !$writerModel) {
@@ -838,6 +838,7 @@ final class Mage
                 }
                 $writer->setFormatter($formatter);
                 $loggers[$file] = new Zend_Log($writer);
+                $loggers[$file]->setEventItem('uri', $_SERVER["REQUEST_URI"]);
             }
 
             if (is_array($message) || is_object($message)) {


### PR DESCRIPTION
Add URI info to the log files, which looks like this 

in system.log:
> 2018-10-13T03:32:43+00:00 DEBUG (7) **[/assets.html]**: Security problem: customs/asset_list has not been whitelisted.

in exception.log:
> 2018-10-18T05:55:08+00:00 ERR (3) **[/index.php/emgs/adminhtml_sales_order_itemOption/save/key/7f...dc7/]**: 
> exception 'Exception' with message 'Warning: explode() expects parameter 2 to be string, array given  in /home/web/public_html/magento/emgsihe/app/code/core/Mage/Catalog/Model/Product/Option/Type/Select.php on line 128' in /home/web/public_html/magento/emgsihe/app/code/core/Mage/Core/functions.php:245
> Stack trace:
> #0 [internal function]: mageCoreErrorHandler(2, 'explode() expec...', '/home/web/publi...', 128, Array)
> ...

I find the URI info useful in debugging during development. 