### PR TITLE
Fix error when try to create URL to unexists store

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Cron.php
@@ -38,24 +38,18 @@ class Mage_Adminhtml_Model_System_Config_Backend_Currency_Cron extends Mage_Core
 
     protected function _afterSave()
     {
-        $enabled = $this->getData('groups/import/fields/enabled/value');
-        $service = $this->getData('groups/import/fields/service/value');
         $time = $this->getData('groups/import/fields/time/value');
         $frequency = $this->getData('groups/import/fields/frequency/value');
-        $errorEmail = $this->getData('groups/import/fields/error_email/value');
 
-        $frequencyDaily = Mage_Adminhtml_Model_System_Config_Source_Cron_Frequency::CRON_DAILY;
         $frequencyWeekly = Mage_Adminhtml_Model_System_Config_Source_Cron_Frequency::CRON_WEEKLY;
         $frequencyMonthly = Mage_Adminhtml_Model_System_Config_Source_Cron_Frequency::CRON_MONTHLY;
-
-        $cronDayOfWeek = date('N');
 
         $cronExprArray = array(
             intval($time[1]),                                   # Minute
             intval($time[0]),                                   # Hour
-            ($frequency == $frequencyMonthly) ? '1' : '*',       # Day of the Month
-            '*',                                                # Month of the Year
-            ($frequency == $frequencyWeekly) ? '1' : '*',        # Day of the Week
+            ($frequency == $frequencyMonthly) ? '1' : '*',          # Day of the Month
+            '*',                                                    # Month of the Year
+            ($frequency == $frequencyWeekly) ? '1' : '*',           # Day of the Week
         );
 
         $cronExprString = join(' ', $cronExprArray);

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Log/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Log/Cron.php
@@ -46,21 +46,18 @@ class Mage_Adminhtml_Model_System_Config_Backend_Log_Cron extends Mage_Core_Mode
     {
         $enabled    = $this->getData('groups/log/fields/enabled/value');
         $time       = $this->getData('groups/log/fields/time/value');
-        $frequncy   = $this->getData('groups/log/fields/frequency/value');
-        $errorEmail = $this->getData('groups/log/fields/error_email/value');
+        $frequency   = $this->getData('groups/log/fields/frequency/value');
 
-        $frequencyDaily     = Mage_Adminhtml_Model_System_Config_Source_Cron_Frequency::CRON_DAILY;
         $frequencyWeekly    = Mage_Adminhtml_Model_System_Config_Source_Cron_Frequency::CRON_WEEKLY;
         $frequencyMonthly   = Mage_Adminhtml_Model_System_Config_Source_Cron_Frequency::CRON_MONTHLY;
 
         if ($enabled) {
-            $cronDayOfWeek = date('N');
             $cronExprArray = array(
                 intval($time[1]),                                   # Minute
                 intval($time[0]),                                   # Hour
-                ($frequncy == $frequencyMonthly) ? '1' : '*',       # Day of the Month
-                '*',                                                # Month of the Year
-                ($frequncy == $frequencyWeekly) ? '1' : '*',        # Day of the Week
+                ($frequency == $frequencyMonthly) ? '1' : '*',          # Day of the Month
+                '*',                                                    # Month of the Year
+                ($frequency == $frequencyWeekly) ? '1' : '*',           # Day of the Week
             );
             $cronExprString = join(' ', $cronExprArray);
         }

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Product/Alert/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Product/Alert/Cron.php
@@ -39,26 +39,18 @@ class Mage_Adminhtml_Model_System_Config_Backend_Product_Alert_Cron extends Mage
 
     protected function _afterSave()
     {
-        $priceEnable = $this->getData('groups/productalert/fields/allow_price/value');
-        $stockEnable = $this->getData('groups/productalert/fields/allow_stock/value');
-
-        $enabled     = $priceEnable || $stockEnable;
-        $frequncy    = $this->getData('groups/productalert_cron/fields/frequency/value');
+        $frequency    = $this->getData('groups/productalert_cron/fields/frequency/value');
         $time        = $this->getData('groups/productalert_cron/fields/time/value');
 
-        $errorEmail  = $this->getData('groups/productalert_cron/fields/error_email/value');
-
-        $frequencyDaily     = Mage_Adminhtml_Model_System_Config_Source_Cron_Frequency::CRON_DAILY;
         $frequencyWeekly    = Mage_Adminhtml_Model_System_Config_Source_Cron_Frequency::CRON_WEEKLY;
         $frequencyMonthly   = Mage_Adminhtml_Model_System_Config_Source_Cron_Frequency::CRON_MONTHLY;
-        $cronDayOfWeek      = date('N');
 
         $cronExprArray      = array(
             intval($time[1]),                                   # Minute
             intval($time[0]),                                   # Hour
-            ($frequncy == $frequencyMonthly) ? '1' : '*',       # Day of the Month
-            '*',                                                # Month of the Year
-            ($frequncy == $frequencyWeekly) ? '1' : '*',         # Day of the Week
+            ($frequency == $frequencyMonthly) ? '1' : '*',          # Day of the Month
+            '*',                                                    # Month of the Year
+            ($frequency == $frequencyWeekly) ? '1' : '*',           # Day of the Week
         );
 
         $cronExprString     = join(' ', $cronExprArray);

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap/Cron.php
@@ -39,24 +39,18 @@ class Mage_Adminhtml_Model_System_Config_Backend_Sitemap_Cron extends Mage_Core_
 
     protected function _afterSave()
     {
-        $enabled = $this->getData('groups/generate/enabled/value');
-        //$service = $this->getData('groups/import/fields/service/value');
         $time = $this->getData('groups/generate/fields/time/value');
-        $frequncy = $this->getData('groups/generate/frequency/value');
-        $errorEmail = $this->getData('groups/generate/error_email/value');
+        $frequency = $this->getData('groups/generate/frequency/value');
 
-        $frequencyDaily = Mage_Adminhtml_Model_System_Config_Source_Cron_Frequency::CRON_DAILY;
         $frequencyWeekly = Mage_Adminhtml_Model_System_Config_Source_Cron_Frequency::CRON_WEEKLY;
         $frequencyMonthly = Mage_Adminhtml_Model_System_Config_Source_Cron_Frequency::CRON_MONTHLY;
-
-        $cronDayOfWeek = date('N');
 
         $cronExprArray = array(
             intval($time[1]),                                   # Minute
             intval($time[0]),                                   # Hour
-            ($frequncy == $frequencyMonthly) ? '1' : '*',       # Day of the Month
-            '*',                                                # Month of the Year
-            ($frequncy == $frequencyWeekly) ? '1' : '*',        # Day of the Week
+            ($frequency == $frequencyMonthly) ? '1' : '*',          # Day of the Month
+            '*',                                                    # Month of the Year
+            ($frequency == $frequencyWeekly) ? '1' : '*',           # Day of the Week
         );
 
         $cronExprString = join(' ', $cronExprArray);

--- a/app/code/core/Mage/Backup/Model/Config/Backend/Cron.php
+++ b/app/code/core/Mage/Backup/Model/Config/Backend/Cron.php
@@ -59,9 +59,9 @@ class Mage_Backup_Model_Config_Backend_Cron extends Mage_Core_Model_Config_Data
             $cronExprArray = array(
                 intval($time[1]),                                   # Minute
                 intval($time[0]),                                   # Hour
-                ($frequency == $frequencyMonthly) ? '1' : '*',      # Day of the Month
-                '*',                                                # Month of the Year
-                ($frequency == $frequencyWeekly) ? '1' : '*',       # Day of the Week
+                ($frequency == $frequencyMonthly) ? '1' : '*',          # Day of the Month
+                '*',                                                    # Month of the Year
+                ($frequency == $frequencyWeekly) ? '1' : '*',           # Day of the Week
             );
             $cronExprString = join(' ', $cronExprArray);
         }

--- a/app/code/core/Mage/Core/Model/Url.php
+++ b/app/code/core/Mage/Core/Model/Url.php
@@ -356,7 +356,14 @@ class Mage_Core_Model_Url extends Varien_Object
      */
     public function setStore($data)
     {
-        $this->setData('store', Mage::app()->getStore($data));
+        try {
+            $this->setData('store', Mage::app()->getStore($data));
+        }
+        catch (Mage_Core_Model_Store_Exception $e) {
+            // store not found (e.g. on developer server)
+            Mage::logException($e);
+        }
+
         return $this;
     }
 

--- a/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cron.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cron.php
@@ -31,7 +31,8 @@ class Mage_Paypal_Model_System_Config_Backend_Cron extends Mage_Core_Model_Confi
 
     /**
      * Cron settings after save
-     * @return void
+     *
+     * @return Mage_Core_Model_Abstract
      */
     protected function _afterSave()
     {

--- a/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cron.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cron.php
@@ -32,7 +32,7 @@ class Mage_Paypal_Model_System_Config_Backend_Cron extends Mage_Core_Model_Confi
     /**
      * Cron settings after save
      *
-     * @return Mage_Core_Model_Abstract
+     * {@inheritDoc}
      */
     protected function _afterSave()
     {


### PR DESCRIPTION
**Problematic usage:**
`echo Mage::getUrl("module/index/policy", array('_store'=>10);`

This calling provides this output:
![Screenshot_1](https://user-images.githubusercontent.com/9967016/66381538-d4cdf600-e9b9-11e9-85df-6ddd97bbb90e.png)

but I only try to output route to page - not redirecting.....

Problematic passage:
```
    public function setStore($data)
    {
        $this->setData('store', Mage::app()->getStore($data));
        return $this;
    }
```
here is thrown `Mage_Core_Model_Store_Exception` exception without message, which is not catched and provides from non-known reason 404 page.