### PR TITLE
Fix double load at customer edit page in administration

### DIFF
--- a/app/design/adminhtml/default/default/template/catalog/product/composite/configure.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/configure.phtml
@@ -26,7 +26,7 @@
  ?>
 <div id="popup-window-mask" style="display:none;"></div>
 <div id="product_composite_configure" class="product-configure-popup" style="display:none;">
-    <iframe name="product_composite_configure_iframe" id="product_composite_configure_iframe" src="#" style="width:0; height:0; border:0px solid #fff; position:absolute; top:-1000px; left:-1000px" onload="window.productConfigure && productConfigure.onLoadIFrame()"></iframe>
+    <iframe name="product_composite_configure_iframe" id="product_composite_configure_iframe" src="" style="width:0; height:0; border:0px solid #fff; position:absolute; top:-1000px; left:-1000px" onload="window.productConfigure && productConfigure.onLoadIFrame()"></iframe>
     <form action="" method="post" id="product_composite_configure_form" enctype="multipart/form-data" onsubmit="productConfigure.onConfirmBtn(); return false;" target="product_composite_configure_iframe">
         <div class="entry-edit">
             <div class="entry-edit-head">


### PR DESCRIPTION
In customer edit are duplicated all requests in Google Chrome and Mozilla Firefox. In Internet Explorer this works correctly. This changes fix this issue.

For example - try behavior in different browsers:
```
<iframe src="">
<p>Your browser does not support iframes.</p>
</iframe>

<iframe src="#">
<p>Your browser does not support iframes.</p>
</iframe>
```