### PR TITLE
Sales_Order_Grids > Search By Customer First and Last Name Fixes

### DIFF
--- a/app/code/core/Mage/Sales/Model/Resource/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order.php
@@ -89,15 +89,14 @@ class Mage_Sales_Model_Resource_Order extends Mage_Sales_Model_Resource_Order_Ab
         $adapter       = $this->getReadConnection();
         $ifnullFirst   = $adapter->getIfNullSql('{{table}}.firstname', $adapter->quote(''));
         $ifnullMiddle  = $adapter->getIfNullSql('{{table}}.middlename', $adapter->quote(''));
-        $middelnameEnd = $adapter->getCheckSql('{{table}}.middlename IS NULL OR {{table}}.middlename="" OR {{table}}.middlename=" "', '""', '" "');
         $ifnullLast    = $adapter->getIfNullSql('{{table}}.lastname', $adapter->quote(''));
-        $concatAddress = $adapter->getConcatSql(array(
+        $concatAddress = trim(replace($adapter->getConcatSql(array(
             $ifnullFirst,
             $adapter->quote(' '),
             $ifnullMiddle,
-            $middelnameEnd,
+            $adapter->quote(' '),
             $ifnullLast
-        ));
+        )),'  ', ' '));
         $this->addVirtualGridColumn(
                 'billing_name',
                 'sales/order_address',

--- a/app/code/core/Mage/Sales/Model/Resource/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order.php
@@ -89,12 +89,13 @@ class Mage_Sales_Model_Resource_Order extends Mage_Sales_Model_Resource_Order_Ab
         $adapter       = $this->getReadConnection();
         $ifnullFirst   = $adapter->getIfNullSql('{{table}}.firstname', $adapter->quote(''));
         $ifnullMiddle  = $adapter->getIfNullSql('{{table}}.middlename', $adapter->quote(''));
+        $middelnameEnd = $adapter->getCheckSql('{{table}}.middlename IS NULL OR {{table}}.middlename="" OR {{table}}.middlename=" "', '""', '" "');
         $ifnullLast    = $adapter->getIfNullSql('{{table}}.lastname', $adapter->quote(''));
         $concatAddress = $adapter->getConcatSql(array(
             $ifnullFirst,
             $adapter->quote(' '),
             $ifnullMiddle,
-            $adapter->quote(' '),
+            $middelnameEnd,
             $ifnullLast
         ));
         $this->addVirtualGridColumn(

--- a/app/code/core/Mage/Sales/Model/Resource/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order.php
@@ -90,13 +90,15 @@ class Mage_Sales_Model_Resource_Order extends Mage_Sales_Model_Resource_Order_Ab
         $ifnullFirst   = $adapter->getIfNullSql('{{table}}.firstname', $adapter->quote(''));
         $ifnullMiddle  = $adapter->getIfNullSql('{{table}}.middlename', $adapter->quote(''));
         $ifnullLast    = $adapter->getIfNullSql('{{table}}.lastname', $adapter->quote(''));
-        $concatAddress = trim(replace($adapter->getConcatSql(array(
+        $concatAddress = $adapter->getConcatSql(array(
             $ifnullFirst,
             $adapter->quote(' '),
             $ifnullMiddle,
             $adapter->quote(' '),
             $ifnullLast
-        )),'  ', ' '));
+        ));
+        $concatAddress = new Zend_Db_Expr("TRIM(REPLACE($concatAddress,'  ', ' '))");
+
         $this->addVirtualGridColumn(
                 'billing_name',
                 'sales/order_address',

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo.php
@@ -82,12 +82,13 @@ class Mage_Sales_Model_Resource_Order_Creditmemo extends Mage_Sales_Model_Resour
         $adapter           = $this->getReadConnection();
         $checkedFirstname  = $adapter->getIfNullSql('{{table}}.firstname', $adapter->quote(''));
         $checkedMiddlename = $adapter->getIfNullSql('{{table}}.middlename', $adapter->quote(''));
+        $middelnameEnd     = $adapter->getCheckSql('{{table}}.middlename IS NULL OR {{table}}.middlename="" OR {{table}}.middlename=" "', '""', '" "');
         $checkedLastname   = $adapter->getIfNullSql('{{table}}.lastname', $adapter->quote(''));
         $concatName        = $adapter->getConcatSql(array(
             $checkedFirstname,
             $adapter->quote(' '),
             $checkedMiddlename,
-            $adapter->quote(' '),
+            $middelnameEnd,
             $checkedLastname
         ));
 

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo.php
@@ -83,13 +83,14 @@ class Mage_Sales_Model_Resource_Order_Creditmemo extends Mage_Sales_Model_Resour
         $checkedFirstname  = $adapter->getIfNullSql('{{table}}.firstname', $adapter->quote(''));
         $checkedMiddlename = $adapter->getIfNullSql('{{table}}.middlename', $adapter->quote(''));
         $checkedLastname   = $adapter->getIfNullSql('{{table}}.lastname', $adapter->quote(''));
-        $concatName        = trim(replace($adapter->getConcatSql(array(
+        $concatName        = $adapter->getConcatSql(array(
             $checkedFirstname,
             $adapter->quote(' '),
             $checkedMiddlename,
             $adapter->quote(' '),
             $checkedLastname
-        )),'  ', ' '));
+        ));
+        $concatName = new Zend_Db_Expr("TRIM(REPLACE($concatName,'  ', ' '))");
 
         $this->addVirtualGridColumn(
             'billing_name',

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo.php
@@ -82,15 +82,14 @@ class Mage_Sales_Model_Resource_Order_Creditmemo extends Mage_Sales_Model_Resour
         $adapter           = $this->getReadConnection();
         $checkedFirstname  = $adapter->getIfNullSql('{{table}}.firstname', $adapter->quote(''));
         $checkedMiddlename = $adapter->getIfNullSql('{{table}}.middlename', $adapter->quote(''));
-        $middelnameEnd     = $adapter->getCheckSql('{{table}}.middlename IS NULL OR {{table}}.middlename="" OR {{table}}.middlename=" "', '""', '" "');
         $checkedLastname   = $adapter->getIfNullSql('{{table}}.lastname', $adapter->quote(''));
-        $concatName        = $adapter->getConcatSql(array(
+        $concatName        = trim(replace($adapter->getConcatSql(array(
             $checkedFirstname,
             $adapter->quote(' '),
             $checkedMiddlename,
-            $middelnameEnd,
+            $adapter->quote(' '),
             $checkedLastname
-        ));
+        )),'  ', ' '));
 
         $this->addVirtualGridColumn(
             'billing_name',

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice.php
@@ -82,6 +82,7 @@ class Mage_Sales_Model_Resource_Order_Invoice extends Mage_Sales_Model_Resource_
         $adapter           = $this->_getReadAdapter();
         $checkedFirstname  = $adapter->getIfNullSql('{{table}}.firstname', $adapter->quote(''));
         $checkedMiddlename = $adapter->getIfNullSql('{{table}}.middlename', $adapter->quote(''));
+        $middelnameEnd     = $adapter->getCheckSql('{{table}}.middlename IS NULL OR {{table}}.middlename="" OR {{table}}.middlename=" "', '""', '" "');
         $checkedLastname   = $adapter->getIfNullSql('{{table}}.lastname', $adapter->quote(''));
 
         $this->addVirtualGridColumn(
@@ -92,7 +93,7 @@ class Mage_Sales_Model_Resource_Order_Invoice extends Mage_Sales_Model_Resource_
                 $checkedFirstname,
                 $adapter->quote(' '),
                 $checkedMiddlename,
-                $adapter->quote(' '),
+                $middelnameEnd,
                 $checkedLastname
             ))
         )

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice.php
@@ -83,18 +83,20 @@ class Mage_Sales_Model_Resource_Order_Invoice extends Mage_Sales_Model_Resource_
         $checkedFirstname  = $adapter->getIfNullSql('{{table}}.firstname', $adapter->quote(''));
         $checkedMiddlename = $adapter->getIfNullSql('{{table}}.middlename', $adapter->quote(''));
         $checkedLastname   = $adapter->getIfNullSql('{{table}}.lastname', $adapter->quote(''));
+        $concatName = $adapter->getConcatSql(array(
+            $checkedFirstname,
+            $adapter->quote(' '),
+            $checkedMiddlename,
+            $adapter->quote(' '),
+            $checkedLastname
+        ));
+        $concatName = new Zend_Db_Expr("TRIM(REPLACE($concatName,'  ', ' '))");
 
         $this->addVirtualGridColumn(
             'billing_name',
             'sales/order_address',
             array('billing_address_id' => 'entity_id'),
-            trim(replace($adapter->getConcatSql(array(
-                $checkedFirstname,
-                $adapter->quote(' '),
-                $checkedMiddlename,
-                $adapter->quote(' '),
-                $checkedLastname
-            )),'  ', ' '))
+            $concatName
         )
         ->addVirtualGridColumn(
             'order_increment_id',

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice.php
@@ -82,20 +82,19 @@ class Mage_Sales_Model_Resource_Order_Invoice extends Mage_Sales_Model_Resource_
         $adapter           = $this->_getReadAdapter();
         $checkedFirstname  = $adapter->getIfNullSql('{{table}}.firstname', $adapter->quote(''));
         $checkedMiddlename = $adapter->getIfNullSql('{{table}}.middlename', $adapter->quote(''));
-        $middelnameEnd     = $adapter->getCheckSql('{{table}}.middlename IS NULL OR {{table}}.middlename="" OR {{table}}.middlename=" "', '""', '" "');
         $checkedLastname   = $adapter->getIfNullSql('{{table}}.lastname', $adapter->quote(''));
 
         $this->addVirtualGridColumn(
             'billing_name',
             'sales/order_address',
             array('billing_address_id' => 'entity_id'),
-            $adapter->getConcatSql(array(
+            trim(replace($adapter->getConcatSql(array(
                 $checkedFirstname,
                 $adapter->quote(' '),
                 $checkedMiddlename,
-                $middelnameEnd,
+                $adapter->quote(' '),
                 $checkedLastname
-            ))
+            )),'  ', ' '))
         )
         ->addVirtualGridColumn(
             'order_increment_id',

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
@@ -82,12 +82,13 @@ class Mage_Sales_Model_Resource_Order_Shipment extends Mage_Sales_Model_Resource
         $adapter           = $this->getReadConnection();
         $checkedFirstname  = $adapter->getIfNullSql('{{table}}.firstname', $adapter->quote(''));
         $checkedMidllename = $adapter->getIfNullSql('{{table}}.middlename', $adapter->quote(''));
+        $middelnameEnd     = $adapter->getCheckSql('{{table}}.middlename IS NULL OR {{table}}.middlename="" OR {{table}}.middlename=" "', '""', '" "');
         $checkedLastname   = $adapter->getIfNullSql('{{table}}.lastname', $adapter->quote(''));
         $concatName        = $adapter->getConcatSql(array(
             $checkedFirstname,
             $adapter->quote(' '),
             $checkedMidllename,
-            $adapter->quote(' '),
+            $middelnameEnd,
             $checkedLastname
         ));
 

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
@@ -83,13 +83,13 @@ class Mage_Sales_Model_Resource_Order_Shipment extends Mage_Sales_Model_Resource
         $checkedFirstname  = $adapter->getIfNullSql('{{table}}.firstname', $adapter->quote(''));
         $checkedMidllename = $adapter->getIfNullSql('{{table}}.middlename', $adapter->quote(''));
         $checkedLastname   = $adapter->getIfNullSql('{{table}}.lastname', $adapter->quote(''));
-        $concatName        = trim(replace($adapter->getConcatSql(array(
+        $concatName        = $adapter->getConcatSql(array(
             $checkedFirstname,
             $adapter->quote(' '),
             $checkedMidllename,
             $adapter->quote(' '),
             $checkedLastname
-        )),'  ', ' '));
+        ));
         $concatName = new Zend_Db_Expr("TRIM(REPLACE($concatName,'  ', ' '))");
 
         $this->addVirtualGridColumn(

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
@@ -82,15 +82,14 @@ class Mage_Sales_Model_Resource_Order_Shipment extends Mage_Sales_Model_Resource
         $adapter           = $this->getReadConnection();
         $checkedFirstname  = $adapter->getIfNullSql('{{table}}.firstname', $adapter->quote(''));
         $checkedMidllename = $adapter->getIfNullSql('{{table}}.middlename', $adapter->quote(''));
-        $middelnameEnd     = $adapter->getCheckSql('{{table}}.middlename IS NULL OR {{table}}.middlename="" OR {{table}}.middlename=" "', '""', '" "');
         $checkedLastname   = $adapter->getIfNullSql('{{table}}.lastname', $adapter->quote(''));
-        $concatName        = $adapter->getConcatSql(array(
+        $concatName        = trim(replace($adapter->getConcatSql(array(
             $checkedFirstname,
             $adapter->quote(' '),
             $checkedMidllename,
-            $middelnameEnd,
+            $adapter->quote(' '),
             $checkedLastname
-        ));
+        )),'  ', ' '));
 
         $this->addVirtualGridColumn(
             'shipping_name',

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
@@ -90,6 +90,7 @@ class Mage_Sales_Model_Resource_Order_Shipment extends Mage_Sales_Model_Resource
             $adapter->quote(' '),
             $checkedLastname
         )),'  ', ' '));
+        $concatName = new Zend_Db_Expr("TRIM(REPLACE($concatName,'  ', ' '))");
 
         $this->addVirtualGridColumn(
             'shipping_name',


### PR DESCRIPTION
Orignal pull request ticket - Unable to search customer by first and last name on sales_order_grid #538

Apologies, had to reset my fork after I'd made the commits to the wrong branch. So just cleared and started again.

As said in previous PR, this fixes searching both customer first and last name.
Other notes can be found https://github.com/OpenMage/magento-lts/pull/538