### PR TITLE
Allow access to current order

### DIFF
--- a/app/code/core/Mage/Sales/Model/Service/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Service/Quote.php
@@ -180,6 +180,7 @@ class Mage_Sales_Model_Service_Quote
         $transaction->addCommitCallback(array($order, 'place'));
         $transaction->addCommitCallback(array($order, 'save'));
 
+        Mage::unregister('current_order');
         Mage::register('current_order', $order);
         
         /**

--- a/app/code/core/Mage/Sales/Model/Service/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Service/Quote.php
@@ -180,6 +180,8 @@ class Mage_Sales_Model_Service_Quote
         $transaction->addCommitCallback(array($order, 'place'));
         $transaction->addCommitCallback(array($order, 'save'));
 
+        Mage::register('current_order', $order);
+        
         /**
          * We can use configuration data for declare new order status
          */


### PR DESCRIPTION
It's a pain in Magento to get the order currently being created. This would be the cleanest solution, even though you could build on the `checkout_type_onepage_save_order` event, but I don't like that. You'd also need to make sure the event is always first and it created clutter.

Magento uses the registry and `current_` prefix for everything, so why not here?

I understand that for Magento 2 this would be a big no-no, but for Magento 1 I think this is perfectly acceptable and would make a lot of people happy.