### PR TITLE
Modified contributors badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 <p align="center">
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-100-orange.svg?style=flat-square)](#contributors-)
+
+[contributors-logo]: https://img.shields.io/badge/all_contributors-100-orange.svg?style=flat-square 'Number of contributors on All-Contributors'
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
+[![All Contributors][contributors-logo]](#contributors-)
 <a href="https://travis-ci.org/openmage/magento-lts"><img src="https://travis-ci.org/openmage/magento-lts.svg" alt="Build Status"></a>
 <a href="https://packagist.org/packages/openmage/magento-lts"><img src="https://poser.pugx.org/openmage/magento-lts/d/total.svg" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/openmage/magento-lts"><img src="https://poser.pugx.org/openmage/magento-lts/license.svg" alt="License"></a>


### PR DESCRIPTION
It seems that the recent contributor badge is not well displayed on github:
![Capture d’écran de 2020-07-03 04-46-55](https://user-images.githubusercontent.com/20956510/86426593-5d2ebc80-bce8-11ea-8b3d-fa1966b2f7f6.png)

I don't know if it's a bug of the all-contributors repo or a github markdown issue but I followed this comment : https://github.com/all-contributors/all-contributors/issues/361#issuecomment-637166066 in order to have a well displayed badge : 

![Capture d’écran de 2020-07-03 04-50-49](https://user-images.githubusercontent.com/20956510/86426770-cc0c1580-bce8-11ea-86a4-5f6809839fc9.png)

For information, it seems that it's working because of the empty line after html comment `<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->` . If I remove this empty line, it's not working anymore...
