### PR TITLE
Add development environment setup files and README.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /app/etc/local.xml
+/media/catalog
+/dev/tests/functional/generated
+/dev/tests/functional/vendor

--- a/dev/openmage/.gitignore
+++ b/dev/openmage/.gitignore
@@ -1,1 +1,2 @@
 docker-magento/
+.env

--- a/dev/openmage/.gitignore
+++ b/dev/openmage/.gitignore
@@ -1,0 +1,1 @@
+docker-magento/

--- a/dev/openmage/README.md
+++ b/dev/openmage/README.md
@@ -14,9 +14,10 @@ For a more robust development environment that supports https, please consider u
 
 ## Step 1
 
-Change to this directory (`dev/openmage`) and run the following command to start MySQL and Apache:
+Change to this directory (`dev/openmage`) and run the following commands to start MySQL and Apache:
 
 ```
+$ docker-compose pull
 $ docker-compose up -d mysql apache
 ```
 

--- a/dev/openmage/README.md
+++ b/dev/openmage/README.md
@@ -1,0 +1,104 @@
+OpenMage Dev Environment
+===
+
+With these files you can have a fully operational OpenMage LTS development environment in three easy steps!
+
+**NOTE: This is not for production use!**
+
+## Prerequisites
+
+- Install [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
+- Clone the OpenMage LTS repo to your location of choice
+
+## Step 1
+
+Change to this directory (`dev/openmage`) and run the following command to start MySQL and Apache:
+
+```
+$ docker-compose up -d mysql apache
+```
+
+Wait about 15 seconds for MySQL to initialize. You can check the logs to make sure there are no issues:
+
+```
+$ docker-compose logs
+```
+
+## Step 2
+
+Setup your `/etc/hosts` file to point `openmage.docker` to the correct IP address. If developing on a local instance
+this might work to use `127.0.0.1`, otherwise if you are using a remote machine or virtual machine you may need to use
+a different IP address.
+
+## Step 3
+
+You are ready to run the Magento installation!
+
+Just run the following command to install via CLI:
+
+```
+$ docker-compose run --rm cli sudo -u www-data php install.php \
+  --license_agreement_accepted yes \
+  --locale en_US \
+  --timezone America/New_York \
+  --default_currency USD \
+  --db_host mysql \
+  --db_name magento \
+  --db_user magento \
+  --db_pass magento \
+  --url 'http://openmage.docker/' \
+  --use_rewrites yes \
+  --use_secure no \
+  --secure_base_url 'http://openmage.docker/' \
+  --use_secure_admin no \
+  --admin_lastname User \
+  --admin_firstname OpenMage  \
+  --admin_email admin@example.com \
+  --admin_username admin \
+  --admin_password v3ryl0ngpassw0rd
+```
+
+Or you can visit [http://openmage.docker/index.php/install/](http://openmage.docker/index.php/install/) to start the web-based installer.
+Use `mysql` as the database host and use `magento` for the database name, database username and database password.
+
+Setup is complete! Visit [http://openmage.docker/](http://openmage.docker/) and start coding!
+
+Tips
+===
+
+See [meanbee/docker-magento](https://github.com/meanbee/docker-magento) for more information on the containers
+used in this setup, but here are some quick tips:
+
+- You can start the cron task using `docker-compose up -d cron`.
+- The `cli` service contains many useful tools like `composer`, `magerun`, `modman`, `mageconfigsync` and more.
+- XDebug is enabled using `remote_connect_back=1` with `idekey=phpstorm`. Customize this in `docker-compose.yml` if needed.
+
+Here are some common commands you may wish to try:
+
+```
+$ docker-compose run --rm cli magerun sys:check
+$ docker-compose run --rm cli magerun cache:clean
+$ docker-compose run --rm cli magerun db:console
+$ docker-compose exec mysql mysql
+```
+
+Wiping
+---
+
+If you want to start fresh, wipe out your installation with the following:
+
+```
+$ docker-compose down --volumes
+$ rm ../../app/etc/local.xml
+```
+
+Building
+===
+
+The Docker images are built using the [meanbee/docker-magento](https://github.com/meanbee/docker-magento) source files so to build new images first
+clone the source files into this directory and then run `docker-compose build`. 
+
+```
+$ git clone https://github.com/meanbee/docker-magento.git
+$ docker-compose build
+```

--- a/dev/openmage/README.md
+++ b/dev/openmage/README.md
@@ -17,7 +17,7 @@ For a more robust development environment that supports https, please consider u
 Change to this directory (`dev/openmage`) and run the following commands to start MySQL and Apache:
 
 ```
-$ docker-compose pull
+$ chmod 777 app/etc media var
 $ docker-compose up -d mysql apache
 ```
 
@@ -103,5 +103,8 @@ clone the source files into this directory and then run `docker-compose build`.
 
 ```
 $ git clone https://github.com/meanbee/docker-magento.git
-$ docker-compose build
+$ docker build -t openmage/php-dev:7.3-cli docker-magento/7.3/cli
+$ docker push openmage/php-dev:7.3-cli
+$ docker build -t openmage/php-dev:7.3-apache docker-magento/7.3/apache
+$ docker push openmage/php-dev:7.3-apache
 ```

--- a/dev/openmage/README.md
+++ b/dev/openmage/README.md
@@ -5,6 +5,8 @@ With these files you can have a fully operational OpenMage LTS development envir
 
 **NOTE: This is not for production use!**
 
+For a more robust development environment that supports https, please consider using [ddev](https://ddev.readthedocs.io/en/stable/users/cli-usage/#magento-1-quickstart).
+
 ## Prerequisites
 
 - Install [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)

--- a/dev/openmage/README.md
+++ b/dev/openmage/README.md
@@ -1,7 +1,7 @@
 OpenMage Dev Environment
 ===
 
-With these files you can have a fully operational OpenMage LTS development environment in three easy steps!
+With these files you can have a fully operational OpenMage LTS development environment in ONE step!
 
 **NOTE: This is not for production use!**
 
@@ -10,61 +10,14 @@ For a more robust development environment that supports https, please consider u
 ## Prerequisites
 
 - Install [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
+- Port 80 on your host must be unused.
 - Clone the OpenMage LTS repo to your location of choice
 
-## Step 1
+## Installation
 
-Change to this directory (`dev/openmage`) and run the following commands to start MySQL and Apache:
+Run `dev/openmage/install.sh`. That's it!
 
-```
-$ chmod 777 app/etc media var
-$ docker-compose up -d mysql apache
-```
-
-Wait about 15 seconds for MySQL to initialize. You can check the logs to make sure there are no issues:
-
-```
-$ docker-compose logs
-```
-
-## Step 2
-
-Setup your `/etc/hosts` file to point `openmage.docker` to the correct IP address. If developing on a local instance
-this might work to use `127.0.0.1`, otherwise if you are using a remote machine or virtual machine you may need to use
-a different IP address.
-
-## Step 3
-
-You are ready to run the Magento installation!
-
-Just run the following command to install via CLI:
-
-```
-$ docker-compose run --rm cli sudo -u www-data php install.php \
-  --license_agreement_accepted yes \
-  --locale en_US \
-  --timezone America/New_York \
-  --default_currency USD \
-  --db_host mysql \
-  --db_name magento \
-  --db_user magento \
-  --db_pass magento \
-  --url 'http://openmage.docker/' \
-  --use_rewrites yes \
-  --use_secure no \
-  --secure_base_url 'http://openmage.docker/' \
-  --use_secure_admin no \
-  --admin_lastname User \
-  --admin_firstname OpenMage  \
-  --admin_email admin@example.com \
-  --admin_username admin \
-  --admin_password v3ryl0ngpassw0rd
-```
-
-Or you can visit [http://openmage.docker/index.php/install/](http://openmage.docker/index.php/install/) to start the web-based installer.
-Use `mysql` as the database host and use `magento` for the database name, database username and database password.
-
-Setup is complete! Visit [http://openmage.docker/](http://openmage.docker/) and start coding!
+Visit [http://openmage-7f000001.nip.io/](http://openmage-7f000001.nip.io/) and start coding!
 
 Tips
 ===
@@ -85,14 +38,26 @@ $ docker-compose run --rm cli magerun db:console
 $ docker-compose exec mysql mysql
 ```
 
+Environment Variables
+---
+
+You can override some defaults using environment variables defined in a file that you must create at `dev/openmage/.env`.
+
+- `HOST_NAME=your-preferred-hostname`
+  - `openmage-7f000001.nip.io` is used by default to resolve to `127.0.0.1`. See nio.io for more info.
+- `HOST_PORT=8888`
+   - `80` is used by default 
+- `ADMIN_EMAIL`
+- `ADMIN_USERNAME`
+- `ADMIN_PASSWORD`
+
 Wiping
 ---
 
-If you want to start fresh, wipe out your installation with the following:
+If you want to start fresh, wipe out your installation with the following command:
 
 ```
-$ docker-compose down --volumes
-$ rm ../../app/etc/local.xml
+$ docker-compose down --volumes && rm -f ../../app/etc/local.xml
 ```
 
 Building

--- a/dev/openmage/docker-compose.yml
+++ b/dev/openmage/docker-compose.yml
@@ -3,15 +3,12 @@ version: "3.7"
 services:
   apache:
     image: openmage/php-dev:7.3-apache
-    hostname: openmage.docker
+    hostname: ${HOST_NAME:-openmage-7f000001.nip.io}
     ports:
-      - "80:80"
+      - "${HOST_PORT:-80}:80"
     volumes:
       - ../..:/var/www/html
     environment:
-      - VIRTUAL_HOST=openmage.docker
-      - VIRTUAL_PORT=80
-      - HTTPS_METHOD=noredirect
       - ENABLE_SENDMAIL=true
       - XDEBUG_CONFIG=remote_connect_back=1 remote_enable=1 idekey=phpstorm
     links:
@@ -44,7 +41,7 @@ services:
 #      - AWS_MEDIA_BUCKET=magemm
     links:
       - mysql
-      - "apache:openmage.docker"
+      - "apache:${HOST_NAME:-openmage-7f000001.nip.io}"
 
   mysql:
     image: mysql:5.7
@@ -53,9 +50,9 @@ services:
     command: --default-authentication-plugin=mysql_native_password
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
-      - MYSQL_USER=magento
-      - MYSQL_PASSWORD=magento
-      - MYSQL_DATABASE=magento
+      - MYSQL_USER=openmage
+      - MYSQL_PASSWORD=openmage
+      - MYSQL_DATABASE=openmage
     volumes:
       - mysql:/var/lib/mysql
 

--- a/dev/openmage/docker-compose.yml
+++ b/dev/openmage/docker-compose.yml
@@ -3,8 +3,6 @@ version: "3.7"
 services:
   apache:
     image: openmage/php-dev:7.3-apache
-    build:
-      context: docker-magento/7.3/apache
     hostname: openmage.docker
     ports:
       - "80:80"
@@ -21,10 +19,9 @@ services:
 
   cron:
     image: openmage/php-dev:7.3-cli
-    build:
-      context: docker-magento/7.3/cli
     working_dir: /var/www/html
     command: /run-cron.sh
+    user: www-data
     volumes:
       - ../..:/var/www/html
     environment:
@@ -34,10 +31,9 @@ services:
 
   cli:
     image: openmage/php-dev:7.3-cli
-    build:
-      context: docker-magento/7.3/cli
     working_dir: /var/www/html
     command: /bin/true
+    user: www-data
     volumes:
       - ../..:/var/www/html
 #    environment:

--- a/dev/openmage/docker-compose.yml
+++ b/dev/openmage/docker-compose.yml
@@ -1,0 +1,66 @@
+version: "3.7"
+
+services:
+  apache:
+    image: openmage/php-dev:7.3-apache
+    build:
+      context: docker-magento/7.3/apache
+    hostname: openmage.docker
+    ports:
+      - "80:80"
+    volumes:
+      - ../..:/var/www/html
+    environment:
+      - VIRTUAL_HOST=openmage.docker
+      - VIRTUAL_PORT=80
+      - HTTPS_METHOD=noredirect
+      - ENABLE_SENDMAIL=true
+      - XDEBUG_CONFIG=remote_connect_back=1 remote_enable=1 idekey=phpstorm
+    links:
+      - mysql
+
+  cron:
+    image: openmage/php-dev:7.3-cli
+    build:
+      context: docker-magento/7.3/cli
+    working_dir: /var/www/html
+    command: /run-cron.sh
+    volumes:
+      - ../..:/var/www/html
+    environment:
+      - ENABLE_SENDMAIL=true
+    links:
+      - mysql
+
+  cli:
+    build:
+      context: docker-magento/7.3/cli
+    working_dir: /var/www/html
+    command: /bin/true
+    volumes:
+      - ../..:/var/www/html
+#    environment:
+#      - AWS_ACCESS_KEY_ID=00000000000000000000
+#      - AWS_SECRET_ACCESS_KEY=0000000000000000000000000000000000000000
+#      - AWS_REGION=eu-west-1
+#      - AWS_BUCKET=magedbm
+#      - AWS_MEDIA_BUCKET=magemm
+    links:
+      - mysql
+      - "apache:openmage.docker"
+
+  mysql:
+    image: mysql:5.7
+    ports:
+      - 3306
+    command: --default-authentication-plugin=mysql_native_password
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+      - MYSQL_USER=magento
+      - MYSQL_PASSWORD=magento
+      - MYSQL_DATABASE=magento
+    volumes:
+      - mysql:/var/lib/mysql
+
+volumes:
+  mysql:

--- a/dev/openmage/docker-compose.yml
+++ b/dev/openmage/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - mysql
 
   cli:
+    image: openmage/php-dev:7.3-cli
     build:
       context: docker-magento/7.3/cli
     working_dir: /var/www/html

--- a/dev/openmage/install.sh
+++ b/dev/openmage/install.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+dir=$(dirname "${BASH_SOURCE[0]}")
+cd $dir
+test -f .env && source .env
+
+chmod 777 ../../app/etc ../../media ../../var
+
+docker-compose up -d mysql apache
+sleep 4
+
+echo "Starting services..."
+for i in $(seq 1 20); do
+  sleep 1
+  docker exec openmage_mysql_1 mysql -e 'show databases;' 2>/dev/null | grep -qF 'openmage' && break
+done
+
+HOST_PORT=":${HOST_PORT:-80}"
+test "$HOST_PORT" = ":80" && HOST_PORT=""
+BASE_URL="http://${HOST_NAME:-openmage-7f000001.nip.io}${HOST_PORT}/"
+ADMIN_EMAIL="${ADMIN_EMAIL:-admin@example.com}"
+ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-veryl0ngpassw0rd}"
+
+echo "Installing OpenMage LTS..."
+docker-compose run --rm cli php install.php \
+  --license_agreement_accepted yes \
+  --locale en_US \
+  --timezone America/New_York \
+  --default_currency USD \
+  --db_host mysql \
+  --db_name openmage \
+  --db_user openmage \
+  --db_pass openmage \
+  --url "$BASE_URL" \
+  --use_rewrites yes \
+  --use_secure no \
+  --secure_base_url "$BASE_URL" \
+  --use_secure_admin no \
+  --skip_url_validation \
+  --admin_firstname OpenMage  \
+  --admin_lastname User \
+  --admin_email "$ADMIN_EMAIL" \
+  --admin_username "$ADMIN_USERNAME" \
+  --admin_password "$ADMIN_PASSWORD"
+
+echo ""
+echo "Setup is complete!"
+echo "Visit ${BASE_URL}admin and login with '$ADMIN_USERNAME' : '$ADMIN_PASSWORD'"
+echo "MySQL server IP: $(docker exec openmage_apache_1 getent hosts mysql | awk '{print $1}')"


### PR DESCRIPTION
Refs #644 

This PR adds the minimal files required to make it easy to setup a fully functioning dev environment. It is not meant to be used for production, just to help people who want to contribute to OpenMage LTS to get up and running super fast.

With this PR you can start an environment in about 2 minutes flat, most of that time is waiting for Magento installer. Here is a ~30 second clip showing the steps:

![openmage-docker](https://user-images.githubusercontent.com/38738/83306007-c72ae200-a1cf-11ea-93c6-10390e7aae08.gif)

Please see the [README](https://github.com/OpenMage/magento-lts/blob/a8142b8a15cfdfdafb8908d5a2388db78ef0482f/dev/openmage/README.md) for the user-guide.

The only requirements are Docker and Docker Compose so I don't think it can get much simpler.