### PR TITLE
Add missing event identifier for comment models

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Comment.php
@@ -47,6 +47,9 @@
  */
 class Mage_Sales_Model_Order_Creditmemo_Comment extends Mage_Sales_Model_Abstract
 {
+    protected $_eventPrefix = 'sales_creditmemo_comment';
+    protected $_eventObject = 'creditmemo_comment';
+
     /**
      * Creditmemo instance
      *

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Comment.php
@@ -47,6 +47,9 @@
  */
 class Mage_Sales_Model_Order_Invoice_Comment extends Mage_Sales_Model_Abstract
 {
+    protected $_eventPrefix = 'sales_invoice_comment';
+    protected $_eventObject = 'invoice_comment';
+
     /**
      * Invoice instance
      *

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Comment.php
@@ -47,6 +47,9 @@
  */
 class Mage_Sales_Model_Order_Shipment_Comment extends Mage_Sales_Model_Abstract
 {
+    protected $_eventPrefix = 'sales_shipment_comment';
+    protected $_eventObject = 'shipment_comment';
+
     /**
      * Shipment instance
      *


### PR DESCRIPTION
Not a bug but all other models like this has an identifier to observing.