### PR TITLE
Fix invoice model cannot be garbage collected (Sales > Invoice export out of memory)

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -990,6 +990,8 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
             foreach ($collection as $item) {
                 call_user_func_array(array($this, $callback), array_merge(array($item), $args));
             }
+            $collection->clear();
+            unset($collection);
         }
     }
 

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -178,12 +178,6 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
      */
     protected $_wasPayCalled = false;
 
-    public function __construct()
-    {
-        register_shutdown_function(array($this, 'destruct'));
-        parent::__construct();
-    }
-
     /**
      * Uploader clean on shutdown
      */
@@ -350,6 +344,7 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
                 if ($canVoid === false) {
                     $this->setCanVoidFlag(false);
                     $this->_saveBeforeDestruct = true;
+                    register_shutdown_function(array($this, 'destruct'));
                 }
             }
             else {


### PR DESCRIPTION
This fixes a memory leak any time an invoice model is instantiated. For example, when exporting the invoices grid even though the export code uses an iterator that loads the result in chunks, the invoice models can never be unloaded because the shutdown functions registered have a reference to each invoice instance.

This fix registers the shutdown function only when the `_saveBeforeDestruct` flag is set to true since otherwise there is nothing to do anyway.

This code is extremely convoluted, setting a flag that is read in a method that is called during shutdown, only when the `canVoid` method is called and only under certain other circumstances... I didn't want to mess with fixing this mess, just make a minimal change that won't break BC.

Also added two lines to `MABWGrid` to improve chances of successful garbage collection and so that if there is special cleanup code in a collection's `clear` method it will be called when exporting. 