### PR TITLE
Add test method to cache models and fix layout update use of test met…

### DIFF
--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -1188,6 +1188,17 @@ class Mage_Core_Model_App
     }
 
     /**
+     * Test cache record availability
+     *
+     * @param   string $id
+     * @return  false|int
+     */
+    public function testCache($id)
+    {
+        return $this->_cache->test($id);
+    }
+
+    /**
      * Remove cache
      *
      * @param   string $id

--- a/app/code/core/Mage/Core/Model/Cache.php
+++ b/app/code/core/Mage/Core/Model/Cache.php
@@ -404,6 +404,17 @@ class Mage_Core_Model_Cache
     }
 
     /**
+     * Test data
+     *
+     * @param string $id
+     * @return false|int
+     */
+    public function test($id)
+    {
+        return $this->getFrontend()->test($this->_id($id));
+    }
+
+    /**
      * Remove cached data by identifier
      *
      * @param   string $id

--- a/app/code/core/Mage/Core/Model/Layout/Update.php
+++ b/app/code/core/Mage/Core/Model/Layout/Update.php
@@ -213,7 +213,7 @@ class Mage_Core_Model_Layout_Update
         Mage::app()->saveCache($hash, $this->getCacheId(), $tags, null);
 
         // Only save actual XML to cache if it doesn't already exist
-        if ( ! Mage::app()->getCache()->test(self::XML_KEY_PREFIX . $hash)) {
+        if ( ! Mage::app()->testCache(self::XML_KEY_PREFIX . $hash)) {
             Mage::app()->saveCache($str, self::XML_KEY_PREFIX . $hash, $tags, null);
         }
         return TRUE;


### PR DESCRIPTION
Use of the test method without these newly added wrappers are broken because the Magento wrappers uppercase all cache ids. This adds wrapper methods so the same behavior is used and also corrects the one use of "test" in the layout cache.