### PR TITLE
Do not call vsprintf when there are no arguments

### DIFF
--- a/app/code/core/Mage/Core/Model/Translate.php
+++ b/app/code/core/Mage/Core/Model/Translate.php
@@ -413,7 +413,7 @@ class Mage_Core_Model_Translate
         //array_unshift($args, $translated);
         //$result = @call_user_func_array('sprintf', $args);
 
-        $result = @vsprintf($translated, $args);
+        $result = !empty($args) ? @vsprintf($translated, $args) : false;
         if ($result === false) {
             $result = $translated;
         }


### PR DESCRIPTION
This patch fixes "vsprintf(): Too few arguments" notice, when magento tries to
prepare JS language labels in Mage_Core_Helper_Js
(they are translated without passing arguments, as args are replaced on js side).
This way we avoid  the notice and processing of the notice in the error handler
(which adds some performance penalty to every request).