### PR TITLE
Fix SQL query quoting/casting when type is passed to where function

### DIFF
--- a/lib/Magento/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Magento/Db/Adapter/Pdo/Mysql.php
@@ -124,9 +124,9 @@ class Magento_Db_Adapter_Pdo_Mysql extends Varien_Db_Adapter_Pdo_Mysql
      * If an array is passed as the value, the array values are quote
      * and then returned as a comma-separated string.
      *
-     * @param mixed $value The value to quote.
-     * @param null $type OPTIONAL the SQL datatype name, or constant, or null.
-     * @return mixed|string An SQL-safe quoted value (or string of separated values).
+     * @param Zend_Db_Select|Zend_Db_Expr|array|null|int|string|float $value OPTIONAL A single value to quote into the condition.
+     * @param null|string|int $type  OPTIONAL The type of the given value e.g. Zend_Db::INT_TYPE, "INT"
+     * @return string An SQL-safe quoted value (or string of separated values).
      */
     public function quote($value, $type = null)
     {

--- a/lib/Varien/Db/Adapter/Interface.php
+++ b/lib/Varien/Db/Adapter/Interface.php
@@ -566,9 +566,9 @@ interface Varien_Db_Adapter_Interface
      * If an array is passed as the value, the array values are quoted
      * and then returned as a comma-separated string.
      *
-     * @param mixed $value The value to quote.
-     * @param mixed $type  OPTIONAL the SQL datatype name, or constant, or null.
-     * @return mixed An SQL-safe quoted value (or string of separated values).
+     * @param Zend_Db_Select|Zend_Db_Expr|array|null|int|string|float $value OPTIONAL A single value to quote into the condition.
+     * @param null|string|int $type  OPTIONAL The type of the given value e.g. Zend_Db::INT_TYPE, "INT"
+     * @return string An SQL-safe quoted value (or string of separated values).
      */
     public function quote($value, $type = null);
 
@@ -586,8 +586,8 @@ interface Varien_Db_Adapter_Interface
      * </code>
      *
      * @param string  $text  The text with a placeholder.
-     * @param mixed   $value The value to quote.
-     * @param string  $type  OPTIONAL SQL datatype
+     * @param Zend_Db_Select|Zend_Db_Expr|array|null|int|string|float $value OPTIONAL A single value to quote into the condition.
+     * @param null|string|int $type  OPTIONAL The type of the given value e.g. Zend_Db::INT_TYPE, "INT"
      * @param integer $count OPTIONAL count of placeholders to replace
      * @return string An SQL-safe quoted value placed into the original text.
      */

--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -1506,8 +1506,8 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
      * Method revrited for handle empty arrays in value param
      *
      * @param string  $text  The text with a placeholder.
-     * @param mixed   $value The value to quote.
-     * @param string  $type  OPTIONAL SQL datatype
+     * @param Zend_Db_Select|Zend_Db_Expr|array|null|int|string|float $value OPTIONAL A single value to quote into the condition.
+     * @param null|string|int $type  OPTIONAL The type of the given value e.g. Zend_Db::INT_TYPE, "INT"
      * @param integer $count OPTIONAL count of placeholders to replace
      * @return string An SQL-safe quoted value placed into the orignal text.
      */

--- a/lib/Varien/Db/Select.php
+++ b/lib/Varien/Db/Select.php
@@ -101,8 +101,8 @@ class Varien_Db_Select extends Zend_Db_Select
      * </code>
      *
      * @param string   $cond  The WHERE condition.
-     * @param string   $value OPTIONAL A single value to quote into the condition.
-     * @param null|string $type  OPTIONAL The type of the given value
+     * @param Zend_Db_Select|Zend_Db_Expr|array|null|int|string|float $value OPTIONAL A single value to quote into the condition.
+     * @param null|string|int $type  OPTIONAL The type of the given value e.g. Zend_Db::INT_TYPE, "INT"
      * @return Varien_Db_Select This Zend_Db_Select object.
      */
     public function where($cond, $value = null, $type = null)
@@ -112,12 +112,13 @@ class Varien_Db_Select extends Zend_Db_Select
         }
         /**
          * Additional internal type used for really null value
+         * cast to string, to prevent false matching 0 == "TYPE_CONDITION"
          */
