### PR TITLE
Add missing method _beforeLoadCollection()

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -547,6 +547,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
             }
 
             if (!$this->_isExport) {
+                $this->_beforeLoadCollection();
                 $this->getCollection()->load();
                 $this->_afterLoadCollection();
             }
@@ -651,6 +652,11 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
     }
 
     protected function _afterLoadCollection()
+    {
+        return $this;
+    }
+
+    protected function _beforeLoadCollection()
     {
         return $this;
     }
@@ -1055,6 +1061,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
         $this->_prepareGrid();
         $this->getCollection()->getSelect()->limit();
         $this->getCollection()->setPageSize(0);
+        $this->_beforeLoadCollection();
         $this->getCollection()->load();
         $this->_afterLoadCollection();
 
@@ -1098,6 +1105,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
         $this->_prepareGrid();
         $this->getCollection()->getSelect()->limit();
         $this->getCollection()->setPageSize(0);
+        $this->_beforeLoadCollection();
         $this->getCollection()->load();
         $this->_afterLoadCollection();
         $indexes = array();
@@ -1197,6 +1205,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
         $this->_prepareGrid();
         $this->getCollection()->getSelect()->limit();
         $this->getCollection()->setPageSize(0);
+        $this->_beforeLoadCollection();
         $this->getCollection()->load();
         $this->_afterLoadCollection();
         $headers = array();


### PR DESCRIPTION
Magento grids are extended from `Mage_Adminhtml_Block_Widget_Grid` class. In this class is method `_afterLoadCollection()` but not the before method.

**Example of usage:**
If you want to extend, for example, customers grid you shold create rewrite and extend this Grid. And if you want to add some column, you have to add some joins to `_prepareCollection` method, but if you don't want to copy-paste code from parent, currently there is only one way how to do this - use `_preparePage` method and inside get collection, modify and return parent. But I think, that this is little bug. Mofify collection in `_prepareCollection` is not possible because collection is loaded, when I call parent.

_I think that this is non-breaking feature._