### PR TITLE
replace call to deprecated function in Mage_Eav

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -757,7 +757,8 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
     {
         $tableAlias = null;
         if (is_array($table)) {
-            list($tableAlias, $tableName) = each($table);
+            $tableAlias = key($table);
+            $tableName = current($table);
         } else {
             $tableName = $table;
         }


### PR DESCRIPTION
`Mage_Eav` has a call to `each` which is deprecated as of PHP 7.2 https://www.php.net/manual/en/function.each.php