### PR TITLE
Remove memory_limit in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -32,10 +32,8 @@
 <IfModule mod_php5.c>
 
 ############################################
-## adjust memory limit
+## adjust max execution time
 
-#    php_value memory_limit 64M
-    php_value memory_limit 256M
     php_value max_execution_time 18000
 
 ############################################
@@ -71,8 +69,6 @@
 ## see above for php_flag descriptions
 
 <IfModule mod_php7.c>
-    #php_value memory_limit 64M
-    php_value memory_limit 256M
     php_value max_execution_time 18000
     php_flag magic_quotes_gpc off
     php_flag session.auto_start off

--- a/.htaccess.sample
+++ b/.htaccess.sample
@@ -29,9 +29,8 @@
 <IfModule mod_php5.c>
 
 ############################################
-## adjust memory limit
+## adjust max execution time
 
-    php_value memory_limit 512M
     php_value max_execution_time 18000
 
 ############################################


### PR DESCRIPTION
Hello,
Is there any reason to let these `memory_limit` instruction in `.htaccess`?

It's very low and can't be overriden by web server configuration. The only solution is to edit this file but it get erased on every Magento upgrade.