### PR TITLE
Update Gallery.php. remove <br/> from labels on multistore

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery.php
@@ -118,11 +118,11 @@ class Mage_Adminhtml_Block_Catalog_Product_Helper_Form_Gallery extends Varien_Da
         }
 
         if ($attribute->isScopeGlobal()) {
-            $html .= '<br/>' . Mage::helper('adminhtml')->__('[GLOBAL]');
+            $html .= Mage::helper('adminhtml')->__('[GLOBAL]');
         } elseif ($attribute->isScopeWebsite()) {
-            $html .= '<br/>' . Mage::helper('adminhtml')->__('[WEBSITE]');
+            $html .= Mage::helper('adminhtml')->__('[WEBSITE]');
         } elseif ($attribute->isScopeStore()) {
-            $html .= '<br/>' . Mage::helper('adminhtml')->__('[STORE VIEW]');
+            $html .= Mage::helper('adminhtml')->__('[STORE VIEW]');
         }
         return $html;
     }


### PR DESCRIPTION
from some version labels in app/design/adminhtml/default/default/template/catalog/product/helper/gallery.phtml 
are escaped, <br/> not working anymore. Gallery in adminhtml on multi(web/store/view) looks ugly. http://i.imgur.com/7nkfcq9.png