### PR TITLE
Prevent resize to 0 width or height.

### DIFF
--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
@@ -385,6 +385,11 @@ class Mage_Cms_Model_Wysiwyg_Images_Storage extends Varien_Object
         $image->open($source);
         $width = $this->getConfigData('resize_width');
         $height = $this->getConfigData('resize_height');
+
+        if ($width == 0 || $height == 0) {
+            return false;
+        }
+
         $image->keepAspectRatio($keepRation);
         $image->resize($width, $height);
         $dest = $targetDir


### PR DESCRIPTION
Splitting previous Pull Request into 2 as asked by @tmotyl in https://github.com/OpenMage/magento-lts/pull/1076

This prevents a exception thrown in the GD2 class when resizing to 0 width or height.