### PR TITLE
Fix notice after reconnect

### DIFF
--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -373,7 +373,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
         }
 
 
-        $hostInfo = $this->_getHostInfo($this->_config['host']);
+        $hostInfo = $this->_getHostInfo(isset($this->_config['host']) ? $this->_config['host'] : isset($this->_config['unix_socket']) ? $this->_config['unix_socket'] : NULL);
 
         switch ($hostInfo->getAddressType()) {
             case self::ADDRESS_TYPE_UNIX_SOCKET:


### PR DESCRIPTION
When connecting to a Unix socket, the `_connect` method will `unset` the 'host' property so that if the connection is disconnected and needs to reconnect the 'host' property will be undefined causing a failure to reconnect and issuing a PHP Notice.