### PR TITLE
Fix fatal error when getRegionCollection() is called

### DIFF
--- a/app/code/core/Mage/Directory/Helper/Data.php
+++ b/app/code/core/Mage/Directory/Helper/Data.php
@@ -107,14 +107,14 @@ class Mage_Directory_Helper_Data extends Mage_Core_Helper_Abstract
 
     /**
      * Retrieve region collection
-     *
+     * @param string|array|null $countryFilter
      * @return Mage_Directory_Model_Resource_Region_Collection
      */
-    public function getRegionCollection()
+    public function getRegionCollection($countryFilter = null)
     {
         if (!$this->_regionCollection) {
             $this->_regionCollection = Mage::getModel('directory/region')->getResourceCollection()
-                ->addCountryFilter($this->getAddress()->getCountryId())
+                ->addCountryFilter($countryFilter)
                 ->load();
         }
         return $this->_regionCollection;


### PR DESCRIPTION
**Issue:** #713 

Tonight I spent some time with research - this bug is in Magento since 1.1.1, and I think that this method never worked before.

**Problematic line:** `->addCountryFilter($this->getAddress()->getCountryId())`

**Implementation of `addCountryFilter`:**
```
    public function addCountryFilter($countryId)
    {
        if (!empty($countryId)) {
            if (is_array($countryId)) {
                $this->addFieldToFilter('main_table.country_id', array('in' => $countryId));
            } else {
                $this->addFieldToFilter('main_table.country_id', $countryId);
            }
        }
        return $this;
    }
```

**Explanation of my code:** `addCountryFilter` accept NULL as param and when getRegionCollection is called, we wants to get full collection without filter (expected behavior according to method name).
