### PR TITLE
Remove unneeded docblock method definition

### DIFF
--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -41,7 +41,6 @@
  * @method $this setCacheTags(array $value)
  * @method $this setClass(string $value)
  * @method $this setDisabled(bool $value)
- * @method string getFormKey()
  * @method $this setLabel(string $value)
  * @method $this setOnclick(string $value)
  * @method string getPosition()


### PR DESCRIPTION
The method getFormKey() exists in Mage_Core_Block_Abstract, so no need to define it with `@method`