### PR TITLE
update Readme.md with PHP Requirement and new version branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Note, the branches older than `1.9.3.x` that were created before this strategy c
 Download the latest archive and extract it, clone the repo, or add a composer dependency to your existing project like so:
 
 ```json
-"openmage/magento-lts": "1.9.3.x"
+"openmage/magento-lts": "1.9.4.x"
 ```
 
 [More Information](http://openmage.github.io/magento-lts/install.html)
 
 ## Requirements
 
-- PHP 5.6+ (PHP 7.1 and OpenSSL extension strongly recommended)
+- PHP 5.6+ (PHP 7.3 and OpenSSL extension strongly recommended)
 - MySQL 5.6+
 
 ## Translations

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Download the latest archive and extract it, clone the repo, or add a composer de
 ## Requirements
 
 - PHP 5.6+ (PHP 7.3 and OpenSSL extension strongly recommended)
-- MySQL 5.6+
+- MySQL 5.6+ (8.0+ Recommended)
 
 ## Translations
 


### PR DESCRIPTION
I was asked a few times about if we support PHP 7.2 already, so I thought we update it directly to 7.3, as I have a demo running on this version, and I remember also one person who mentioned running it in production(?)

Should we also add a newer MySql version as recommended?