### PR TITLE
Added dash(-) as an allowed character for store code

### DIFF
--- a/app/code/core/Mage/Core/Model/Resource/Store.php
+++ b/app/code/core/Mage/Core/Model/Resource/Store.php
@@ -64,9 +64,9 @@ class Mage_Core_Model_Resource_Store extends Mage_Core_Model_Resource_Db_Abstrac
      */
     protected function _beforeSave(Mage_Core_Model_Abstract $model)
     {
-        if (!preg_match('/^[a-z]+[a-z0-9_]*$/', $model->getCode())) {
+        if (!preg_match('/^[a-z]+[a-z0-9_\-]*$/', $model->getCode())) {
             Mage::throwException(
-                Mage::helper('core')->__('The store code may contain only letters (a-z), numbers (0-9) or underscore(_), the first character must be a letter')
+                Mage::helper('core')->__('The store code may contain only letters (a-z), numbers (0-9), underscore(_) or dash(-), the first character must be a letter')
             );
         }
 

--- a/app/locale/en_US/Mage_Core_LTS.csv
+++ b/app/locale/en_US/Mage_Core_LTS.csv
@@ -1,0 +1,1 @@
+"The store code may contain only letters (a-z), numbers (0-9), underscore(_) or dash(-), the first character must be a letter","The store code may contain only letters (a-z), numbers (0-9), underscore(_) or dash(-), the first character must be a letter"


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
Allow dash in store code
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Currently, it is not possible to create a store with a store code containing dash (-). When using the feature "add store code in url", this can lead to conflicts with SEO purposes.

There is a lot of literature (for example https://stackoverflow.com/a/2318376/7497291) on it and I am not a SEO specialist but what I know is that I have often been asked to add the dash in the store code and I had to rewrite this resource model. That's why I submit this PR.

Furthermore, the reason why dash is not allowed in Magento is not clear for me. The only answer I found is here :
https://magento.stackexchange.com/a/237309/50208 

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a store with code "en-uk". This is not possible without this PR and this becomes possible with it.

### Questions or comments

I am not sure it was necessary to create a Mage_Core_LTS.csv file : The text I changed is not used anymore in the source code,  so I hesitated to modify directly the Mage_Core.csv file because it could be considered as dead code. But, if for some reason, somebody has specific code using this old key and need this old translated key, this will not break it. That's why I created a new csv file as suggested in the README.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
