### PR TITLE
Fix warning "Warning: A non-numeric value encountered" in Model_Url

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -676,7 +676,7 @@ class Mage_Catalog_Model_Url
                 $match['increment'] = $lastRequestPath;
             }
             return $match['prefix']
-                . (isset($match['increment']) ? ($match['increment'] + 1) : '1')
+                . (!empty($match['increment']) ? ((int)$match['increment'] + 1) : '1')
                 . $match['suffix'];
         }
         else {


### PR DESCRIPTION
Cast value to int and change isset to !empty to privent
url model to add empty string to an 1.

I've encountered the issue when I tried to reindex url rewrite from the backend, after truncating the core_url_rewrite table.

the warning is thrown only since PHP 7.1 see
https://www.php.net/manual/en/migration71.other-changes.php