### PR TITLE
Prevent redundant simultaneous requests to remote storage in get.php

### DIFF
--- a/app/code/core/Mage/Core/Model/File/Storage/File.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/File.php
@@ -275,4 +275,22 @@ class Mage_Core_Model_File_Storage_File extends Mage_Core_Model_File_Storage_Abs
 
         return false;
     }
+
+    /**
+     * @param $filePath
+     * @return bool
+     */
+    public function lockCreateFile($filePath)
+    {
+        return $this->getResource()->lockCreateFile($filePath);
+    }
+
+    /**
+     * @param $filePath
+     */
+    public function removeLockedFile($filePath)
+    {
+        $this->getResource()->removeLockedFile($filePath);
+    }
+
 }

--- a/app/code/core/Mage/Core/Model/Resource/File/Storage/File.php
+++ b/app/code/core/Mage/Core/Model/Resource/File/Storage/File.php
@@ -47,6 +47,9 @@ class Mage_Core_Model_Resource_File_Storage_File
      */
     protected $_ignoredFiles;
 
+    /** @var resource */
+    protected $filePointer;
+
     /**
      * Files at storage
      *
@@ -200,14 +203,22 @@ class Mage_Core_Model_Resource_File_Storage_File
         }
 
         $fullPath = $path . DS . $filename;
-        if (!file_exists($fullPath) || $overwrite) {
+        if ($this->filePointer || !file_exists($fullPath) || $overwrite) {
+            // If we already opened the file using lockCreateFile method
+            if ($this->filePointer) {
+                $fp = $this->filePointer;
+                $this->filePointer = NULL;
+                if (@fwrite($fp, $content) !== false && @fflush($fp) && @flock($fp, LOCK_UN) && @fclose($fp)) {
+                    return true;
+                }
+            }
             // If overwrite is not required then return if file could not be locked (assume it is being written by another process)
             // Exception is only thrown if file was opened but could not be written.
-            if (!$overwrite) {
+            else if (!$overwrite) {
                 if (!($fp = @fopen($fullPath, 'x'))) {
                     return false;
                 }
-                if (@fwrite($fp, $content) !== false && @fclose($fp)) {
+                if (@fwrite($fp, $content) !== false && @fflush($fp) && @fclose($fp)) {
                     return true;
                 }
             }
@@ -221,4 +232,58 @@ class Mage_Core_Model_Resource_File_Storage_File
 
         return false;
     }
+
+    /**
+     * Create a new file already locked by this process and save the handle for later writing by saveFile method.
+     *
+     * @param $filePath
+     * @return bool
+     */
+    public function lockCreateFile($filePath)
+    {
+        $filename = basename($filePath);
+        $path = $this->getMediaBaseDirectory() . DS . str_replace('/', DS ,dirname($filePath));
+
+        if (!is_dir($path)) {
+            @mkdir($path, 0777, true);
+        }
+
+        $fullPath = $path . DS . $filename;
+
+        // Get exclusive lock on new or existing file
+        if ($fp = @fopen($fullPath, 'c')) {
+            @flock($fp, LOCK_EX);
+            @fseek($fp, 0, SEEK_END);
+            if (@ftell($fp) === 0) { // If the file is empty we can write to it
+                $this->filePointer = $fp;
+                return true;
+            } else { // Otherwise we should not write to it
+                @flock($fp, LOCK_UN);
+                @fclose($fp);
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Unlock, close and remove a locked file (in case the file could not be read from remote storage)
+     *
+     * @param $filePath
+     */
+    public function removeLockedFile($filePath)
+    {
+        $filename = basename($filePath);
+        $path = $this->getMediaBaseDirectory() . DS . str_replace('/', DS ,dirname($filePath));
+        $fullPath = $path . DS . $filename;
+        if ($this->filePointer) {
+            $fp = $this->filePointer;
+            $this->filePointer = NULL;
+            @flock($fp, LOCK_UN);
+            @fclose($fp);
+        }
+        @unlink($fullPath);
+    }
+
 }


### PR DESCRIPTION
The current get.php mechanism for fetching files from remote storage does not fully prevent a stampede of requests for the same resource from resulting in multiple fetch operations from the remote storage. That is, the remote fetching happens before the file locking. When the database storage is rewritten to use a third-party extension like Thai_S3 this can result in significantly more bandwidth being used and files being written multiple times. A situation that is not too uncommon would be if you update the watermark parameters then every resized image suddenly must be regenerated and there is currently not a good way (that I know of) to pre-warm the cache for this scenario so we are trying to make the remote fetching as efficient as possible.

This change reduces race conditions and duplicate fetch operations by locking the file before it is fetched and only releasing the lock after it is written so that other processes will be able to read the file written by the first process even if they started before the file existed locally.