### PR TITLE
remove deprecated function from Mage_Adminhtml

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Page/Menu.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Menu.php
@@ -177,7 +177,7 @@ class Mage_Adminhtml_Block_Page_Menu extends Mage_Adminhtml_Block_Template
 
         uasort($parentArr, array($this, '_sortMenu'));
 
-        while (list($key, $value) = each($parentArr)) {
+        foreach($parentArr as $key => $value) {
             $last = $key;
         }
         if (isset($last)) {


### PR DESCRIPTION
`each()` is deprecated as of PHP 7.2 https://www.php.net/manual/en/function.each.php