### PR TITLE
Fixed .thumbnail load

### DIFF
--- a/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
+++ b/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
@@ -92,7 +92,7 @@ class Mage_Cms_Helper_Wysiwyg_Images extends Mage_Core_Helper_Abstract
      */
     public function getBaseUrl()
     {
-        return Mage::getBaseUrl('media') . Mage_Cms_Model_Wysiwyg_Config::IMAGE_DIRECTORY . '/';
+        return Mage::getBaseUrl('media');
     }
 
     /**

--- a/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
+++ b/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
@@ -92,7 +92,7 @@ class Mage_Cms_Helper_Wysiwyg_Images extends Mage_Core_Helper_Abstract
      */
     public function getBaseUrl()
     {
-        return Mage::getBaseUrl('media');
+        return Mage::getBaseUrl('media') . Mage_Cms_Model_Wysiwyg_Config::IMAGE_DIRECTORY . '/';
     }
 
     /**

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
@@ -138,10 +138,9 @@ class Mage_Cms_Model_Wysiwyg_Images_Storage extends Varien_Object
             $item->setUrl($helper->getCurrentUrl() . $item->getBasename());
 
             if ($this->isImage($item->getBasename())) {
-                $thumbUrl = $this->getThumbnailUrl(
-                    Mage_Core_Model_File_Uploader::getCorrectFileName($item->getFilename()),
-                    true
-                );
+                $thumbImg = Mage_Core_Model_File_Uploader::getCorrectFileName($item->getBasename());
+                $thumbUrl = $this->getThumbnailUrl($path . DS . $thumbImg, true);
+
                 // generate thumbnail "on the fly" if it does not exists
                 if (! $thumbUrl) {
                     $thumbUrl = Mage::getSingleton('adminhtml/url')->getUrl('*/*/thumbnail', array('file' => $item->getId()));
@@ -344,24 +343,18 @@ class Mage_Cms_Model_Wysiwyg_Images_Storage extends Varien_Object
      *
      * @param  string $filePath original file path
      * @param  boolean $checkFile OPTIONAL is it necessary to check file availability
-     * @return string | false
+     * @return string|false
      */
     public function getThumbnailUrl($filePath, $checkFile = false)
     {
         $mediaRootDir = Mage::getConfig()->getOptions()->getMediaDir() . DS;
-
         if (strpos($filePath, $mediaRootDir) === 0) {
-            $thumbSuffix = self::THUMBS_DIRECTORY_NAME . DS . Mage_Cms_Model_Wysiwyg_Config::IMAGE_DIRECTORY
-                . DS . substr($filePath, strlen($mediaRootDir));
-
-            if (! $checkFile || is_readable($this->getHelper()->getStorageRoot() . $thumbSuffix)) {
+            $thumbSuffix = self::THUMBS_DIRECTORY_NAME . DS . substr($filePath, strlen($mediaRootDir));
+            if (!$checkFile || is_readable($this->getHelper()->getStorageRoot() . $thumbSuffix)) {
                 $randomIndex = '?rand=' . time();
-                $thumbUrl = $this->getHelper()->getBaseUrl() . Mage_Cms_Model_Wysiwyg_Config::IMAGE_DIRECTORY
-                    . DS . $thumbSuffix;
-                return str_replace('\\', '/', $thumbUrl) . $randomIndex;
+                return str_replace('\\', '/', $this->getHelper()->getBaseUrl() . $thumbSuffix) . $randomIndex;
             }
         }
-
         return false;
     }
 

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
@@ -352,7 +352,9 @@ class Mage_Cms_Model_Wysiwyg_Images_Storage extends Varien_Object
             $thumbSuffix = self::THUMBS_DIRECTORY_NAME . DS . substr($filePath, strlen($mediaRootDir));
             if (!$checkFile || is_readable($this->getHelper()->getStorageRoot() . $thumbSuffix)) {
                 $randomIndex = '?rand=' . time();
-                return str_replace('\\', '/', $this->getHelper()->getBaseUrl() . $thumbSuffix) . $randomIndex;
+                $thumbUrl = $this->getHelper()->getBaseUrl() . Mage_Cms_Model_Wysiwyg_Config::IMAGE_DIRECTORY
+                    . DS . $thumbSuffix;
+                return str_replace('\\', '/', $thumbUrl) . $randomIndex;
             }
         }
         return false;


### PR DESCRIPTION
### Description (*)
Fixes a bug that .thumbnail images are generated every time.

Read here: https://www.ctidigital.com/blog/fixing-magento-improving-performance-of-the-wysiwyg-editor/

Or here:  https://magento.stackexchange.com/questions/279596/1-9-4-breaking-broken-features-what-is-mage-core-model-file-uploadergetcorre

### Related Pull Requests
1. OpenMage/magento-lts#261: Fixes issue with wysiwyg editor re-creating thumbnails 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. OpenMage/magento-lts#355: Performance improvement for WYSIWYG editor

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. go to CMS page or block
2. add an image via "Insert image" button
3. Save and continue
4. add xdebug breakpoint here and you'll see `$thumbUrl` is alsways `false`

```
// generate thumbnail "on the fly" if it does not exists
if (! $thumbUrl) {
    $thumbUrl = Mage::getSingleton('adminhtml/url')->getUrl('*/*/thumbnail', array('file' => $item->getId()));
}
```
5. Use "Insert image" button again ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
