### PR TITLE
Improve performance of the products sold report

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -112,6 +112,9 @@ class Mage_CatalogInventory_Model_Observer
     public function addStockStatusToCollection($observer)
     {
         $productCollection = $observer->getEvent()->getCollection();
+        if ($productCollection->hasFlag('no_stock_data')) {
+            return $this;
+        }
         if ($productCollection->hasFlag('require_stock_items')) {
             Mage::getModel('cataloginventory/stock')->addItemsToProducts($productCollection);
         } else {

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Sold/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Sold/Collection.php
@@ -42,6 +42,8 @@ class Mage_Reports_Model_Resource_Product_Sold_Collection extends Mage_Reports_M
     {
         parent::_construct();
         $this->_useAnalyticFunction = true;
+        // skip adding stock information to collection for perfromance reasons
+        $this->setFlag('no_stock_data', true);
     }
     /**
      * Set Date range to collection
@@ -53,7 +55,6 @@ class Mage_Reports_Model_Resource_Product_Sold_Collection extends Mage_Reports_M
     public function setDateRange($from, $to)
     {
         $this->_reset()
-            ->addAttributeToSelect('*')
             ->addOrderedQty($from, $to)
             ->setOrder('ordered_qty', self::SORT_ORDER_DESC);
         return $this;


### PR DESCRIPTION
Disable inventory status loading event on after_load
And prevent collection from fetching all attributes (at later point name and entity_id is added).
I did a blackfire profile with monthly report 
And had 30% speed improvement on both CPU, Memory and DB queries.
![image](https://user-images.githubusercontent.com/515397/78461748-f6d7d500-76cb-11ea-92b4-ed06857bd316.png)


Alternative implementation woud be to add new flag to product collection and read it in inventory observer similar to the "require_stock_items" flag which is already in place there see:

https://github.com/OpenMage/magento-lts/blob/1.9.4.x/app/code/core/Mage/CatalogInventory/Model/Observer.php#L112