### PR TITLE
Allow "email" to be used in address templates

### DIFF
--- a/app/code/core/Mage/Customer/Block/Address/Renderer/Default.php
+++ b/app/code/core/Mage/Customer/Block/Address/Renderer/Default.php
@@ -135,6 +135,11 @@ class Mage_Customer_Block_Address_Renderer_Default extends Mage_Core_Block_Abstr
             }
         }
 
+        if($address instanceof \Mage_Sales_Model_Order_Address){
+            $order = $address->getOrder();
+            $data['email'] = $order->getCustomerEmail();
+        }
+
         if ($this->getType()->getHtmlEscape()) {
             foreach ($data as $key => $value) {
                 $data[$key] = $this->escapeHtml($value);


### PR DESCRIPTION
Only fields from the address can be used in address templates, but a client of ours needed the "email" on the Invoice PDF, so I thought it made sense to have access to the "email" var in the address fields.

There are other options, like building the $data array in a new protected method, that could then be overridden, or throw a new event, but I wanted to start simple. This kind of thing probably won't be extended much.