### PR TITLE
Remove 'nightly' from PHP tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,10 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - nightly
 
 matrix:
   allow_failures:
     - php:
-      - nightly
       - 7.3
 
 script:


### PR DESCRIPTION
I don't see the point of running tests with PHP nightly for this project. When a new PHP version is officially released we can deal with fixes then, but until then the nightly test just creates noise. For example:

- Failing Pull Request: https://github.com/OpenMage/magento-lts/pull/630
- Failing Pipeline: https://travis-ci.org/OpenMage/magento-lts/jobs/512072513

I get that the `allow_failures` is intended to alleviate this, but it doesn't seem to be working.