### PR TITLE
composer.json require php < 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "license": "OSL-3.0",
   "type": "magento-source",
   "require": {
-    "php": ">=5.6 <7.2",
+    "php": ">=5.6 <7.3",
     "magento-hackathon/magento-composer-installer": "*"
   },
   "authors": [


### PR DESCRIPTION
Allow `composer upgrade` on PHP 7.2.x

#557