### PR TITLE
Fix issues with json_encode() and floats after upgrading to PHP 7.1

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -32,3 +32,8 @@
 if (function_exists('libxml_disable_entity_loader')) {
     libxml_disable_entity_loader(false);
 }
+
+/* For data consistency between displaying (printing) and serialization a float number */
+/* Added to fix issues with json_encode() and floats after upgrading to PHP 7.1 */
+ini_set('precision', 14);
+ini_set('serialize_precision', 14);

--- a/shell/abstract.php
+++ b/shell/abstract.php
@@ -81,6 +81,11 @@ abstract class Mage_Shell_Abstract
      */
     public function __construct()
     {
+        /* For data consistency between displaying (printing) and serialization a float number */
+        /* Added to fix issues with json_encode() and floats after upgrading to PHP 7.1 */
+        ini_set('precision', 14);
+        ini_set('serialize_precision', 14);
+
         if ($this->_includeMage) {
             require_once $this->_getRootPath() . 'app' . DIRECTORY_SEPARATOR . 'Mage.php';
             Mage::app($this->_appCode, $this->_appType);


### PR DESCRIPTION
Issue description:
https://bugs.php.net/bug.php?id=72567

More info:
https://wiki.php.net/rfc/precise_float_value

Workaround in Magento 2:
https://github.com/magento/magento2/blob/2.3-develop/app/bootstrap.php#L74
