### PR TITLE
fixed return value of saveCache method

### DIFF
--- a/app/code/core/Mage/Core/Model/Layout/Update.php
+++ b/app/code/core/Mage/Core/Model/Layout/Update.php
@@ -210,13 +210,13 @@ class Mage_Core_Model_Layout_Update
         // Cache key is sha1 hash of actual XML string
         $hash = sha1($str);
         $tags[] = self::LAYOUT_GENERAL_CACHE_TAG;
-        Mage::app()->saveCache($hash, $this->getCacheId(), $tags, null);
+        $returnValue = Mage::app()->saveCache($hash, $this->getCacheId(), $tags, null);
 
         // Only save actual XML to cache if it doesn't already exist
         if ( ! Mage::app()->getCache()->test(self::XML_KEY_PREFIX . $hash)) {
-            Mage::app()->saveCache($str, self::XML_KEY_PREFIX . $hash, $tags, null);
+            $returnValue = Mage::app()->saveCache($str, self::XML_KEY_PREFIX . $hash, $tags, null);
         }
-        return TRUE;
+        return $returnValue;
     }
 
     /**


### PR DESCRIPTION
The original method did not return a boolean value, but the return value of `Mage_Core_Model_App::saveCache`. See https://github.com/OpenMage/magento-mirror/blob/fe6a94e281cb3e8e166f4eece31c4df1faa8cec6/app/code/core/Mage/Core/Model/Layout/Update.php#L198.