### PR TITLE
Add created_at and updated_at to all relevant REST API resources

### DIFF
--- a/app/code/core/Mage/Catalog/etc/api2.xml
+++ b/app/code/core/Mage/Catalog/etc/api2.xml
@@ -60,7 +60,7 @@
                         <retrieve>1</retrieve>
                     </guest>
                 </privileges>
-                <attributes translate="entity_id type_id attribute_set_id stock_data image_url is_saleable total_reviews_count url buy_now_url has_custom_options is_in_stock regular_price_with_tax regular_price_without_tax final_price_with_tax final_price_without_tax use_config_gift_message_available use_config_gift_wrapping_available url_key_create_redirect" module="api2">
+                <attributes translate="entity_id type_id attribute_set_id stock_data image_url is_saleable total_reviews_count url buy_now_url has_custom_options is_in_stock regular_price_with_tax regular_price_without_tax final_price_with_tax final_price_without_tax use_config_gift_message_available use_config_gift_wrapping_available url_key_create_redirect created_at updated_at" module="api2">
                     <entity_id>Product ID</entity_id>
                     <type_id>Product Type</type_id>
                     <attribute_set_id>Attribute Set</attribute_set_id>
@@ -79,6 +79,8 @@
                     <use_config_gift_message_available>Use Config Settings for Allow Gift Message</use_config_gift_message_available>
                     <use_config_gift_wrapping_available>Use Config Settings for Allow Gift Wrapping</use_config_gift_wrapping_available>
                     <url_key_create_redirect>Create Permanent Redirect for old URL</url_key_create_redirect>
+                    <created_at>Created Date</created_at>
+                    <updated_at>Updated Date</updated_at>
                 </attributes>
                 <entity_only_attributes>
                     <customer>
@@ -175,6 +177,8 @@
                             <recurring_profile>1</recurring_profile>
                             <thumbnail>1</thumbnail>
                             <entity_id>1</entity_id>
+                            <created_at>1</created_at>
+                            <updated_at>1</updated_at>
                         </write>
                     </admin>
                 </exclude_attributes>
@@ -229,9 +233,19 @@
                         <retrieve>1</retrieve>
                     </guest>
                 </privileges>
-                <attributes translate="category_id" module="api2">
+                <attributes translate="category_id created_at updated_at" module="api2">
                     <category_id>Category ID</category_id>
+                    <created_at>Created Date</created_at>
+                    <updated_at>Updated Date</updated_at>
                 </attributes>
+                <exclude_attributes>
+                    <admin>
+                        <write>
+                            <created_at>1</created_at>
+                            <updated_at>1</updated_at>
+                        </write>
+                    </admin>
+                </exclude_attributes>
                 <routes>
                     <route_collection>
                         <route>/products/:id/categories</route>

--- a/app/code/core/Mage/CatalogInventory/etc/api2.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/api2.xml
@@ -45,7 +45,7 @@
                         <update>1</update>
                     </admin>
                 </privileges>
-                <attributes translate="item_id product_id stock_id qty min_qty use_config_min_qty is_qty_decimal backorders use_config_backorders min_sale_qty use_config_min_sale_qty max_sale_qty use_config_max_sale_qty is_in_stock low_stock_date notify_stock_qty use_config_notify_stock_qty manage_stock use_config_manage_stock stock_status_changed_auto use_config_qty_increments qty_increments use_config_enable_qty_inc enable_qty_increments is_decimal_divided" module="api2">
+                <attributes translate="item_id product_id stock_id qty min_qty use_config_min_qty is_qty_decimal backorders use_config_backorders min_sale_qty use_config_min_sale_qty max_sale_qty use_config_max_sale_qty is_in_stock low_stock_date notify_stock_qty use_config_notify_stock_qty manage_stock use_config_manage_stock stock_status_changed_auto use_config_qty_increments qty_increments use_config_enable_qty_inc enable_qty_increments is_decimal_divided created_at updated_at" module="api2">
                     <item_id>Item ID</item_id>
                     <product_id>Product ID</product_id>
                     <stock_id>Stock ID</stock_id>
@@ -71,6 +71,8 @@
                     <use_config_enable_qty_inc>Use Config Settings for Enable Qty Increments</use_config_enable_qty_inc>
                     <enable_qty_increments>Enable Qty Increments</enable_qty_increments>
                     <is_decimal_divided>Can Be Divided into Multiple Boxes for Shipping</is_decimal_divided>
+                    <created_at>Created Date</created_at>
+                    <updated_at>Updated Date</updated_at>
                 </attributes>
                 <exclude_attributes>
                     <admin>
@@ -79,6 +81,8 @@
                             <product_id>1</product_id>
                             <stock_id>1</stock_id>
                             <low_stock_date>1</low_stock_date>
