### PR TITLE
Added missing config nodes, closes #609 #614

### DIFF
--- a/app/code/core/Mage/Adminhtml/etc/config.xml
+++ b/app/code/core/Mage/Adminhtml/etc/config.xml
@@ -47,6 +47,11 @@
                 <class>Mage_Adminhtml_Block</class>
             </adminhtml>
         </blocks>
+        <helpers>
+            <adminhtml>
+                <class>Mage_Adminhtml_Helper</class>
+            </adminhtml>
+        </helpers>
         <template>
             <email>
                 <admin_emails_forgot_email_template translate="label" module="adminhtml">

--- a/app/code/core/Mage/Api/etc/config.xml
+++ b/app/code/core/Mage/Api/etc/config.xml
@@ -73,6 +73,11 @@
                 </entities>
             </api_resource>
         </models>
+        <helpers>
+            <api>
+                <class>Mage_Api_Helper</class>
+            </api>
+        </helpers>
         <resources>
             <api_setup>
                 <setup>

--- a/app/code/core/Mage/Captcha/etc/config.xml
+++ b/app/code/core/Mage/Captcha/etc/config.xml
@@ -53,6 +53,11 @@
                 </entities>
             </captcha_resource>
         </models>
+        <helpers>
+            <captcha>
+                <class>Mage_Captcha_Helper</class>
+            </captcha>
+        </helpers>
         <events>
             <controller_action_predispatch_customer_account_loginpost>
                 <observers>
@@ -150,6 +155,15 @@
                 </args>
             </captcha>
         </routers>
+        <translate>
+            <modules>
+                <Mage_Captcha>
+                    <files>
+                        <default>Mage_Captcha.csv</default>
+                    </files>
+                </Mage_Captcha>
+            </modules>
+        </translate>
         <layout>
             <updates>
                 <captcha>

--- a/app/code/core/Mage/Sendfriend/etc/config.xml
+++ b/app/code/core/Mage/Sendfriend/etc/config.xml
@@ -61,6 +61,11 @@
                 <class>Mage_Sendfriend_Block</class>
             </sendfriend>
         </blocks>
+        <helpers>
+            <sendfriend>
+                <class>Mage_Sendfriend_Helper</class>
+            </sendfriend>
+        </helpers>
         <template>
             <email>
                 <sendfriend_email_template translate="label" module="sendfriend">

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
   "type": "magento-source",
   "require": {
     "php": ">=5.6 <7.3",
-    "magento-hackathon/magento-composer-installer": "*"
+    "magento-hackathon/magento-composer-installer": "*",
+    "ext-simplexml": "*"
   },
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
   "type": "magento-source",
   "require": {
     "php": ">=5.6 <7.3",
-    "magento-hackathon/magento-composer-installer": "*",
-    "ext-simplexml": "*"
+    "magento-hackathon/magento-composer-installer": "*"
   },
   "authors": [
     {


### PR DESCRIPTION
- adds translation for Mage_Captcha ref #609
- adds missing `helpers` nodes to config.xml

