### PR TITLE
Credit Memo Adjustment Fix

### DIFF
--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/totals/adjustments.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/totals/adjustments.phtml
@@ -35,14 +35,14 @@
     </tr>
     <tr>
         <td class="label"><?php echo $this->helper('sales')->__('Adjustment Refund') ?></td>
-        <td><input type="text" name="creditmemo[adjustment_positive]" value="<?php echo $_source->getBaseAdjustmentFeePositive()*1 ?>" class="input-text not-negative-amount" style="width:60px;text-align:right" id="adjustment_positive" /></td>
+        <td><input type="text" name="creditmemo[adjustment_positive]" value="<?php echo $_source->getBaseAdjustmentPositive()*1 ?>" class="input-text not-negative-amount" style="width:60px;text-align:right" id="adjustment_positive" /></td>
     </tr>
     <tr>
         <td colspan="2"><div id="adjustment_positive_adv"></div></td>
     </tr>
     <tr>
         <td class="label"><?php echo $this->helper('sales')->__('Adjustment Fee') ?></td>
-        <td><input type="text" name="creditmemo[adjustment_negative]" value="<?php echo $_source->getBaseAdjustmentFeeNegative()*1 ?>" class="input-text not-negative-amount" style="width:60px;text-align:right" id="adjustment_negative"/></td>
+        <td><input type="text" name="creditmemo[adjustment_negative]" value="<?php echo $_source->getBaseAdjustmentNegative()*1 ?>" class="input-text not-negative-amount" style="width:60px;text-align:right" id="adjustment_negative"/></td>
     </tr>
     <tr>
         <td colspan="2"><div id="adjustment_negative_adv"></div></td>


### PR DESCRIPTION
When creating a credit memo, if you put in an amount in the adjustment fee or adjustment refund and then press update quantities. It removes the values from these boxes because it's trying to get a non existing value.

One thing that still gets me is that if you zero all of the quantities first and press update quantities button. Afterwards you put a value in the adjustment box, but it doesn't refresh the values so you cannot create the credit memo. I'll investigate that next.