### PR TITLE
Mark indexProcess as STATUS_REQUIRE_REINDEX; it is cleared after

### DIFF
--- a/app/code/core/Mage/CatalogRule/Model/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule.php
@@ -318,6 +318,7 @@ class Mage_CatalogRule_Model_Rule extends Mage_Rule_Model_Abstract
         $this->_getResource()->applyAllRules();
         $this->_invalidateCache();
         $indexProcess = Mage::getSingleton('index/indexer')->getProcessByCode('catalog_product_price');
+        $indexProcess->changeStatus(Mage_Index_Model_Process::STATUS_REQUIRE_REINDEX);
         if ($indexProcess) {
             $indexProcess->reindexAll();
         }

--- a/app/code/core/Mage/CatalogRule/Model/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule.php
@@ -318,8 +318,8 @@ class Mage_CatalogRule_Model_Rule extends Mage_Rule_Model_Abstract
         $this->_getResource()->applyAllRules();
         $this->_invalidateCache();
         $indexProcess = Mage::getSingleton('index/indexer')->getProcessByCode('catalog_product_price');
-        $indexProcess->changeStatus(Mage_Index_Model_Process::STATUS_REQUIRE_REINDEX);
         if ($indexProcess) {
+            $indexProcess->changeStatus(Mage_Index_Model_Process::STATUS_REQUIRE_REINDEX);
             $indexProcess->reindexAll();
         }
     }


### PR DESCRIPTION
Mark indexProcess as STATUS_REQUIRE_REINDEX

it is cleared directly after if the indexer can run

$indexProcess->changeStatus(Mage_Index_Model_Process::STATUS_REQUIRE_REINDEX);

if it cannot then at least the indexer is marked as dirty

(sometimes the indexer is already running and the process cannot start; in this case there is no way to see this for the admin or some watching process)