### PR TITLE
Fix logical error in SQL query; multiple OR clauses should be surroun…

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Collection.php
@@ -408,10 +408,9 @@ class Mage_Catalog_Model_Resource_Category_Collection extends Mage_Catalog_Model
         if (!is_array($paths)) {
             $paths = array($paths);
         }
-        $write  = $this->getResource()->getWriteConnection();
         $cond   = array();
         foreach ($paths as $path) {
-            $cond[] = $write->quoteInto('e.path LIKE ?', "$path%");
+            $cond[] = $this->getResource()->getReadConnection()->quoteInto('e.path LIKE ?', "$path%");
         }
         if ($cond) {
             $this->getSelect()->where(join(' OR ', $cond));

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
@@ -341,14 +341,12 @@ class Mage_Catalog_Model_Resource_Category_Flat_Collection extends Mage_Core_Mod
             $paths = array($paths);
         }
         $select = $this->getSelect();
-        $orWhere = false;
+        $cond   = array();
         foreach ($paths as $path) {
-            if ($orWhere) {
-                $select->orWhere('main_table.path LIKE ?', "$path%");
-            } else {
-                $select->where('main_table.path LIKE ?', "$path%");
-                $orWhere = true;
-            }
+            $cond[] = $this->getResource()->getReadConnection()->quoteInto('main_table.path LIKE ?', "$path%");
+        }
+        if ($cond) {
+            $select->where(join(' OR ', $cond));
         }
         return $this;
     }


### PR DESCRIPTION
…ded by parentheses.

Currently a query generated by `addPathsFilter` looks like this:

```sql
SELECT `main_table`.`entity_id`,`main_table`.`is_active`, `main_table`.`is_anchor`, `main_table`.`name`, `url_rewrite`.`request_path` 
FROM `catalog_category_flat_store_10` AS `main_table` 
LEFT JOIN `core_url_rewrite` AS `url_rewrite` 
ON url_rewrite.category_id=main_table.entity_id AND url_rewrite.is_system=1 AND url_rewrite.product_id IS NULL AND url_rewrite.store_id='10' AND url_rewrite.id_path LIKE 'category/%' 
WHERE (is_active = '1') AND 
(main_table.path LIKE '1/5/148%') OR (main_table.path LIKE '1/5/325%') OR (main_table.path LIKE '1/5/332%')
ORDER BY `main_table`.`entity_id` ASC
```

The query should look like this:
```sql
SELECT `main_table`.`entity_id`,`main_table`.`is_active`, `main_table`.`is_anchor`, `main_table`.`name`, `url_rewrite`.`request_path` 
FROM `catalog_category_flat_store_10` AS `main_table` 
LEFT JOIN `core_url_rewrite` AS `url_rewrite` 
ON url_rewrite.category_id=main_table.entity_id AND url_rewrite.is_system=1 AND url_rewrite.product_id IS NULL AND url_rewrite.store_id='10' AND url_rewrite.id_path LIKE 'category/%' 
WHERE (is_active = '1') AND 
((main_table.path LIKE '1/5/148%') OR (main_table.path LIKE '1/5/325%') OR (main_table.path LIKE '1/5/332%'))
ORDER BY `main_table`.`entity_id` ASC
```
