### PR TITLE
Fix performance issue with bruteforce search in review observer

### DIFF
--- a/app/code/core/Mage/Review/Model/Review.php
+++ b/app/code/core/Mage/Review/Model/Review.php
@@ -158,7 +158,7 @@ class Mage_Review_Model_Review extends Mage_Core_Model_Abstract
     {
         $entityIds = array();
         foreach ($collection->getItems() as $_itemId => $_item) {
-            $entityIds[] = $_item->getEntityId();
+            $entityIds[] = $_item->getId();
         }
 
         if (sizeof($entityIds) == 0) {
@@ -170,11 +170,9 @@ class Mage_Review_Model_Review extends Mage_Core_Model_Abstract
             ->addStoreFilter(Mage::app()->getStore()->getId())
             ->load();
 
-        foreach ($collection->getItems() as $_item ) {
-            foreach ($summaryData as $_summary) {
-                if ($_summary->getEntityPkValue() == $_item->getEntityId()) {
-                    $_item->setRatingSummary($_summary);
-                }
+        foreach ($summaryData as $_summary) {
+            if (($_item = $collection->getItemById($_summary->getEntityPkValue()))) {
+                $_item->setRatingSummary($_summary);
             }
         }
 


### PR DESCRIPTION
The current observer does a brute-force search to find a current summary related to a product in the collection. It becomes visible when you show 1000 products on a page and increases exponentially with the increased size of product collection. 
Fix replaces brute force search (O(n^m)) with a hash map lookup (O(n))