### PR TITLE
fix PHP Warning: "continue" targeting switch is equivalent to "break"…

### DIFF
--- a/lib/Zend/Feed/Entry/Atom.php
+++ b/lib/Zend/Feed/Entry/Atom.php
@@ -103,7 +103,7 @@ class Zend_Feed_Entry_Atom extends Zend_Feed_Entry_Abstract
                 // Redirect
                 case 3:
                     $deleteUri = $response->getHeader('Location');
-                    continue;
+                    continue 2;
                 // Error
                 default:
                     /**

--- a/lib/Zend/Form.php
+++ b/lib/Zend/Form.php
@@ -1170,7 +1170,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
                 } else {
                     switch ($argc) {
                         case 0:
-                            continue;
+                            continue 2;
                         case (1 <= $argc):
                             $type = array_shift($spec);
                         case (2 <= $argc):
@@ -1687,7 +1687,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
                 $order = null;
                 switch ($argc) {
                     case 0:
-                        continue;
+                        continue 2;
                     case (1 <= $argc):
                         $subForm = array_shift($spec);
 

--- a/lib/Zend/Pdf/FileParser/Font/OpenType.php
+++ b/lib/Zend/Pdf/FileParser/Font/OpenType.php
@@ -898,7 +898,7 @@ abstract class Zend_Pdf_FileParser_Font_OpenType extends Zend_Pdf_FileParser_Fon
                     if ($language != 0) {
                         $this->_debugLog('Type 0 cmap tables must be language-independent;'
                                          . ' language: %d; skipping', $language);
-                        continue;
+                        continue 2;
                     }
                     break;
 
@@ -917,7 +917,7 @@ abstract class Zend_Pdf_FileParser_Font_OpenType extends Zend_Pdf_FileParser_Fon
                 case 0xa:    // break intentionally omitted
                 case 0xc:
                     $this->_debugLog('Format: 0x%x currently unsupported; skipping', $format);
-                    continue;
+                    continue 2;
                     //$this->skipBytes(2);
                     //$cmapLength = $this->readUInt(4);
                     //$language = $this->readUInt(4);
@@ -929,7 +929,7 @@ abstract class Zend_Pdf_FileParser_Font_OpenType extends Zend_Pdf_FileParser_Fon
 
                 default:
                     $this->_debugLog('Unknown subtable format: 0x%x; skipping', $format);
-                    continue;
+                    continue 2;
             }
             $cmapType = $format;
             break;

--- a/lib/Zend/Reflection/File.php
+++ b/lib/Zend/Reflection/File.php
@@ -355,7 +355,7 @@ class Zend_Reflection_File implements Reflector
                 case T_DOLLAR_OPEN_CURLY_BRACES:
                 case T_CURLY_OPEN:
                     $embeddedVariableTrapped = true;
-                    continue;
+                    continue 2;
 
                 // Name of something
                 case T_STRING:
@@ -366,7 +366,7 @@ class Zend_Reflection_File implements Reflector
                         $this->_classes[] = $value;
                         $classTrapped = false;
                     }
-                    continue;
+                    continue 2;
 
                 // Required file names are T_CONSTANT_ENCAPSED_STRING
                 case T_CONSTANT_ENCAPSED_STRING:
@@ -374,7 +374,7 @@ class Zend_Reflection_File implements Reflector
                         $this->_requiredFiles[] = $value ."\n";
                         $requireTrapped = false;
                     }
-                    continue;
+                    continue 2;
 
                 // Functions
                 case T_FUNCTION:


### PR DESCRIPTION
A fix for PHP 7.3/7.4 Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?
