### PR TITLE
Add a new event 'adminhtml_widget_tabs_add_after' for adding custom tab.

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
@@ -189,6 +189,7 @@ class Mage_Adminhtml_Block_Widget_Tabs extends Mage_Adminhtml_Block_Widget
 
     protected function _beforeToHtml()
     {
+        Mage::dispatchEvent('adminhtml_widget_tabs_html_before', array('block' => $this));
         if ($activeTab = $this->getRequest()->getParam('active_tab')) {
             $this->setActiveTab($activeTab);
         } elseif ($activeTabId = Mage::getSingleton('admin/session')->getActiveTabId()) {


### PR DESCRIPTION
There are only a handful for events in core block and none is useful for adding custom tab in admin pages. 

1. `core_block_abstract_prepare_layout_after` can be used to add custom tab, but it doesn't set the active tab correctly.
2. `adminhtml_block_html_before` would not render the custom tab at all as we need `html_after`.
3. `core_block_abstract_to_html_after` also wouldn't render the custom tab.

So the reliable option is to overwrite `Mage_Adminhtml_Block_Customer_Edit_Tabs`, which is what happened with some 3rd-party extensions, totally not ideal.

Here's the observer for reference when the event `adminhtml_widget_tabs_add_after` is added:

    public function addTab($observer)
    {
        /**
         * @var Mage_Adminhtml_Block_Customer_Edit_Tabs $block block data:
         * [id] => customer_info_tabs
         * [title] => Customer Information
         * [type] => adminhtml/customer_edit_tabs
         * [module_name] => Webkul_Marketplace // 3rd-party extension overwrite
         */
        $block = $observer->getBlock();
        //if ($block instanceof Mage_Adminhtml_Block_Customer_Edit_Tabs) { // problem when 3rd-party overwrite the block
        if ($block->getId() == 'customer_info_tabs') {
            if (Mage::registry('current_customer')->getId() && Mage::getSingleton('admin/session')->isAllowed('customer/manage/logger')) {  
                $block->addTabAfter('changelog_grid', [
                    'label'     => Mage::helper('logger')->__('Changelog'),
                    'class'     => 'ajax',
                    'active'    => false,
                    'url'       => $block->getUrl(
                        '*/changelog_grid', ['_current' => true, 'prefix' => 'customer']
                    ),
                ], 'tags');
            }
        }
    }