### PR TITLE
Replace utf8 by utf8mb4

### DIFF
--- a/app/code/core/Mage/Cron/sql/cron_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Cron/sql/cron_setup/mysql4-install-0.7.0.php
@@ -19,8 +19,6 @@ $installer->startSetup();
 
 $installer->run("
 
-SET NAMES utf8;
-
 SET SQL_MODE='';
 
 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO';

--- a/app/code/core/Mage/Install/etc/config.xml
+++ b/app/code/core/Mage/Install/etc/config.xml
@@ -84,8 +84,8 @@
         <databases>
             <mysql4>
                 <type>pdo_mysql</type>
-                <initStatements>SET NAMES utf8</initStatements>
-                <min_version>4.1.20</min_version>
+                <initStatements>SET NAMES utf8mb4</initStatements>
+                <min_version>5.5.3</min_version>
                 <extensions>
                     <pdo_mysql>1</pdo_mysql>
                 </extensions>

--- a/app/etc/config.xml
+++ b/app/etc/config.xml
@@ -27,7 +27,7 @@
                     <password/>
                     <dbname>openmage_lts</dbname>
                     <model>mysql4</model>
-                    <initStatements>SET NAMES utf8</initStatements>
+                    <initStatements>SET NAMES utf8mb4</initStatements>
                     <type>pdo_mysql</type>
                     <active>0</active>
                     <persistent>0</persistent>


### PR DESCRIPTION
For #430. This allow (partially, because this doesn't change database column) use emojis in database for new install. For existing install, edit manually app/etc/local.xml and change utf8 by utf8mb4.