### PR TITLE
magento-lts-869 Default setting for validate_formkey_checkout => 1

### DIFF
--- a/app/code/core/Mage/Checkout/sql/checkout_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/install-1.6.0.0.php
@@ -780,4 +780,12 @@ if ($data) {
     }
 }
 
+$setup->insert(
+    $this->getTable('core_config_data'),
+    array(
+        'path' => 'admin/security/validate_formkey_checkout',
+        'value' => '1'
+    )
+);
+
 $installer->endSetup();


### PR DESCRIPTION
Fixes #869 

Changed existing install script to ensure existing installations are not effected by this change. 