### PR TITLE
Fixing Magento Invalid attribute name issue after SUPEE-11219

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -464,7 +464,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
     {
         if ($this->getCollection()) {
             $field = ( $column->getFilterIndex() ) ? $column->getFilterIndex() : $column->getIndex();
-            if ($column->getFilterConditionCallback() && $column->getFilterConditionCallback()[0] instanceof self) {
+            if ($column->getFilterConditionCallback()) {            
                 call_user_func($column->getFilterConditionCallback(), $this->getCollection(), $column);
             } else {
                 $cond = $column->getFilter()->getCondition();


### PR DESCRIPTION
Removed 2nd if check after M version upgrade broke this for many grids
Described here 
https://www.garybell.co.uk/fix-magento-invalid-attribute-error-supee-11219/
and here https://magento.stackexchange.com/a/292307/78

Fixes https://github.com/OpenMage/magento-lts/issues/882