### PR TITLE
Do not sum columns with undefined total function

### DIFF
--- a/app/code/core/Mage/Reports/Model/Totals.php
+++ b/app/code/core/Mage/Reports/Model/Totals.php
@@ -45,7 +45,7 @@ class Mage_Reports_Model_Totals
     {
         $columns = array();
         foreach ($grid->getColumns() as $col) {
-            if ($col->getTotal() === null){
+            if ($col->getTotal() === null) {
                 continue;
             }
             $columns[$col->getIndex()] = array("total" => $col->getTotal(), "value" => 0);

--- a/app/code/core/Mage/Reports/Model/Totals.php
+++ b/app/code/core/Mage/Reports/Model/Totals.php
@@ -45,6 +45,9 @@ class Mage_Reports_Model_Totals
     {
         $columns = array();
         foreach ($grid->getColumns() as $col) {
+            if ($col->getTotal() === null){
+                continue;
+            }
             $columns[$col->getIndex()] = array("total" => $col->getTotal(), "value" => 0);
         }
 


### PR DESCRIPTION
This function only supports non-empty total functions (avg, sum, or total with slash)
so we can safely ignore fields which have 'total' undefined (null).
Fixes: https://github.com/OpenMage/magento-lts/issues/915