### PR TITLE
Grid container without header

### DIFF
--- a/app/design/adminhtml/default/default/template/widget/grid/container.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/container.phtml
@@ -24,6 +24,7 @@
  * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
+<?php if (!empty($this->getHeaderText()) || !empty($this->getButtonsHtml())): ?>
 <div class="content-header">
     <table cellspacing="0">
         <tr>
@@ -32,6 +33,7 @@
         </tr>
     </table>
 </div>
+<?php endif; ?>
 <div>
     <?php echo $this->getGridHtml() ?>
 </div>


### PR DESCRIPTION
New little feature. When you have grid only for showing some "static" data, you sometimes no need button and header text. When there are no buttons and header text is empty is hidden header block. Now if there are no buttons and header text is empty, there is gray border.