-        if ($type == self::TYPE_CONDITION) {
+        if ((string)$type === self::TYPE_CONDITION) {
             $type = null;
         }
         if (is_array($value)) {
-            $cond = $this->_adapter->quoteInto($cond, $value);
+            $cond = $this->_adapter->quoteInto($cond, $value, $type);
             $value = null;
         }
         return parent::where($cond, $value, $type);

--- a/lib/Zend/Db/Adapter/Abstract.php
+++ b/lib/Zend/Db/Adapter/Abstract.php
@@ -852,9 +852,9 @@ abstract class Zend_Db_Adapter_Abstract
      * If an array is passed as the value, the array values are quoted
      * and then returned as a comma-separated string.
      *
-     * @param mixed $value The value to quote.
-     * @param mixed $type  OPTIONAL the SQL datatype name, or constant, or null.
-     * @return mixed An SQL-safe quoted value (or string of separated values).
+     * @param Zend_Db_Select|Zend_Db_Expr|array|null|int|string|float $value OPTIONAL A single value to quote into the condition.
+     * @param null|string|int $type  OPTIONAL The type of the given value e.g. Zend_Db::INT_TYPE, "INT"
+     * @return string An SQL-safe quoted value (or string of separated values).
      */
     public function quote($value, $type = null)
     {
@@ -920,8 +920,8 @@ abstract class Zend_Db_Adapter_Abstract
      * </code>
      *
      * @param string  $text  The text with a placeholder.
-     * @param mixed   $value The value to quote.
-     * @param string  $type  OPTIONAL SQL datatype
+     * @param Zend_Db_Select|Zend_Db_Expr|array|null|int|string|float $value OPTIONAL A single value to quote into the condition.
+     * @param null|string|int $type  OPTIONAL The type of the given value e.g. Zend_Db::INT_TYPE, "INT"
      * @param integer $count OPTIONAL count of placeholders to replace
      * @return string An SQL-safe quoted value placed into the original text.
      */

--- a/lib/Zend/Db/Select.php
+++ b/lib/Zend/Db/Select.php
@@ -468,7 +468,7 @@ class Zend_Db_Select
      * </code>
      *
      * @param string   $cond  The WHERE condition.
-     * @param mixed    $value OPTIONAL The value to quote into the condition.
+     * @param Zend_Db_Select|Zend_Db_Expr|array|null|int|string|float $value OPTIONAL The value to quote into the condition.
      * @param int      $type  OPTIONAL The type of the given value
      * @return Zend_Db_Select This Zend_Db_Select object.
      */
@@ -485,7 +485,7 @@ class Zend_Db_Select
      * Otherwise identical to where().
      *
      * @param string   $cond  The WHERE condition.
-     * @param mixed    $value OPTIONAL The value to quote into the condition.
+     * @param Zend_Db_Select|Zend_Db_Expr|array|null|int|string|float $value OPTIONAL The value to quote into the condition.
      * @param int      $type  OPTIONAL The type of the given value
      * @return Zend_Db_Select This Zend_Db_Select object.
      *
@@ -991,7 +991,7 @@ class Zend_Db_Select
      * Internal function for creating the where clause
      *
      * @param string   $condition
-     * @param mixed    $value  optional
+     * @param Zend_Db_Select|Zend_Db_Expr|array|null|int|string|float    $value  optional
      * @param string   $type   optional
      * @param boolean  $bool  true = AND, false = OR
      * @return string  clause


### PR DESCRIPTION
The `$type` variable can be both string or int, so before comparing it to
`TYPE_CONDITION` string it has to be casted to avoid comparing integer zero
with string `(0 == 'TYPE_CONDITION')` which will wrongly return true,
and remove the information about type.

Pass type provided to where function down the chain to allow automatic
casting of arrays of values e.g. to int.

This fixes following cases:
```
->where('attr_table.store_id IN (?)', $storeIds, Zend_Db::INT_TYPE);
```
and
```
->where('attr_table.store_id = ?', $storeId, Zend_Db::INT_TYPE);
```
In both cases now passed value is correctly casted to int
(either single value, or each value from array)

Passing `Zend_Db::INT_TYPE` to where condition will prevent mysql performance
issues which might occur when mixed types are passed in "`in()`" condition.
related: https://github.com/OpenMage/magento-lts/pull/381

Also fixes type hints along the way.

Related PR on Magento2 side https://github.com/magento/magento2/pull/27980