### PR TITLE
Fix broken file upload for downloadables caused by PATCH SUPEE-11314

### DIFF
--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -287,7 +287,6 @@ class Mage_Downloadable_Block_Adminhtml_Catalog_Product_Edit_Tab_Downloadable_Li
             ->setFileParameterName($type)
             ->setTarget(
                 Mage::getModel('adminhtml/url')
-                    ->addSessionParam()
                     ->getUrl('*/downloadable_file/upload', array('type' => $type, '_secure' => true))
             );
         $this->getMiscConfig()

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
@@ -188,7 +188,6 @@ class Mage_Downloadable_Block_Adminhtml_Catalog_Product_Edit_Tab_Downloadable_Sa
             ->setFileParameterName('samples')
             ->setTarget(
                 Mage::getModel('adminhtml/url')
-                    ->addSessionParam()
                     ->getUrl('*/downloadable_file/upload', array('type' => 'samples', '_secure' => true))
             );
         $this->getMiscConfig()


### PR DESCRIPTION
Removed session params from upload URL to allow file uploads for downloadable products.

Signed-off-by: Frank Rochlitzer <f.rochlitzer@b3-it.de>