### PR TITLE
maintain hash_equals first argument which shouldn't be NULL.

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/IndexController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/IndexController.php
@@ -391,7 +391,7 @@ class Mage_Adminhtml_IndexController extends Mage_Adminhtml_Controller_Action
         }
 
         $userToken = $user->getRpToken();
-        if (!hash_equals($userToken, $resetPasswordLinkToken) || $user->isResetPasswordLinkTokenExpired()) {
+        if ($user->isResetPasswordLinkTokenExpired() || !hash_equals($userToken, $resetPasswordLinkToken)) {
             throw Mage::exception('Mage_Core', Mage::helper('adminhtml')->__('Your password reset link has expired.'));
         }
     }


### PR DESCRIPTION
rp_token come frome database default as NULL
!! here, function isResetPasswordLinkTokenExpired ( app/code/core/Mage/Adminhtml/Helper/Dashboard/Data.php ) will take it and it should be first!!
someone who know 'good patterns' can tell if it should be so or it should be like :
        if (!isset($userToken) || !hash_equals($userToken, $resetPasswordLinkToken) || $user->isResetPasswordLinkTokenExpired()) {

Certainly, it should not remain like it is now.

effect isnt painful
just resetting password without active RP token throw error
Warning: hash_equals(): Expected known_string to be a string, null given in [...]app/code/core/Mage/Adminhtml/controllers/IndexController.php on line 394
