### PR TITLE
Fix email/admin_new_user_notification template

### DIFF
--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -1094,6 +1094,15 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </password_reset_link_expiration_period>
+                        <admin_notification_email_template translate="label">
+                            <label>New Admin User Email Template</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_email_template</source_model>
+                            <sort_order>40</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </admin_notification_email_template>
                     </fields>
                 </emails>
                 <startup translate="label">

--- a/app/locale/en_US/Mage_Core.csv
+++ b/app/locale/en_US/Mage_Core.csv
@@ -210,6 +210,7 @@
 "Module ""%1$s"" requires module ""%2$s"".","Module ""%1$s"" requires module ""%2$s""."
 "Name","Name"
 "New Admin User Create Notification","New Admin User Create Notification"
+"New Admin User Email Template","New Admin User Email Template"
 "New Design Change","New Design Change"
 "New Store","New Store"
 "New Store View","New Store View"

--- a/app/locale/en_US/template/email/admin_new_user_notification.html
+++ b/app/locale/en_US/template/email/admin_new_user_notification.html
@@ -3,7 +3,7 @@
 {"store url=\"\"":"Store Url",
 "var logo_url":"Email Logo Image Url",
 "var logo_alt":"Email Logo Image Alt",
-"htmlescape var=$user.name":"New Admin Name",
+"htmlescape var=$user.name":"New Admin Name"}
 @-->
 
 <!--@styles


### PR DESCRIPTION
Someone missed a } in the template @vars header line 6 which then results in a "Fix Decoding failed: Syntax error" when loading said template in the "System -> Transactional Emails" area.

Issue introduced in 1.9.3.10.

https://magento.com/tech-resources/bug-tracking/issue/index/id/1994/

This should allow users to load this template in the "System -> Transactional Emails" area.
