### PR TITLE
Suggested fix to make $quote->getItemById more robust

### DIFF
--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -831,7 +831,18 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
      */
     public function getItemById($itemId)
     {
-        return $this->getItemsCollection()->getItemById($itemId);
+        $quoteItem = null;
+        if ($quoteItem = $this->getItemsCollection()->getItemById($itemId)) {
+            return $quoteItem
+        } else {
+            foreach (this->getItemsCollection() as $item) {
+                if ($item->getId() == $itemId) {
+                    $quoteItem = $itemId;
+                    return $quoteItem;
+                } 
+            }
+        }
+        return $quoteItem;
     }
 
     /**

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -837,7 +837,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
         } else {
             foreach (this->getItemsCollection() as $item) {
                 if ($item->getId() == $itemId) {
-                    $quoteItem = $itemId;
+                    $quoteItem = $item;
                     return $quoteItem;
                 } 
             }


### PR DESCRIPTION
Several new quote and order flows do not always trigger and set the quoteid ... the quote is then created with items but has no id yet ...  and getItemById () does not work in these case because there is a different key. This happens for instance when orders are created via

            /** @var Mage_Sales_Model_Service_Quote $service */
            $service = Mage::getModel('sales/service_quote', $quote);
            $service->submitAll();

Please review and UPDATE my code suggestion directly. Needs a proper review as it is quite in the core of quotes of M1