### PR TITLE
Remove unsupported PHP 7.x settings from .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -70,11 +70,9 @@
 
 <IfModule mod_php7.c>
     php_value max_execution_time 18000
-    php_flag magic_quotes_gpc off
     php_flag session.auto_start off
     #php_flag zlib.output_compression on
     php_flag suhosin.session.cryptua off
-    php_flag zend.ze1_compatibility_mode Off
 </IfModule>
 
 <IfModule mod_security.c>


### PR DESCRIPTION
- https://www.php.net/manual/en/ini.core.php#ini.zend.ze1-compatibility-mode
- https://www.php.net/manual/en/info.configuration.php#ini.magic-quotes-gpc

Both have been removed before PHP 7.x