### PR TITLE
Zend_Validate_File_Extension::isValid() fails if filename doesn't exist

### DIFF
--- a/lib/Zend/Validate/File/ExcludeExtension.php
+++ b/lib/Zend/Validate/File/ExcludeExtension.php
@@ -60,12 +60,6 @@ class Zend_Validate_File_ExcludeExtension extends Zend_Validate_File_Extension
      */
     public function isValid($value, $file = null)
     {
-        // Is file readable ?
-        #require_once 'Zend/Loader.php';
-        if (!Zend_Loader::isReadable($value)) {
-            return $this->_throw($file, self::NOT_FOUND);
-        }
-
         if ($file !== null) {
             $info['extension'] = substr($file['name'], strrpos($file['name'], '.') + 1);
         } else {

--- a/lib/Zend/Validate/File/Extension.php
+++ b/lib/Zend/Validate/File/Extension.php
@@ -185,12 +185,6 @@ class Zend_Validate_File_Extension extends Zend_Validate_Abstract
      */
     public function isValid($value, $file = null)
     {
-        // Is file readable ?
-        #require_once 'Zend/Loader.php';
-        if (!Zend_Loader::isReadable($value)) {
-            return $this->_throw($file, self::NOT_FOUND);
-        }
-
         if ($file !== null) {
             $info['extension'] = substr($file['name'], strrpos($file['name'], '.') + 1);
         } else {


### PR DESCRIPTION
Fixes regression introduced in 1.9.4.1. See #646. The root cause has been in the Magento core since probably forever, the class is just barely used so it wasn't an issue until now.

The few places that actually use the class have their own file checks in place already, like [here](https://github.com/OpenMage/magento-lts/blob/1.9.4.x/app/code/core/Mage/Core/Model/Email/Template/Abstract.php#L242).
