### PR TITLE
Fix <br/> in gallery header

### DIFF
--- a/app/design/adminhtml/default/default/template/catalog/product/helper/gallery.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/helper/gallery.phtml
@@ -59,7 +59,7 @@ $_block = $this;
             <th><?php echo Mage::helper('catalog')->__('Label') ?></th>
             <th><?php echo Mage::helper('catalog')->__('Sort Order') ?></th>
             <?php foreach ($_block->getImageTypes() as $typeId => $type): ?>
-                <th><?php echo $this->escapeHtml($type['label']); ?></th>
+                <th><?php echo str_replace("&lt;br/&gt;","<br/>",$this->escapeHtml($type['label'])); ?></th>
             <?php endforeach; ?>
             <th><?php echo Mage::helper('catalog')->__('Exclude') ?></th>
             <th class="last"><?php echo Mage::helper('catalog')->__('Remove') ?></th>


### PR DESCRIPTION
#553 Keeps the escapehtml() by adding a str_replace() to convert back just the `<br/>` tag.