### PR TITLE
Prevent fatal error in Mage_Catalog_Model_Resource_Category_Collectio…

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Visibility.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Visibility.php
@@ -60,13 +60,12 @@ class Mage_Catalog_Model_Product_Visibility extends Varien_Object
      * Add visible in catalog filter to collection
      *
      * @deprecated
-     * @param Mage_Eav_Model_Entity_Collection_Abstract $collection
+     * @param Mage_Catalog_Model_Resource_Product_Collection $collection
      * @return $this
      */
-    public function addVisibleInCatalogFilterToCollection(Mage_Eav_Model_Entity_Collection_Abstract $collection)
+    public function addVisibleInCatalogFilterToCollection(Mage_Catalog_Model_Resource_Product_Collection $collection)
     {
         $collection->setVisibility($this->getVisibleInCatalogIds());
-//        $collection->addAttributeToFilter('visibility', array('in'=>$this->getVisibleInCatalogIds()));
         return $this;
     }
 
@@ -74,13 +73,12 @@ class Mage_Catalog_Model_Product_Visibility extends Varien_Object
      * Add visibility in searchfilter to collection
      *
      * @deprecated
-     * @param Mage_Eav_Model_Entity_Collection_Abstract $collection
+     * @param Mage_Catalog_Model_Resource_Product_Collection $collection
      * @return $this
      */
-    public function addVisibleInSearchFilterToCollection(Mage_Eav_Model_Entity_Collection_Abstract $collection)
+    public function addVisibleInSearchFilterToCollection(Mage_Catalog_Model_Resource_Product_Collection $collection)
     {
         $collection->setVisibility($this->getVisibleInSearchIds());
-        //$collection->addAttributeToFilter('visibility', array('in'=>$this->getVisibleInSearchIds()));
         return $this;
     }
 
@@ -88,13 +86,12 @@ class Mage_Catalog_Model_Product_Visibility extends Varien_Object
      * Add visibility in site filter to collection
      *
      * @deprecated
-     * @param Mage_Eav_Model_Entity_Collection_Abstract $collection
+     * @param Mage_Catalog_Model_Resource_Product_Collection $collection
      * @return $this
      */
-    public function addVisibleInSiteFilterToCollection(Mage_Eav_Model_Entity_Collection_Abstract $collection)
+    public function addVisibleInSiteFilterToCollection(Mage_Catalog_Model_Resource_Product_Collection $collection)
     {
         $collection->setVisibility($this->getVisibleInSiteIds());
-        //$collection->addAttributeToFilter('visibility', array('in'=>$this->getVisibleInSiteIds()));
         return $this;
     }
 


### PR DESCRIPTION
…n::setVisibility()

Pass a non-product eav colletion ...

```
$collection = Mage::getModel('catalog/category')->getCollection();
Mage::getSingleton('catalog/product_visibility')->addVisibleInSearchFilterToCollection($collection);
```

... gives Uncaught Error: Call to undefined method Mage_Catalog_Model_Resource_Category_Collection::setVisibility()