### PR TITLE
Remove duplicated array key in Mage_Page_Block_Js_Translate

### DIFF
--- a/app/design/adminhtml/default/default/template/page/js/translate.phtml
+++ b/app/design/adminhtml/default/default/template/page/js/translate.phtml
@@ -54,7 +54,6 @@ $_data = array(
     'Please enter a valid $ amount. For example $100.00.' => $this->__('Please enter a valid $ amount. For example $100.00.'),
     'Please select one of the above options.' => $this->__('Please select one of the above options.'),
     'Please select one of the options.' => $this->__('Please select one of the options.'),
-    'Please enter a valid number in this field.' => $this->__('Please enter a valid number in this field.'),
     'Please select State/Province.' => $this->__('Please select State/Province.'),
     'Please enter valid password.' => $this->__('Please enter valid password.'),
     'Please enter a number greater than 0 in this field.' => $this->__('Please enter a number greater than 0 in this field.'),


### PR DESCRIPTION
Array has two same keys. Lets remove the duplicate