### PR TITLE
Add Countable to implemented interfaces when appropriate

### DIFF
--- a/app/code/core/Mage/XmlConnect/Model/Simplexml/Form/Element/Collection.php
+++ b/app/code/core/Mage/XmlConnect/Model/Simplexml/Form/Element/Collection.php
@@ -31,7 +31,7 @@
  * @package     Mage_XmlConnect
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Mage_XmlConnect_Model_Simplexml_Form_Element_Collection implements ArrayAccess, IteratorAggregate
+class Mage_XmlConnect_Model_Simplexml_Form_Element_Collection implements ArrayAccess, IteratorAggregate, Countable
 {
     /**
      * Elements storage
@@ -175,9 +175,7 @@ class Mage_XmlConnect_Model_Simplexml_Form_Element_Collection implements ArrayAc
     }
 
     /**
-     * Count elements in collection
-     *
-     * @return int
+     * Implementation of Countable:count()
      */
     public function count()
     {

--- a/lib/Varien/Data/Tree/Node/Collection.php
+++ b/lib/Varien/Data/Tree/Node/Collection.php
@@ -31,7 +31,7 @@
  * @package    Varien_Data
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Varien_Data_Tree_Node_Collection implements ArrayAccess, IteratorAggregate
+class Varien_Data_Tree_Node_Collection implements ArrayAccess, IteratorAggregate, Countable
 {
     private $_nodes;
     private $_container;
@@ -111,7 +111,10 @@ class Varien_Data_Tree_Node_Collection implements ArrayAccess, IteratorAggregate
         }
         return $this;
     }
-    
+
+    /**
+     * Implementation of Countable:count()
+     */
     public function count()
     {
         return count($this->_nodes);


### PR DESCRIPTION
This PR addresses #619

List of classes that implement IteratorAggregate without a count method:
- Mage_Sales_Model_Entity_Sale_Collection
- Zend_Db_Table_Row_Abstract
- Zend_Db_Statement_Pdo
- Zend_Rest_Client_Result
- Zend_Rest_Client_Result
- Zend_TimeSync