### PR TITLE
Fix removing coupon from cart

### DIFF
--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -620,6 +620,7 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
                     );
                 }
             } else {
+                $this->_getSession()->setCartCouponCode('');
                 $this->_getSession()->addSuccess($this->__('Coupon code was canceled.'));
             }
 


### PR DESCRIPTION
Actually you can't remove coupon from cart, because session is not upate.

More information : 

https://github.com/OpenMage/magento-lts/pull/512
https://community.magento.com/t5/Magento-1-x-Technical-Issues/Coupon-code-still-work-after-remove-1-9-3/td-p/68856

I just update the PR from @SafrazSSears according to @Flyingmana suggestions.