### PR TITLE
Make oldFields mapping hardcoded to speed up system

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Do not use 20.x.x if you need IE support.
 - add redis as a valid option for `global/session_save` #1513
 - possibility to disable global search in backend #1532
 - reduce needless saves by avoiding setting `_hasDataChanges` flag #2066
+- removed support for `global/sales/old_fields_map` defined in XML #921
 
 For full list of changes, you can [compare tags](https://github.com/OpenMage/magento-lts/compare/1.9.4.x...20.0).
 

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -362,7 +362,6 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('catalog')->getOldFieldMap();
         return $this;
     }
 

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
@@ -177,6 +177,7 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
      */
     protected function _initOldFieldsMap()
     {
+        // pre 1.6 fields names, old => new
         $this->_oldFieldsMap = array(
             'stock_status_changed_automatically' => 'stock_status_changed_auto',
             'use_config_enable_qty_increments'   => 'use_config_enable_qty_inc'

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -526,7 +526,12 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('sales')->getOldFieldMap('order');
+        // pre 1.6 fields names, old => new
+        $this->_oldFieldsMap = [
+            'payment_authorization_expiration' => 'payment_auth_expiration',
+            'forced_do_shipment_with_invoice' => 'forced_shipment_with_invoice',
+            'base_shipping_hidden_tax_amount' => 'base_shipping_hidden_tax_amnt',
+        ];
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Order/Address.php
@@ -112,7 +112,6 @@ class Mage_Sales_Model_Order_Address extends Mage_Customer_Model_Address_Abstrac
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('sales')->getOldFieldMap('order_address');
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
@@ -224,7 +224,6 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('sales')->getOldFieldMap('order_creditmemo');
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Item.php
@@ -153,7 +153,10 @@ class Mage_Sales_Model_Order_Creditmemo_Item extends Mage_Core_Model_Abstract
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('sales')->getOldFieldMap('creditmemo_item');
+        // pre 1.6 fields names, old => new
+        $this->_oldFieldsMap = [
+            'base_weee_tax_applied_row_amount' => 'base_weee_tax_applied_row_amnt',
+        ];
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -223,7 +223,6 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('sales')->getOldFieldMap('order_invoice');
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Item.php
@@ -125,7 +125,10 @@ class Mage_Sales_Model_Order_Invoice_Item extends Mage_Core_Model_Abstract
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('sales')->getOldFieldMap('invoice_item');
+        // pre 1.6 fields names, old => new
+        $this->_oldFieldsMap = [
+            'base_weee_tax_applied_row_amount' => 'base_weee_tax_applied_row_amnt',
+        ];
         return $this;
     }
     /**

--- a/app/code/core/Mage/Sales/Model/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Item.php
@@ -246,7 +246,10 @@ class Mage_Sales_Model_Order_Item extends Mage_Core_Model_Abstract
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('sales')->getOldFieldMap('order_item');
+        // pre 1.6 fields names, old => new
+        $this->_oldFieldsMap = [
+            'base_weee_tax_applied_row_amount' => 'base_weee_tax_applied_row_amnt',
+        ];
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment.php
@@ -127,7 +127,6 @@ class Mage_Sales_Model_Order_Shipment extends Mage_Sales_Model_Abstract
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('sales')->getOldFieldMap('order_shipment');
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -262,7 +262,6 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('sales')->getOldFieldMap('quote');
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -321,7 +321,6 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('sales')->getOldFieldMap('quote_address');
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item.php
@@ -247,7 +247,6 @@ class Mage_Sales_Model_Quote_Item extends Mage_Sales_Model_Quote_Item_Abstract
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('sales')->getOldFieldMap('quote_item');
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/etc/config.xml
+++ b/app/code/core/Mage/Sales/etc/config.xml
@@ -1198,13 +1198,6 @@
             </product>
         </catalog>
         <sales>
-            <old_fields_map>
-                <order>
-                    <payment_authorization_expiration>payment_auth_expiration</payment_authorization_expiration>
-                    <forced_do_shipment_with_invoice>forced_shipment_with_invoice</forced_do_shipment_with_invoice>
-                    <base_shipping_hidden_tax_amount>base_shipping_hidden_tax_amnt</base_shipping_hidden_tax_amount>
-                </order>
-            </old_fields_map>
             <quote>
                 <totals>
                     <nominal>

--- a/app/code/core/Mage/Weee/etc/config.xml
+++ b/app/code/core/Mage/Weee/etc/config.xml
@@ -225,17 +225,6 @@
                     </weee>
                 </totals>
             </order_creditmemo>
-            <old_fields_map>
-                <order_item>
-                    <base_weee_tax_applied_row_amount>base_weee_tax_applied_row_amnt</base_weee_tax_applied_row_amount>
-                </order_item>
-                <invoice_item>
-                    <base_weee_tax_applied_row_amount>base_weee_tax_applied_row_amnt</base_weee_tax_applied_row_amount>
-                </invoice_item>
-                <creditmemo_item>
-                    <base_weee_tax_applied_row_amount>base_weee_tax_applied_row_amnt</base_weee_tax_applied_row_amount>
-                </creditmemo_item>
-            </old_fields_map>
         </sales>
     </global>
     <adminhtml>


### PR DESCRIPTION
The mapping came with Magneto 1.6 to provide a backward compatibility
for old (pre 1.6) db field names.
Now the mapping is hardcoded in the class instead of saved
in the configuration.
This improves performance as Magento will not create tons of objects for
every new product/order/... entities.

Related: https://github.com/OpenMage/magento-lts/issues/920