### PR TITLE
Fix bug on filter issues in Role Users.

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Role/Grid/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Role/Grid/User.php
@@ -157,7 +157,7 @@ class Mage_Adminhtml_Block_Permissions_Role_Grid_User extends Mage_Adminhtml_Blo
     protected function _getUsers($json=false)
     {
         if ( $this->getRequest()->getParam('in_role_user') != "" ) {
-            return (int)$this->getRequest()->getParam('in_role_user');
+            return $this->getRequest()->getParam('in_role_user');
         }
         $roleId = ( $this->getRequest()->getParam('rid') > 0 ) ? $this->getRequest()->getParam('rid') : Mage::registry('RID');
         $users  = Mage::getModel('admin/roles')->setId($roleId)->getRoleUsers();


### PR DESCRIPTION
Unable to filter Role Users in Permission->Roles->Role Users or go to next Page or change the number of rows displayed per page.

This bug is introduced in pull request https://github.com/OpenMage/magento-lts/commit/d644768c998cf37c0f633482e8765e4e630457cc

Mage_Adminhtml_Block_Permissions_Role_Grid_User->_getUsers() is returning an int instead of an array on line 160.