### PR TITLE
Create a global config cache rather than a config cache per store

### DIFF
--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -655,9 +655,11 @@ class Mage_Core_Model_App
         $websiteGroups = array();
         $groupStores   = array();
 
+        $storeCollection->initConfigCache();
+
         foreach ($storeCollection as $store) {
             /** @var Mage_Core_Model_Store $store */
-            $store->initConfigCache();
+            // $store->initConfigCache();
             $store->setWebsite($websiteCollection->getItemById($store->getWebsiteId()));
             $store->setGroup($groupCollection->getItemById($store->getGroupId()));
 

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -659,7 +659,6 @@ class Mage_Core_Model_App
 
         foreach ($storeCollection as $store) {
             /** @var Mage_Core_Model_Store $store */
-            // $store->initConfigCache();
             $store->setWebsite($websiteCollection->getItemById($store->getWebsiteId()));
             $store->setGroup($groupCollection->getItemById($store->getGroupId()));
 

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -434,6 +434,32 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
     }
 
     /**
+     * Get the basic configuration nodes for this store view
+     * @return array
+     */
+    public function getConfigCache()
+    {
+        $data = [];
+
+        foreach ($this->_configCacheBaseNodes as $node) {
+            $data[$node] = $this->getConfig($node);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Sets the internal configuration cache for this store view
+     * @param array $data
+     * @return $this
+     */
+    public function setConfigCache($data)
+    {
+        $this->_configCache = $data;
+        return $this;
+    }
+
+    /**
      * Set config value for CURRENT model
      *
      * This value don't save in config


### PR DESCRIPTION
Related to: https://github.com/OpenMage/magento-lts/issues/925

Magento stores a small configuration cache with a limited number of parameters where each cache key is scoped to a store. For shops with a lot of store view this will generate n-queries (where n is the number of stores) to the cache backend.

This patch will add a initConfigCache method to the collection level rather than applying it per store. It will loop through all the stores and assign the configuration cache to each store therefore making just one query to the cache backend.

This is an draft PR to get feedback. It works well in my test environment reducing the number of requests to Redis from 99 to 1.