### PR TITLE
Fixed issue with admin login after forced password rehash

### DIFF
--- a/app/code/core/Mage/Admin/Model/Observer.php
+++ b/app/code/core/Mage/Admin/Model/Observer.php
@@ -147,7 +147,7 @@ class Mage_Admin_Model_Observer
                 Mage_Core_Model_Encryption::HASH_VERSION_SHA256
             )
         ) {
-            Mage::getModel('admin/user')->load($user->getId())
+            $user
                 ->setNewPassword($password)->setForceNewPassword(true)
                 ->save();
             $user->setPasswordUpgraded(true);


### PR DESCRIPTION
Admin user is logged to panel after second attempt because of setting new password on newly loaded admin user model instead of use already loaded and present in observer.