### PR TITLE
Admin's password validation during Api's role/user removing process

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Api/Buttons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Buttons.php
@@ -65,14 +65,9 @@ class Mage_Adminhtml_Block_Api_Buttons extends Mage_Adminhtml_Block_Template
             $this->getLayout()->createBlock('adminhtml/widget_button')
                 ->setData(array(
                     'label'     => Mage::helper('adminhtml')->__('Delete Role'),
-                    'onclick'   => 'deleteConfirm(\''
-                        . Mage::helper('core')->jsQuoteEscape(
-                            Mage::helper('adminhtml')->__('Are you sure you want to do this?'),
-                            true
-                        )
-                        . '\', \''
-                        . $this->getUrlSecure('*/*/delete', array('rid' => $this->getRequest()->getParam('rid')))
-                        . '\')',
+                    'onclick'   => 'if(confirm(\'' . Mage::helper('core')->jsQuoteEscape(
+                            Mage::helper('adminhtml')->__('Are you sure you want to do this?')
+                        ) . '\')) roleForm.submit(\'' . $this->getUrl('*/*/delete') . '\'); return false;',
                     'class' => 'delete'
                 ))
         );

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit.php
@@ -43,6 +43,9 @@ class Mage_Adminhtml_Block_Api_User_Edit extends Mage_Adminhtml_Block_Widget_For
 
         $this->_updateButton('save', 'label', Mage::helper('adminhtml')->__('Save User'));
         $this->_updateButton('delete', 'label', Mage::helper('adminhtml')->__('Delete User'));
+        $this->_updateButton('delete', 'onclick', 'if(confirm(\'' . Mage::helper('core')->jsQuoteEscape(
+                Mage::helper('adminhtml')->__('Are you sure you want to do this?')
+            ) . '\')) editForm.submit(\'' . $this->getUrl('*/*/delete') . '\'); return false;');
     }
 
     public function getHeaderText()

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Buttons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Buttons.php
@@ -65,13 +65,9 @@ class Mage_Adminhtml_Block_Permissions_Buttons extends Mage_Adminhtml_Block_Temp
             $this->getLayout()->createBlock('adminhtml/widget_button')
                 ->setData(array(
                     'label'     => Mage::helper('adminhtml')->__('Delete Role'),
-                    'onclick'   => 'deleteConfirm(\''
-                        . Mage::helper('core')->jsQuoteEscape(
+                    'onclick'   => 'if(confirm(\'' . Mage::helper('core')->jsQuoteEscape(
                             Mage::helper('adminhtml')->__('Are you sure you want to do this?')
-                        )
-                        . '\', \''
-                        . $this->getUrlSecure('*/*/delete', array('rid' => $this->getRequest()->getParam('rid')))
-                        . '\')',
+                        ) . '\')) roleForm.submit(\'' . $this->getUrl('*/*/delete') . '\'); return false;',
                     'class' => 'delete'
                 ))
         );

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit.php
@@ -43,6 +43,9 @@ class Mage_Adminhtml_Block_Permissions_User_Edit extends Mage_Adminhtml_Block_Wi
 
         $this->_updateButton('save', 'label', Mage::helper('adminhtml')->__('Save User'));
         $this->_updateButton('delete', 'label', Mage::helper('adminhtml')->__('Delete User'));
+        $this->_updateButton('delete', 'onclick', 'if(confirm(\'' . Mage::helper('core')->jsQuoteEscape(
+                Mage::helper('adminhtml')->__('Are you sure you want to do this?')
+            ) . '\')) editForm.submit(\'' . $this->getUrl('*/*/delete') . '\'); return false;');
     }
 
     public function getHeaderText()

