### PR TITLE
workaround 404 dashboard on first admin login on multi store views

### DIFF
--- a/app/design/adminhtml/default/default/template/login.phtml
+++ b/app/design/adminhtml/default/default/template/login.phtml
@@ -48,7 +48,7 @@
 <body id="page-login" onload="document.forms.loginForm.username.focus();">
     <div class="login-container">
         <div class="login-box">
-            <form method="post" action="" id="loginForm" autocomplete="off">
+            <form method="post" action="<?php echo $this->getUrl('adminhtml') ?>" id="loginForm" autocomplete="off">
                 <div class="login-form">
                     <input name="form_key" type="hidden" value="<?php echo $this->getFormKey() ?>" />
                     <h2><?php echo Mage::helper('adminhtml')->__('Log in to Admin Panel') ?></h2>


### PR DESCRIPTION
So this bug has been annoying me for a while now.

I have 3 multilingual websites which were installed so that the admin url would be just `/admin` . After changing the frontName in `app/etc/local.xml` to secure them, the first time the admin user logs in, the initial page (usually the dashboard) will show a 404 page. 

Removing all the extensions etc etc never helped and I was never able to determine the exact reason why it was giving a 404. Everything proceeded correctly after xDebugging the controller actions and the correct URL was found. However the response that was sent was 404.  

If you directly logged out and logged in it would work OK for the next attempts and only the first login is affected.

Refreshing the browser completely, I would get a 404 again. 

Changing the initial page from the settings from let's say the Dashboard to the Orders Grid had no effect. The issue persisted. The user is redirected to the URL for the correct page, but 404 response is sent. 

At some point I bumped into this article with a workaround so I decided to send a pull request here which was life-saving so to speak. 

https://www.mcnab.co/blog/e-commerce/magento/magento-admin-dashboard-404-with-multiple-store/

Hopefully you will merge it, but if you decide not to, it's OK. At least people who search for it, will find it. 