+                            <created_at>1</created_at>
+                            <updated_at>1</updated_at>
                         </write>
                     </admin>
                 </exclude_attributes>

--- a/app/code/core/Mage/Customer/etc/api2.xml
+++ b/app/code/core/Mage/Customer/etc/api2.xml
@@ -51,7 +51,7 @@
                         <update>1</update>
                     </customer>
                 </privileges>
-                <attributes translate="entity_id last_logged_in firstname lastname email website_id created_in group_id confirmation disable_auto_group_change" module="api2">
+                <attributes translate="entity_id last_logged_in firstname lastname email website_id created_in group_id confirmation disable_auto_group_change created_at updated_at" module="api2">
                     <entity_id>Customer ID</entity_id>
                     <last_logged_in>Last Logged In</last_logged_in>
                     <firstname>First Name</firstname>
@@ -62,12 +62,15 @@
                     <group_id>Group</group_id>
                     <confirmation>Is Confirmed</confirmation>
                     <disable_auto_group_change>Disable automatic group change based on VAT ID</disable_auto_group_change>
+                    <created_at>Created Date</created_at>
+                    <updated_at>Updated Date</updated_at>
                 </attributes>
                 <exclude_attributes>
                     <admin>
                         <write>
                             <entity_id>1</entity_id>
                             <created_at>1</created_at>
+                            <updated_at>1</updated_at>
                             <created_in>1</created_in>
                             <last_logged_in>1</last_logged_in>
                         </write>
@@ -81,7 +84,6 @@
                             <group_id>1</group_id>
                             <disable_auto_group_change>1</disable_auto_group_change>
                             <confirmation>1</confirmation>
-                            <created_at>1</created_at>
                         </read>
                         <write>
                             <entity_id>1</entity_id>
@@ -92,6 +94,7 @@
                             <disable_auto_group_change>1</disable_auto_group_change>
                             <confirmation>1</confirmation>
                             <created_at>1</created_at>
+                            <updated_at>1</updated_at>
                         </write>
                     </customer>
                 </exclude_attributes>
@@ -145,10 +148,12 @@
                         <delete>1</delete>
                     </customer>
                 </privileges>
-                <attributes translate="entity_id is_default_billing is_default_shipping" module="api2">
+                <attributes translate="entity_id is_default_billing is_default_shipping created_at updated_at" module="api2">
                     <entity_id>Customer Address ID</entity_id>
                     <is_default_billing>Is Default Billing Address</is_default_billing>
                     <is_default_shipping>Is Default Shipping Address</is_default_shipping>
+                    <created_at>Created Date</created_at>
+                    <updated_at>Updated Date</updated_at>
                 </attributes>
                 <exclude_attributes>
                     <admin>
@@ -166,6 +171,8 @@
                             <vat_request_date>1</vat_request_date>
                             <vat_request_id>1</vat_request_id>
                             <vat_request_success>1</vat_request_success>
+                            <created_at>1</created_at>
+                            <updated_at>1</updated_at>
                         </write>
                     </admin>
                     <customer>
@@ -175,6 +182,8 @@
                         <write>
                             <entity_id>1</entity_id>
                             <region_id>1</region_id>
+                            <created_at>1</created_at>
+                            <updated_at>1</updated_at>
                         </write>
                     </customer>
                 </exclude_attributes>

--- a/app/code/core/Mage/Sales/etc/api2.xml
+++ b/app/code/core/Mage/Sales/etc/api2.xml
@@ -63,10 +63,11 @@
                         <action_type>collection</action_type>
                     </route_collection>
                 </routes>
-                <attributes translate="entity_id increment_id created_at status shipping_description _payment_method base_currency_code store_currency_code store_name remote_ip store_to_order_rate subtotal subtotal_incl_tax discount_amount base_grand_total grand_total shipping_amount shipping_tax_amount shipping_incl_tax tax_amount _tax_name _tax_rate coupon_code base_discount_amount base_subtotal base_shipping_amount base_shipping_tax_amount base_tax_amount total_paid base_total_paid total_refunded base_total_refunded base_subtotal_incl_tax base_total_due total_due shipping_discount_amount base_shipping_discount_amount discount_description customer_balance_amount base_customer_balance_amount base_customer_balance_amount _gift_message _order_comments customer_id" module="api2">
+                <attributes translate="entity_id increment_id created_at updated_at status shipping_description _payment_method base_currency_code store_currency_code store_name remote_ip store_to_order_rate subtotal subtotal_incl_tax discount_amount base_grand_total grand_total shipping_amount shipping_tax_amount shipping_incl_tax tax_amount _tax_name _tax_rate coupon_code base_discount_amount base_subtotal base_shipping_amount base_shipping_tax_amount base_tax_amount total_paid base_total_paid total_refunded base_total_refunded base_subtotal_incl_tax base_total_due total_due shipping_discount_amount base_shipping_discount_amount discount_description customer_balance_amount base_customer_balance_amount base_customer_balance_amount _gift_message _order_comments customer_id" module="api2">
                     <entity_id>Order ID (internal)</entity_id>
                     <increment_id>Order ID</increment_id>
                     <created_at>Order Date</created_at>
