### PR TITLE
Feature/Fix for SameSite Cookies, option to set to None during 5 minutes afte…

### DIFF
--- a/app/code/core/Mage/Checkout/Helper/Data.php
+++ b/app/code/core/Mage/Checkout/Helper/Data.php
@@ -336,7 +336,7 @@ class Mage_Checkout_Helper_Data extends Mage_Core_Helper_Abstract
 
     public function updateCookiesSameSiteNone5Min()
     {
-        $cookies = ['frontend', 'frontend_cid'];
+        $cookies = array('frontend', 'frontend_cid');
         foreach ($cookies as $feCookieName) {
             /** @var $cookieModel Mage_Core_Model_Cookie */
             $cookieModel = Mage::getSingleton('core/cookie');
@@ -351,7 +351,7 @@ class Mage_Checkout_Helper_Data extends Mage_Core_Helper_Abstract
                 null,
                 true,
                 null,
-                'None',
+                'None'
             );
         }
     }

--- a/app/code/core/Mage/Checkout/Helper/Data.php
+++ b/app/code/core/Mage/Checkout/Helper/Data.php
@@ -333,4 +333,26 @@ class Mage_Checkout_Helper_Data extends Mage_Core_Helper_Abstract
     {
         return Mage::getStoreConfigFlag(self::XML_PATH_CUSTOMER_MUST_BE_LOGGED);
     }
+
+    public function updateCookiesSameSiteNone5Min()
+    {
+        $cookies = ['frontend', 'frontend_cid'];
+        foreach ($cookies as $feCookieName) {
+            /** @var $cookieModel Mage_Core_Model_Cookie */
+            $cookieModel = Mage::getSingleton('core/cookie');
+            $frontendCookieValue = $cookieModel->get($feCookieName);
+            $cookieModel->setSameSite('None');
+            $cookieModel->setLifetime(strtotime("+5 minutes"));
+            $cookieModel->set(
+                $feCookieName,
+                $frontendCookieValue,
+                300, // 5 minutes
+                null,
+                null,
+                true,
+                null,
+                'None',
+            );
+        }
+    }
 }

