### PR TITLE
Replacing Admin Notifications feed URL

### DIFF
--- a/app/code/core/Mage/AdminNotification/etc/config.xml
+++ b/app/code/core/Mage/AdminNotification/etc/config.xml
@@ -91,7 +91,7 @@
     <default>
         <system>
             <adminnotification>
-                <feed_url>notifications.magentocommerce.com/community/notifications.rss</feed_url>
+                <feed_url>openmage.github.io/Web_Notifications/notifications_v1.rss</feed_url>
                 <popup_url>widgets.magentocommerce.com/notificationPopup</popup_url>
                 <severity_icons_url>widgets.magentocommerce.com/%s/%s.gif</severity_icons_url>
                 <use_https>0</use_https>


### PR DESCRIPTION
This will allow us to control the Feed so that only relevant/important notifications are displayed to merchants.