### PR TITLE
Stop calling getLastPageNumber() when not necessary

### DIFF
--- a/lib/Varien/Data/Collection.php
+++ b/lib/Varien/Data/Collection.php
@@ -205,7 +205,7 @@ class Varien_Data_Collection implements IteratorAggregate, Countable
      */
     public function getCurPage($displacement = 0)
     {
-        if ($this->_curPage + $displacement < 1) {
+        if ($this->_curPage + $displacement <= 1) {
             return 1;
         }
         elseif ($this->_curPage + $displacement > $this->getLastPageNumber()) {


### PR DESCRIPTION
Community, what do you think?

When the `$this->_curPage` is `1` the `$this->getLastPageNumber()` is called. In eav collection it is slow operation, because `$this->getSize()` is called inside.