### PR TITLE
Fix for critical checkout breaking bug for IE11 users

### DIFF
--- a/js/varien/js.js
+++ b/js/varien/js.js
@@ -773,6 +773,8 @@ function customFormSubmitToParent(url, parametersArray, method) {
 
 function buttonDisabler() {
     const buttons = document.querySelectorAll('button.save');
-    buttons.forEach(button => button.disabled = true);
+    buttons.forEach(function(button){
+        button.disabled = true;
+    });
 }
 


### PR DESCRIPTION
Magento 1.9.4.4 added a new function to js/varien/js.js called buttonDisable (only used by the Compilation page in admin). Unfortunately it uses arrow functions which IE11 doesn't support and so breaks the ability of IE11 users to purchase anything.

I've rewritten and tested the function to make it compatible with IE11.