### PR TITLE
1.9.4.x => E-Mail templates only: replace plaintext password with hint of choosen password

### DIFF
--- a/app/locale/en_US/template/email/account_new.html
+++ b/app/locale/en_US/template/email/account_new.html
@@ -4,8 +4,7 @@
 "var logo_url":"Email Logo Image Url",
 "htmlescape var=$customer.name":"Customer Name",
 "store url=\"customer/account/\"":"Customer Account Url",
-"var customer.email":"Customer Email",
-"htmlescape var=$customer.password":"Customer Password"}
+"var customer.email":"Customer Email"}
 @-->
 
 <!--@styles

--- a/app/locale/en_US/template/email/account_new.html
+++ b/app/locale/en_US/template/email/account_new.html
@@ -22,7 +22,7 @@
             <p class="highlighted-text">
                 Use the following values when prompted to log in:<br/>
                 <strong>Email</strong>: {{var customer.email}}<br/>
-                <strong>Password</strong>: {{htmlescape var=$customer.password}}
+                <strong>Password</strong>: (the password you set when creating your account)
             </p>
             <p>When you log in to your account, you will be able to do the following:</p>
             <ul>

--- a/app/locale/en_US/template/email/account_new_confirmation.html
+++ b/app/locale/en_US/template/email/account_new_confirmation.html
@@ -6,8 +6,8 @@
 "store url=\"customer/account/\"":"Customer Account Url",
 "htmlescape var=$customer.name":"Customer Name",
 "var customer.email":"Customer Email",
-"store url=\"customer/account/confirm/\" _query_id=$customer.id _query_key=$customer.confirmation _query_back_url=$back_url":"Confirmation Url",
-"htmlescape var=$customer.password":"Customer password"}
+"store url=\"customer/account/confirm/\" _query_id=$customer.id _query_key=$customer.confirmation _query_back_url=$back_url":"Confirmation Url"
+}
 @-->
 
 <!--@styles

--- a/app/locale/en_US/template/email/account_new_confirmation.html
+++ b/app/locale/en_US/template/email/account_new_confirmation.html
@@ -27,7 +27,7 @@
                         <p class="highlighted-text">
                             Use the following values when prompted to log in:<br/>
                             <strong>Email:</strong> {{var customer.email}}<br/>
-                            <strong>Password:</strong> {{htmlescape var=$customer.password}}
+                            <strong>Password</strong>: (the password you set when creating your account)
                         </p>
                         <p>Click here to confirm your email and instantly log in (the link is valid only once):</p>
                         <table cellspacing="0" cellpadding="0" class="action-button" >

--- a/app/locale/en_US/template/email/admin_password_new.html
+++ b/app/locale/en_US/template/email/admin_password_new.html
@@ -18,7 +18,7 @@
     <tr>
         <td class="action-content">
             <h1>{{htmlescape var=$user.name}},</h1>
-            <p><strong>Your new password is:</strong> {{htmlescape var=$password}}</p>
+            <p><strong>Password</strong>: (the password you set when creating your account) </p>
             <p>You can change your password at any time by logging into <a href="{{store url="adminhtml/system_account/"}}">your account</a>.</p>
         </td>
     </tr>

--- a/app/locale/en_US/template/email/admin_password_new.html
+++ b/app/locale/en_US/template/email/admin_password_new.html
@@ -4,7 +4,6 @@
 "var logo_url":"Email Logo Image Url",
 "var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$user.name":"Admin Name",
-"htmlescape var=$password":"Admin Password",
 "store url=\"adminhtml/system_account/\"":"Admin Account Url"}
 @-->
 

--- a/app/locale/en_US/template/email/password_new.html
+++ b/app/locale/en_US/template/email/password_new.html
@@ -17,7 +17,7 @@
     <tr>
         <td class="action-content">
             <h1>{{htmlescape var=$customer.name}},</h1>
-            <p><strong>Your new password is:</strong> {{htmlescape var=$customer.password}}</p>
+            <p><strong>Password</strong>: (the password you set when creating your account) </p>
             <p>You can change your password at any time by logging into <a href="{{store url="customer/account/"}}">your account</a>.</p>
         </td>
     </tr>

--- a/app/locale/en_US/template/email/password_new.html
+++ b/app/locale/en_US/template/email/password_new.html
@@ -5,7 +5,6 @@
 "var logo_alt":"Email Logo Image Alt",
 "store url=\"customer/account/\"":"Customer Account Url",
 "htmlescape var=$customer.name":"Customer Name",
-"htmlescape var=$customer.password":"Customer New Password"}
 @-->
 <!--@styles
 @-->


### PR DESCRIPTION
See  #307

_To replace plaintext password with <strong>Password</strong>: (the password you set when creating your account) and also remove reference to plaintext password in email templates._

Fixes #307 