### PR TITLE
Ensure coupon code times_used decrements on cancel

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Observer.php
+++ b/app/code/core/Mage/SalesRule/Model/Observer.php
@@ -133,6 +133,40 @@ class Mage_SalesRule_Model_Observer
     }
 
     /**
+     * Registered callback: called after an order payment is canceled
+     *
+     * @param $observer
+     */
+    public function sales_order_paymentCancel($observer)
+    {
+        /** @var Varien_Event $event */
+        $event = $observer->getEvent();
+        /** @var Mage_Sales_Model_Order $order */
+        $order = $event->getPayment()->getOrder();
+
+        if ($order->canCancel()) {
+            if ($code = $order->getCouponCode()) {
+                // Decrement coupon times_used
+                $coupon = Mage::getModel('salesrule/coupon')->loadByCode($code);
+                $coupon->setTimesUsed($coupon->getTimesUsed() - 1);
+                $coupon->save();
+
+
+                if ($customerId = $order->getCustomerId()) {
+                    // Decrement coupon_usage times_used
+                    Mage::getResourceModel('salesrule/coupon_usage')->updateCustomerCouponTimesUsed($customerId, $coupon->getId(), TRUE);
+
+                    // Decrement rule times_used
+                    if ($customerCoupon = Mage::getModel('salesrule/rule_customer')->loadByCustomerRule($customerId, $coupon->getId())) {
+                        $customerCoupon->setTimesUsed($customerCoupon->getTimesUsed() - 1);
+                        $customerCoupon->save();
+                    }
+                }
+            }
+        }
+    }
+
+    /**
      * Refresh sales coupons report statistics for last day
      *
      * @param Mage_Cron_Model_Schedule $schedule

--- a/app/code/core/Mage/SalesRule/Model/Observer.php
+++ b/app/code/core/Mage/SalesRule/Model/Observer.php
@@ -154,7 +154,7 @@ class Mage_SalesRule_Model_Observer
 
                 if ($customerId = $order->getCustomerId()) {
                     // Decrement coupon_usage times_used
-                    Mage::getResourceModel('salesrule/coupon_usage')->updateCustomerCouponTimesUsed($customerId, $coupon->getId(), TRUE);
+                    Mage::getResourceModel('salesrule/coupon_usage')->updateCustomerCouponTimesUsed($customerId, $coupon->getId(), true);
 
                     // Decrement rule times_used
                     if ($customerCoupon = Mage::getModel('salesrule/rule_customer')->loadByCustomerRule($customerId, $coupon->getId())) {
@@ -332,4 +332,3 @@ class Mage_SalesRule_Model_Observer
         return $this;
     }
 }
-

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
@@ -46,11 +46,11 @@ class Mage_SalesRule_Model_Resource_Coupon_Usage extends Mage_Core_Model_Resourc
     /**
      * Increment times_used counter
      *
-     *
      * @param unknown_type $customerId
      * @param unknown_type $couponId
+     * @param bool $decrement   Decrement instead of increment times_used
      */
-    public function updateCustomerCouponTimesUsed($customerId, $couponId)
+    public function updateCustomerCouponTimesUsed($customerId, $couponId, $decrement = FALSE)
     {
         $read = $this->_getReadAdapter();
         $select = $read->select();
@@ -60,11 +60,11 @@ class Mage_SalesRule_Model_Resource_Coupon_Usage extends Mage_Core_Model_Resourc
 
         $timesUsed = $read->fetchOne($select, array(':coupon_id' => $couponId, ':customer_id' => $customerId));
 
-        if ($timesUsed > 0) {
+        if ($timesUsed !== FALSE && $timesUsed > 0) {
             $this->_getWriteAdapter()->update(
                 $this->getMainTable(),
                 array(
-                    'times_used' => $timesUsed + 1
+                    'times_used' => $timesUsed + ($decrement ? -1 : 1)
                 ),
                 array(
                     'coupon_id = ?' => $couponId,
@@ -98,9 +98,9 @@ class Mage_SalesRule_Model_Resource_Coupon_Usage extends Mage_Core_Model_Resourc
         if ($read && $couponId && $customerId) {
             $select = $read->select()
                 ->from($this->getMainTable())
-                ->where('customer_id =:customet_id')
+                ->where('customer_id =:customer_id')
                 ->where('coupon_id = :coupon_id');
-            $data = $read->fetchRow($select, array(':coupon_id' => $couponId, ':customet_id' => $customerId));
+            $data = $read->fetchRow($select, array(':coupon_id' => $couponId, ':customer_id' => $customerId));
             if ($data) {
                 $object->setData($data);
             }

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
@@ -60,7 +60,7 @@ class Mage_SalesRule_Model_Resource_Coupon_Usage extends Mage_Core_Model_Resourc
 
         $timesUsed = $read->fetchOne($select, array(':coupon_id' => $couponId, ':customer_id' => $customerId));
 
-        if ($timesUsed !== FALSE && $timesUsed > 0) {
+        if ($timesUsed !== false && $timesUsed > 0) {
             $this->_getWriteAdapter()->update(
                 $this->getMainTable(),
                 array(

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
@@ -50,7 +50,7 @@ class Mage_SalesRule_Model_Resource_Coupon_Usage extends Mage_Core_Model_Resourc
      * @param unknown_type $couponId
      * @param bool $decrement   Decrement instead of increment times_used
      */
-    public function updateCustomerCouponTimesUsed($customerId, $couponId, $decrement = FALSE)
+    public function updateCustomerCouponTimesUsed($customerId, $couponId, $decrement = false)
     {
         $read = $this->_getReadAdapter();
         $select = $read->select();

--- a/app/code/core/Mage/SalesRule/etc/config.xml
+++ b/app/code/core/Mage/SalesRule/etc/config.xml
@@ -112,6 +112,14 @@
                     </salesrule>
                 </observers>
             </sales_order_place_after>
+            <sales_order_payment_cancel>
+                <observers>
+                    <salesrule>
+                        <class>salesrule/observer</class>
+                        <method>sales_order_paymentCancel</method>
+                    </salesrule>
+                </observers>
+            </sales_order_payment_cancel>
             <sales_quote_config_get_product_attributes>
                 <observers>
                     <salesrule>


### PR DESCRIPTION
To implement this cleanly in the observer (without instantiating new connection objects, fetching records, etc.) I added a parameter `$decrement` to `updateCustomerCouponTimesUsed` which should be a non-breaking change.

fixes #167