### PR TITLE
Some Transaction Isolation Level Freedom

### DIFF
--- a/app/code/core/Mage/Core/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Abstract.php
@@ -281,7 +281,7 @@ abstract class Mage_Core_Model_Resource_Abstract
     }
 
     /**
-     * Prepare transaction isolation level for backup process
+     * Prepare transaction isolation level for session.
      *
      * @param int $isolationLevel Any of the supported isolation levels defined in this class.
      * @return void
@@ -295,7 +295,7 @@ abstract class Mage_Core_Model_Resource_Abstract
     }
 
     /**
-     * Restore transaction isolation level after backup
+     * Restore transaction isolation level for session
      *
      * @return void
      */

--- a/app/code/core/Mage/Core/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Abstract.php
@@ -59,16 +59,20 @@ abstract class Mage_Core_Model_Resource_Abstract
     /**
      * Default transaction isolation level defined in the database.
      *
+     * @todo Default this value with whatever the database reports in SELECT @@GLOBAL.TX_ISOLATION
+     *
      * @var int
      */
-    static protected $_defaultIsolationLevel = self::REPEATABLE_READ;
+    static protected $_defaultIsolationLevel = self::READ_COMMITTED;
 
     /**
      * Current transaction isolation level changed in prepareTransactionIsolationLevel
      *
+     * @todo Default this value with whatever the database reports in SELECT @@GLOBAL.TX_ISOLATION
+     *
      * @var int
      */
-    static protected $_currentIsolationLevel = self::REPEATABLE_READ;
+    static protected $_currentIsolationLevel = self::READ_COMMITTED;
 
     /**
      * Array of callbacks subscribed to commit transaction commit

--- a/app/code/core/Mage/Core/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Abstract.php
@@ -38,7 +38,7 @@ abstract class Mage_Core_Model_Resource_Abstract
     const REPEATABLE_READ = 2;
     const SERIALIZABLE = 3;
 
-    protected const SUPPORTED_ISOLATION_LEVELS = [
+    const SUPPORTED_ISOLATION_LEVELS = [
         self::READ_UNCOMMITTED => "READ UNCOMMITTED",
         self::READ_COMMITTED   => "READ COMMITTED",
         self::REPEATABLE_READ  => "REPEATABLE READ",

--- a/app/code/core/Mage/Core/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Abstract.php
@@ -33,10 +33,10 @@
  */
 abstract class Mage_Core_Model_Resource_Abstract
 {
-    public const READ_UNCOMMITTED = 0;
-    public const READ_COMMITTED = 1;
-    public const REPEATABLE_READ = 2;
-    public const SERIALIZABLE = 3;
+    const READ_UNCOMMITTED = 0;
+    const READ_COMMITTED = 1;
+    const REPEATABLE_READ = 2;
+    const SERIALIZABLE = 3;
 
     protected const SUPPORTED_ISOLATION_LEVELS = [
         self::READ_UNCOMMITTED => "READ UNCOMMITTED",


### PR DESCRIPTION
What do you guys think about making this change to allow a little freedom in changing the default Transaction Isolation Level of MySql / Percona from **Repeatable Read** to **Read Committed** in certain situations.

As an example, take **app/code/core/Mage/Catalog/Model/Resource/Category/Indexer/Product.php**, with the suggested change we could do the following in the **reindexAll** function:

```
-        $this->beginTransaction();
+        $this->beginTransaction(TRUE);
```

By passing TRUE, the isolation level for the enclosed indexing transaction would be changed from the default **Repeatable Read** to **Read Committed**, thus possibly reducing deadlock situations for large catalogs.

### Why I am Suggesting This
I used this technique on my own store to fix a deadlock issue I was getting on checkout with the Ebizmart_Mailchimp extension's cron and newOrder observer.

I've also seen suggestions all the way up to Magento 2.3 to make the default database transaction isolation level Read Committed, but every discussion stops short of saying to actually do this, so I figured a change like this would be optimal because we don't need to change the default, but for transactions like indexing or MailChimp cron, we can reduce the number of locks by changing the isolation level per transaction.

### Quote from [MySql](https://dev.mysql.com/doc/refman/5.6/en/set-transaction.html) 
#### This is Why I don't use SESSION or GLOBAL
> Without any SESSION or GLOBAL keyword: The statement applies only to the next single transaction performed within the session. Subsequent transactions revert to using the session value of the named characteristics. The statement is not permitted within transactions:

Anyway, let me know what you all think or if there is a better way.