--- a/app/code/core/Mage/Checkout/controllers/OnepageController.php
+++ b/app/code/core/Mage/Checkout/controllers/OnepageController.php
@@ -33,6 +33,8 @@
  */
 class Mage_Checkout_OnepageController extends Mage_Checkout_Controller_Action
 {
+    const XML_PATH_COOKIE_USE_SAME_SITE_NONE = 'checkout/options/enable_same_site';
+
     /**
      * List of functions for section update
      *
@@ -649,6 +651,14 @@ class Mage_Checkout_OnepageController extends Mage_Checkout_Controller_Action
          * when there is redirect to third party, we don't want to save order yet.
          * we will save the order in return action.
          */
+        // self::XML_PATH_COOKIE_USE_SAME_SITE_NONE
+        $isSameSiteNoneEnabled = Mage::getStoreConfig(self::XML_PATH_COOKIE_USE_SAME_SITE_NONE, Mage::app()->getStore()) === '1';
+        if ($isSameSiteNoneEnabled) {
+            /** @var $checkoutHelper Mage_Checkout_Helper_Data */
+            $checkoutHelper = Mage::helper('checkout');
+            $checkoutHelper->updateCookiesSameSiteNone5Min();
+        }
+
         if (isset($redirectUrl)) {
             $result['redirect'] = $redirectUrl;
         }

--- a/app/code/core/Mage/Checkout/etc/system.xml
+++ b/app/code/core/Mage/Checkout/etc/system.xml
@@ -71,7 +71,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
-                        </customer_must_be_logged>                        
+                        </customer_must_be_logged>
                         <enable_agreements translate="label">
                             <label>Enable Terms and Conditions</label>
                             <frontend_type>select</frontend_type>
@@ -81,6 +81,19 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </enable_agreements>
+                        <enable_same_site translate="label">
+                            <label>Enable SameSite=None for 5min post place order</label>
+                            <comment><![CDATA[
+                                See: <a rel="noopener" target="_blank" href="https://www.chromestatus.com/feature/5088147346030592">https://www.chromestatus.com/feature/5088147346030592</a><br />
+                                NB! Requires the checkout to be <b>secure</b> (https).
+                            ]]></comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>30</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </enable_same_site>
                     </fields>
                 </options>
 

--- a/app/code/core/Mage/Core/Model/Cookie.php
+++ b/app/code/core/Mage/Core/Model/Cookie.php
@@ -40,6 +40,18 @@ class Mage_Core_Model_Cookie
     const XML_PATH_COOKIE_HTTPONLY  = 'web/cookie/cookie_httponly';
 
     protected $_lifetime;
+    protected $_sameSite = 'Lax';
+
+    public function setSameSite($sameSite)
+    {
+        $this->_sameSite = $sameSite;
+        return $this;
+    }
+
+    public function getSameSite()
+    {
+        return $this->_sameSite;
+    }
 
     /**
      * Store object
@@ -203,10 +215,19 @@ class Mage_Core_Model_Cookie
      * @param string $domain
      * @param int|bool $secure
      * @param bool $httponly
+     * @param string $sameSite Strict, Lax or None
      * @return $this
      */
-    public function set($name, $value, $period = null, $path = null, $domain = null, $secure = null, $httponly = null)
-    {
+    public function set(
+        $name,
+        $value,
+        $period = null,
+        $path = null,
+        $domain = null,
+        $secure = null,
+        $httponly = null,
+        $sameSite = null
+    ) {
         /**
          * Check headers sent
          */
@@ -238,8 +259,18 @@ class Mage_Core_Model_Cookie
         if (is_null($httponly)) {
             $httponly = $this->getHttponly();
         }
+        if (is_null($sameSite)) {
+            $sameSite = $this->getSameSite();
+        }
 
-        setcookie($name, $value, $expire, $path, $domain, $secure, $httponly);
+        setcookie($name, $value, array(
+            'expires' => $expire,
+            'path' => $path,
+            'domain' => $domain,
+            'Secure' => $secure,
+            'httponly' => $httponly,
+            'SameSite' => $sameSite,
+        ));
 
         return $this;
     }
@@ -252,16 +283,18 @@ class Mage_Core_Model_Cookie
      * @param string $path
      * @param string $domain
      * @param int|bool $secure
+     * @param bool $httponly
+     * @param string $sameSite Strict, Lax or None
      * @return $this
      */
-    public function renew($name, $period = null, $path = null, $domain = null, $secure = null, $httponly = null)
+    public function renew($name, $period = null, $path = null, $domain = null, $secure = null, $httponly = null, $sameSite = null)
     {
         if (($period === null) && !$this->getLifetime()) {
             return $this;
         }
         $value = $this->_getRequest()->getCookie($name, false);
         if ($value !== false) {
-            $this->set($name, $value, $period, $path, $domain, $secure, $httponly);
+            $this->set($name, $value, $period, $path, $domain, $secure, $httponly, $sameSite);
         }
         return $this;
     }
@@ -285,9 +318,10 @@ class Mage_Core_Model_Cookie
      * @param string $domain
      * @param int|bool $secure
      * @param int|bool $httponly
+     * @param string $sameSite Strict, Lax or None
      * @return $this
      */
-    public function delete($name, $path = null, $domain = null, $secure = null, $httponly = null)
+    public function delete($name, $path = null, $domain = null, $secure = null, $httponly = null, $sameSite = null)
     {
         /**
          * Check headers sent
@@ -308,8 +342,19 @@ class Mage_Core_Model_Cookie
         if (is_null($httponly)) {
             $httponly = $this->getHttponly();
         }
+        if (is_null($sameSite)) {
+            $sameSite = $this->getSameSite();
+        }
 
-        setcookie($name, null, null, $path, $domain, $secure, $httponly);
+        setcookie($name, null, array(
+            'expires' => null,
+            'path' => $path,
+            'domain' => $domain,
+            'Secure' => $secure,
+            'httponly' => $httponly,
+            'SameSite' => $sameSite,
+        ));
+
         return $this;
     }
 }

--- a/app/code/core/Mage/Core/Model/Cookie.php
+++ b/app/code/core/Mage/Core/Model/Cookie.php
@@ -269,7 +269,7 @@ class Mage_Core_Model_Cookie
             'domain' => $domain,
             'Secure' => $secure,
             'httponly' => $httponly,
-            'SameSite' => $sameSite,
+            'SameSite' => $sameSite
         ));
 
         return $this;
@@ -352,7 +352,7 @@ class Mage_Core_Model_Cookie
             'domain' => $domain,
             'Secure' => $secure,
             'httponly' => $httponly,
-            'SameSite' => $sameSite,
+            'SameSite' => $sameSite
         ));
 
         return $this;


### PR DESCRIPTION
…r order placement so that services like **3d-Secure** can post back to Magento, and Chrome+Magento is able to read the session cookies so an order is created.

Magento automatically reverts back to 'Lax' when you come back to the Success page (or any other page).

This is a **major** issue if you use Adyen for example with credit card iframes in the checkout. 

See issue description here: 
- https://github.com/GoogleChromeLabs/samesite-examples/blob/3d-secure-impl/3d-secure.md
- https://www.chromestatus.com/feature/5088147346030592 
- https://web.dev/samesite-cookies-explained/ 