### PR TITLE
Check for null byte at the time of writing a file.

### DIFF
--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -486,7 +486,8 @@ class Varien_Io_File extends Varien_Io_Abstract
      */
     protected function _IsValidSource($src)
     {
-        if (is_string($src) || is_resource($src)) {
+        //Treat string that contains a null byte as invalid
+        if ((is_string($src) && strpos($src, char(0)) === false) || is_resource($src)) {
             return true;
         }
 
@@ -505,7 +506,7 @@ class Varien_Io_File extends Varien_Io_Abstract
     {
         $error = false;
         @chdir($this->_cwd);
-         if (file_exists($filename)) {
+        if (file_exists($filename)) {
             if (!is_writeable($filename)) {
                 $error = "File '{$this->getFilteredPath($filename)}' isn't writeable";
             }
@@ -532,8 +533,7 @@ class Varien_Io_File extends Varien_Io_Abstract
     protected function _checkSrcIsFile($src)
     {
         $result = false;
-        // both is_readable() and is_file() emit E_WARNING if there is a null byte in $src
-        if (is_string($src) && @is_readable($src) && @is_file($src)) {
+        if (is_string($src) && is_readable($src) && is_file($src)) {
             $result = true;
         }
 
@@ -846,7 +846,7 @@ class Varien_Io_File extends Varien_Io_Abstract
     {
         return $this->getCleanPath(dirname($file));
     }
-    
+
     public function getStreamHandler()
     {
         return $this->_streamHandler;


### PR DESCRIPTION
Good afternoon everyone,

I decided to tackle the #959 issue, by adding a byte null check in the protected method `_IsValidSource`. 

However, I introduced a new behaviour, I arbitrarily decided to flag any strings that contain a null byte character as invalid (for safety reasons).

Then removed any null byte related error suppressors.

I'm not sure what are the guidelines for Pull Requests. Shall I provide a unit test to highlight this change?