### PR TITLE
Wexo M1 Fixes

### DIFF
--- a/app/code/core/Mage/Adminhtml/etc/config.xml
+++ b/app/code/core/Mage/Adminhtml/etc/config.xml
@@ -87,6 +87,14 @@
                     </configuration_files_access_level_verification>
                 </observers>
             </admin_user_authenticate_after>
+            <controller_action_predispatch>
+                <observers>
+                    <bad_controller_login_prevention>
+                        <class>adminhtml/observer</class>
+                        <method>preventBadControllerLogin</method>
+                    </bad_controller_login_prevention>
+                </observers>
+            </controller_action_predispatch>
         </events>
     </global>
     <admin>

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
@@ -385,6 +385,11 @@ class Mage_Cms_Model_Wysiwyg_Images_Storage extends Varien_Object
         $image->open($source);
         $width = $this->getConfigData('resize_width');
         $height = $this->getConfigData('resize_height');
+
+        if ($width == 0 || $height == 0) {
+            return false;
+        }
+
         $image->keepAspectRatio($keepRation);
         $image->resize($width, $height);
         $dest = $targetDir


### PR DESCRIPTION
In this pull request there are two fixes which improves the stability and security on the Magento 1 shops we manage.

The "preventBadControllerLogin" fix prevents posting of login requests to controllers that is not an instance of "Mage_Adminhtml_IndexController" which is the default login controller.
This helps to stop brute force attacks on controllers that has been configured wrong in the config.xml.
 
The fix in "app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php" is to prevent the the GD2 library from throwing an exception when trying to resize to 0 width or height.