### PR TITLE
Execute the total model 'shipping' after 'tax_subtotal'

### DIFF
--- a/app/code/core/Mage/Tax/etc/config.xml
+++ b/app/code/core/Mage/Tax/etc/config.xml
@@ -162,7 +162,7 @@
                 <totals>
                     <tax_subtotal>
                         <class>tax/sales_total_quote_subtotal</class>
-                        <after>subtotal,nominal,shipping,freeshipping</after>
+                        <after>subtotal,nominal,freeshipping</after>
                         <before>tax,discount</before>
                     </tax_subtotal>
                     <tax_shipping>


### PR DESCRIPTION
This pull request solves the problem I've mentioned earlier in #80 :

### Description (*)
This is a major change which is causing troubles for the calculation of shipping rate! Is "shipping" really needed as prerequisite for subtotal?
A: shipping is not included within subtotal
B: some shipping methods calculate there rate based on subtotal

This change led to strange behavior: once the totals are already calculated and stored/cached then the subtotal doesn't include tax anymore (as expected) BUT when totals will be collected first time the "shipping" total is executed before "tax_subtotal", so the subtotal still contains tax, which leads to inconsistency...

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#80

### Manual testing scenarios (*)
This issue applies only to external shipping modules like matrixrates from webshopapps (I haven't tested it but it might apply to tablerates from Magento core, too)
1. configure two shipping rates for a certain threshold (e.g. rate A for subtotal < 10 EUR and rate B for subtotal > 10 EUR)
2. add a product to cart (with tax 11 EUR, and without tax 9.24 EUR)
3. in step "shipping method" I can choose rate A since subtotal is expected to be without tax
4. in final step I click "place order" and get an error message "Please select a shipping method"
5. I go back to step shipping method and now I get rate B

This different behavior depends on whether totals are already calculated and cached (then subtotal does not contain tax anymore because subtotal_tax is already collected) or not (then the total model "shipping" is executed before "subtotal_tax")!

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
