### PR TITLE
ZendClient breaks when receiving a HTTP/2 response

### DIFF
--- a/lib/Zend/Http/Response.php
+++ b/lib/Zend/Http/Response.php
@@ -182,7 +182,7 @@ class Zend_Http_Response
         $this->body = $body;
 
         // Set the HTTP version
-        if (! preg_match('|^\d\.\d$|', $version)) {
+        if (! preg_match('|^\d+(?:\.\d+)?$|', $version)) {
             #require_once 'Zend/Http/Exception.php';
             throw new Zend_Http_Exception("Invalid HTTP response version: $version");
         }
@@ -514,7 +514,7 @@ class Zend_Http_Response
         $last_header = null;
 
         foreach($lines as $index => $line) {
-            if ($index === 0 && preg_match('#^HTTP/\d+(?:\.\d+) [1-5]\d+#', $line)) {
+            if ($index === 0 && preg_match('#^HTTP/\d+(?:\.\d+)? [1-5]\d+#', $line)) {
                 // Status line; ignore
                 continue;
             }


### PR DESCRIPTION
Ref https://github.com/magento/zf1/pull/23

> The issue is caused by the fact that the response result is checked by a regular expression that expects the Protocol version in the d.d format (for example, 1.0 or 1.1). For HTTP 2.0, the header returns a value in the format "HTTP/2 200 OK" without the decimal part. This results in an error.

A typical error for this would be surfaced in the UI as `An error occurred while saving this configuration: Invalid header line detected` (e.g. if a HTTP request was made when saving config in adminhtml)

I believe this would also solve #589

This users solution was to force the request to be HTTP 1.1 so the server would respond with a HTTP 1.1 response. The patch in this PR should handle HTTP/2 thereby solving that use-case too (from my read of the issue, I may be wrong!)
