### PR TITLE
replaced deprecated php function - each()

### DIFF
--- a/lib/Zend/Cache/Backend.php
+++ b/lib/Zend/Cache/Backend.php
@@ -76,7 +76,7 @@ class Zend_Cache_Backend
     public function setDirectives($directives)
     {
         if (!is_array($directives)) Zend_Cache::throwException('Directives parameter must be an array');
-        while (list($name, $value) = each($directives)) {
+        foreach($directives as $name => $value) {
             if (!is_string($name)) {
                 Zend_Cache::throwException("Incorrect option name : $name");
             }


### PR DESCRIPTION
I found deprecated function in Zend cache. It throws this:
`ERR (3): Deprecated functionality: The each() function is deprecated. This message will be suppressed on further calls  in .../lib/Zend/Cache/Backend.php on line 81`