### PR TITLE
Fix checkout address for guest order

### DIFF
--- a/app/code/core/Mage/Checkout/Block/Onepage/Billing.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Billing.php
@@ -113,6 +113,8 @@ class Mage_Checkout_Block_Onepage_Billing extends Mage_Checkout_Block_Onepage_Ab
                 if (!$this->_address->getLastname()) {
                     $this->_address->setLastname($this->getQuote()->getCustomer()->getLastname());
                 }
+            } else if ($this->getQuote()->getCustomerIsGuest() || !$this->getQuote()->getCustomerId()) {
+                $this->_address = $this->getQuote()->getBillingAddress();
             } else {
                 $this->_address = Mage::getModel('sales/quote_address');
             }

--- a/app/code/core/Mage/Checkout/Block/Onepage/Billing.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Billing.php
@@ -113,10 +113,8 @@ class Mage_Checkout_Block_Onepage_Billing extends Mage_Checkout_Block_Onepage_Ab
                 if (!$this->_address->getLastname()) {
                     $this->_address->setLastname($this->getQuote()->getCustomer()->getLastname());
                 }
-            } else if ($this->getQuote()->getCustomerIsGuest() || !$this->getQuote()->getCustomerId()) {
-                $this->_address = $this->getQuote()->getBillingAddress();
             } else {
-                $this->_address = Mage::getModel('sales/quote_address');
+                $this->_address = $this->getQuote()->getBillingAddress();
             }
         }
 

--- a/app/code/core/Mage/Checkout/Block/Onepage/Shipping.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Shipping.php
@@ -71,6 +71,8 @@ class Mage_Checkout_Block_Onepage_Shipping extends Mage_Checkout_Block_Onepage_A
         if (is_null($this->_address)) {
             if ($this->isCustomerLoggedIn()) {
                 $this->_address = $this->getQuote()->getShippingAddress();
+            } else if ($this->getQuote()->getCustomerIsGuest() || !$this->getQuote()->getCustomerId()) {
+                $this->_address = $this->getQuote()->getShippingAddress();
             } else {
                 $this->_address = Mage::getModel('sales/quote_address');
             }

--- a/app/code/core/Mage/Checkout/Block/Onepage/Shipping.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Shipping.php
@@ -69,13 +69,7 @@ class Mage_Checkout_Block_Onepage_Shipping extends Mage_Checkout_Block_Onepage_A
     public function getAddress()
     {
         if (is_null($this->_address)) {
-            if ($this->isCustomerLoggedIn()) {
-                $this->_address = $this->getQuote()->getShippingAddress();
-            } else if ($this->getQuote()->getCustomerIsGuest() || !$this->getQuote()->getCustomerId()) {
-                $this->_address = $this->getQuote()->getShippingAddress();
-            } else {
-                $this->_address = Mage::getModel('sales/quote_address');
-            }
+            $this->_address = $this->getQuote()->getShippingAddress();
         }
 
         return $this->_address;


### PR DESCRIPTION
If the guest wants to change the shopping cart again during checkout or the payment process has failed, the guest does not have to fill in his address again.