### PR TITLE
fix php7.4 syntax deprecated warnings

### DIFF
--- a/app/code/core/Mage/Core/Controller/Front/Router.php
+++ b/app/code/core/Mage/Core/Controller/Front/Router.php
@@ -71,7 +71,7 @@ class Mage_Core_Controller_Front_Router
         if (!empty($params)) {
             $paramsStr = '';
             foreach ($params as $key=>$value) {
-                if (!isset($reservedKeys[$key]) && '_'!==$key{0} && !empty($value)) {
+                if (!isset($reservedKeys[$key]) && '_'!==$key[0] && !empty($value)) {
                     $paramsStr .= $key.'/'.$value.'/';
                 }
             }

--- a/app/code/core/Mage/Core/Model/Layout.php
+++ b/app/code/core/Mage/Core/Model/Layout.php
@@ -440,7 +440,7 @@ class Mage_Core_Model_Layout extends Varien_Simplexml_Config
             return false;
         }
 
-        if (empty($name) || '.'===$name{0}) {
+        if (empty($name) || '.'===$name[0]) {
             $block->setIsAnonymous(true);
             if (!empty($name)) {
                 $block->setAnonSuffix(substr($name, 1));

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Alphanum.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Alphanum.php
@@ -58,7 +58,7 @@ class Mage_Eav_Model_Entity_Increment_Alphanum extends Mage_Eav_Model_Entity_Inc
         $lid = strlen($lastId)-1;
 
         for ($i = $lid; $i >= 0; $i--) {
-            $p = strpos($chars, $lastId{$i});
+            $p = strpos($chars, $lastId[$i]);
             if (false===$p) {
                 throw Mage::exception('Mage_Eav', Mage::helper('eav')->__('Invalid character encountered in increment ID: %s', $lastId));
             }

--- a/app/code/core/Mage/Eav/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Setup.php
@@ -1157,7 +1157,7 @@ class Mage_Eav_Model_Entity_Setup extends Mage_Core_Model_Resource_Setup
                 if (!empty($attr['backend'])) {
                     if ('_' === $attr['backend']) {
                         $attr['backend'] = $backendPrefix;
-                    } elseif ('_' === $attr['backend']{0}) {
+                    } elseif ('_' === $attr['backend'][0]) {
                         $attr['backend'] = $backendPrefix.$attr['backend'];
                     }
                 }

--- a/app/code/core/Mage/SalesRule/Model/Coupon/Codegenerator.php
+++ b/app/code/core/Mage/SalesRule/Model/Coupon/Codegenerator.php
@@ -43,7 +43,7 @@ class Mage_SalesRule_Model_Coupon_Codegenerator extends Varien_Object
         $indexMax = strlen($alphabet) - 1;
         for ($i = 0; $i < $length; $i++) {
             $index = rand(0, $indexMax);
-            $result .= $alphabet{$index};
+            $result .= $alphabet[$index];
         }
         return $result;
     }

--- a/downloader/lib/Mage/Connect/Command.php
+++ b/downloader/lib/Mage/Connect/Command.php
@@ -314,7 +314,7 @@ class Mage_Connect_Command
         while (list($option, $info) = each($commandInfo['options'])) {
             $larg = $sarg = '';
             if (isset($info['arg'])) {
-                if ($info['arg']{0} == '(') {
+                if ($info['arg'][0] == '(') {
                     $larg = '==';
                     $sarg = '::';
                 } else {

--- a/downloader/lib/Mage/Connect/Command/Registry.php
+++ b/downloader/lib/Mage/Connect/Command/Registry.php
@@ -284,7 +284,7 @@ extends Mage_Connect_Command
                 }
 
                 while ($ent = readdir($dp)) {
-                    if ($ent{0} == '.' || substr($ent, -4) != '.reg') {
+                    if ($ent[0] == '.' || substr($ent, -4) != '.reg') {
                         continue;
                     }
                     $pkglist[] = array('file'=>$ent, 'channel'=>$channel);

--- a/downloader/lib/Mage/Connect/Ftp.php
+++ b/downloader/lib/Mage/Connect/Ftp.php
@@ -481,7 +481,7 @@ class Mage_Connect_Ftp
                 $info = preg_split("/[\s]+/", $rawfile, 9);
                 $arraypointer[] = array(
                     'name'   => $info[8],
-                    'dir'  => $info[0]{0} == 'd',
+                    'dir'  => $info[0][0] == 'd',
                     'size'   => (int) $info[4],
                     'chmod'  => self::chmodnum($info[0]),
                     'rawdata' => $info,

--- a/downloader/lib/Mage/System/Ftp.php
+++ b/downloader/lib/Mage/System/Ftp.php
@@ -470,7 +470,7 @@ class Mage_System_Ftp
                 $info = preg_split("/[\s]+/", $rawfile, 9);
                 $arraypointer[] = array(
                     'name'   => $info[8],
-                    'dir'  => $info[0]{0} == 'd',
+                    'dir'  => $info[0][0] == 'd',
                     'size'   => (int) $info[4],
                     'chmod'  => self::chmodnum($info[0]),
                     'rawdata' => $info,

--- a/lib/Mage/Connect/Command.php
+++ b/lib/Mage/Connect/Command.php
@@ -249,7 +249,7 @@ class Mage_Connect_Command
         while (list($option, $info) = each($commandInfo['options'])) {
             $larg = $sarg = '';
             if (isset($info['arg'])) {
-                if ($info['arg']{0} == '(') {
+                if ($info['arg'][0] == '(') {
                     $larg = '==';
                     $sarg = '::';
                     $arg = substr($info['arg'], 1, -1);

--- a/lib/Mage/System/Ftp.php
+++ b/lib/Mage/System/Ftp.php
@@ -470,7 +470,7 @@ class Mage_System_Ftp
                 $info = preg_split("/[\s]+/", $rawfile, 9);
                 $arraypointer[] = array(
                     'name'   => $info[8],
-                    'dir'  => $info[0]{0} == 'd',
+                    'dir'  => $info[0][0] == 'd',
                     'size'   => (int) $info[4],
                     'chmod'  => self::chmodnum($info[0]),
                     'rawdata' => $info,

--- a/lib/Magento/Crypt.php
+++ b/lib/Magento/Crypt.php
@@ -79,7 +79,7 @@ class Magento_Crypt
                 $abc = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
                 $initVector = '';
                 for ($i = 0; $i < $initVectorSize; $i++) {
-                    $initVector .= $abc{rand(0, strlen($abc) - 1)};
+                    $initVector .= $abc[rand(0, strlen($abc) - 1)];
                 }
             } else if (false === $initVector) {
                 /* Set vector to zero bytes to not use it */

--- a/lib/Net/IDNA2.php
+++ b/lib/Net/IDNA2.php
@@ -2683,7 +2683,7 @@ class Net_IDNA2
 
         if ($delim_pos > self::_byteLength($this->_punycode_prefix)) {
             for ($k = self::_byteLength($this->_punycode_prefix); $k < $delim_pos; ++$k) {
-                $decoded[] = ord($encoded{$k});
+                $decoded[] = ord($encoded[$k]);
             }
         } else {
             $decoded = array();

--- a/lib/Varien/Filter/Template/Tokenizer/Abstract.php
+++ b/lib/Varien/Filter/Template/Tokenizer/Abstract.php
@@ -86,7 +86,7 @@ abstract class Varien_Filter_Template_Tokenizer_Abstract
      */
     public function char()
     {
-        return $this->_string{$this->_currentIndex};
+        return $this->_string[$this->_currentIndex];
     }
     
     


### PR DESCRIPTION
PHP Deprecated:  Array and string offset access syntax with curly braces
is deprecated

see https://github.com/OpenMage/magento-lts/pull/829