### PR TITLE
Fix for installing on MySQL 8. Fixes #935

### DIFF
--- a/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
@@ -270,6 +270,7 @@ abstract class Mage_Core_Model_Resource_Helper_Abstract
                 break;
             case 'tinyint':
             case 'smallint':
+            case 'smallint unsigned':
                 $type = Varien_Db_Ddl_Table::TYPE_SMALLINT;
                 break;
             case 'mediumint':

--- a/app/code/core/Mage/Eav/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Helper/Mysql4.php
@@ -83,6 +83,9 @@ class Mage_Eav_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Resource_Hel
             case 'tinyint':
                 $columnType = 'smallint';
                 break;
+            case 'int unsigned':
+                $columnType = 'int';
+                break;
         }
 
         return array_search($columnType, $this->_ddlColumnTypes);

--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -1884,12 +1884,16 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
             case 'longblob':
                 return Varien_Db_Ddl_Table::TYPE_BLOB;
             case 'tinyint':
+            case 'tinyint unsigned':
             case 'smallint':
+            case 'smallint unsigned':
                 return Varien_Db_Ddl_Table::TYPE_SMALLINT;
             case 'mediumint':
             case 'int':
+            case 'int unsigned':
                 return Varien_Db_Ddl_Table::TYPE_INTEGER;
             case 'bigint':
+            case 'bigint unsigned':
                 return Varien_Db_Ddl_Table::TYPE_BIGINT;
             case 'datetime':
                 return Varien_Db_Ddl_Table::TYPE_DATETIME;


### PR DESCRIPTION
As per discussion on #935 this fixes installation on MySQL 8.0.

Testing procedure:

- Created fresh install using an empty MySQL 8 database
- Loaded some frontend pages
- Voted in poll
- Logged into admin UI
- Created a simple product
- Created a subcategory of Default Category as anchor
- Assigned product to new category and Default Category
- Reindexed all indexes
- Browsed frontend to new category and product pages
- Added one item to cart and completed checkout
- Created a fresh install using an empty MySQL 5.7 database to ensure no regressions

No issues found!