### PR TITLE
Allow 3rd-party applications to operate in get.php scope

### DIFF
--- a/app/code/core/Mage/Core/Model/File/Storage.php
+++ b/app/code/core/Mage/Core/Model/File/Storage.php
@@ -47,6 +47,7 @@ class Mage_Core_Model_File_Storage extends Mage_Core_Model_Abstract
     const XML_PATH_STORAGE_MEDIA_DATABASE   = 'default/system/media_storage_configuration/media_database';
     const XML_PATH_MEDIA_RESOURCE_WHITELIST = 'default/system/media_storage_configuration/allowed_resources';
     const XML_PATH_MEDIA_RESOURCE_IGNORED   = 'default/system/media_storage_configuration/ignored_resources';
+    const XML_PATH_MEDIA_LOADED_MODULES     = 'default/system/media_storage_configuration/loaded_modules';
     const XML_PATH_MEDIA_UPDATE_TIME        = 'system/media_storage_configuration/configuration_update_time';
 
 
@@ -220,6 +221,11 @@ class Mage_Core_Model_File_Storage extends Mage_Core_Model_Abstract
     {
         $config = array();
         $config['media_directory'] = Mage::getBaseDir('media');
+
+        $loadedModules = (array) Mage::app()->getConfig()->getNode(self::XML_PATH_MEDIA_LOADED_MODULES);
+        foreach ($loadedModules as $key => $loadedModule) {
+            $config['loaded_modules'][] = $loadedModule->getName();
+        }
 
         $allowedResources = (array) Mage::app()->getConfig()->getNode(self::XML_PATH_MEDIA_RESOURCE_WHITELIST);
         foreach ($allowedResources as $key => $allowedResource) {

--- a/app/code/core/Mage/Core/etc/config.xml
+++ b/app/code/core/Mage/Core/etc/config.xml
@@ -324,6 +324,9 @@
                     <compiled_js_folder>js</compiled_js_folder>
                 </allowed_resources>
                 <ignored_resources>.svn,.htaccess</ignored_resources>
+                <loaded_modules>
+                    <Mage_Core />
+                </loaded_modules>
             </media_storage_configuration>
         </system>
         <trans_email>

--- a/get.php
+++ b/get.php
@@ -116,7 +116,7 @@ if (empty($mediaDirectory)) {
         $mageRunCode,
         $mageRunType,
         array('cache' => array('disallow_save' => true)),
-        array('Mage_Core')
+        isset($config['loaded_modules']) ? $config['loaded_modules'] : ['Mage_Core']
     );
 }
 


### PR DESCRIPTION
Sometimes it might be useful to allow third-party modules to operate in the get.php scope. To accommodate this, a configuration point called 'loaded_modules' is added, into which third-party modules may register, thereby allowing their classes to be loaded during requests to get.php.