### PR TITLE
Store unserialized data in local cache of Zend_Data

### DIFF
--- a/lib/Zend/Locale/Data.php
+++ b/lib/Zend/Locale/Data.php
@@ -966,7 +966,7 @@ class Zend_Locale_Data
             } else {
                 self::$_cache->save( $data, $id);
             }
-            static::$_localCache[$id] = $data;
+            static::$_localCache[$id] = $temp;
         }
 
         return $temp;
@@ -1523,7 +1523,7 @@ class Zend_Locale_Data
             } else {
                 self::$_cache->save( $data, $id);
             }
-            static::$_localCache[$id] = $data;
+            static::$_localCache[$id] = $temp;
         }
 
         return $temp;


### PR DESCRIPTION
fixes regression introduced in https://github.com/OpenMage/magento-lts/pull/918