### PR TITLE
Add missing methods to category collection class.

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Collection.php
@@ -363,6 +363,29 @@ class Mage_Catalog_Model_Resource_Category_Collection extends Mage_Catalog_Model
     }
 
     /**
+     * Add filter by path to collection
+     *
+     * @param string $parent
+     * @return $this
+     */
+    public function addParentPathFilter($parent)
+    {
+        $this->addFieldToFilter('path', array('like' => "{$parent}/%"));
+        return $this;
+    }
+
+    /**
+     * Add store filter
+     *
+     * @return $this
+     */
+    public function addStoreFilter()
+    {
+        $this->addFieldToFilter('main_table.store_id', $this->getStoreId());
+        return $this;
+    }
+
+    /**
      * Add active category filter
      *
      * @return $this


### PR DESCRIPTION
These two methods exist on `Mage_Catalog_Model_Resource_Category_Flat_Collection` but not on `Mage_Catalog_Model_Resource_Category_Collection` so if flat categories is enabled but they are being temporarily rebuilt and any frontend code relies on these methods, calls to these methods will generate PHP errors since the flat collection and eav collection classes expose a different set of methods on the public API.