### PR TITLE
Fix for 'Fixed PHP Notice' to work without 'unix_socket' defined.

### DIFF
--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -373,7 +373,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
         }
 
 
-        $hostInfo = $this->_getHostInfo(isset($this->_config['host']) ? $this->_config['host'] : isset($this->_config['unix_socket']) ? $this->_config['unix_socket'] : NULL);
+        $hostInfo = $this->_getHostInfo(isset($this->_config['host']) ? $this->_config['host'] : (isset($this->_config['unix_socket']) ? $this->_config['unix_socket'] : NULL));
 
         switch ($hostInfo->getAddressType()) {
             case self::ADDRESS_TYPE_UNIX_SOCKET:


### PR DESCRIPTION
I just created this pull request to fix the issue for the initial DB-connection not working anymore after the commit https://github.com/OpenMage/magento-lts/commit/ad136b858c24884221f298e81e7e4b9694bfd629 for defined `host`only (without defined `unix_socket`).

Without the additional braces the decision ends in `NULL` as long as there is no `unix_socket` defined... even if the `host` is defined.