### PR TITLE
fix array_intersect

### DIFF
--- a/app/code/core/Mage/CatalogSearch/Model/Indexer/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Indexer/Fulltext.php
@@ -335,6 +335,7 @@ class Mage_CatalogSearch_Model_Indexer_Fulltext extends Mage_Index_Model_Indexer
             $attributeCollection = Mage::getResourceModel('catalog/product_attribute_collection');
             $attributeCollection->addIsSearchableFilter();
 
+            $this->_searchableAttributes = [];
             foreach ($attributeCollection as $attribute) {
                 $this->_searchableAttributes[] = $attribute->getAttributeCode();
             }


### PR DESCRIPTION
When there is no searchable attributes.

2020-06-12T08:41:42+00:00 DEBUG (7): Exception message: Warning: array_intersect(): Expected parameter 1 to be an array, null given  in app/code/core/Mage/CatalogSearch/Model/Indexer/Fulltext.php on line 305