### PR TITLE
Url reindexer update

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Indexer/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Indexer/Url.php
@@ -237,9 +237,12 @@ class Mage_Catalog_Model_Indexer_Url extends Mage_Index_Model_Indexer_Abstract
                  $urlModel->refreshProductRewrite($productId);
             }
         }
-        if (isset($data['rewrite_category_ids'])) {
+
+        $rewriteCategoryIds = $data['rewrite_category_ids'] ?? null;
+        if ($rewriteCategoryIds) {
+            $rewriteCategoryIds = array_unique($rewriteCategoryIds);
             $urlModel->clearStoreInvalidRewrites(); // Maybe some categories were moved
-            foreach ($data['rewrite_category_ids'] as $categoryId) {
+            foreach ($rewriteCategoryIds as $categoryId) {
                 $urlModel->refreshCategoryRewrite($categoryId);
             }
         }

--- a/app/code/core/Mage/Index/Model/Event.php
+++ b/app/code/core/Mage/Index/Model/Event.php
@@ -171,6 +171,8 @@ class Mage_Index_Model_Event extends Mage_Core_Model_Abstract
                 }
             } elseif (!array_key_exists($key, $current) || is_null($current[$key])) {
                 $current[$key] = $previous[$key];
+            } elseif (array_key_exists($key, $current) && array_key_exists($key, $previous) && ($previous[$key] == $current[$key])) {
+                return $current;
             } elseif (!is_array($previous[$key]) && !is_string($key)) {
                 $current[] = $previous[$key];
             }


### PR DESCRIPTION
**This work was created more for discussion point of view**

For internal projects we are using Fast Asynchronous Re-indexing for Magento 1 which will be present is some of screenshots.

**Problem**
While working at an internal task following was discovered through debugging (hard debugging) i.e. Function `\Mage_Index_Model_Event::_mergeNewDataRecursive` produces duplicates
![image](https://user-images.githubusercontent.com/22006850/48895388-ddb6e700-ee3c-11e8-9be1-9259e245a996.png)
Based on the image above it's clear that there will be duplicated values in `$current` array
![image1](https://user-images.githubusercontent.com/22006850/48839202-9409c600-ed82-11e8-9056-d3ea0518474a.png)
Unfortunately did not dig too much into understand a fix for this approach as i have no information if that logic is indented thus for now you can view my approach at fixing it https://github.com/OpenMage/magento-lts/commit/9119c011461c36772633d1627bb83b833bf0b535

On side not this was impacting category url rewrite logic
![image2](https://user-images.githubusercontent.com/22006850/48839217-a257e200-ed82-11e8-884d-cac541513cae.png)

Which in turn is used only in https://github.com/OpenMage/magento-lts/blob/1.9.3.x/app/code/core/Mage/Catalog/Model/Indexer/Url.php#L240-L244 so for that just making values unique https://github.com/OpenMage/magento-lts/commit/51a94e3ed7ed7e4397cd274a931cae874e864973 was fastest way to update it.

P.S. i have raised this PR mainly to try and understand more if that is a bug or a feature :smile: 