### PR TITLE
Warning: count(): Parameter must be an array.

### DIFF
--- a/lib/Varien/File/Uploader.php
+++ b/lib/Varien/File/Uploader.php
@@ -504,9 +504,9 @@ class Varien_File_Uploader
             $this->_uploadType = self::MULTIPLE_STYLE;
             $this->_file = $fileId;
         } else {
-            preg_match("/^(.*?)\[(.*?)\]$/", $fileId, $file);
+            $result = preg_match("/^(.*?)\[(.*?)\]$/", $fileId, $file);
 
-            if (count($file) > 0 && (count($file[0]) > 0) && (count($file[1]) > 0)) {
+            if ($result && count($file) === 3) {
                 array_shift($file);
                 $this->_uploadType = self::MULTIPLE_STYLE;
 


### PR DESCRIPTION
I added fix for sometimes it appears "Warning: count(): Parameter must be an array.".