+                    <updated_at>Order Updated Date</updated_at>
                     <status>Order Status</status>
                     <shipping_description>Shipping Method</shipping_description>
                     <_payment_method>Payment Method</_payment_method>
@@ -108,12 +109,21 @@
                     <_order_comments>Order Comments</_order_comments>
                     <customer_id>Customer ID</customer_id>
                 </attributes>
+                <exclude_attributes>
+                    <admin>
+                        <write>
+                            <created_at>1</created_at>
+                            <updated_at>1</updated_at>
+                        </write>
+                    </admin>
+                </exclude_attributes>
                 <include_attributes>
                     <customer>
                         <read>
                             <entity_id>1</entity_id>
                             <increment_id>1</increment_id>
                             <created_at>1</created_at>
+                            <updated_at>1</updated_at>
                             <status>1</status>
                             <shipping_description>1</shipping_description>
                             <_payment_method>1</_payment_method>
@@ -175,7 +185,7 @@
                         <retrieve>1</retrieve>
                     </customer>
                 </privileges>
-                <attributes translate="item_id name parent_item_id sku price price_incl_tax qty_ordered qty_invoiced qty_shipped qty_canceled qty_refunded row_total row_total_incl_tax base_price original_price base_original_price base_price_incl_tax tax_percent tax_amount base_tax_amount discount_amount base_discount_amount base_row_total base_row_total_incl_tax" module="api2">
+                <attributes translate="item_id name parent_item_id sku price price_incl_tax qty_ordered qty_invoiced qty_shipped qty_canceled qty_refunded row_total row_total_incl_tax base_price original_price base_original_price base_price_incl_tax tax_percent tax_amount base_tax_amount discount_amount base_discount_amount base_row_total base_row_total_incl_tax created_at updated_at" module="api2">
                     <item_id>Order Item ID</item_id>
                     <name>Product and Custom Options Name</name>
                     <parent_item_id>Parent Order Item ID</parent_item_id>
@@ -200,7 +210,17 @@
                     <base_discount_amount>Base Discount Amount</base_discount_amount>
                     <base_row_total>Base Item Subtotal</base_row_total>
                     <base_row_total_incl_tax>Base Item Subtotal Including Tax</base_row_total_incl_tax>
+                    <created_at>Created Date</created_at>
+                    <updated_at>Updated Date</updated_at>
                 </attributes>
+                <excluded_attributes>
+                    <admin>
+                        <write>
+                            <created_at>1</created_at>
+                            <updated_at>1</updated_at>
+                        </write>
+                    </admin>
+                </excluded_attributes>
                 <include_attributes>
                     <customer>
                         <read>
@@ -253,7 +273,7 @@
                     </route_collection>
                 </routes>
                 <versions>1</versions>
-                <attributes translate="lastname firstname middlename prefix suffix company street city region postcode country_id telephone address_type email" module="api2">
+                <attributes translate="lastname firstname middlename prefix suffix company street city region postcode country_id telephone address_type email created_at updated_at" module="api2">
                     <lastname>Customer Last Name</lastname>
                     <firstname>Customer First Name</firstname>
                     <middlename>Customer Middle Name</middlename>
@@ -268,7 +288,17 @@
                     <telephone>Phone Number</telephone>
                     <address_type>Address Type</address_type>
                     <email>Email</email>
+                    <created_at>Created Date</created_at>
+                    <updated_at>Updated Date</updated_at>
                 </attributes>
+                <excluded_attributes>
+                    <admin>
+                        <write>
+                            <created_at>1</created_at>
+                            <updated_at>1</updated_at>
+                        </write>
+                    </admin>
+                </excluded_attributes>
             </order_address>
             <order_comment translate="title" module="api2">
                 <group>sales_order</group>


### PR DESCRIPTION
When developing an integration with the Magento 1.9 REST API, I came across an issue in accessing fields `created_at` and `updated_at` for certain resources. Orders by default have `created_at` available, but not `updated_at` which is useful for incremental syncing. In addition, other resources such as `/products` and `/stockitems` have neither `created_at` or `updated_at` fields available to the consumer.

These dates are valuable for applications consuming the API, and should be available as attributes which can be enabled for applicable roles (Admin, Customer). In addition, these values should never be writable, and should only be included in the configuration for resources which have these dates in the database.

This PR adds both `created_at` and `updated_at` fields to all applicable resources, while excluding them from writes via configuration files.