### PR TITLE
Fix 'No date part in '' found. Upgrade from 1.9.0.x to 1.9.2.2

### DIFF
--- a/lib/Zend/Locale/Format.php
+++ b/lib/Zend/Locale/Format.php
@@ -905,9 +905,8 @@ class Zend_Locale_Format
 
         // split number parts
         $split = false;
-        preg_match_all('/\d+/u', $number, $splitted);
 
-        if (!empty($number) && count($splitted[0]) == 0) {
+        if ( ! preg_match_all('/\d+/u', $number, $splitted)) {
             self::_setEncoding($oenc);
             #require_once 'Zend/Locale/Exception.php';
             throw new Zend_Locale_Exception("No date part in '$date' found.");

--- a/lib/Zend/Locale/Format.php
+++ b/lib/Zend/Locale/Format.php
@@ -907,7 +907,7 @@ class Zend_Locale_Format
         $split = false;
         preg_match_all('/\d+/u', $number, $splitted);
 
-        if (count($splitted[0]) == 0) {
+        if (!empty($number) && count($splitted[0]) == 0) {
             self::_setEncoding($oenc);
             #require_once 'Zend/Locale/Exception.php';
             throw new Zend_Locale_Exception("No date part in '$date' found.");


### PR DESCRIPTION
https://magento.stackexchange.com/questions/93202/no-date-part-in-found-when-upgrading-from-magento-1-9-0-x-to-1-9-2-2/99914