### PR TITLE
Only resize images when their file size has improved

### DIFF
--- a/app/code/core/Mage/Core/Model/File/Validator/Image.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/Image.php
@@ -98,6 +98,7 @@ class Mage_Core_Model_File_Validator_Image
                 //replace tmp image with re-sampled copy to exclude images with malicious data
                 $image = imagecreatefromstring(file_get_contents($filePath));
                 if ($image !== false) {
+                    $tmpFilePath = $filePath . '_';
                     $img = imagecreatetruecolor($imageWidth, $imageHeight);
                     imagealphablending($img, false);
                     imagecopyresampled($img, $image, 0, 0, 0, 0, $imageWidth, $imageHeight, $imageWidth, $imageHeight);
@@ -119,17 +120,24 @@ class Mage_Core_Model_File_Validator_Image
                             if (!imageistruecolor($image)) {
                                 imagetruecolortopalette($img, false, imagecolorstotal($image));
                             }
-                            imagegif($img, $filePath);
+                            imagegif($img, $tmpFilePath);
                             break;
                         case IMAGETYPE_JPEG:
-                            imagejpeg($img, $filePath, 100);
+                            imagejpeg($img, $tmpFilePath, 100);
                             break;
                         case IMAGETYPE_PNG:
-                            imagepng($img, $filePath);
+                            imagepng($img, $tmpFilePath);
                             break;
                         default:
                             break;
                     }
+                    // START optimizing file size on upload
+                    if (filesize($tmpFilePath) < filesize($filePath)) {
+                        rename($tmpFilePath, $filePath);
+                    } else {
+                        unlink($tmpFilePath);
+                    }
+                    // END optimizing file size on upload
 
                     imagedestroy($img);
                     imagedestroy($image);


### PR DESCRIPTION
This change is fixing issues with increasing file sizes after image upload.

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
After uploading already web optimized images it appears that some of them have increased image size. This fix keeps resized images only when their size is decreased in comparison to the original uploaded one.

### Manual testing scenarios (*)
1. Upload different sized images in  WYSIWYG editor
2. Check their sizes in /media/

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
