### PR TITLE
Fix 404 page - getUrl for unexists store

### DIFF
--- a/app/code/core/Mage/Core/Model/Url.php
+++ b/app/code/core/Mage/Core/Model/Url.php
@@ -361,8 +361,6 @@ class Mage_Core_Model_Url extends Varien_Object
         }
         catch (Mage_Core_Model_Store_Exception $e) {
             Mage::logException($e);
-
-            throw new Mage_Core_Exception("Store with id {$data} was not found!");
         }
 
         return $this;

--- a/app/code/core/Mage/Core/Model/Url.php
+++ b/app/code/core/Mage/Core/Model/Url.php
@@ -362,6 +362,7 @@ class Mage_Core_Model_Url extends Varien_Object
         catch (Mage_Core_Model_Store_Exception $e) {
             // store not found (e.g. on developer server)
             Mage::logException($e);
+            throw new Mage_Core_Exception("Store with id {$data} was not found!");
         }
 
         return $this;

--- a/app/code/core/Mage/Core/Model/Url.php
+++ b/app/code/core/Mage/Core/Model/Url.php
@@ -356,7 +356,14 @@ class Mage_Core_Model_Url extends Varien_Object
      */
     public function setStore($data)
     {
-        $this->setData('store', Mage::app()->getStore($data));
+        try {
+            $this->setData('store', Mage::app()->getStore($data));
+        }
+        catch (Mage_Core_Model_Store_Exception $e) {
+            // store not found (e.g. on developer server)
+            Mage::logException($e);
+        }
+
         return $this;
     }
 

--- a/app/code/core/Mage/Core/Model/Url.php
+++ b/app/code/core/Mage/Core/Model/Url.php
@@ -360,8 +360,8 @@ class Mage_Core_Model_Url extends Varien_Object
             $this->setData('store', Mage::app()->getStore($data));
         }
         catch (Mage_Core_Model_Store_Exception $e) {
-            // store not found (e.g. on developer server)
             Mage::logException($e);
+
             throw new Mage_Core_Exception("Store with id {$data} was not found!");
         }
 


### PR DESCRIPTION
**Problematic usage:**
`echo Mage::getUrl("module/index/policy", array('_store'=>15);`

This calling provides this output (in case when store with id 15 not exists):
![Screenshot_1](https://user-images.githubusercontent.com/9967016/66381538-d4cdf600-e9b9-11e9-85df-6ddd97bbb90e.png)

but I only try to output route to page - not redirecting.....

Problematic passage:
```
    public function setStore($data)
    {
        $this->setData('store', Mage::app()->getStore($data));
        return $this;
    }
```
here is thrown `Mage_Core_Model_Store_Exception` exception without message, which is catched in `Mage` class:

```
        } catch (Mage_Core_Model_Store_Exception $e) {
            require_once(self::getBaseDir() . DS . 'errors' . DS . '404.php');
            die();
        }
```

**Error after this changes:**

![Screenshot_2](https://user-images.githubusercontent.com/9967016/66385324-98ea5f00-e9c0-11e9-8085-6335bc19f243.png)
