### PR TITLE
Suggestion to add some logging if in error

### DIFF
--- a/app/code/core/Mage/Paypal/Model/Api/Nvp.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Nvp.php
@@ -1164,6 +1164,7 @@ class Mage_Paypal_Model_Api_Nvp extends Mage_Paypal_Model_Api_Abstract
         if (isset($this->_requiredResponseParams[$method])) {
             foreach ($this->_requiredResponseParams[$method] as $param) {
                 if (!isset($response[$param])) {
+                    Mage::log("Expected PayPal field not found in NVP Response: $param");
                     return false;
                 }
             }


### PR DESCRIPTION
Suggestion to add some logging if in error

https://community.magento.com/t5/Payments-PayPal/PayPal-response-hasn-t-required-fields-AMT-field-is-deprecated/td-p/51852