### PR TITLE
Remove whitespace in addBodyClass($className)

### DIFF
--- a/app/code/core/Mage/Page/Block/Html.php
+++ b/app/code/core/Mage/Page/Block/Html.php
@@ -131,7 +131,8 @@ class Mage_Page_Block_Html extends Mage_Core_Block_Template
     public function addBodyClass($className)
     {
         $className = preg_replace('#[^a-z0-9]+#', '-', strtolower($className));
-        $this->setBodyClass($this->getBodyClass() . ' ' . $className);
+        $class = $this->getBodyClass() ? $this->getBodyClass() . ' ' . $className : $className;
+        $this->setBodyClass($class);
         return $this;
     }
 


### PR DESCRIPTION
Remove whitespace that is generated in body class string. 

if no result from $this->getBodyClass() output just classname instead of null+whitespace+classname
E.g. 
`<body class=" classnames">`

Fixed Result:
`<body class="classnames">`