### PR TITLE
Define frontend area and store in subscriber sends out email

### DIFF
--- a/app/code/core/Mage/Newsletter/Model/Subscriber.php
+++ b/app/code/core/Mage/Newsletter/Model/Subscriber.php
@@ -513,6 +513,7 @@ class Mage_Newsletter_Model_Subscriber extends Mage_Core_Model_Abstract
         $translate->setTranslateInline(false);
 
         $email = Mage::getModel('core/email_template');
+        $email->setDesignConfig(array('area' => 'frontend', 'store' => $this->getStoreId()));
 
         $email->sendTransactional(
             Mage::getStoreConfig(self::XML_PATH_CONFIRM_EMAIL_TEMPLATE),
@@ -549,6 +550,7 @@ class Mage_Newsletter_Model_Subscriber extends Mage_Core_Model_Abstract
         $translate->setTranslateInline(false);
 
         $email = Mage::getModel('core/email_template');
+        $email->setDesignConfig(array('area' => 'frontend', 'store' => $this->getStoreId()));
 
         $email->sendTransactional(
             Mage::getStoreConfig(self::XML_PATH_SUCCESS_EMAIL_TEMPLATE),
@@ -584,6 +586,7 @@ class Mage_Newsletter_Model_Subscriber extends Mage_Core_Model_Abstract
         $translate->setTranslateInline(false);
 
         $email = Mage::getModel('core/email_template');
+        $email->setDesignConfig(array('area' => 'frontend', 'store' => $this->getStoreId()));
 
         $email->sendTransactional(
             Mage::getStoreConfig(self::XML_PATH_UNSUBSCRIBE_EMAIL_TEMPLATE),


### PR DESCRIPTION
Issue: Wrong logo url and store url in subscriber template in `newsletter_unsub_success`, `newsletter_subscr_success`, `newsletter_subscr_confirm`.

- Define frontend area and store in subscriber sends out email

To reproduce it, simply register or unsubscribe a customer to the newsletter from the backoffice (with different url).