### PR TITLE
Fix types in doc comments part 1

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -420,8 +420,10 @@ final class Mage
      *
      * @param string $eventName
      * @param callback $callback
-     * @param array $arguments
+     * @param array $data
      * @param string $observerName
+     * @param string $observerClass
+     * @return Varien_Event_Collection
      */
     public static function addObserver($eventName, $callback, $data = array(), $observerName = '', $observerClass = '')
     {

--- a/app/code/community/Phoenix/Moneybookers/Model/Abstract.php
+++ b/app/code/community/Phoenix/Moneybookers/Model/Abstract.php
@@ -73,7 +73,7 @@ abstract class Phoenix_Moneybookers_Model_Abstract extends Mage_Payment_Model_Me
      * Capture payment through Moneybookers api
      *
      * @param Varien_Object $payment
-     * @param decimal $amount
+     * @param float $amount
      * @return Phoenix_Moneybookers_Model_Abstract
      */
     public function capture(Varien_Object $payment, $amount)

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Adminpass.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Adminpass.php
@@ -53,6 +53,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Renderer_Adminpass
     }
 
     /**
+     * @param Varien_Data_Form_Element_Abstract $element
      * @return string
      */
     protected function _getScriptHtml(Varien_Data_Form_Element_Abstract $element)

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Wishlist.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Wishlist.php
@@ -125,7 +125,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_View_Wishlist extends Mage_Adminhtm
     /**
      * Get row url
      *
-     * @param Mage_Wishlist_Model_Item $item
+     * @param Mage_Wishlist_Model_Item $row
      * @return string
      */
     public function getRowUrl($row)

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Bar.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Bar.php
@@ -72,9 +72,9 @@ class Mage_Adminhtml_Block_Dashboard_Bar extends Mage_Adminhtml_Block_Dashboard_
     }
 
     /**
-     * Formating value specific for this store
+     * Formatting value specific for this store
      *
-     * @param decimal $price
+     * @param float $price
      * @return string
      */
     public function format($price)

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Abstract.php
@@ -267,7 +267,7 @@ class Mage_Adminhtml_Block_Report_Grid_Abstract extends Mage_Adminhtml_Block_Wid
     /**
      * Get currency rate (base to given currency)
      *
-     * @param string|Mage_Directory_Model_Currency $currencyCode
+     * @param string|Mage_Directory_Model_Currency $toCurrency
      * @return double
      */
     public function getRate($toCurrency)

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Abstract.php
@@ -510,7 +510,7 @@ class  Mage_Adminhtml_Block_Sales_Items_Abstract extends Mage_Adminhtml_Block_Te
     /**
      * Retrieve invoice model instance
      *
-     * @return Mage_Sales_Model_Invoice
+     * @return Mage_Sales_Model_Order_Invoice
      */
     public function getInvoice()
     {

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Abstract.php
@@ -93,9 +93,9 @@ class Mage_Adminhtml_Block_Sales_Order_Abstract extends Mage_Adminhtml_Block_Wid
 
 
     /**
-     * Retrieve subtotal price include tax html formated content
+     * Retrieve subtotal price include tax html formatted content
      *
-     * @param Varien_Object $item
+     * @param Mage_Sales_Model_Order $order
      * @return string
      */
     public function displayShippingPriceInclTax($order)

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Abstract.php
@@ -104,9 +104,9 @@ abstract class Mage_Adminhtml_Block_Sales_Order_Create_Abstract extends Mage_Adm
     }
 
     /**
-     * Retrieve formated price
+     * Retrieve formatted price
      *
-     * @param   decimal $value
+     * @param   float $value
      * @return  string
      */
     public function formatPrice($value)

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Giftmessage/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Giftmessage/Form.php
@@ -279,7 +279,7 @@ class Mage_Adminhtml_Block_Sales_Order_Create_Giftmessage_Form extends Mage_Admi
     /**
      * Retrive real html id for field
      *
-     * @param string $name
+     * @param string $id
      * @return string
      */
     protected  function _getFieldId($id)
