### PR TITLE
fix(oauth): sort parameters in a standard way as per the specs

### DIFF
--- a/lib/Zend/Oauth/Signature/SignatureAbstract.php
+++ b/lib/Zend/Oauth/Signature/SignatureAbstract.php
@@ -167,7 +167,7 @@ abstract class Zend_Oauth_Signature_SignatureAbstract
     protected function _toByteValueOrderedQueryString(array $params)
     {
         $return = array();
-        uksort($params, 'strnatcmp');
+        ksort($params);
         foreach ($params as $key => $value) {
             if (is_array($value)) {
                 natsort($value);


### PR DESCRIPTION
Hi folks!

We have detected what seems to be a flaw in the way the OAuth signature is calculated to ensure the received request is correct.
From our understanding it seems to be a bug, but I’d really appreciate if someone more used to this standard could have a look :)

The symptom is: 401 errors with an `invalid_signature` error for requests containing numerical indexes.

## Example:

Given the following params:
* `limit` => `21`
* `filter[0][attribute]` => `sku`
* `filter[0][in][0]` => `msj000`
* `filter[0][in][1]` => `msj001`
* `filter[0][in][2]` => `msj002`
* `filter[0][in][3]` => `msj000xs`
* `filter[0][in][4]` => `msj000xl`
* `filter[0][in][5]` => `msj003xs`
* `filter[0][in][6]` => `msj003xl`
* `filter[0][in][7]` => `msj006`
* `filter[0][in][8]` => `msj007`
* `filter[0][in][9]` => `msj008`
* `filter[0][in][10]` => `msj006xl`
* `filter[0][in][11]` => `msj006xs`

Magento will use `natsort` to sort them before generating the signature. The order will thus be:

* `filter[0][attribute]` => `sku`
* `filter[0][in][0]` => `msj000`
* `filter[0][in][1]` => `msj001`
* `filter[0][in][2]` => `msj002`
* `filter[0][in][3]` => `msj000xs`
* `filter[0][in][4]` => `msj000xl`
* `filter[0][in][5]` => `msj003xs`
* `filter[0][in][6]` => `msj003xl`
* `filter[0][in][7]` => `msj006`
* `filter[0][in][8]` => `msj007`
* `filter[0][in][9]` => `msj008`
* `filter[0][in][10]` => `msj006xl` <------
* `filter[0][in][11]` => `msj006xs` <------
* `limit` => `21`

The library we use in nodeJS uses a standard sort (see https://github.com/ddo/oauth-1.0a/blob/d2ec1e2820ff60e99da4444deae630d8eac31d91/oauth-1.0a.js#L366) and will generate a signature with the following order:

* `filter[0][attribute]` => `sku`
* `filter[0][in][0]` => `msj000`
* `filter[0][in][1]` => `msj001`
* `filter[0][in][10]` => `msj006xl` <-------
* `filter[0][in][11]` => `msj006xs` <-------
* `filter[0][in][2]` => `msj002`
* `filter[0][in][3]` => `msj000xs`
* `filter[0][in][4]` => `msj000xl`
* `filter[0][in][5]` => `msj003xs`
* `filter[0][in][6]` => `msj003xl`
* `filter[0][in][7]` => `msj006`
* `filter[0][in][8]` => `msj007`
* `filter[0][in][9]` => `msj008`
* `limit` => `21`

As a consequence, signatures will not match…

## Resources

Our researches led us to the OAuth spec which says:
> parameters are sorted by name, using lexicographical byte value ordering. If two or more parameters share the same name, they are sorted by their value
(source: https://oauth.net/core/1.0a/#rfc.section.9.1.1)

From our understanding it seems that the Zend_Oauth is the wrong implementation…

Also, it seems that other implementations such as https://github.com/thephpleague/oauth1-client/blob/master/src/Client/Signature/HmacSha1Signature.php#L73 are also sorting parameters as the node library linked above.

## Breaking change

This IS a breaking change, also I am not sure whether you think it could be merged or not in its current state.

## Tests

This is my first contribution here, so I am relying on the CI process to see if it breaks things. I could add tests later if you think it is necessary.


Please let me know if you need further information.