### PR TITLE
Fix showsTime bug in js calendar in which the option to set the time …

### DIFF
--- a/app/code/core/Mage/Core/Block/Html/Date.php
+++ b/app/code/core/Mage/Core/Block/Html/Date.php
@@ -51,7 +51,7 @@ class Mage_Core_Block_Html_Date extends Mage_Core_Block_Template
             var calendarSetupObject = {
                 inputField  : "' . $this->getId() . '",
                 ifFormat    : "' . $displayFormat . '",
-                showsTime   : "' . ($this->getTime() ? 'true' : 'false') . '",
+                showsTime   : ' . ($this->getTime() ? 'true' : 'false') . ',
                 button      : "' . $this->getId() . '_trig",
                 align       : "Bl",
                 singleClick : true


### PR DESCRIPTION
…is always shown.

![z](https://user-images.githubusercontent.com/1106470/47262542-af807780-d51d-11e8-8d6c-ac2ce5834c95.png)

Following is the js copied from browser before applying the fix:

```
<script type="text/javascript">
//<![CDATA[
	var calendarSetupObject = {
		inputField  : "options_221_date",
		ifFormat    : "%d/%m/%Y",
		showsTime   : "false",
		button      : "options_221_date_trig",
		align       : "Bl",
		singleClick : true
	}
		calendarSetupObject.range = [1918, 2035]
//]]>
</script>
```

The `showsTime` param always evaluate to `true`.  

After the fix is applied, `showsTime` is set properly to `false`:

```
<script type="text/javascript">
//<![CDATA[
	var calendarSetupObject = {
		inputField  : "options_221_date",
		ifFormat    : "%d/%m/%Y",
		showsTime   : false,
		button      : "options_221_date_trig",
		align       : "Bl",
		singleClick : true
	}
		calendarSetupObject.range = [1918, 2035]
//]]>
</script>
```
