### PR TITLE
Fix HTTP/2 errors with cURL post

### DIFF
--- a/lib/Varien/Http/Adapter/Curl.php
+++ b/lib/Varien/Http/Adapter/Curl.php
@@ -180,7 +180,8 @@ class Varien_Http_Adapter_Curl implements Zend_Http_Client_Adapter_Interface
         $options = array(
             CURLOPT_URL                     => $url,
             CURLOPT_RETURNTRANSFER          => true,
-            CURLOPT_HEADER                  => $header
+            CURLOPT_HEADER                  => $header,
+            CURLOPT_HTTP_VERSION            => CURL_HTTP_VERSION_1_1
         );
         if ($method == Zend_Http_Client::POST) {
             $options[CURLOPT_POST]          = true;


### PR DESCRIPTION
Latest cURL update defaults to HTTP/2, but Magento's HTTP CURL Adapter is incompatible. This patch is necessary for newer server environments.