### PR TITLE
Array and string offset access syntax with curly braces

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Alphanum.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Alphanum.php
@@ -77,7 +77,7 @@ class Mage_Eav_Model_Entity_Increment_Alphanum extends Mage_Eav_Model_Entity_Inc
                 $p = 0;
                 $bumpNextChar = true;
             }
-            $nextId = $chars{$p}.$nextId;
+            $nextId = $chars[$p].$nextId;
         }
 
         return $this->format($nextId);

--- a/app/code/core/Mage/Eav/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Setup.php
@@ -1231,14 +1231,14 @@ class Mage_Eav_Model_Entity_Setup extends Mage_Core_Model_Resource_Setup
                 if (!empty($attr['frontend'])) {
                     if ('_' === $attr['frontend']) {
                         $attr['frontend'] = $frontendPrefix;
-                    } elseif ('_' === $attr['frontend']{0}) {
+                    } elseif (strpos($attr['frontend'], '_') === 0) {
                         $attr['frontend'] = $frontendPrefix.$attr['frontend'];
                     }
                 }
                 if (!empty($attr['source'])) {
                     if ('_' === $attr['source']) {
                         $attr['source'] = $sourcePrefix;
-                    } elseif ('_' === $attr['source']{0}) {
+                    } elseif (strpos($attr['source'], '_') === 0) {
                         $attr['source'] = $sourcePrefix . $attr['source'];
                     }
                 }

--- a/lib/Net/IDNA2.php
+++ b/lib/Net/IDNA2.php
@@ -2700,7 +2700,7 @@ class Net_IDNA2
 
         for ($enco_idx = ($delim_pos)? ($delim_pos + 1) : 0; $enco_idx < $enco_len; ++$deco_len) {
             for ($old_idx = $idx, $w = 1, $k = $this->_base; 1 ; $k += $this->_base) {
-                $digit = $this->_decodeDigit($encoded{$enco_idx++});
+                $digit = $this->_decodeDigit($encoded[$enco_idx++]);
                 $idx += $digit * $w;
 
                 $t = ($k <= $bias) ?
@@ -3112,7 +3112,7 @@ class Net_IDNA2
         $mode = 'next';
         $test = 'none';
         for ($k = 0; $k < $inp_len; ++$k) {
-            $v = ord($input{$k}); // Extract byte from input string
+            $v = ord($input[$k]); // Extract byte from input string
 
             if ($v < 128) { // We found an ASCII char - put into stirng as is
                 $output[$out_len] = $v;
@@ -3279,7 +3279,7 @@ class Net_IDNA2
                 $out_len++;
                 $output[$out_len] = 0;
             }
-            $output[$out_len] += ord($input{$i}) << (8 * (3 - ($i % 4) ) );
+            $output[$out_len] += ord($input[$i]) << (8 * (3 - ($i % 4) ) );
         }
         return $output;
     }


### PR DESCRIPTION
Fixed: "PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated" for php7.4

Ref #829, #859 (@kkrieger85)