--- a/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
@@ -116,7 +116,20 @@ class Mage_Adminhtml_Api_RoleController extends Mage_Adminhtml_Controller_Action
 
     public function deleteAction()
     {
-        $rid = $this->getRequest()->getParam('rid', false);
+        $rid = $this->getRequest()->getParam('role_id', false);
+
+        //Validate current admin password
+        $currentPassword = $this->getRequest()->getParam('current_password', null);
+        $this->getRequest()->setParam('current_password', null);
+        $result = $this->_validateCurrentPassword($currentPassword);
+
+        if (is_array($result)) {
+            foreach ($result as $error) {
+                $this->_getSession()->addError($error);
+            }
+            $this->_redirect('*/*/editrole', array('rid' => $rid));
+            return;
+        }
 
         try {
             Mage::getModel("api/roles")->load($rid)->delete();

--- a/app/code/core/Mage/Adminhtml/controllers/Api/UserController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Api/UserController.php
@@ -184,8 +184,22 @@ class Mage_Adminhtml_Api_UserController extends Mage_Adminhtml_Controller_Action
 
     public function deleteAction()
     {
-        if ($id = $this->getRequest()->getParam('user_id')) {
+        $id = $this->getRequest()->getParam('user_id');
 
+        //Validate current admin password
+        $currentPassword = $this->getRequest()->getParam('current_password', null);
+        $this->getRequest()->setParam('current_password', null);
+        $result = $this->_validateCurrentPassword($currentPassword);
+
+        if (is_array($result)) {
+            foreach ($result as $error) {
+                $this->_getSession()->addError($error);
+            }
+            $this->_redirect('*/*/edit', array('user_id' => $id));
+            return;
+        }
+
+        if ($id) {
             try {
                 $model = Mage::getModel('api/user')->load($id);
                 $model->delete();
@@ -195,7 +209,7 @@ class Mage_Adminhtml_Api_UserController extends Mage_Adminhtml_Controller_Action
             }
             catch (Exception $e) {
                 Mage::getSingleton('adminhtml/session')->addError($e->getMessage());
-                $this->_redirect('*/*/edit', array('user_id' => $this->getRequest()->getParam('user_id')));
+                $this->_redirect('*/*/edit', array('user_id' => $id));
                 return;
             }
         }

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
@@ -186,6 +186,21 @@ class Mage_Adminhtml_Permissions_UserController extends Mage_Adminhtml_Controlle
 
     public function deleteAction()
     {
+        $id = $this->getRequest()->getParam('user_id');
+
+        //Validate current admin password
+        $currentPassword = $this->getRequest()->getParam('current_password', null);
+        $this->getRequest()->setParam('current_password', null);
+        $result = $this->_validateCurrentPassword($currentPassword);
+
+        if (is_array($result)) {
+            foreach ($result as $error) {
+                $this->_getSession()->addError($error);
+            }
+            $this->_redirect('*/*/edit', array('user_id' => $id));
+            return;
+        }
+
         $currentUser = Mage::getSingleton('admin/session')->getUser();
 
         if ($id = $this->getRequest()->getParam('user_id')) {

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Buttons.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Buttons.php
@@ -124,9 +124,9 @@ class Mage_Api2_Block_Adminhtml_Roles_Buttons extends Mage_Adminhtml_Block_Templ
         }
 
         $this->getChild('deleteButton')->setData('onclick', sprintf(
-            "deleteConfirm('%s', '%s')",
+            "if(confirm('%s')) roleForm.submit('%s'); return false;",
             Mage::helper('core')->jsQuoteEscape(Mage::helper('adminhtml')->__('Are you sure you want to do this?')),
-            $this->getUrlSecure('*/*/delete', array('id' => $this->getRole()->getId()))
+            $this->getUrl('*/*/delete')
         ));
 
         return $this->getChildHtml('deleteButton');

--- a/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/RoleController.php
+++ b/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/RoleController.php
@@ -270,6 +270,19 @@ class Mage_Api2_Adminhtml_Api2_RoleController extends Mage_Adminhtml_Controller_
     {
         $id = $this->getRequest()->getParam('id', false);
 
+        //Validate current admin password
+        $currentPassword = $this->getRequest()->getParam('current_password', null);
+        $this->getRequest()->setParam('current_password', null);
+        $result = $this->_validateCurrentPassword($currentPassword);
+
+        if (is_array($result)) {
+            foreach ($result as $error) {
+                $this->_getSession()->addError($error);
+            }
+            $this->_redirect('*/*/edit', array('id' => $id));
+            return;
+        }
+
         try {
             /** @var Mage_Api2_Model_Acl_Global_Role $model */
             $model = Mage::getModel("api2/acl_global_role");

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit.php
@@ -76,6 +76,9 @@ class Mage_Oauth_Block_Adminhtml_Oauth_Consumer_Edit extends Mage_Adminhtml_Bloc
         $this->_updateButton('save', 'label', $this->__('Save'));
         $this->_updateButton('save', 'id', 'save_button');
         $this->_updateButton('delete', 'label', $this->__('Delete'));
+        $this->_updateButton('delete', 'onclick', 'if(confirm(\'' . Mage::helper('core')->jsQuoteEscape(
+                Mage::helper('adminhtml')->__('Are you sure you want to do this?')
+            ) . '\')) editForm.submit(\'' . $this->getUrl('*/*/delete') . '\'); return false;');
 
         /** @var Mage_Admin_Model_Session $session */
         $session = Mage::getSingleton('admin/session');

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/ConsumerController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/ConsumerController.php
@@ -285,6 +285,20 @@ class Mage_Oauth_Adminhtml_Oauth_ConsumerController extends Mage_Adminhtml_Contr
     public function deleteAction()
     {
         $consumerId = (int) $this->getRequest()->getParam('id');
+
+        //Validate current admin password
+        $currentPassword = $this->getRequest()->getParam('current_password', null);
+        $this->getRequest()->setParam('current_password', null);
+        $result = $this->_validateCurrentPassword($currentPassword);
+
+        if (is_array($result)) {
+            foreach ($result as $error) {
+                $this->_getSession()->addError($error);
+            }
+            $this->_redirect('*/*/edit', array('id' => $consumerId));
+            return;
+        }
+
         if ($consumerId) {
             try {
                 /** @var Mage_Oauth_Model_Consumer $consumer */


### PR DESCRIPTION
This PR adds the admin's password validation during api's role/user is removing. The password validation is present on save but it is missing on delete.