### PR TITLE
Fixed currency convert exception

### DIFF
--- a/app/code/core/Mage/Directory/Model/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Currency.php
@@ -183,15 +183,22 @@ class Mage_Directory_Model_Currency extends Mage_Core_Model_Abstract
     {
         if (is_null($toCurrency)) {
             return $price;
-        } else {
-            $rate = $this->getRate($toCurrency);
-            if ($rate) {
-                return $price * $rate;
-            }
         }
 
-        throw new Exception(Mage::helper('directory')->__('Undefined rate from "%s-%s".', $this->getCode(),
-            $toCurrency->getCode()));
+        $rate = $this->getRate($toCurrency);
+        if ($rate) {
+            return $price * $rate;
+        }
+
+        if ($toCurrency instanceof Mage_Directory_Model_Currency) {
+            $toCurrencyCode = $toCurrency->getCode();
+        } else {
+            $toCurrencyCode = $toCurrency;
+        }
+
+        throw new Exception(
+            Mage::helper('directory')->__('Undefined rate from "%s-%s".', $this->getCode(), $toCurrencyCode)
+        );
     }
 
     /**

--- a/app/code/core/Mage/Directory/Model/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Currency.php
@@ -190,10 +190,8 @@ class Mage_Directory_Model_Currency extends Mage_Core_Model_Abstract
             }
         }
 
-        throw new Exception(
-            Mage::helper('directory')->__('Undefined rate from "%s-%s".', $this->getCode(),
-                $toCurrency instanceof Mage_Directory_Model_Currency ? $toCurrency->getCode() : $toCurrency)
-        );
+        throw new Exception(Mage::helper('directory')->__('Undefined rate from "%s-%s".', $this->getCode(),
+            $toCurrency instanceof Mage_Directory_Model_Currency ? $toCurrency->getCode() : $toCurrency));
     }
 
     /**

--- a/app/code/core/Mage/Directory/Model/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Currency.php
@@ -183,15 +183,16 @@ class Mage_Directory_Model_Currency extends Mage_Core_Model_Abstract
     {
         if (is_null($toCurrency)) {
             return $price;
-        }
-
-        $rate = $this->getRate($toCurrency);
-        if ($rate) {
-            return $price * $rate;
+        } else {
+            $rate = $this->getRate($toCurrency);
+            if ($rate) {
+                return $price * $rate;
+            }
         }
 
         throw new Exception(
-            Mage::helper('directory')->__('Undefined rate from "%s-%s".', $this->getCode(), $toCurrency instanceof Mage_Directory_Model_Currency ? $toCurrency->getCode() : $toCurrency)
+            Mage::helper('directory')->__('Undefined rate from "%s-%s".', $this->getCode(),
+                $toCurrency instanceof Mage_Directory_Model_Currency ? $toCurrency->getCode() : $toCurrency)
         );
     }
 

--- a/app/code/core/Mage/Directory/Model/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Currency.php
@@ -190,14 +190,8 @@ class Mage_Directory_Model_Currency extends Mage_Core_Model_Abstract
             return $price * $rate;
         }
 
-        if ($toCurrency instanceof Mage_Directory_Model_Currency) {
-            $toCurrencyCode = $toCurrency->getCode();
-        } else {
-            $toCurrencyCode = $toCurrency;
-        }
-
         throw new Exception(
-            Mage::helper('directory')->__('Undefined rate from "%s-%s".', $this->getCode(), $toCurrencyCode)
+            Mage::helper('directory')->__('Undefined rate from "%s-%s".', $this->getCode(), $toCurrency instanceof Mage_Directory_Model_Currency ? $toCurrency->getCode() : $toCurrency)
         );
     }
 


### PR DESCRIPTION
Parameter `$toCurrency` can be `null` or `string` or `Mage_Directory_Model_Currency` object. If `$toCurrency` is `string` and rate doen't exists then we have fatal error (`Call to a member function ... on string` against exception. This is fix for described problem.