### PR TITLE
Fix broken logging in 1.9.4.1, also see #648

### DIFF
--- a/api.php
+++ b/api.php
@@ -24,8 +24,8 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-if (version_compare(phpversion(), '5.2.0', '<')) {
-    echo 'It looks like you have an invalid PHP version. Magento supports PHP 5.2.0 or newer';
+if (version_compare(phpversion(), '5.6.0', '<')) {
+    echo 'It looks like you have an invalid PHP version. Magento supports PHP 5.6.0 or newer';
     exit;
 }
 

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -809,14 +809,7 @@ final class Mage
         $file = empty($file) ?
             (string) self::getConfig()->getNode('dev/log/file', Mage_Core_Model_Store::DEFAULT_CODE) : basename($file);
 
-        // Validate file extension before save. Allowed file extensions: log, txt, html, csv
-        $_allowedFileExtensions = explode(
-            ',',
-            (string) self::getConfig()->getNode('dev/log/allowedFileExtensions', Mage_Core_Model_Store::DEFAULT_CODE)
-        );
-        $logValidator = new Zend_Validate_File_Extension($_allowedFileExtensions);
-        $logDir = self::getBaseDir('var') . DS . 'log';
-        if (!$logValidator->isValid($logDir . DS . $file)) {
+        if (!self::helper('log')->isLogFileExtensionValid($file)) {
             return;
         }
 

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -809,6 +809,7 @@ final class Mage
         $file = empty($file) ?
             (string) self::getConfig()->getNode('dev/log/file', Mage_Core_Model_Store::DEFAULT_CODE) : basename($file);
 
+        $logDir = self::getBaseDir('var') . DS . 'log';
         if (!self::helper('log')->isLogFileExtensionValid($file)) {
             return;
         }

--- a/app/code/core/Mage/Log/Helper/Data.php
+++ b/app/code/core/Mage/Log/Helper/Data.php
@@ -36,11 +36,6 @@ class Mage_Log_Helper_Data extends Mage_Core_Helper_Abstract
      */
     protected $_logLevel;
 
-    /**
-     * Allowed extensions that can be used to create a log file
-     */
-    private $_allowedFileExtensions = array('log', 'txt', 'html', 'csv');
-
     public function __construct(array $data = array())
     {
         $this->_logLevel = isset($data['log_level']) ? $data['log_level']
@@ -86,9 +81,13 @@ class Mage_Log_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function isLogFileExtensionValid($file)
     {
+        $_allowedFileExtensions = explode(
+            ',',
+            (string) Mage::getConfig()->getNode('dev/log/allowedFileExtensions', Mage_Core_Model_Store::DEFAULT_CODE)
+        );
         $result = false;
         $validatedFileExtension = pathinfo($file, PATHINFO_EXTENSION);
-        if ($validatedFileExtension && in_array($validatedFileExtension, $this->_allowedFileExtensions)) {
+        if ($validatedFileExtension && in_array($validatedFileExtension, $allowedFileExtensions)) {
             $result = true;
         }
 

--- a/app/code/core/Mage/Log/Helper/Data.php
+++ b/app/code/core/Mage/Log/Helper/Data.php
@@ -87,7 +87,7 @@ class Mage_Log_Helper_Data extends Mage_Core_Helper_Abstract
         );
         $result = false;
         $validatedFileExtension = pathinfo($file, PATHINFO_EXTENSION);
-        if ($validatedFileExtension && in_array($validatedFileExtension, $allowedFileExtensions)) {
+        if ($validatedFileExtension && in_array($validatedFileExtension, $_allowedFileExtensions)) {
             $result = true;
         }
 

--- a/get.php
+++ b/get.php
@@ -23,11 +23,11 @@
  * @copyright  Copyright (c) 2006-2019 Magento, Inc. (http://www.magento.com)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-if (version_compare(phpversion(), '5.2.0', '<')===true) {
+if (version_compare(phpversion(), '5.6.0', '<')===true) {
     echo  '<div style="font:12px/1.35em arial, helvetica, sans-serif;"><div style="margin:0 0 25px 0; '
         . 'border-bottom:1px solid #ccc;"><h3 style="margin:0; font-size:1.7em; font-weight:normal; '
         . 'text-transform:none; text-align:left; color:#2f2f2f;">Whoops, it looks like you have an invalid PHP version.'
-        . '</h3></div><p>Magento supports PHP 5.2.0 or newer. <a href="http://www.magentocommerce.com/install" '
+        . '</h3></div><p>Magento supports PHP 5.6.0 or newer. <a href="http://www.magentocommerce.com/install" '
         . 'target="">Find out</a> how to install</a> Magento using PHP-CGI as a work-around.</p></div>';
     exit;
 }

--- a/index.php
+++ b/index.php
@@ -24,11 +24,11 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-if (version_compare(phpversion(), '5.3.0', '<')===true) {
+if (version_compare(phpversion(), '5.6.0', '<')===true) {
     echo  '<div style="font:12px/1.35em arial, helvetica, sans-serif;">
 <div style="margin:0 0 25px 0; border-bottom:1px solid #ccc;">
 <h3 style="margin:0; font-size:1.7em; font-weight:normal; text-transform:none; text-align:left; color:#2f2f2f;">
-Whoops, it looks like you have an invalid PHP version.</h3></div><p>Magento supports PHP 5.3.0 or newer.
+Whoops, it looks like you have an invalid PHP version.</h3></div><p>Magento supports PHP 5.6.0 or newer.
 <a href="http://www.magentocommerce.com/install" target="">Find out</a> how to install</a>
  Magento using PHP-CGI as a work-around.</p></div>';
     exit;

--- a/index.php.sample
+++ b/index.php.sample
@@ -24,8 +24,8 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-if (version_compare(phpversion(), '5.2.0', '<')===true) {
-    echo  '<div style="font:12px/1.35em arial, helvetica, sans-serif;"><div style="margin:0 0 25px 0; border-bottom:1px solid #ccc;"><h3 style="margin:0; font-size:1.7em; font-weight:normal; text-transform:none; text-align:left; color:#2f2f2f;">Whoops, it looks like you have an invalid PHP version.</h3></div><p>Magento supports PHP 5.2.0 or newer. <a href="http://www.magentocommerce.com/install" target="">Find out</a> how to install</a> Magento using PHP-CGI as a work-around.</p></div>';
+if (version_compare(phpversion(), '5.6.0', '<')===true) {
+    echo  '<div style="font:12px/1.35em arial, helvetica, sans-serif;"><div style="margin:0 0 25px 0; border-bottom:1px solid #ccc;"><h3 style="margin:0; font-size:1.7em; font-weight:normal; text-transform:none; text-align:left; color:#2f2f2f;">Whoops, it looks like you have an invalid PHP version.</h3></div><p>Magento supports PHP 5.6.0 or newer. <a href="http://www.magentocommerce.com/install" target="">Find out</a> how to install</a> Magento using PHP-CGI as a work-around.</p></div>';
     exit;
 }
 

--- a/install.php
+++ b/install.php
@@ -118,8 +118,8 @@
  *
  */
 
-if (version_compare(phpversion(), '5.2.0', '<')===true) {
-    die('ERROR: Whoops, it looks like you have an invalid PHP version. Magento supports PHP 5.2.0 or newer.');
+if (version_compare(phpversion(), '5.6.0', '<')===true) {
+    die('ERROR: Whoops, it looks like you have an invalid PHP version. Magento supports PHP 5.6.0 or newer.');
 }
 set_include_path(dirname(__FILE__) . PATH_SEPARATOR . get_include_path());
 require 'app/bootstrap.php';

--- a/lib/Zend/Validate/File/Exists.php
+++ b/lib/Zend/Validate/File/Exists.php
@@ -100,7 +100,7 @@ class Zend_Validate_File_Exists extends Zend_Validate_Abstract
      * Sets the file directory which will be checked
      *
      * @param  string|array $directory The directories to validate
-     * @return Zend_Validate_File_Extension Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDirectory($directory)
     {
@@ -114,7 +114,7 @@ class Zend_Validate_File_Exists extends Zend_Validate_Abstract
      *
      * @param  string|array $directory The directory to add for validation
      * @throws Zend_Validate_Exception
-     * @return Zend_Validate_File_Extension Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addDirectory($directory)
     {

--- a/lib/Zend/Validate/File/Extension.php
+++ b/lib/Zend/Validate/File/Extension.php
@@ -106,7 +106,7 @@ class Zend_Validate_File_Extension extends Zend_Validate_Abstract
      * Sets the case to use
      *
      * @param  boolean $case
-     * @return Zend_Validate_File_Extension Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setCase($case)
     {
@@ -130,7 +130,7 @@ class Zend_Validate_File_Extension extends Zend_Validate_Abstract
      * Sets the file extensions
      *
      * @param  string|array $extension The extensions to validate
-     * @return Zend_Validate_File_Extension Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setExtension($extension)
     {
@@ -143,7 +143,7 @@ class Zend_Validate_File_Extension extends Zend_Validate_Abstract
      * Adds the file extensions
      *
      * @param  string|array $extension The extensions to add for validation
-     * @return Zend_Validate_File_Extension Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addExtension($extension)
     {

--- a/lib/Zend/Validate/File/MimeType.php
+++ b/lib/Zend/Validate/File/MimeType.php
@@ -305,7 +305,7 @@ class Zend_Validate_File_MimeType extends Zend_Validate_Abstract
      * Sets the mimetypes
      *
      * @param  string|array $mimetype The mimetypes to validate
-     * @return Zend_Validate_File_Extension Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setMimeType($mimetype)
     {
@@ -319,7 +319,7 @@ class Zend_Validate_File_MimeType extends Zend_Validate_Abstract
      *
      * @param  string|array $mimetype The mimetypes to add for validation
      * @throws Zend_Validate_Exception
-     * @return Zend_Validate_File_Extension Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addMimeType($mimetype)
     {


### PR DESCRIPTION
This reverts that part of last patch that uses Zend_Validate_File_Extension. The new feature, that gets allowed extensions from system.xml has moved to `Mage_Log_Helper_Data::isLogFileExtensionValid().`

Ref #646 #648 