### PR TITLE
Fatal error: Call to protected function in Varien_Date

### DIFF
--- a/lib/Varien/Date.php
+++ b/lib/Varien/Date.php
@@ -124,7 +124,7 @@ class Varien_Date
     public static function toTimestamp($date)
     {
         if ($date instanceof Zend_Date) {
-            return $date->getUnixTimestamp();
+            return $date->getTimestamp();
         }
 
         if ($date === true) {


### PR DESCRIPTION
**Error message:** PHP Fatal error:  Uncaught Error: Call to protected method Zend_Date_DateObject::getUnixTimestamp() from context 'Varien_Date' in lib/Varien/Date.php:127

Method `getUnixTimestamp` is protected. This method is located in `Zend_Date_DateObject` and its protected. But In `Zend_Date_DateObject::getUnixTimestamp()` is this line: `if ($date instanceof Zend_Date) {` and if i go to `Zend_Date` there is this public method:

```
    public function getTimestamp()
    {
        return $this->getUnixTimestamp();
    }
```