### PR TITLE
Limit post-checkout stock re-index to only products that manage stock…

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -745,9 +745,11 @@ class Mage_CatalogInventory_Model_Observer
          * This limits the number of stock re-indexing that takes place,
          * especially in stores where stock is not managed
          **/
+        $productIds = array_map('intval', $productIds);
         $stockCollection = Mage::getModel('cataloginventory/stock_item')->getCollection()
             ->addFieldToFilter('product_id', array('in' => $productIds))
             ->addFieldToFilter('manage_stock', array('eq' => 1));
+        $stockCollection->getSelect()->reset(Zend_Db_Select::COLUMNS)->columns(['product_id']);
         $productIds = $stockCollection->getColumnValues('product_id');
 
         if (count($productIds)) {

--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -737,6 +737,19 @@ class Mage_CatalogInventory_Model_Observer
             }
         }
 
+        /**
+         * ref: https://github.com/OpenMage/magento-lts/issues/152
+         *
+         * get product stock setup.
+         * We only want to re-index products that actually have stock management setup.
+         * This limits the number of stock re-indexing that takes place,
+         * especially in stores where stock is not managed
+         **/
+        $stockCollection = Mage::getModel('cataloginventory/stock_item')->getCollection()
+            ->addFieldToFilter('product_id', array('in' => $productIds))
+            ->addFieldToFilter('manage_stock', array('eq' => 1));
+        $productIds = $stockCollection->getColumnValues('product_id');
+
         if (count($productIds)) {
             Mage::getResourceSingleton('cataloginventory/indexer_stock')->reindexProducts($productIds);
         }


### PR DESCRIPTION
ref #152

The core post checkout stock reindex routine will stock re-indx all products in order placed.
This is not needed, when an item is not stock managed.

This change has been used in a live environment on two sites. Both sites only manage about 10% of their stock items in magento.
This change removed all instanced of the dreaded Lock Table during checkout.

The change will most likely have zero effect on stores with full stock management.
