### PR TITLE
Upgrade Script Made PHP7 compatible

### DIFF
--- a/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -84,7 +84,7 @@ $select = $connection->select()
 $oldConfigValues = $connection->fetchAll($select);
 
 foreach ($oldConfigValues as $oldValue) {
-    $newValue = '';
+    $newValue = array();
     if (stripos($oldValue['path'], 'free_method') && isset($oldToNewMethodCodesMap[$oldValue['value']])) {
         $newValue = $oldToNewMethodCodesMap[$oldValue['value']];
     } else if (stripos($oldValue['path'], 'allowed_methods')) {


### PR DESCRIPTION
Fixes error uncaught Error: [] operator not supported for strings in app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.1-1.6.0.2.php: 93