### PR TITLE
restore Mage_AdminNotification use https constant

### DIFF
--- a/app/code/core/Mage/AdminNotification/Model/Feed.php
+++ b/app/code/core/Mage/AdminNotification/Model/Feed.php
@@ -34,6 +34,7 @@
  */
 class Mage_AdminNotification_Model_Feed extends Mage_Core_Model_Abstract
 {
+    const XML_USE_HTTPS_PATH    = 'system/adminnotification/use_https';
     const XML_FEED_URL_PATH     = 'system/adminnotification/feed_url';
     const XML_FREQUENCY_PATH    = 'system/adminnotification/frequency';
     const XML_LAST_UPDATE_PATH  = 'system/adminnotification/last_update';


### PR DESCRIPTION
#799 removed this. #800 partially restored it, this PR restores the constant `XML_USE_HTTPS_PATH`.  Here are some more details for others searching in future:

Some extensions, notably `Amasty_Base` (which is required by most if not all of their m1 extensions), rely on the presence of this constant.

Having this around for backwards extension compatibility is good IMO. The logic of the core `AdminNotification` does not take it into account so HTTPS is effectively forced for that and this is not exposed to the system config ui to be changed. 

In the case that users have a `core_config` entry of false the third party extensions will defer to their own logic. To work around this, that developer can change the setting `core_config` `system/adminnotification/use_https` to the true value (`1`), or change the effected third party module's handling (like #799 does for core) will achieve the same "https everywhere" goal.

Ideally we'd be able to force it, or have everyone running on an up-to-date version of third party extensions but with different extension update policies and infrequent updates (at best) it's going to be a mixed bag of versions for users - thus, keeping this constant helps not break stuff! 