### PR TITLE
Make Adminhtml field comment translatable

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
@@ -94,7 +94,7 @@ class Mage_Adminhtml_Block_System_Config_Form_Field
             $html .= $this->_getElementHtml($element);
         };
         if ($element->getComment()) {
-            $html.= '<p class="note"><span>'.$element->getComment().'</span></p>';
+            $html.= '<p class="note"><span>'.$this->__($element->getComment()).'</span></p>';
         }
         $html.= '</td>';
 


### PR DESCRIPTION
I'm on a mission of translating a lot of modules and I just noticed that the field comments (those messages that shows when you hover the "?" next to the field") ware not being translated. I think Magento tries to translate it somewhere but it's not working.