### PR TITLE
Fix an issue with Failed IPN changing to Payment Received incorrectly

### DIFF
--- a/app/code/core/Mage/Paypal/Model/Ipn.php
+++ b/app/code/core/Mage/Paypal/Model/Ipn.php
@@ -532,6 +532,11 @@ class Mage_Paypal_Model_Ipn
     protected function _registerPaymentFailure()
     {
         $this->_importPaymentInformation();
+
+        foreach ($this->_order->getInvoiceCollection() as $invoice){
+            $invoice->cancel()->save();
+        }
+
         $this->_order
             ->registerCancellation($this->_createIpnComment(''), false)
             ->save();


### PR DESCRIPTION
Hello everyone,

We recently had some issues with Failed IPN requests from Paypal changing the status of an order from `REVIEW` to `PROCESSING` instead of `CANCELED`. Some orders that were paid using eCheck didn't clear the payment and the IPN request did not cancel the order which caused us to ship an order without correct payment.

The main issue resides in `Mage_Sales_Model_Order::registerCancellation` which is where the change actually occurs:

```
if ($this->canCancel() || $this->isPaymentReview()) {
            $cancelState = self::STATE_CANCELED;
            foreach ($this->getAllItems() as $item) {
                if ($cancelState != self::STATE_PROCESSING && $item->getQtyToRefund()) {
                    if ($item->getQtyToShip() > $item->getQtyToCancel()) {
                        $cancelState = self::STATE_PROCESSING;
                    } else {
                        $cancelState = self::STATE_COMPLETE;
                    }
                }
                $item->cancel();
            }

            // (...)
}
```

however the root cause is that un the case of an order in the `REVIEW` status from Paypal there is an invoice with the `PENDING` status which causes `$this->canCancel()` to be `false` and `$this->isPaymentReview()` to be `true`.

Issue + Solution Found:
- https://magento.com/tech-resources/bug-tracking/issue/index/id/1041
- https://stackoverflow.com/a/37028929/541884

Thank you!