### PR TITLE
Disable url rewrite check for admin store

### DIFF
--- a/app/code/core/Mage/Core/Controller/Varien/Front.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Front.php
@@ -162,7 +162,9 @@ class Mage_Core_Controller_Varien_Front extends Varien_Object
 
         $request->setPathInfo()->setDispatched(false);
 
-        $this->_getRequestRewriteController()->rewrite();
+        if (!Mage::app()->getStore()->isAdmin()) {
+            $this->_getRequestRewriteController()->rewrite();
+        }
 
         Varien_Profiler::start('mage::dispatch::routers_match');
         $i = 0;


### PR DESCRIPTION
Url rewrites for admin store is not supported, so i disabled the check for this store. Will reduce one MySQL query per request.