### PR TITLE
Json POST suggestion

### DIFF
--- a/lib/Mage/HTTP/Client/Curl.php
+++ b/lib/Mage/HTTP/Client/Curl.php
@@ -345,7 +345,7 @@ implements Mage_HTTP_IClient
      * Make request
      * @param string $method
      * @param string $uri
-     * @param array $params
+     * @param array|string $params pass an array to form post, pass a json encoded string to directly post json
      * @return null
      */
     protected function makeRequest($method, $uri, $params = array())

--- a/lib/Mage/HTTP/Client/Curl.php
+++ b/lib/Mage/HTTP/Client/Curl.php
@@ -248,14 +248,6 @@ implements Mage_HTTP_IClient
         $this->makeRequest("POST", $uri, $params);
     }
 
-    /**
-     * Make JSON POST request
-     * @see lib/Mage/HTTP/Mage_HTTP_Client#post_json($uri, $params)
-     */
-    public function post_json($uri, $params)
-    {
-        $this->makeRequest("JSON", $uri, $params);
-    }
 
     /**
      * Get response headers
@@ -362,13 +354,9 @@ implements Mage_HTTP_IClient
         $this->curlOption(CURLOPT_URL, $uri);
         if($method == 'POST') {
             $this->curlOption(CURLOPT_POST, 1);
-            $this->curlOption(CURLOPT_POSTFIELDS, http_build_query($params));
+            $this->curlOption(CURLOPT_POSTFIELDS, is_array($params) ? http_build_query($params) : $params);
         } elseif($method == "GET") {
             $this->curlOption(CURLOPT_HTTPGET, 1);
-        } elseif($method == "JSON") {
-            $this->curlOption(CURLOPT_CUSTOMREQUEST, 'POST');
-            $this->curlOption(CURLOPT_POSTFIELDS, json_encode($params));
-            $this->curlOption(CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
         } else {
             $this->curlOption(CURLOPT_CUSTOMREQUEST, $method);
         }

--- a/lib/Mage/HTTP/Client/Curl.php
+++ b/lib/Mage/HTTP/Client/Curl.php
@@ -248,6 +248,14 @@ implements Mage_HTTP_IClient
         $this->makeRequest("POST", $uri, $params);
     }
 
+    /**
+     * Make JSON POST request
+     * @see lib/Mage/HTTP/Mage_HTTP_Client#post_json($uri, $params)
+     */
+    public function post_json($uri, $params)
+    {
+        $this->makeRequest("JSON", $uri, $params);
+    }
 
     /**
      * Get response headers
@@ -357,6 +365,10 @@ implements Mage_HTTP_IClient
             $this->curlOption(CURLOPT_POSTFIELDS, http_build_query($params));
         } elseif($method == "GET") {
             $this->curlOption(CURLOPT_HTTPGET, 1);
+        } elseif($method == "JSON") {
+            $this->curlOption(CURLOPT_CUSTOMREQUEST, 'POST');
+            $this->curlOption(CURLOPT_POSTFIELDS, json_encode($params));
+            $this->curlOption(CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
         } else {
             $this->curlOption(CURLOPT_CUSTOMREQUEST, $method);
         }


### PR DESCRIPTION
What does everybody think about adding this method to allow the Mage Curl client to do proper POSTs of JSON directly.  I know of a few REST apis that require this.

This would allow doing this in code to POST json data directly:

```
$curl = new Mage_HTTP_Client_Curl();
$curl->post_json($url, $params);
```
