### PR TITLE
Disable select-all for large collections.

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid.php
@@ -198,6 +198,7 @@ class Mage_Adminhtml_Block_Newsletter_Subscriber_Grid extends Mage_Adminhtml_Blo
     {
         $this->setMassactionIdField('subscriber_id');
         $this->getMassactionBlock()->setFormFieldName('subscriber');
+        $this->getMassactionBlock()->setUseSelectAll(false);
 
         $this->getMassactionBlock()->addItem('unsubscribe', array(
              'label'        => Mage::helper('newsletter')->__('Unsubscribe'),

--- a/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
@@ -210,6 +210,7 @@ class Mage_Adminhtml_Block_Review_Grid extends Mage_Adminhtml_Block_Widget_Grid
         $this->setMassactionIdFilter('rt.review_id');
         $this->setMassactionIdFieldOnlyIndexValue(true);
         $this->getMassactionBlock()->setFormFieldName('reviews');
+        $this->getMassactionBlock()->setUseSelectAll(false);
 
         $this->getMassactionBlock()->addItem('delete', array(
             'label'=> Mage::helper('review')->__('Delete'),


### PR DESCRIPTION
For tables with a particularly large number of records, it may be useful to disable the front end 'select-all' for performance reasons. Reduces likelihood of encountering PHP memory limit issues in these cases. 