### PR TITLE
Prevent double firing events in Category_Flat_Collection

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
@@ -127,31 +127,6 @@ class Mage_Catalog_Model_Resource_Category_Flat_Collection extends Mage_Core_Mod
     }
 
     /**
-     * Before collection load
-     *
-     * @return Mage_Catalog_Model_Resource_Category_Flat_Collection
-     */
-    protected function _beforeLoad()
-    {
-        Mage::dispatchEvent($this->_eventPrefix . '_load_before',
-                            array($this->_eventObject => $this));
-        return parent::_beforeLoad();
-    }
-
-    /**
-     * After collection load
-     *
-     * @return Mage_Catalog_Model_Resource_Category_Flat_Collection
-     */
-    protected function _afterLoad()
-    {
-        Mage::dispatchEvent($this->_eventPrefix . '_load_after',
-                            array($this->_eventObject => $this));
-
-        return parent::_afterLoad();
-    }
-
-    /**
      * Set store id
      *
      * @param integer $storeId


### PR DESCRIPTION
The events catalog_category_collection_load_after and catalog_category_collection_load_before
are already fired in the parent class, so they can be removed from Mage_Catalog_Model_Resource_Category_Flat_Collection
fixes: https://github.com/OpenMage/magento-lts/issues/597