### PR TITLE
Cache all attribute options for display in layered navigation #943

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
@@ -51,17 +51,16 @@ class Mage_Eav_Model_Entity_Attribute_Source_Table extends Mage_Eav_Model_Entity
             $this->_optionsDefault = array();
         }
         if (!isset($this->_options[$storeId])) {
-            $prefixId = 'ATTRIBUTE_OPTIONS_ID_' . $this->getAttribute()->getId();
-            $tags = array(
-                'eav',
-                Mage_Core_Model_Translate::CACHE_TAG,
-                Mage_Eav_Model_Entity_Attribute::CACHE_TAG,
+            $idPrefix = 'ATTRIBUTE_OPTIONS_ID_' . $this->getAttribute()->getId();
+            $tags = array_merge(
+                array('eav', Mage_Core_Model_Translate::CACHE_TAG),
+                $this->getAttribute()->getCacheTags()
             );
             $collection = Mage::getResourceModel('eav/entity_attribute_option_collection')
                 ->setPositionOrder('asc')
                 ->setAttributeFilter($this->getAttribute()->getId())
                 ->setStoreFilter($this->getAttribute()->getStoreId())
-                ->initCache(Mage::app()->getCache(), $prefixId, $tags)
+                ->initCache(Mage::app()->getCache(), $idPrefix, $tags)
                 ->load();
             $this->_options[$storeId]        = $collection->toOptionArray();
             $this->_optionsDefault[$storeId] = $collection->toOptionArray('default_value');

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
@@ -51,10 +51,17 @@ class Mage_Eav_Model_Entity_Attribute_Source_Table extends Mage_Eav_Model_Entity
             $this->_optionsDefault = array();
         }
         if (!isset($this->_options[$storeId])) {
+            $prefixId = 'ATTRIBUTE_OPTIONS_ID_' . $this->getAttribute()->getId();
+            $tags = array(
+                'eav',
+                Mage_Core_Model_Translate::CACHE_TAG,
+                Mage_Eav_Model_Entity_Attribute::CACHE_TAG,
+            );
             $collection = Mage::getResourceModel('eav/entity_attribute_option_collection')
                 ->setPositionOrder('asc')
                 ->setAttributeFilter($this->getAttribute()->getId())
                 ->setStoreFilter($this->getAttribute()->getStoreId())
+                ->initCache(Mage::app()->getCache(), $prefixId, $tags)
                 ->load();
             $this->_options[$storeId]        = $collection->toOptionArray();
             $this->_optionsDefault[$storeId] = $collection->toOptionArray('default_value');


### PR DESCRIPTION
Related to issue #934. 

This will improve performance by reducing the amount of SQL Queries when fetching all possible attributes to display in the layered navigation. The amount of queries you will save is related to the amount of attributes you each store has configured to be available for layered navigation.

When saving attributes Magento will [clear the translate cache tag](https://github.com/OpenMage/magento-lts/blob/4c72dcd46a20ec1032b638c79280b453fc84e357/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php#L315) so that cache tag as well as the EAV cache tag are included with this cache object.