### PR TITLE
Clean review_entity_summary when reviews are deleted

### DIFF
--- a/app/code/core/Mage/Review/Model/Resource/Review.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review.php
@@ -249,6 +249,25 @@ class Mage_Review_Model_Resource_Review extends Mage_Core_Model_Resource_Db_Abst
      */
     public function afterDeleteCommit(Mage_Core_Model_Abstract $object)
     {
+        $read_adapter = $this->_getReadAdapter();
+        $select = $read_adapter->select()
+            ->from(
+                $this->_reviewTable,
+                array(
+                    'review_count' => new Zend_Db_Expr('COUNT(*)')
+                )
+            )
+            ->where("entity_id = ?", $object->getEntityId())
+            ->where("entity_pk_value = ?", $object->getEntityPkValue());
+        $total_reviews = $read_adapter->fetchOne($select);
+        if ($total_reviews == 0) {
+            $this->_getWriteAdapter()->delete($this->_aggregateTable, array(
+                'entity_type = ?'   => $object->getEntityId(),
+                'entity_pk_value = ?' => $object->getEntityPkValue()
+            ));
+            return $this;
+        }
+
         $this->aggregate($object);
 
         // reaggregate ratings, that depended on this review
@@ -324,6 +343,9 @@ class Mage_Review_Model_Resource_Review extends Mage_Core_Model_Resource_Db_Abst
                 true,
                 $ratingSummaryObject->getStoreId()
             );
+
+            Mage::log($reviewsCount . " " . $ratingSummaryObject->getStoreId());
+
             $select = $readAdapter->select()
                 ->from($this->_aggregateTable)
                 ->where('entity_pk_value = :pk_value')

--- a/app/code/core/Mage/Review/Model/Resource/Review.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review.php
@@ -343,9 +343,6 @@ class Mage_Review_Model_Resource_Review extends Mage_Core_Model_Resource_Db_Abst
                 true,
                 $ratingSummaryObject->getStoreId()
             );
-
-            Mage::log($reviewsCount . " " . $ratingSummaryObject->getStoreId());
-
             $select = $readAdapter->select()
                 ->from($this->_aggregateTable)
                 ->where('entity_pk_value = :pk_value')


### PR DESCRIPTION
This PR should fix bug https://github.com/OpenMage/magento-lts/issues/1102

When deleting all reviews of an entity the review_entity_summary isn't cleaned correctly. I tried many different ways to approach the problem but the implemented one seems the easiest and most effective.

Also, the default implementation some of the methods of the Mage_Review modules seem incomplete, they lack the "entity_type" parameters which make the implementations prone to errors when different entities have the same PkValue.