### PR TITLE
Reset session saved grid parameters on exception like sql error

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -647,7 +647,13 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
 
     protected function _beforeToHtml()
     {
-        $this->_prepareGrid();
+        try {
+            $this->_prepareGrid();
+        } catch (Exception $e) {
+            $this->resetSavedParametersInSession();
+            throw $e;
+        }
+
         return parent::_beforeToHtml();
     }
 
@@ -1308,6 +1314,23 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
     {
         $this->_saveParametersInSession = $flag;
         return $this;
+    }
+
+    public function resetSavedParametersInSession()
+    {
+        $session = Mage::getSingleton('adminhtml/session');
+
+        $params = array(
+           $this->_varNameLimit,
+           $this->_varNamePage,
+           $this->_varNameSort,
+           $this->_varNameDir,
+           $this->_varNameFilter
+        );
+
+        foreach ($params as $param) {
+            $session->unsetData($this->getId().$param);
+        }
     }
 
     public function getJsObjectName()


### PR DESCRIPTION
If the grid parameters are stored in the session and there is an error, the user will not get out of the error.

The current workaround was always to log out and log in again.