@@ -290,7 +290,7 @@ class Mage_Adminhtml_Block_Sales_Order_Create_Giftmessage_Form extends Mage_Admi
     /**
      * Retrive field html id prefix
      *
-     * @return unknown
+     * @return string
      */
     protected  function _getFieldIdPrefix()
     {

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Adjustments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Adjustments.php
@@ -27,9 +27,9 @@ class Mage_Adminhtml_Block_Sales_Order_Creditmemo_Create_Adjustments extends Mag
 {
     protected $_source;
     /**
-     * Initialize creditmemo agjustment totals
+     * Initialize creditmemo adjustment totals
      *
-     * @return Mage_Tax_Block_Sales_Order_Tax
+     * @return Mage_Adminhtml_Block_Sales_Order_Creditmemo_Create_Adjustments
      */
     public function initTotals()
     {

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging/Grid.php
@@ -92,8 +92,8 @@ class Mage_Adminhtml_Block_Sales_Order_Shipment_Packaging_Grid extends Mage_Admi
     /**
      * Format price
      *
-     * @param   decimal $value
-     * @return  double
+     * @param   float $value
+     * @return  string
      */
     public function formatPrice($value)
     {

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals/Tax.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals/Tax.php
@@ -64,6 +64,8 @@ class Mage_Adminhtml_Block_Sales_Order_Totals_Tax extends Mage_Tax_Block_Sales_O
     /**
      * Display tax amount
      *
+     * @param $amount
+     * @param $baseAmount
      * @return string
      */
     public function displayAmount($amount, $baseAmount)

--- a/app/code/core/Mage/Adminhtml/Model/Giftmessage/Save.php
+++ b/app/code/core/Mage/Adminhtml/Model/Giftmessage/Save.php
@@ -244,8 +244,8 @@ class Mage_Adminhtml_Model_Giftmessage_Save extends Varien_Object
     /**
      * Imports quote items for gift messages from products data
      *
-     * @param unknown_type $products
-     * @return unknown
+     * @param array $products
+     * @return Mage_Adminhtml_Model_Giftmessage_Save
      */
     public function importAllowQuoteItemsFromProducts($products)
     {

--- a/app/code/core/Mage/Adminhtml/Model/System/Store.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Store.php
@@ -78,7 +78,7 @@ class Mage_Adminhtml_Model_System_Store extends Varien_Object
     /**
      * Load/Reload Website collection
      *
-     * @return array
+     * @return Mage_Adminhtml_Model_System_Store
      */
     protected function _loadWebsiteCollection()
     {
@@ -89,7 +89,7 @@ class Mage_Adminhtml_Model_System_Store extends Varien_Object
     /**
      * Load/Reload Group collection
      *
-     * @return array
+     * @return Mage_Adminhtml_Model_System_Store
      */
     protected function _loadGroupCollection()
     {
@@ -105,7 +105,7 @@ class Mage_Adminhtml_Model_System_Store extends Varien_Object
     /**
      * Load/Reload Store collection
      *
-     * @return array
+     * @return Mage_Adminhtml_Model_System_Store
      */
     protected function _loadStoreCollection()
     {

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
@@ -244,7 +244,7 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
      * Return helper instance
      *
      * @param string $className
-     * @return Mage_Core_Model_Abstract
+     * @return Mage_Core_Helper_Abstract
      */
     protected function _getHelperModel($className)
     {

--- a/app/code/core/Mage/Authorizenet/Model/Directpost.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost.php
@@ -67,7 +67,7 @@ class Mage_Authorizenet_Model_Directpost extends Mage_Paygate_Model_Authorizenet
      * Send authorize request to gateway
      *
      * @param  Varien_Object $payment
-     * @param  decimal $amount
+     * @param  float $amount
      * @return Mage_Paygate_Model_Authorizenet
      * @throws Mage_Core_Exception
      */
@@ -80,7 +80,7 @@ class Mage_Authorizenet_Model_Directpost extends Mage_Paygate_Model_Authorizenet
      * Send capture request to gateway
      *
      * @param Varien_Object $payment
-     * @param decimal $amount
+     * @param float $amount
      * @return Mage_Authorizenet_Model_Directpost
      * @throws Mage_Core_Exception
      */
@@ -211,7 +211,7 @@ class Mage_Authorizenet_Model_Directpost extends Mage_Paygate_Model_Authorizenet
      * Need to decode Last 4 digits for request.
      *
      * @param Varien_Object $payment
-     * @param decimal $amount
+     * @param float $amount
      * @return Mage_Authorizenet_Model_Directpost
      * @throws Mage_Core_Exception
      */

--- a/app/code/core/Mage/Bundle/Block/Checkout/Cart/Item/Renderer.php
+++ b/app/code/core/Mage/Bundle/Block/Checkout/Cart/Item/Renderer.php
@@ -50,7 +50,7 @@ class Mage_Bundle_Block_Checkout_Cart_Item_Renderer extends Mage_Checkout_Block_
      * Obtain final price of selection in a bundle product
      *
      * @param Mage_Catalog_Model_Product $selectionProduct
-     * @return decimal
+     * @return float
      */
     protected function _getSelectionFinalPrice($selectionProduct)
     {
@@ -63,7 +63,7 @@ class Mage_Bundle_Block_Checkout_Cart_Item_Renderer extends Mage_Checkout_Block_
      * Get selection quantity
      *
      * @param int $selectionId
-     * @return decimal
+     * @return float
      */
     protected function _getSelectionQty($selectionId)
     {

--- a/app/code/core/Mage/Bundle/Helper/Catalog/Product/Configuration.php
+++ b/app/code/core/Mage/Bundle/Helper/Catalog/Product/Configuration.php
@@ -40,7 +40,7 @@ class Mage_Bundle_Helper_Catalog_Product_Configuration extends Mage_Core_Helper_
      * @param Mage_Catalog_Model_Product $product
      * @param int $selectionId
      *
-     * @return decimal
+     * @return float
      */
     public function getSelectionQty($product, $selectionId)
     {
@@ -57,7 +57,7 @@ class Mage_Bundle_Helper_Catalog_Product_Configuration extends Mage_Core_Helper_
      * @param Mage_Catalog_Model_Product_Configuration_Item_Interface $item
      * @param Mage_Catalog_Model_Product $selectionProduct
      *
-     * @return decimal
+     * @return float
      */
     public function getSelectionFinalPrice(Mage_Catalog_Model_Product_Configuration_Item_Interface $item,
         $selectionProduct)

--- a/app/code/core/Mage/Bundle/Model/Price/Index.php
+++ b/app/code/core/Mage/Bundle/Model/Price/Index.php
@@ -28,7 +28,6 @@
 /**
  * Bundle Product Price Index
  *
- * @method Mage_Bundle_Model_Resource_Price_Index _getResource()
  * @method Mage_Bundle_Model_Resource_Price_Index getResource()
  * @method Mage_Bundle_Model_Price_Index setEntityId(int $value)
  * @method int getWebsiteId()

--- a/app/code/core/Mage/Bundle/Model/Product/Price.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Price.php
@@ -141,7 +141,7 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
      * @param float $productQty
      * @param Mage_Catalog_Model_Product $childProduct
      * @param float $childProductQty
-     * @return decimal
+     * @return float
      */
     public function getChildFinalPrice($product, $productQty, $childProduct, $childProductQty)
     {
@@ -156,7 +156,7 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
      *
      * @param  Mage_Catalog_Model_Product $product
      * @param  string $which
-     * @return decimal|array
+     * @return float|array
      */
     public function getPrices($product, $which = null)
     {
@@ -172,7 +172,7 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
      * @param  Mage_Catalog_Model_Product $product
      * @param  string $which
      * @param  bool|null $includeTax
-     * @return decimal|array
+     * @return float|array
      */
     public function getPricesDependingOnTax($product, $which = null, $includeTax = null)
     {
@@ -186,7 +186,7 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
      * @param  string|null $which
      * @param  bool|null $includeTax
      * @param  bool $takeTierPrice
-     * @return decimal|array
+     * @return float|array
      */
     public function getTotalPrices($product, $which = null, $includeTax = null, $takeTierPrice = true)
     {
@@ -386,7 +386,7 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
      * Calculate Minimal price of bundle (counting all required options)
      *
      * @param  Mage_Catalog_Model_Product $product
-     * @return decimal
+     * @return float
      */
     public function getMinimalPrice($product)
     {
@@ -397,7 +397,7 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
      * Calculate maximal price of bundle
      *
      * @param Mage_Catalog_Model_Product $product
-     * @return decimal
+     * @return float
      */
     public function getMaximalPrice($product)
     {
@@ -449,8 +449,8 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
      *
      * @param Mage_Catalog_Model_Product $bundleProduct
      * @param Mage_Catalog_Model_Product $selectionProduct
-     * @param decimal $qty
-     * @return decimal
+     * @param float $qty
+     * @return float
      */
     public function getSelectionPreFinalPrice($bundleProduct, $selectionProduct, $qty = null)
     {
@@ -465,10 +465,10 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
      *
      * @param  Mage_Catalog_Model_Product $bundleProduct
      * @param  Mage_Catalog_Model_Product $selectionProduct
-     * @param  decimal $bundleQty
-     * @param  decimal $selectionQty
+     * @param  float $bundleQty
+     * @param  float $selectionQty
      * @param  bool $multiplyQty
-     * @return decimal
+     * @return float
      */
     public function getSelectionFinalPrice($bundleProduct, $selectionProduct, $bundleQty, $selectionQty = null,
                                            $multiplyQty = true)
@@ -601,9 +601,9 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
      * Apply tier price for bundle
      *
      * @param   Mage_Catalog_Model_Product $product
-     * @param   decimal $qty
-     * @param   decimal $finalPrice
-     * @return  decimal
+     * @param   float $qty
+     * @param   float $finalPrice
+     * @return  float
      */
     protected function _applyTierPrice($product, $qty, $finalPrice)
     {
@@ -625,9 +625,9 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
     /**
      * Get product tier price by qty
      *
-     * @param   decimal $qty
+     * @param   float $qty
      * @param   Mage_Catalog_Model_Product $product
-     * @return  decimal
+     * @return  float
      */
     public function getTierPrice($qty = null, $product)
     {

--- a/app/code/core/Mage/Bundle/Model/Product/Type.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Type.php
@@ -165,7 +165,7 @@ class Mage_Bundle_Model_Product_Type extends Mage_Catalog_Model_Product_Type_Abs
      * Return product weight based on weight_type attribute
      *
      * @param Mage_Catalog_Model_Product $product
-     * @return decimal
+     * @return float
      */
     public function getWeight($product = null)
     {

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Abstract.php
@@ -104,9 +104,10 @@ abstract class Mage_Catalog_Block_Product_View_Options_Abstract extends Mage_Cor
     }
 
     /**
-     * Return formated price
+     * Return formatted price
      *
      * @param array $value
+     * @param bool $flag
      * @return string
      */
     protected function _formatPrice($value, $flag=true)
@@ -149,9 +150,9 @@ abstract class Mage_Catalog_Block_Product_View_Options_Abstract extends Mage_Cor
     /**
      * Get price with including/excluding tax
      *
-     * @param decimal $price
+     * @param float $price
      * @param bool $includingTax
-     * @return decimal
+     * @return float
      */
     public function getPrice($price, $includingTax = null)
     {

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Product.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Product.php
@@ -37,7 +37,7 @@ class Mage_Catalog_Block_Seo_Sitemap_Product extends Mage_Catalog_Block_Seo_Site
     /**
      * Initialize products collection
      *
-     * @return Mage_Catalog_Block_Seo_Sitemap_Category
+     * @return Mage_Catalog_Block_Seo_Sitemap_Product
      */
     protected function _prepareLayout()
     {
@@ -59,7 +59,7 @@ class Mage_Catalog_Block_Seo_Sitemap_Product extends Mage_Catalog_Block_Seo_Site
     /**
      * Get item URL
      *
-     * @param Mage_Catalog_Model_Product $category
+     * @param Mage_Catalog_Model_Product $product
      * @return string
      */
     public function getItemUrl($product)

--- a/app/code/core/Mage/Catalog/Helper/Category.php
+++ b/app/code/core/Mage/Catalog/Helper/Category.php
@@ -148,7 +148,7 @@ class Mage_Catalog_Helper_Category extends Mage_Core_Helper_Abstract
     /**
      * Retrieve clear url for category as parrent
      *
-     * @param string $url
+     * @param string $urlPath
      * @param bool $slash
      * @param int $storeId
      *

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Validator/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Validator/Product.php
@@ -130,7 +130,9 @@ class Mage_Catalog_Model_Api2_Product_Validator_Product extends Mage_Api2_Model_
      *
      * @param array $data
      * @param Mage_Eav_Model_Entity_Type $productEntity
-     * @return array
+     * @throws Mage_Api2_Exception
+     * @throws Mage_Core_Exception
+     * @throws Zend_Validate_Exception
      */
     protected function _validateAttributes($data, $productEntity)
     {

--- a/app/code/core/Mage/Catalog/Model/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Category.php
@@ -831,7 +831,7 @@ class Mage_Catalog_Model_Category extends Mage_Catalog_Model_Abstract
     }
 
     /**
-     * Retuen children categories of current category
+     * Return children categories of current category
      *
      * @return array
      */

--- a/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
@@ -350,8 +350,8 @@ class Mage_Catalog_Model_Convert_Adapter_Product
     /**
      * Retrieve store object by code
      *
-     * @param string $store
-     * @return Mage_Core_Model_Store
+     * @param string $id
+     * @return Mage_Core_Model_Store|bool
      */
     public function getStoreById($id)
     {

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -202,9 +202,9 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     }
 
     /**
-     * Get product price throught type instance
+     * Get product price through type instance
      *
-     * @return unknown
+     * @return float
      */
     public function getPrice()
     {
@@ -574,7 +574,6 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     /**
      * Init indexing process after product delete commit
      *
-     * @return Mage_Catalog_Model_Product
      */
     protected function _afterDeleteCommit()
     {

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Media.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Media.php
@@ -590,8 +590,8 @@ class Mage_Catalog_Model_Product_Attribute_Backend_Media extends Mage_Eav_Model_
     /**
      * Check whether file to move exists. Getting unique name
      *
-     * @param <type> $file
-     * @param <type> $dirsep
+     * @param string $file
+     * @param string $dirsep
      * @return string
      */
     protected function _getUniqueFileName($file, $dirsep) {

--- a/app/code/core/Mage/Catalog/Model/Product/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option.php
@@ -415,7 +415,7 @@ class Mage_Catalog_Model_Product_Option extends Mage_Core_Model_Abstract
      *  return converted percent to price
      *
      * @param bool $flag
-     * @return decimal
+     * @return float
      */
     public function getPrice($flag = false)
     {

--- a/app/code/core/Mage/Catalog/Model/Product/Status.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Status.php
@@ -28,7 +28,6 @@
 /**
  * Product status functionality model
  *
- * @method Mage_Catalog_Model_Resource_Product_Status _getResource()
  * @method Mage_Catalog_Model_Resource_Product_Status getResource()
  * @method int getProductId()
  * @method Mage_Catalog_Model_Product_Status setProductId(int $value)

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
@@ -707,7 +707,6 @@ abstract class Mage_Catalog_Model_Product_Type_Abstract
     /**
      * Check if product qty is fractional number
      *
-     * @param Mage_Catalog_Model_Product $product
      * @return bool
      */
     public function canUseQtyDecimals()
@@ -773,7 +772,7 @@ abstract class Mage_Catalog_Model_Product_Type_Abstract
      * Default action to get weight of product
      *
      * @param Mage_Catalog_Model_Product $product
-     * @return decimal
+     * @return float
      */
     public function getWeight($product = null)
     {
@@ -843,7 +842,7 @@ abstract class Mage_Catalog_Model_Product_Type_Abstract
      * Set store filter for associated products
      *
      * @param $store int|Mage_Core_Model_Store
-     * @return Mage_Catalog_Model_Product_Type_Configurable
+     * @return Mage_Catalog_Model_Product_Type_Abstract
      */
     public function setStoreFilter($store=null, $product = null)
     {

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
@@ -775,7 +775,7 @@ class Mage_Catalog_Model_Product_Type_Configurable extends Mage_Catalog_Model_Pr
      * weight or configurable product weight
      *
      * @param  Mage_Catalog_Model_Product $product
-     * @return decimal
+     * @return float
      */
     public function getWeight($product = null)
     {

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Price.php
@@ -106,8 +106,8 @@ class Mage_Catalog_Model_Product_Type_Configurable_Price extends Mage_Catalog_Mo
      * Calculate configurable product selection price
      *
      * @param   array $priceInfo
-     * @param   decimal $productPrice
-     * @return  decimal
+     * @param   float $productPrice
+     * @return  float
      */
     protected function _calcSelectionPrice($priceInfo, $productPrice)
     {

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
@@ -40,7 +40,7 @@ class Mage_Catalog_Model_Product_Type_Price
     /**
      * Default action to get price of product
      *
-     * @return decimal
+     * @return float
      */
     public function getPrice($product)
     {

--- a/app/code/core/Mage/Catalog/Model/Product/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Website.php
@@ -28,7 +28,6 @@
 /**
  * Catalog Product Website Model
  *
- * @method Mage_Catalog_Model_Resource_Product_Website _getResource()
  * @method Mage_Catalog_Model_Resource_Product_Website getResource()
  * @method int getWebsiteId()
  * @method Mage_Catalog_Model_Product_Website setWebsiteId(int $value)

--- a/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
@@ -365,7 +365,7 @@ abstract class Mage_Catalog_Model_Resource_Abstract extends Mage_Eav_Model_Entit
             $adapter->update($table, $bind, $where);
         } else {
             $bind  = array(
-                $idField            => (int)$object->getId(),
+                'entity_field_id'   => (int)$object->getId(),
                 'entity_type_id'    => (int)$object->getEntityTypeId(),
                 'attribute_id'      => (int)$attribute->getId(),
                 'value'             => $this->_prepareValueForSave($value, $attribute),

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
@@ -51,7 +51,7 @@ class Mage_Catalog_Model_Resource_Category_Flat_Collection extends Mage_Core_Mod
     /**
      * Store id of application
      *
-     * @var integer
+     * @var integer|null
      */
     protected $_storeId        = null;
 
@@ -192,7 +192,7 @@ class Mage_Catalog_Model_Resource_Category_Flat_Collection extends Mage_Core_Mod
     }
 
     /**
-     * Enter description here ...
+     * Add active category filter
      *
      * @return Mage_Catalog_Model_Resource_Category_Flat_Collection
      */
@@ -330,9 +330,9 @@ class Mage_Catalog_Model_Resource_Category_Flat_Collection extends Mage_Core_Mod
     }
 
     /**
-     * Enter description here ...
+     * Add category path filter
      *
-     * @param unknown_type $paths
+     * @param array|string $paths
      * @return Mage_Catalog_Model_Resource_Category_Flat_Collection
      */
     public function addPathsFilter($paths)
@@ -354,9 +354,9 @@ class Mage_Catalog_Model_Resource_Category_Flat_Collection extends Mage_Core_Mod
     }
 
     /**
-     * Enter description here ...
+     * Add category level filter
      *
-     * @param unknown_type $level
+     * @param int $level
      * @return Mage_Catalog_Model_Resource_Category_Flat_Collection
      */
     public function addLevelFilter($level)
@@ -366,9 +366,9 @@ class Mage_Catalog_Model_Resource_Category_Flat_Collection extends Mage_Core_Mod
     }
 
     /**
-     * Enter description here ...
+     * Add order field
      *
-     * @param unknown_type $field
+     * @param string $field
      * @return Mage_Catalog_Model_Resource_Category_Flat_Collection
      */
     public function addOrderField($field)

--- a/app/code/core/Mage/Catalog/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Helper/Mysql4.php
@@ -40,7 +40,7 @@ class Mage_Catalog_Model_Resource_Helper_Mysql4 extends Mage_Eav_Model_Resource_
      *
      * @param string $tableAlias
      * @param string $eavType
-     * @return array
+     * @return string|array
      */
     public function attributeSelectFields($tableAlias, $eavType)
     {

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice/Abstract.php
@@ -40,7 +40,7 @@ abstract class Mage_Catalog_Model_Resource_Product_Attribute_Backend_Groupprice_
      *
      * @param int $productId
      * @param int $websiteId
-     * @return Mage_Catalog_Model_Resource_Product_Attribute_Backend_Tierprice
+     * @return array
      */
     public function loadPriceData($productId, $websiteId = null)
     {

--- a/app/code/core/Mage/CatalogIndex/Model/Aggregation.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Aggregation.php
@@ -84,6 +84,7 @@ class Mage_CatalogIndex_Model_Aggregation extends Mage_Core_Model_Abstract
     /**
      * Save aggregation data to cache
      *
+     * @param array $data
      * @param   string $key
      * @param   array $tags
      * @param   null|int|string|Mage_Core_Model_Store $store

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Abstract.php
@@ -75,7 +75,7 @@ class Mage_CatalogIndex_Model_Data_Abstract extends Mage_Core_Model_Abstract
      * Return all children ids
      *
      * @param Mage_Core_Model_Store $store
-     * @param int $parentId
+     * @param int|array $parentIds
      * @return mixed
      */
     public function getChildProductIds($store, $parentIds)
@@ -95,7 +95,7 @@ class Mage_CatalogIndex_Model_Data_Abstract extends Mage_Core_Model_Abstract
      * Return all parent ids
      *
      * @param Mage_Core_Model_Store $store
-     * @param int $childId
+     * @param int|array $childIds
      * @return mixed
      */
     public function getParentProductIds($store, $childIds)
@@ -117,7 +117,7 @@ class Mage_CatalogIndex_Model_Data_Abstract extends Mage_Core_Model_Abstract
      * @param Mage_Core_Model_Store $store
      * @param array $settings
      * @param int $type
-     * @param int $suppliedId
+     * @param int|array $suppliedId
      */
     protected function fetchLinkInformation($store, $settings, $type, $suppliedId)
     {

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Abstract.php
@@ -85,7 +85,7 @@ class Mage_CatalogIndex_Model_Resource_Data_Abstract extends Mage_Core_Model_Res
      * @param array $products
      * @param array $attributes
      * @param int $store
-     * @return unknown
+     * @return array
      */
     public function getAttributeData($products, $attributes, $store)
     {
@@ -128,7 +128,7 @@ class Mage_CatalogIndex_Model_Resource_Data_Abstract extends Mage_Core_Model_Res
      * @param string $table
      * @param string $idField
      * @param string $whereField
-     * @param int $id
+     * @param int|array $id
      * @param array $additionalWheres
      * @return mixed
      */

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Abstract.php
@@ -117,8 +117,8 @@ class Mage_CatalogIndex_Model_Resource_Indexer_Abstract extends Mage_Core_Model_
     /**
      * Enter description here ...
      *
-     * @param unknown_type $conditions
-     * @return unknown
+     * @param array|string $conditions
+     * @return array
      */
     public function loadAttributeCodesByCondition($conditions)
     {

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Price.php
@@ -149,10 +149,10 @@ class Mage_CatalogIndex_Model_Resource_Price extends Mage_CatalogIndex_Model_Res
     /**
      * Enter description here ...
      *
-     * @param unknown_type $range
+     * @param int $range
      * @param unknown_type $attribute
-     * @param unknown_type $entitySelect
-     * @return unknown
+     * @param Zend_Db_Select $entitySelect
+     * @return array
      */
     public function getCount($range, $attribute, $entitySelect)
     {
@@ -199,12 +199,12 @@ class Mage_CatalogIndex_Model_Resource_Price extends Mage_CatalogIndex_Model_Res
     /**
      * Enter description here ...
      *
-     * @param unknown_type $range
-     * @param unknown_type $index
+     * @param int $range
+     * @param int $index
      * @param unknown_type $attribute
      * @param unknown_type $entityIdsFilter
-     * @param unknown_type $tableName
-     * @return unknown
+     * @param string $tableName
+     * @return array
      */
     public function getFilteredEntities($range, $index, $attribute, $entityIdsFilter, $tableName = 'price_table')
     {
@@ -291,7 +291,7 @@ class Mage_CatalogIndex_Model_Resource_Price extends Mage_CatalogIndex_Model_Res
      * Enter description here ...
      *
      * @param unknown_type $ids
-     * @return unknown
+     * @return array
      */
     public function getMinimalPrices($ids)
     {

--- a/app/code/core/Mage/CatalogInventory/Model/Indexer/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Indexer/Stock.php
@@ -28,7 +28,6 @@
 /**
  * CatalogInventory Stock Status Indexer Model
  *
- * @method Mage_CatalogInventory_Model_Resource_Indexer_Stock _getResource()
  * @method Mage_CatalogInventory_Model_Resource_Indexer_Stock getResource()
  * @method int getProductId()
  * @method Mage_CatalogInventory_Model_Indexer_Stock setProductId(int $value)

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
@@ -198,7 +198,7 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
     /**
      * Subtract quote item quantity
      *
-     * @param   decimal $qty
+     * @param   float $qty
      * @return  Mage_CatalogInventory_Model_Stock_Item
      */
     public function subtractQty($qty)
@@ -444,7 +444,7 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
     /**
      * Check quantity
      *
-     * @param   decimal $qty
+     * @param   float $qty
      * @exception Mage_Core_Exception
      * @return  bool
      */

--- a/app/code/core/Mage/CatalogSearch/Model/Advanced.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Advanced.php
@@ -27,7 +27,6 @@
 /**
  * Catalog advanced search model
  *
- * @method Mage_CatalogSearch_Model_Resource_Advanced _getResource()
  * @method Mage_CatalogSearch_Model_Resource_Advanced getResource()
  * @method int getEntityTypeId()
  * @method Mage_CatalogSearch_Model_Advanced setEntityTypeId(int $value)
@@ -113,7 +112,7 @@ class Mage_CatalogSearch_Model_Advanced extends Mage_Core_Model_Abstract
      */
     public function getAttributes()
     {
-        /* @var $attributes Mage_Catalog_Model_Resource_Eav_Resource_Product_Attribute_Collection */
+        /* @var $attributes Mage_Catalog_Model_Resource_Product_Attribute_Collection */
         $attributes = $this->getData('attributes');
         if (is_null($attributes)) {
             $product = Mage::getModel('catalog/product');

--- a/app/code/core/Mage/CatalogSearch/Model/Query.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Query.php
@@ -167,7 +167,6 @@ class Mage_CatalogSearch_Model_Query extends Mage_Core_Model_Abstract
      * Set Store Id
      *
      * @param int $storeId
-     * @return Mage_CatalogSearch_Model_Query
      */
     public function setStoreId($storeId)
     {

--- a/app/code/core/Mage/Checkout/Block/Cart/Sidebar.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Sidebar.php
@@ -84,7 +84,7 @@ class Mage_Checkout_Block_Cart_Sidebar extends Mage_Checkout_Block_Cart_Minicart
      * It will include tax, if required by config settings.
      *
      * @param   bool $skipTax flag for getting price with tax or not. Ignored in case when we display just subtotal incl.tax
-     * @return  decimal
+     * @return  float
      */
     public function getSubtotal($skipTax = true)
     {
@@ -114,7 +114,7 @@ class Mage_Checkout_Block_Cart_Sidebar extends Mage_Checkout_Block_Cart_Minicart
      * Get subtotal, including tax.
      * Will return > 0 only if appropriate config settings are enabled.
      *
-     * @return decimal
+     * @return float
      */
     public function getSubtotalInclTax()
     {

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Addresses.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Addresses.php
@@ -63,6 +63,7 @@ class Mage_Checkout_Block_Multishipping_Addresses extends Mage_Sales_Block_Items
      * Retrieve HTML for addresses dropdown
      *
      * @param  $item
+     * @param $index
      * @return string
      */
     public function getAddressesHtmlSelect($item, $index)

--- a/app/code/core/Mage/Checkout/Helper/Cart.php
+++ b/app/code/core/Mage/Checkout/Helper/Cart.php
@@ -143,7 +143,7 @@ class Mage_Checkout_Helper_Cart extends Mage_Core_Helper_Url
     /**
      * Get shopping cart summary qty
      *
-     * @return decimal
+     * @return float
      */
     public function getItemsQty()
     {
@@ -153,7 +153,7 @@ class Mage_Checkout_Helper_Cart extends Mage_Core_Helper_Url
     /**
      * Get shopping cart items summary (inchlude config settings)
      *
-     * @return decimal
+     * @return float
      */
     public function getSummaryCount()
     {

--- a/app/code/core/Mage/Checkout/controllers/Multishipping/AddressController.php
+++ b/app/code/core/Mage/Checkout/controllers/Multishipping/AddressController.php
@@ -46,7 +46,7 @@ class Mage_Checkout_Multishipping_AddressController extends Mage_Core_Controller
     /**
      * Retrieve checkout state model
      *
-     * @return Mage_Checkot_Model_Type_Multishipping_State
+     * @return Mage_Checkout_Model_Type_Multishipping_State
      */
     protected function _getState()
     {

--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -1079,7 +1079,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      * Returns helper object
      *
      * @param string $name
-     * @return Mage_Core_Block_Abstract
+     * @return Mage_Core_Helper_Abstract
      */
     public function helper($name)
     {

--- a/app/code/core/Mage/Core/Controller/Front/Action.php
+++ b/app/code/core/Mage/Core/Controller/Front/Action.php
@@ -105,7 +105,7 @@ class Mage_Core_Controller_Front_Action extends Mage_Core_Controller_Varien_Acti
      *                              that case
      * @param string $contentType
      * @param int $contentLength    explicit content length, if strlen($content) isn't applicable
-     * @return Mage_Adminhtml_Controller_Action
+     * @return Mage_Core_Controller_Front_Action
      */
     protected function _prepareDownloadResponse($fileName, $content, $contentType = 'application/octet-stream',
         $contentLength = null

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Admin.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Admin.php
@@ -53,7 +53,7 @@ class Mage_Core_Controller_Varien_Router_Admin extends Mage_Core_Controller_Vari
     /**
      * dummy call to pass through checking
      *
-     * @return unknown
+     * @return bool
      */
     protected function _beforeModuleMatch()
     {

--- a/app/code/core/Mage/Core/Model/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Abstract.php
@@ -100,8 +100,6 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
      * Standard model initialization
      *
      * @param string $resourceModel
-     * @param string $idFieldName
-     * @return Mage_Core_Model_Abstract
      */
     protected function _init($resourceModel)
     {

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -138,7 +138,7 @@ class Mage_Core_Model_App
     /**
      * Cache object
      *
-     * @var Zend_Cache_Core
+     * @var Mage_Core_Model_Cache
      */
     protected $_cache;
 
@@ -469,7 +469,7 @@ class Mage_Core_Model_App
      *
      * @param string $scopeCode code of default scope (website/store_group/store code)
      * @param string $scopeType type of default scope (website/group/store)
-     * @return unknown_type
+     * @return Mage_Core_Model_App
      */
     protected function _initCurrentStore($scopeCode, $scopeType)
     {
@@ -517,7 +517,9 @@ class Mage_Core_Model_App
     /**
      * Check get store
      *
+     * @param string $type
      * @return Mage_Core_Model_App
+     * @throws Mage_Core_Model_Store_Exception
      */
     protected function _checkGetStore($type)
     {
@@ -949,6 +951,7 @@ class Mage_Core_Model_App
     /**
      * Retrieve application website object
      *
+     * @param null|Mage_Core_Model_Website|true|int|string $id
      * @return Mage_Core_Model_Website
      */
     public function getWebsite($id=null)
@@ -1004,6 +1007,7 @@ class Mage_Core_Model_App
     /**
      * Retrieve application store group object
      *
+     * @param null|Mage_Core_Model_Store_Group|int|string $id
      * @return Mage_Core_Model_Store_Group
      */
     public function getGroup($id=null)
@@ -1159,6 +1163,7 @@ class Mage_Core_Model_App
      * @param   mixed $data
      * @param   string $id
      * @param   array $tags
+     * @param null|false|int $lifeTime
      * @return  Mage_Core_Model_App
      */
     public function saveCache($data, $id, $tags=array(), $lifeTime=false)
@@ -1193,10 +1198,11 @@ class Mage_Core_Model_App
     }
 
     /**
-    * Check whether to use cache for specific component
-    *
-    * @return boolean
-    */
+     * Check whether to use cache for specific component
+     *
+     * @param null|string $type
+     * @return bool|array
+     */
     public function useCache($type=null)
     {
         return $this->_cache->canUse($type);

--- a/app/code/core/Mage/Core/Model/Cache.php
+++ b/app/code/core/Mage/Core/Model/Cache.php
@@ -385,7 +385,7 @@ class Mage_Core_Model_Cache
      * @param string $data
      * @param string $id
      * @param array $tags
-     * @param int $lifeTime
+     * @param null|false|int $lifeTime
      * @return bool
      */
     public function save($data, $id, $tags = array(), $lifeTime = null)
@@ -512,7 +512,7 @@ class Mage_Core_Model_Cache
      * Check if cache can be used for specific data type
      *
      * @param string $typeCode
-     * @return bool
+     * @return bool|array
      */
     public function canUse($typeCode)
     {

--- a/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
@@ -152,7 +152,6 @@ abstract class Mage_Core_Model_Resource_Db_Abstract extends Mage_Core_Model_Reso
      *
      * @param string $mainTable
      * @param string $idFieldName
-     * @return Mage_Core_Model_Resource_Abstract
      */
     protected function _init($mainTable, $idFieldName)
     {

--- a/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
@@ -74,7 +74,7 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends Varien_Da
     /**
      * Fields to select changed flag
      *
-     * @var booleam
+     * @var boolean
      */
     protected $_fieldsToSelectChanged  = false;
 

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -393,7 +393,7 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
      *
      * Method provide cache configuration data without loading store config XML
      *
-     * @return Mage_Core_Model_Config
+     * @return Mage_Core_Model_Store
      */
     public function initConfigCache()
     {
@@ -717,7 +717,7 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
     /**
      * Check if store is admin store
      *
-     * @return unknown
+     * @return bool
      */
     public function isAdmin()
     {

--- a/app/code/core/Mage/Core/Model/Template.php
+++ b/app/code/core/Mage/Core/Model/Template.php
@@ -136,6 +136,7 @@ abstract class Mage_Core_Model_Template extends Mage_Core_Model_Abstract
      * Event is not dispatched.
      *
      * @param int|string $storeId
+     * @param string $area
      */
     public function emulateDesign($storeId, $area=self::DEFAULT_DESIGN_AREA)
     {

--- a/app/code/core/Mage/Customer/Model/Address/Abstract.php
+++ b/app/code/core/Mage/Customer/Model/Address/Abstract.php
@@ -153,8 +153,8 @@ class Mage_Customer_Model_Address_Abstract extends Mage_Core_Model_Abstract
     /**
      * set address street informa
      *
-     * @param unknown_type $street
-     * @return unknown
+     * @param array|string $street
+     * @return Mage_Customer_Model_Address_Abstract
      */
     public function setStreet($street)
     {

--- a/app/code/core/Mage/Customer/Model/Convert/Adapter/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Convert/Adapter/Customer.php
@@ -167,7 +167,7 @@ class Mage_Customer_Model_Convert_Adapter_Customer
      * Retrieve region id by country code and region name (if exists)
      *
      * @param string $country
-     * @param string $region
+     * @param string $regionName
      * @return int
      */
     public function getRegionId($country, $regionName)

--- a/app/code/core/Mage/Customer/Model/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Customer.php
@@ -696,8 +696,8 @@ class Mage_Customer_Model_Customer extends Mage_Core_Model_Abstract
     /**
      * Send corresponding email template
      *
-     * @param string $emailTemplate configuration path of email template
-     * @param string $emailSender configuration path of email identity
+     * @param string $template configuration path of email template
+     * @param string $sender configuration path of email identity
      * @param array $templateParams
      * @param int|null $storeId
      * @param string|null $customerEmail
@@ -1125,7 +1125,6 @@ class Mage_Customer_Model_Customer extends Mage_Core_Model_Abstract
     /**
      * Clean all addresses
      *
-     * @return Mage_Customer_Model_Customer
      */
     function cleanAllAddresses() {
         $this->_addressesCollection = null;

--- a/app/code/core/Mage/Customer/Model/Resource/Address.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address.php
@@ -90,7 +90,7 @@ class Mage_Customer_Model_Resource_Address extends Mage_Eav_Model_Entity_Abstrac
      *
      * @param Mage_Customer_Model_Address $object
      * @param int $id
-     * @return Mage_Customer_Model_Address
+     * @return Mage_Customer_Model_Resource_Address
      */
     public function setCustomerId($object, $id)
     {

--- a/app/code/core/Mage/Directory/Model/Currency/Filter.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Filter.php
@@ -34,7 +34,7 @@ class Mage_Directory_Model_Currency_Filter implements Zend_Filter_Interface
     /**
      * Rate value
      *
-     * @var decimal
+     * @var float
      */
     protected $_rate;
 

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -216,10 +216,10 @@ class Mage_Downloadable_Block_Adminhtml_Catalog_Product_Edit_Tab_Downloadable_Li
     }
 
     /**
-     * Return formated price with two digits after decimal point
+     * Return formatted price with two digits after decimal point
      *
-     * @param decimal $value
-     * @return decimal
+     * @param float $value
+     * @return string
      */
     public function getPriceValue($value)
     {

--- a/app/code/core/Mage/Eav/Model/Entity/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Abstract.php
@@ -66,7 +66,7 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
     /**
      * Attributes array by attribute name
      *
-     * @var unknown_type
+     * @var array
      */
     protected $_attributesByCode            = array();
 
@@ -504,7 +504,7 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
     /**
      * Retrieve configuration for all attributes
      *
-     * @return Mage_Eav_Model_Entity_Attribute_Abstract
+     * @return Mage_Eav_Model_Entity_Abstract
      */
     public function loadAllAttributes($object=null)
     {
@@ -1501,7 +1501,7 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
      * @param   Varien_Object $object
      * @param   string $table
      * @param   array $info
-     * @return  Varien_Object
+     * @return  Mage_Eav_Model_Entity_Abstract
      */
     protected function _deleteAttributes($object, $table, $info)
     {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Abstract.php
@@ -53,7 +53,7 @@ abstract class Mage_Eav_Model_Entity_Attribute_Source_Abstract
      * Set attribute instance
      *
      * @param Mage_Eav_Model_Entity_Attribute_Abstract $attribute
-     * @return Mage_Eav_Model_Entity_Attribute_Frontend_Abstract
+     * @return Mage_Eav_Model_Entity_Attribute_Source_Abstract
      */
     public function setAttribute($attribute)
     {

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -177,7 +177,9 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
      * Standard resource collection initalization
      *
      * @param string $model
-     * @return Mage_Core_Model_Mysql4_Collection_Abstract
+     * @param null|string $entityModel
+     * @return Mage_Eav_Model_Entity_Collection_Abstract
+     * @throws Mage_Eav_Exception
      */
     protected function _init($model, $entityModel = null)
     {
@@ -292,7 +294,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
      * @see self::_getConditionSql for $condition
      * @param Mage_Eav_Model_Entity_Attribute_Interface|integer|string|array $attribute
      * @param null|string|array $condition
-     * @param string $operator
+     * @param string $joinType
      * @return Mage_Eav_Model_Entity_Collection_Abstract
      */
     public function addAttributeToFilter($attribute, $condition = null, $joinType = 'inner')
@@ -890,7 +892,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
     /**
      * Clone and reset collection
      *
-     * @return Mage_Eav_Model_Entity_Collection_Abstract
+     * @return Varien_Db_Select
      */
     protected function _getAllIdsSelect($limit = null, $offset = null)
     {
@@ -919,7 +921,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
      * Retrive all ids sql
      *
      * @deprecated
-     * @return array
+     * @return Varien_Db_Select
      */
     public function getAllIdsSql()
     {
@@ -1127,7 +1129,9 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
      * Retrieve attributes load select
      *
      * @param   string $table
-     * @return  Mage_Eav_Model_Entity_Collection_Abstract
+     * @param array $attributeIds
+     * @return  Varien_Db_Select
+     * @throws Mage_Core_Exception
      */
     protected function _getLoadAttributesSelect($table, $attributeIds = array())
     {

--- a/app/code/core/Mage/Eav/Model/Form/Element.php
+++ b/app/code/core/Mage/Eav/Model/Form/Element.php
@@ -28,7 +28,6 @@
 /**
  * Eav Form Element Model
  *
- * @method Mage_Eav_Model_Resource_Form_Element _getResource()
  * @method Mage_Eav_Model_Resource_Form_Element getResource()
  * @method int getTypeId()
  * @method Mage_Eav_Model_Form_Element setTypeId(int $value)

--- a/app/code/core/Mage/Eav/Model/Form/Fieldset.php
+++ b/app/code/core/Mage/Eav/Model/Form/Fieldset.php
@@ -28,7 +28,6 @@
 /**
  * Eav Form Fieldset Model
  *
- * @method Mage_Eav_Model_Resource_Form_Fieldset _getResource()
  * @method Mage_Eav_Model_Resource_Form_Fieldset getResource()
  * @method int getTypeId()
  * @method Mage_Eav_Model_Form_Fieldset setTypeId(int $value)

--- a/app/code/core/Mage/Eav/Model/Form/Type.php
+++ b/app/code/core/Mage/Eav/Model/Form/Type.php
@@ -28,7 +28,6 @@
 /**
  * Eav Form Type Model
  *
- * @method Mage_Eav_Model_Resource_Form_Type _getResource()
  * @method Mage_Eav_Model_Resource_Form_Type getResource()
  * @method string getCode()
  * @method Mage_Eav_Model_Form_Type setCode(string $value)

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute.php
@@ -91,7 +91,7 @@ class Mage_Eav_Model_Resource_Entity_Attribute extends Mage_Core_Model_Resource_
     /**
      * Load attribute data by attribute code
      *
-     * @param Mage_Eav_Model_Entity_Attribute $object
+     * @param Mage_Core_Model_Abstract $object
      * @param int $entityTypeId
      * @param string $code
      * @return boolean
@@ -158,7 +158,7 @@ class Mage_Eav_Model_Resource_Entity_Attribute extends Mage_Core_Model_Resource_
     /**
      * Validate attribute data before save
      *
-     * @param Mage_Eav_Model_Entity_Attribute $object
+     * @param Mage_Core_Model_Abstract $object
      * @return Mage_Eav_Model_Resource_Entity_Attribute
      */
     protected function _beforeSave(Mage_Core_Model_Abstract $object)
@@ -187,7 +187,7 @@ class Mage_Eav_Model_Resource_Entity_Attribute extends Mage_Core_Model_Resource_
     /**
      * Save additional attribute data after save attribute
      *
-     * @param Mage_Eav_Model_Entity_Attribute $object
+     * @param Mage_Core_Model_Abstract $object
      * @return Mage_Eav_Model_Resource_Entity_Attribute
      */
     protected function _afterSave(Mage_Core_Model_Abstract $object)
@@ -203,7 +203,7 @@ class Mage_Eav_Model_Resource_Entity_Attribute extends Mage_Core_Model_Resource_
     /**
      * Save store labels
      *
-     * @param Mage_Eav_Model_Entity_Attribute $object
+     * @param Mage_Core_Model_Abstract $object
      * @return Mage_Eav_Model_Resource_Entity_Attribute
      */
     protected function _saveStoreLabels(Mage_Core_Model_Abstract $object)
@@ -234,7 +234,7 @@ class Mage_Eav_Model_Resource_Entity_Attribute extends Mage_Core_Model_Resource_
     /**
      * Save additional data of attribute
      *
-     * @param Mage_Eav_Model_Entity_Attribute $object
+     * @param Mage_Core_Model_Abstract $object
      * @return Mage_Eav_Model_Resource_Entity_Attribute
      */
     protected function _saveAdditionalAttributeData(Mage_Core_Model_Abstract $object)
@@ -299,7 +299,7 @@ class Mage_Eav_Model_Resource_Entity_Attribute extends Mage_Core_Model_Resource_
     /**
      *  Save attribute options
      *
-     * @param Mage_Eav_Model_Entity_Attribute $object
+     * @param Mage_Core_Model_Abstract $object
      * @return Mage_Eav_Model_Resource_Entity_Attribute
      */
     protected function _saveOption(Mage_Core_Model_Abstract $object)
@@ -487,7 +487,7 @@ class Mage_Eav_Model_Resource_Entity_Attribute extends Mage_Core_Model_Resource_
      * Load additional attribute data.
      * Load label of current active store
      *
-     * @param Mage_Eav_Model_Entity_Attribute $object
+     * @param Mage_Core_Model_Abstract $object
      * @return Mage_Eav_Model_Resource_Entity_Attribute
      */
     protected function _afterLoad(Mage_Core_Model_Abstract $object)

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Store.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Store.php
@@ -45,7 +45,7 @@ class Mage_Eav_Model_Resource_Entity_Store extends Mage_Core_Model_Resource_Db_A
     /**
      * Load an object by entity type and store
      *
-     * @param Varien_Object $object
+     * @param Mage_Core_Model_Abstract $object
      * @param int $entityTypeId
      * @param int $storeId
      * @return boolean

--- a/app/code/core/Mage/ImportExport/Model/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Abstract.php
@@ -109,7 +109,7 @@ abstract class Mage_ImportExport_Model_Abstract extends Varien_Object
     /**
      * Return human readable debug trace.
      *
-     * @return array
+     * @return string
      */
     public function getFormatedLogTrace()
     {

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Abstract.php
@@ -328,7 +328,7 @@ abstract class Mage_ImportExport_Model_Export_Entity_Abstract
      *
      * @param string $errorCode Error code or simply column name
      * @param int $errorRowNum Row number.
-     * @return Mage_ImportExport_Model_Import_Adapter_Abstract
+     * @return Mage_ImportExport_Model_Export_Entity_Abstract
      */
     public function addRowError($errorCode, $errorRowNum)
     {
@@ -344,7 +344,7 @@ abstract class Mage_ImportExport_Model_Export_Entity_Abstract
      *
      * @param string $errorCode Error code
      * @param string $message Message template
-     * @return Mage_ImportExport_Model_Import_Entity_Abstract
+     * @return Mage_ImportExport_Model_Export_Entity_Abstract
      */
     public function addMessageTemplate($errorCode, $message)
     {

--- a/app/code/core/Mage/Install/Model/Wizard.php
+++ b/app/code/core/Mage/Install/Model/Wizard.php
@@ -71,8 +71,8 @@ class Mage_Install_Model_Wizard
     /**
      * Get wizard step by request
      *
-     * @param   Mage_Core_Controller_Zend_Request $request
-     * @return  Varien_Object || false
+     * @param   Zend_Controller_Request_Abstract $request
+     * @return  Varien_Object | false
      */
     public function getStepByRequest(Zend_Controller_Request_Abstract $request)
     {

--- a/app/code/core/Mage/Install/controllers/WizardController.php
+++ b/app/code/core/Mage/Install/controllers/WizardController.php
@@ -63,7 +63,7 @@ class Mage_Install_WizardController extends Mage_Install_Controller_Action
     /**
      * Prepare layout
      *
-     * @return unknown
+     * @return Mage_Install_WizardController
      */
     protected function _prepareLayout()
     {
@@ -81,7 +81,7 @@ class Mage_Install_WizardController extends Mage_Install_Controller_Action
     /**
      * Checking installation status
      *
-     * @return unknown
+     * @return bool
      */
     protected function _checkIfInstalled()
     {

--- a/app/code/core/Mage/Newsletter/Model/Template.php
+++ b/app/code/core/Mage/Newsletter/Model/Template.php
@@ -83,7 +83,6 @@ class Mage_Newsletter_Model_Template extends Mage_Core_Model_Email_Template_Abst
      * Validate Newsletter template
      *
      * @throws Mage_Core_Exception
-     * @return bool
      */
     public function validate()
     {

--- a/app/code/core/Mage/Paygate/Model/Authorizenet.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet.php
@@ -314,7 +314,7 @@ class Mage_Paygate_Model_Authorizenet extends Mage_Payment_Model_Method_Cc
      * Send authorize request to gateway
      *
      * @param  Mage_Payment_Model_Info $payment
-     * @param  decimal $amount
+     * @param  float $amount
      * @return Mage_Paygate_Model_Authorizenet
      */
     public function authorize(Varien_Object $payment, $amount)
@@ -340,7 +340,7 @@ class Mage_Paygate_Model_Authorizenet extends Mage_Payment_Model_Method_Cc
      * Send capture request to gateway
      *
      * @param Mage_Payment_Model_Info $payment
-     * @param decimal $amount
+     * @param float $amount
      * @return Mage_Paygate_Model_Authorizenet
      */
     public function capture(Varien_Object $payment, $amount)
@@ -409,7 +409,7 @@ class Mage_Paygate_Model_Authorizenet extends Mage_Payment_Model_Method_Cc
      * Refund the amount with transaction id
      *
      * @param Mage_Payment_Model_Info $payment
-     * @param decimal $amount
+     * @param float $amount
      * @return Mage_Paygate_Model_Authorizenet
      * @throws Mage_Core_Exception
      */
@@ -497,7 +497,7 @@ class Mage_Paygate_Model_Authorizenet extends Mage_Payment_Model_Method_Cc
      * Send request with new payment to gateway
      *
      * @param Mage_Payment_Model_Info $payment
-     * @param decimal $amount
+     * @param float $amount
      * @param string $requestType
      * @return Mage_Paygate_Model_Authorizenet
      * @throws Mage_Core_Exception
@@ -587,7 +587,7 @@ class Mage_Paygate_Model_Authorizenet extends Mage_Payment_Model_Method_Cc
      * Send request with new payment to gateway during partial authorization process
      *
      * @param Mage_Payment_Model_Info $payment
-     * @param decimal $amount
+     * @param float $amount
      * @param string $requestType
      * @return Mage_Paygate_Model_Authorizenet
      */
@@ -679,7 +679,7 @@ class Mage_Paygate_Model_Authorizenet extends Mage_Payment_Model_Method_Cc
      * Send capture request to gateway for capture authorized transactions
      *
      * @param Mage_Payment_Model_Info $payment
-     * @param decimal $amount
+     * @param float $amount
      * @return Mage_Paygate_Model_Authorizenet
      */
     protected function _preauthorizeCapture($payment, $requestedAmount)
@@ -734,7 +734,7 @@ class Mage_Paygate_Model_Authorizenet extends Mage_Payment_Model_Method_Cc
      * Send capture request to gateway for capture authorized transactions of card
      *
      * @param Mage_Payment_Model_Info $payment
-     * @param decimal $amount
+     * @param float $amount
      * @param Varien_Object $card
      * @return Mage_Sales_Model_Order_Payment_Transaction
      */

--- a/app/code/core/Mage/Payment/Model/Method/Abstract.php
+++ b/app/code/core/Mage/Payment/Model/Method/Abstract.php
@@ -385,7 +385,7 @@ abstract class Mage_Payment_Model_Method_Abstract extends Varien_Object
     /**
      * Validate payment method information object
      *
-     * @return Mage_Payment_Model_Abstract
+     * @return Mage_Payment_Model_Method_Abstract
      */
     public function validate()
     {
@@ -410,7 +410,7 @@ abstract class Mage_Payment_Model_Method_Abstract extends Varien_Object
      * @param Varien_Object $payment
      * @param float $amount
      *
-     * @return Mage_Payment_Model_Abstract
+     * @return Mage_Payment_Model_Method_Abstract
      */
     public function order(Varien_Object $payment, $amount)
     {
@@ -426,7 +426,7 @@ abstract class Mage_Payment_Model_Method_Abstract extends Varien_Object
      * @param Varien_Object $payment
      * @param float $amount
      *
-     * @return Mage_Payment_Model_Abstract
+     * @return Mage_Payment_Model_Method_Abstract
      */
     public function authorize(Varien_Object $payment, $amount)
     {
@@ -442,7 +442,7 @@ abstract class Mage_Payment_Model_Method_Abstract extends Varien_Object
      * @param Varien_Object $payment
      * @param float $amount
      *
-     * @return Mage_Payment_Model_Abstract
+     * @return Mage_Payment_Model_Method_Abstract
      */
     public function capture(Varien_Object $payment, $amount)
     {
@@ -486,7 +486,7 @@ abstract class Mage_Payment_Model_Method_Abstract extends Varien_Object
      * @param Varien_Object $payment
      * @param float $amount
      *
-     * @return Mage_Payment_Model_Abstract
+     * @return Mage_Payment_Model_Method_Abstract
      */
     public function refund(Varien_Object $payment, $amount)
     {
@@ -516,7 +516,7 @@ abstract class Mage_Payment_Model_Method_Abstract extends Varien_Object
      *
      * @param Varien_Object $payment
      *
-     * @return Mage_Payment_Model_Abstract
+     * @return Mage_Payment_Model_Method_Abstract
      */
     public function cancel(Varien_Object $payment)
     {
@@ -542,7 +542,7 @@ abstract class Mage_Payment_Model_Method_Abstract extends Varien_Object
      *
      * @param Varien_Object $payment
      *
-     * @return Mage_Payment_Model_Abstract
+     * @return Mage_Payment_Model_Method_Abstract
      */
     public function void(Varien_Object $payment)
     {
@@ -625,7 +625,7 @@ abstract class Mage_Payment_Model_Method_Abstract extends Varien_Object
      * Assign data to info model instance
      *
      * @param   mixed $data
-     * @return  Mage_Payment_Model_Info
+     * @return  Mage_Payment_Model_Method_Abstract
      */
     public function assignData($data)
     {
@@ -641,7 +641,7 @@ abstract class Mage_Payment_Model_Method_Abstract extends Varien_Object
    /**
      * Parepare info instance for save
      *
-     * @return Mage_Payment_Model_Abstract
+     * @return Mage_Payment_Model_Method_Abstract
      */
     public function prepareSave()
     {
@@ -741,7 +741,7 @@ abstract class Mage_Payment_Model_Method_Abstract extends Varien_Object
      * @param string $paymentAction
      * @param object $stateObject
      *
-     * @return Mage_Payment_Model_Abstract
+     * @return Mage_Payment_Model_Method_Abstract
      */
     public function initialize($paymentAction, $stateObject)
     {

--- a/app/code/core/Mage/Paypal/Model/Api/Abstract.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Abstract.php
@@ -333,7 +333,7 @@ abstract class Mage_Paypal_Model_Api_Abstract extends Varien_Object
     /**
      * Export $this public data to private request array
      *
-     * @param array $internalRequestMap
+     * @param array $privateRequestMap
      * @param array $request
      * @return array
      */
@@ -527,7 +527,7 @@ abstract class Mage_Paypal_Model_Api_Abstract extends Varien_Object
      * (keys should go as 3rd, 4th[...] parameters)
      *
      * @param Varien_Object $address
-     * @param array $request
+     * @param array $to
      */
     protected function _importStreetFromAddress(Varien_Object $address, array &$to)
     {

--- a/app/code/core/Mage/Paypal/Model/Express/Checkout.php
+++ b/app/code/core/Mage/Paypal/Model/Express/Checkout.php
@@ -82,7 +82,7 @@ class Mage_Paypal_Model_Express_Checkout
     /**
      * Payment method type
      *
-     * @var unknown_type
+     * @var string
      */
     protected $_methodType = Mage_Paypal_Model_Config::METHOD_WPP_EXPRESS;
 

--- a/app/code/core/Mage/ProductAlert/Block/Email/Abstract.php
+++ b/app/code/core/Mage/ProductAlert/Block/Email/Abstract.php
@@ -126,7 +126,7 @@ abstract class Mage_ProductAlert_Block_Email_Abstract extends Mage_Core_Block_Te
     /**
      * Get store url params
      *
-     * @return string
+     * @return array
      */
     protected function _getUrlParams()
     {

--- a/app/code/core/Mage/Rating/Model/Rating.php
+++ b/app/code/core/Mage/Rating/Model/Rating.php
@@ -103,7 +103,7 @@ class Mage_Rating_Model_Rating extends Mage_Core_Model_Abstract
     /**
      * Get rating collection object
      *
-     * @return Varien_Data_Collection_Db
+     * @return array
      */
 
     public function getEntitySummary($entityPkValue,  $onlyForCurrentStore = true)

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
@@ -122,7 +122,7 @@ abstract class Mage_Reports_Model_Resource_Report_Abstract extends Mage_Core_Mod
      * @param string|null $from
      * @param string|null $to
      * @param Zend_Db_Select|string|null $subSelect
-     * @param unknown_type $doNotUseTruncate
+     * @param bool $doNotUseTruncate
      * @return Mage_Reports_Model_Resource_Report_Abstract
      */
     protected function _clearTableByDateRange($table, $from = null, $to = null, $subSelect = null,
@@ -159,7 +159,7 @@ abstract class Mage_Reports_Model_Resource_Report_Abstract extends Mage_Core_Mod
      * @param string|null $from
      * @param string|null $to
      * @param array $additionalWhere
-     * @param unknown_type $alias
+     * @param string $alias
      * @return Varien_Db_Select
      */
     protected function _getTableDateRangeSelect($table, $column, $whereColumn, $from = null, $to = null,
@@ -202,11 +202,10 @@ abstract class Mage_Reports_Model_Resource_Report_Abstract extends Mage_Core_Mod
      * Make condition for using in where section
      * from select statement with single date column
      *
-     * @result string|false
      *
      * @param Varien_Db_Select $select
      * @param string $periodColumn
-     * @return unknown
+     * @return string|false
      */
     protected function _makeConditionFromDateRangeSelect($select, $periodColumn)
     {
@@ -256,8 +255,8 @@ abstract class Mage_Reports_Model_Resource_Report_Abstract extends Mage_Core_Mod
      * @param string|null $from
      * @param string|null $to
      * @param array $additionalWhere
-     * @param unknown_type $alias
-     * @param unknown_type $relatedAlias
+     * @param string $alias
+     * @param string $relatedAlias
      * @return Varien_Db_Select
      */
     protected function _getTableDateRangeRelatedSelect($table, $relatedTable, $joinCondition, $column, $whereColumn,

--- a/app/code/core/Mage/Review/Model/Resource/Review/Summary.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Summary.php
@@ -49,7 +49,7 @@ class Mage_Review_Model_Resource_Review_Summary extends Mage_Core_Model_Resource
      * @param string $field
      * @param mixed $value
      * @param Mage_Core_Model_Abstract $object
-     * @return unknown
+     * @return Zend_Db_Select
      */
     protected function _getLoadSelect($field, $value, $object)
     {

--- a/app/code/core/Mage/Review/controllers/ProductController.php
+++ b/app/code/core/Mage/Review/controllers/ProductController.php
@@ -129,7 +129,7 @@ class Mage_Review_ProductController extends Mage_Core_Controller_Front_Action
      * Load review model with data by passed id.
      * Return false if review was not loaded or review is not approved.
      *
-     * @param int $productId
+     * @param int $reviewId
      * @return bool|Mage_Review_Model_Review
      */
     protected function _loadReview($reviewId)
@@ -282,7 +282,7 @@ class Mage_Review_ProductController extends Mage_Core_Controller_Front_Action
 
     /**
      * Load specific layout handles by product type id
-     *
+     * @param Mage_Catalog_Model_Product $product
      */
     protected function _initProductLayout($product)
     {

--- a/app/code/core/Mage/Rss/Model/Resource/Order.php
+++ b/app/code/core/Mage/Rss/Model/Resource/Order.php
@@ -107,7 +107,7 @@ class Mage_Rss_Model_Resource_Order
      *
      * @deprecated after 1.4.1.0
      *
-     * @param unknown_type $entityIds
+     * @param array $entityIds
      * @return array
      */
     public function getAllEntityIds($entityIds = array())

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Items.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Items.php
@@ -67,7 +67,7 @@ class Mage_Adminhtml_Block_Sales_Recurring_Profile_View_Items extends Mage_Admin
     /**
      * Retrieve formated price
      *
-     * @param   decimal $value
+     * @param   float $value
      * @return  string
      */
     public function formatPrice($value)

--- a/app/code/core/Mage/Sales/Block/Billing/Agreements.php
+++ b/app/code/core/Mage/Sales/Block/Billing/Agreements.php
@@ -79,9 +79,9 @@ class Mage_Sales_Block_Billing_Agreements extends Mage_Core_Block_Template
     /**
      * Retrieve item value by key
      *
-     * @param Varien_Object $item
+     * @param Mage_Sales_Model_Billing_Agreement $item
      * @param string $key
-     * @return mixed
+     * @return string
      */
     public function getItemValue(Mage_Sales_Model_Billing_Agreement $item, $key)
     {

--- a/app/code/core/Mage/Sales/Block/Items/Abstract.php
+++ b/app/code/core/Mage/Sales/Block/Items/Abstract.php
@@ -58,7 +58,7 @@ class Mage_Sales_Block_Items_Abstract extends Mage_Core_Block_Template
      * @param   string $type
      * @param   string $block
      * @param   string $template
-     * @return  Mage_Checkout_Block_Cart_Abstract
+     * @return  Mage_Sales_Block_Items_Abstract
      */
     public function addItemRender($type, $block, $template)
     {

--- a/app/code/core/Mage/Sales/Helper/Data.php
+++ b/app/code/core/Mage/Sales/Helper/Data.php
@@ -47,7 +47,7 @@ class Mage_Sales_Helper_Data extends Mage_Core_Helper_Data
      * Check quote amount
      *
      * @param Mage_Sales_Model_Quote $quote
-     * @param decimal $amount
+     * @param float $amount
      * @return Mage_Sales_Helper_Data
      */
     public function checkQuoteAmount(Mage_Sales_Model_Quote $quote, $amount)

--- a/app/code/core/Mage/Sales/Model/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Model/Billing/Agreement.php
@@ -255,8 +255,8 @@ class Mage_Sales_Model_Billing_Agreement extends Mage_Payment_Model_Billing_Agre
     /**
      * Retrieve available customer Billing Agreements
      *
-     * @param int $customer
-     * @return Mage_Paypal_Controller_Express_Abstract
+     * @param int $customerId
+     * @return Mage_Sales_Model_Resource_Billing_Agreement_Collection
      */
     public function getAvailableCustomerBillingAgreements($customerId)
     {

--- a/app/code/core/Mage/Sales/Model/Convert/Order.php
+++ b/app/code/core/Mage/Sales/Model/Convert/Order.php
@@ -37,6 +37,7 @@ class Mage_Sales_Model_Convert_Order extends Varien_Object
      * Converting order object to quote object
      *
      * @param   Mage_Sales_Model_Order $order
+     * @param null|Mage_Sales_Model_Quote $quote
      * @return  Mage_Sales_Model_Quote
      */
     public function toQuote(Mage_Sales_Model_Order $order, $quote=null)

--- a/app/code/core/Mage/Sales/Model/Convert/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Convert/Quote.php
@@ -61,7 +61,8 @@ class Mage_Sales_Model_Convert_Quote extends Varien_Object
     /**
      * Convert quote address model to order
      *
-     * @param   Mage_Sales_Model_Quote $quote
+     * @param   Mage_Sales_Model_Quote_Address $address
+     * @param   null|Mage_Sales_Model_Order $order
      * @return  Mage_Sales_Model_Order
      */
     public function addressToOrder(Mage_Sales_Model_Quote_Address $address, $order=null)

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -1094,7 +1094,7 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
     /**
      * Overrides entity id, which will be saved to comments history status
      *
-     * @param string $status
+     * @param string $entityName
      * @return Mage_Sales_Model_Order
      */
     public function setHistoryEntityName( $entityName )
@@ -1789,7 +1789,7 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
      * See the entity_id attribute backend model.
      * Or the history record can be saved standalone after this.
      *
-     * @param Mage_Sales_Model_Order_Status_History $status
+     * @param Mage_Sales_Model_Order_Status_History $history
      * @return Mage_Sales_Model_Order
      */
     public function addStatusHistory(Mage_Sales_Model_Order_Status_History $history)

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -627,7 +627,7 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
      *
      * Apply to order, order items etc.
      *
-     * @return unknown
+     * @return Mage_Sales_Model_Order_Invoice
      */
     public function register()
     {
@@ -714,6 +714,7 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
      * Adds comment to invoice with additional possibility to send it to customer via email
      * and show it in customer account
      *
+     * @param Mage_Sales_Model_Order_Invoice_Comment|string $comment
      * @param bool $notify
      * @param bool $visibleOnFront
      *

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
@@ -117,7 +117,7 @@ class Mage_Sales_Model_Order_Invoice_Api extends Mage_Sales_Model_Api_Resource
      * @param string $orderIncrementId
      * @param array $itemsQty
      * @param string $comment
-     * @param booleam $email
+     * @param boolean $email
      * @param boolean $includeComment
      * @return string
      */

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Api.php
@@ -122,7 +122,7 @@ class Mage_Sales_Model_Order_Shipment_Api extends Mage_Sales_Model_Api_Resource
      * @param string $orderIncrementId
      * @param array $itemsQty
      * @param string $comment
-     * @param booleam $email
+     * @param boolean $email
      * @param boolean $includeComment
      * @return string
      */

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -349,6 +349,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
     /**
      * Loading quote data by customer
      *
+     * @param int|Mage_Customer_Model_Customer $customer
      * @return Mage_Sales_Model_Quote
      */
     public function loadByCustomer($customer)
@@ -732,7 +733,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
     /**
      * Retrieve quote items collection
      *
-     * @param   bool $loaded
+     * @param   bool $useCache
      * @return  Mage_Eav_Model_Entity_Collection_Abstract
      */
     public function getItemsCollection($useCache = true)

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Abstract.php
@@ -162,7 +162,7 @@ abstract class Mage_Sales_Model_Quote_Address_Total_Abstract
     /**
      * Set total model base amount value to address
      *
-     * @param   float $amount
+     * @param   float $baseAmount
      * @return  Mage_Sales_Model_Quote_Address_Total_Abstract
      */
     protected function _setBaseAmount($baseAmount)
@@ -190,7 +190,7 @@ abstract class Mage_Sales_Model_Quote_Address_Total_Abstract
     /**
      * Add total model base amount value to address
      *
-     * @param   float $amount
+     * @param   float $baseAmount
      * @return  Mage_Sales_Model_Quote_Address_Total_Abstract
      */
     protected function _addBaseAmount($baseAmount)

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Subtotal.php
@@ -73,7 +73,8 @@ class Mage_Sales_Model_Quote_Address_Total_Subtotal extends Mage_Sales_Model_Quo
     /**
      * Address item initialization
      *
-     * @param  $item
+     * @param $address
+     * @param $item
      * @return bool
      */
     protected function _initItem($address, $item)

--- a/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
@@ -511,7 +511,7 @@ abstract class Mage_Sales_Model_Quote_Item_Abstract extends Mage_Core_Model_Abst
     /**
      * Get item price. Item price currency is website base currency.
      *
-     * @return decimal
+     * @return float
      */
     public function getPrice()
     {
@@ -695,7 +695,7 @@ abstract class Mage_Sales_Model_Quote_Item_Abstract extends Mage_Core_Model_Abst
      * Get item tax amount
      *
      * @deprecated
-     * @return  decimal
+     * @return  float
      */
     public function getTaxAmount()
     {
@@ -707,7 +707,7 @@ abstract class Mage_Sales_Model_Quote_Item_Abstract extends Mage_Core_Model_Abst
      * Get item base tax amount
      *
      * @deprecated
-     * @return decimal
+     * @return float
      */
     public function getBaseTaxAmount()
     {
@@ -718,7 +718,7 @@ abstract class Mage_Sales_Model_Quote_Item_Abstract extends Mage_Core_Model_Abst
      * Get item price (item price always exclude price)
      *
      * @deprecated
-     * @return decimal
+     * @return float
      */
     protected function _calculatePrice($value, $saveTaxes = true)
     {

--- a/app/code/core/Mage/Sales/Model/Resource/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Collection/Abstract.php
@@ -116,7 +116,7 @@ abstract class Mage_Sales_Model_Resource_Collection_Abstract extends Mage_Core_M
      *
      * @param int $limit
      * @param int $offset
-     * @return Mage_Eav_Model_Entity_Collection_Abstract
+     * @return Varien_Db_Select
      */
     protected function _getAllIdsSelect($limit = null, $offset = null)
     {

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Abstract.php
@@ -367,7 +367,7 @@ abstract class Mage_Sales_Model_Resource_Order_Abstract extends Mage_Sales_Model
     /**
      * Perform actions before object save
      *
-     * @param Varien_Object $object
+     * @param Mage_Core_Model_Abstract $object
      * @return Mage_Sales_Model_Resource_Order_Abstract
      */
     protected function _beforeSave(Mage_Core_Model_Abstract $object)

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Address.php
@@ -77,7 +77,7 @@ class Mage_Sales_Model_Resource_Order_Address extends Mage_Sales_Model_Resource_
     /**
      * Update related grid table after object save
      *
-     * @param Varien_Object $object
+     * @param Mage_Core_Model_Abstract $object
      * @return Mage_Core_Model_Resource_Db_Abstract
      */
     protected function _afterSave(Mage_Core_Model_Abstract $object)

--- a/app/code/core/Mage/Sales/Model/Service/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Service/Quote.php
@@ -215,7 +215,6 @@ class Mage_Sales_Model_Service_Quote
     /**
      * Submit nominal items
      *
-     * @return array
      */
     public function submitNominalItems()
     {

--- a/app/code/core/Mage/SalesRule/Model/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule.php
@@ -42,7 +42,6 @@
  * @method Mage_SalesRule_Model_Rule setUsesPerCustomer(int $value)
  * @method int getUsesPerCoupon()
  * @method Mage_SalesRule_Model_Rule setUsesPerCoupon(int $value)
- * @method string getCustomerGroupIds()
  * @method Mage_SalesRule_Model_Rule setCustomerGroupIds(string $value)
  * @method int getIsActive()
  * @method Mage_SalesRule_Model_Rule setIsActive(int $value)

--- a/app/code/core/Mage/Shipping/Model/Carrier/Abstract.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Abstract.php
@@ -480,7 +480,7 @@ abstract class Mage_Shipping_Model_Carrier_Abstract extends Varien_Object
     /**
      * set the number of boxes for shipping
      *
-     * @return weight
+     * @return float
      */
     public function getTotalNumOfBoxes($weight)
     {

--- a/app/code/core/Mage/Tag/Model/Api.php
+++ b/app/code/core/Mage/Tag/Model/Api.php
@@ -229,8 +229,8 @@ class Mage_Tag_Model_Api extends Mage_Catalog_Model_Api_Resource
     /**
      * Check data before update
      *
-     * @param $data
-     * @return
+     * @param array $data
+     * @return array
      */
     protected function _prepareDataForUpdate($data)
     {

--- a/app/code/core/Mage/Tag/Model/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Tag/Relation.php
@@ -28,7 +28,6 @@
 /**
  * Tag relation model
  *
- * @method Mage_Tag_Model_Resource_Tag_Relation _getResource()
  * @method Mage_Tag_Model_Resource_Tag_Relation getResource()
  * @method int getTagId()
  * @method Mage_Tag_Model_Tag_Relation setTagId(int $value)

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Tax.php
@@ -152,7 +152,7 @@ class Mage_Tax_Model_Sales_Total_Quote_Tax extends Mage_Sales_Model_Quote_Addres
      * Collect tax totals for quote address
      *
      * @param   Mage_Sales_Model_Quote_Address $address
-     * @return  Mage_Tax_Model_Sales_Total_Quote
+     * @return  Mage_Tax_Model_Sales_Total_Quote_Tax
      */
     public function collect(Mage_Sales_Model_Quote_Address $address)
     {
@@ -378,7 +378,7 @@ class Mage_Tax_Model_Sales_Total_Quote_Tax extends Mage_Sales_Model_Quote_Addres
      *
      * @param   Mage_Sales_Model_Quote_Address $address
      * @param   Varien_Object $taxRateRequest
-     * @return  Mage_Tax_Model_Sales_Total_Quote
+     * @return  Mage_Tax_Model_Sales_Total_Quote_Tax
      */
     protected function _calculateShippingTax(Mage_Sales_Model_Quote_Address $address, $taxRateRequest)
     {
@@ -407,7 +407,8 @@ class Mage_Tax_Model_Sales_Total_Quote_Tax extends Mage_Sales_Model_Quote_Addres
      * Calculate address tax amount based on one unit price and tax amount
      *
      * @param   Mage_Sales_Model_Quote_Address $address
-     * @return  Mage_Tax_Model_Sales_Total_Quote
+     * @param $taxRateRequest
+     * @return  Mage_Tax_Model_Sales_Total_Quote_Tax
      */
     protected function _unitBaseCalculation(Mage_Sales_Model_Quote_Address $address, $taxRateRequest)
     {
@@ -509,7 +510,7 @@ class Mage_Tax_Model_Sales_Total_Quote_Tax extends Mage_Sales_Model_Quote_Addres
      * @param   array $taxGroups
      * @param   string $taxId
      * @param   boolean $recalculateRowTotalInclTax
-     * @return  Mage_Tax_Model_Sales_Total_Quote
+     * @return  Mage_Tax_Model_Sales_Total_Quote_Tax
      */
     protected function _calcUnitTaxAmount(
         $item, $rate, &$taxGroups = null, $taxId = null, $recalculateRowTotalInclTax = false
@@ -657,7 +658,7 @@ class Mage_Tax_Model_Sales_Total_Quote_Tax extends Mage_Sales_Model_Quote_Addres
      *
      * @param   Mage_Sales_Model_Quote_Address $address
      * @param   Varien_Object $taxRateRequest
-     * @return  Mage_Tax_Model_Sales_Total_Quote
+     * @return  Mage_Tax_Model_Sales_Total_Quote_Tax
      */
     protected function _rowBaseCalculation(Mage_Sales_Model_Quote_Address $address, $taxRateRequest)
     {
@@ -755,7 +756,7 @@ class Mage_Tax_Model_Sales_Total_Quote_Tax extends Mage_Sales_Model_Quote_Addres
      * @param   array $taxGroups
      * @param   string $taxId
      * @param   boolean $recalculateRowTotalInclTax
-     * @return  Mage_Tax_Model_Sales_Total_Quote
+     * @return  Mage_Tax_Model_Sales_Total_Quote_Tax
      */
     protected function _calcRowTaxAmount(
         $item, $rate, &$taxGroups = null, $taxId = null, $recalculateRowTotalInclTax = false
@@ -908,7 +909,7 @@ class Mage_Tax_Model_Sales_Total_Quote_Tax extends Mage_Sales_Model_Quote_Addres
      *
      * @param   Mage_Sales_Model_Quote_Address $address
      * @param   Varien_Object $taxRateRequest
-     * @return  Mage_Tax_Model_Sales_Total_Quote
+     * @return  Mage_Tax_Model_Sales_Total_Quote_Tax
      */
     protected function _totalBaseCalculation(Mage_Sales_Model_Quote_Address $address, $taxRateRequest)
     {
@@ -1023,7 +1024,9 @@ class Mage_Tax_Model_Sales_Total_Quote_Tax extends Mage_Sales_Model_Quote_Addres
      * @param   Mage_Sales_Model_Quote_Item_Abstract $item
      * @param   float $rate
      * @param   array $taxGroups
-     * @return  Mage_Tax_Model_Sales_Total_Quote
+     * @param  $taxId
+     * @param bool $recalculateRowTotalInclTax
+     * @return  Mage_Tax_Model_Sales_Total_Quote_Tax
      */
     protected function _aggregateTaxPerRate(
         $item, $rate, &$taxGroups, $taxId = null, $recalculateRowTotalInclTax = false
@@ -1399,7 +1402,7 @@ class Mage_Tax_Model_Sales_Total_Quote_Tax extends Mage_Sales_Model_Quote_Addres
      * Recalculate parent item amounts base on children data
      *
      * @param   Mage_Sales_Model_Quote_Item_Abstract $item
-     * @return  Mage_Tax_Model_Sales_Total_Quote
+     * @return  Mage_Tax_Model_Sales_Total_Quote_Tax
      */
     protected function _recalculateParent(Mage_Sales_Model_Quote_Item_Abstract $item)
     {
@@ -1470,7 +1473,7 @@ class Mage_Tax_Model_Sales_Total_Quote_Tax extends Mage_Sales_Model_Quote_Addres
      * Add tax totals information to address object
      *
      * @param   Mage_Sales_Model_Quote_Address $address
-     * @return  Mage_Tax_Model_Sales_Total_Quote
+     * @return  Mage_Tax_Model_Sales_Total_Quote_Tax
      */
     public function fetch(Mage_Sales_Model_Quote_Address $address)
     {

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract.php
@@ -305,7 +305,7 @@ abstract class Mage_Usa_Model_Shipping_Carrier_Abstract extends Mage_Shipping_Mo
      * Do request to shipment
      *
      * @param Mage_Shipping_Model_Shipment_Request $request
-     * @return array
+     * @return Varien_Object
      */
     public function requestToShipment(Mage_Shipping_Model_Shipment_Request $request)
     {
@@ -353,7 +353,7 @@ abstract class Mage_Usa_Model_Shipping_Carrier_Abstract extends Mage_Shipping_Mo
      * Do request to RMA shipment
      *
      * @param $request
-     * @return array
+     * @return Varien_Object
      */
     public function returnOfShipment($request)
     {

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Backend/Abstract.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Backend/Abstract.php
@@ -76,7 +76,7 @@ abstract class Mage_Usa_Model_Shipping_Carrier_Abstract_Backend_Abstract extends
      * Check for presence in array with allow value.
      *
      * @throws Mage_Core_Exception
-     * @return Mage_Usa_Model_Shipping_Carrier_Ups_Backend_FreeShipment
+     * @return Mage_Usa_Model_Shipping_Carrier_Abstract_Backend_Abstract
      */
     protected function _beforeSave()
     {

--- a/app/code/core/Mage/Weee/Model/Attribute/Backend/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Attribute/Backend/Weee/Tax.php
@@ -33,7 +33,7 @@ class Mage_Weee_Model_Attribute_Backend_Weee_Tax extends Mage_Catalog_Model_Prod
     /**
      * Retrieve resource model
      *
-     * @return Mage_Catalog_Model_Resource_Eav_Mysql4_Product_Attribute_Backend_Weee
+     * @return Mage_Weee_Model_Resource_Attribute_Backend_Weee_Tax
      */
     protected function _getResource()
     {
@@ -44,7 +44,7 @@ class Mage_Weee_Model_Attribute_Backend_Weee_Tax extends Mage_Catalog_Model_Prod
      * Validate data
      *
      * @param   Mage_Catalog_Model_Product $object
-     * @return  this
+     * @return  Mage_Weee_Model_Attribute_Backend_Weee_Tax
      */
     public function validate($object)
     {
@@ -76,7 +76,7 @@ class Mage_Weee_Model_Attribute_Backend_Weee_Tax extends Mage_Catalog_Model_Prod
      * Assign WEEE taxes to product data
      *
      * @param   Mage_Catalog_Model_Product $object
-     * @return  Mage_Catalog_Model_Product_Attribute_Backend_Weee
+     * @return  Mage_Weee_Model_Attribute_Backend_Weee_Tax
      */
     public function afterLoad($object)
     {

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
@@ -63,7 +63,7 @@ class Mage_Widget_Block_Adminhtml_Widget_Instance_Edit_Tab_Main_Layout
      * Setter
      *
      * @param Varien_Data_Form_Element_Abstract $element
-     * @return
+     * @return Mage_Widget_Block_Adminhtml_Widget_Instance_Edit_Tab_Main_Layout
      */
     public function setElement(Varien_Data_Form_Element_Abstract $element)
     {

--- a/app/code/core/Mage/XmlConnect/Block/Checkout/Payment/Method/Info/Paypal/Abstract.php
+++ b/app/code/core/Mage/XmlConnect/Block/Checkout/Payment/Method/Info/Paypal/Abstract.php
@@ -37,7 +37,6 @@ abstract class Mage_XmlConnect_Block_Checkout_Payment_Method_Info_Paypal_Abstrac
      * Add CC Save Payment info to order XML object
      *
      * @param Mage_XmlConnect_Model_Simplexml_Element $orderItemXmlObj
-     * @return Mage_XmlConnect_Model_Simplexml_Element
      */
     public function addPaymentInfoToXmlObj(Mage_XmlConnect_Model_Simplexml_Element $orderItemXmlObj)
     {

--- a/app/code/core/Mage/XmlConnect/Model/OfflineCatalog/Product.php
+++ b/app/code/core/Mage/XmlConnect/Model/OfflineCatalog/Product.php
@@ -51,7 +51,6 @@ class Mage_XmlConnect_Model_OfflineCatalog_Product extends Mage_XmlConnect_Block
     /**
      * Export product data
      *
-     * @return Mage_XmlConnect_Model_OfflineCatalog_Product
      */
     public function exportData()
     {

--- a/app/code/core/Mage/XmlConnect/Model/Preview/Abstract.php
+++ b/app/code/core/Mage/XmlConnect/Model/Preview/Abstract.php
@@ -101,7 +101,7 @@ abstract class Mage_XmlConnect_Model_Preview_Abstract extends Varien_Object
      * Set active tab
      *
      * @param string $tab
-     * @return Mage_XmlConnect_Block_Adminhtml_Mobile_Preview_Tabitems
+     * @return Mage_XmlConnect_Model_Preview_Abstract
      */
     public function setActiveTab($tab)
     {

--- a/app/code/core/Mage/XmlConnect/Model/Preview/Android.php
+++ b/app/code/core/Mage/XmlConnect/Model/Preview/Android.php
@@ -65,7 +65,7 @@ class Mage_XmlConnect_Model_Preview_Android extends Mage_XmlConnect_Model_Previe
     /**
      * Get application banner image url
      *
-     * @return string
+     * @return array
      */
     public function getBannerImage()
     {

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
@@ -193,7 +193,7 @@ var productOptionType = {
                 $(element.readAttribute('id')+'_'+group).show();
 
             } else {
-                template = '<div id="'+element.readAttribute('id')+'_'+group+'" class="grid tier form-list">'+template+'</div><div id="'+element.readAttribute('id')+'_'+group+'_advice"></div';
+                template = '<div id="'+element.readAttribute('id')+'_'+group+'" class="grid tier form-list">'+template+'</div><div id="'+element.readAttribute('id')+'_'+group+'_advice"></div>';
                 this.secondTemplate = new Template(template, this.templateSyntax);
 
                 data = {};


### PR DESCRIPTION
This commit fixes many issues with doc comments in Magento,
to ease the pain of reading the code and debugging.

This patch does not fix everything, but quite a lot.
Once this is accepted I can provide more.

What is changed:
- add missing doc comments for some params
- change "decimal" to "float"
- fix some non existing class names (like "Mage_Sales_Model_Invoice")
- fix wrong variable names in doc comments
- fix wrong class names (e.g. Mage_Core_Model_Cache instead of Mage_Core_Model_Cache
in Mage_Core_Model_App)
- remove `@return` doc comment for methods which are not returning

Let me know whether this kind of cleanup is wanted. If yes, i will most probably split this PR into few chunks (e.g. move decimal->float to a separate PR) to make it easier for a review.

I'm also open for doing a one-to-one review session, I think 30min is enough to go through all the changed places and verify them.