### PR TITLE
Get cookie restriction block for current store

### DIFF
--- a/app/code/core/Mage/Page/Block/Html/CookieNotice.php
+++ b/app/code/core/Mage/Page/Block/Html/CookieNotice.php
@@ -41,7 +41,8 @@ class Mage_Page_Block_Html_CookieNotice extends Mage_Core_Block_Template
     public function getCookieRestrictionBlockContent()
     {
         $blockIdentifier = Mage::helper('core/cookie')->getCookieRestrictionNoticeCmsBlockIdentifier();
-        $block = Mage::getModel('cms/block')->load($blockIdentifier, 'identifier');
+        $block = Mage::getModel('cms/block')->setStoreId(Mage::app()->getStore()->getId());
+        $block->load($blockIdentifier, 'identifier');
 
         $html = '';
         if ($block->getIsActive()) {


### PR DESCRIPTION
Issue : Magento EU Cookie law restriction block is not loaded per store id.

Fix found here : https://magento.stackexchange.com/questions/70931/magento-eu-cookie-law-restriction-block-not-loaded-per-store-id-cookie-restrict