### PR TITLE
Ensure correctly sorted block children after unset some of them

### DIFF
--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -755,6 +755,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      */
     public function sortChildren($force = false)
     {
+        $this->_sortedChildren = array_values($this->_sortedChildren); // reset indexes which might have gaps after unsetting blocks
         foreach ($this->_sortInstructions as $name => $list) {
             list($siblingName, $after, $exists) = $list;
             if ($exists && !$force) {


### PR DESCRIPTION
Reset indices of block children array since they have gaps after unsetting blocks... this is causing wrong sort order

### Description (*)
To "unset" blocks in layout XML is causing missing numbers in the array index of block children. This leads to wrong positions of child blocks (despite their attribute values of after/before in block definition) since the sort algorithm can not handle missing numbers in array index.

### Manual testing scenarios (*)
1. add several child blocks in layout XML by using attribute before="" or after=""
2. unset at least two of them
3. if you are lucky the sort order of child blocks is still correct (by accident) but depending on what blocks are unset it will be wrong (using xdebug will show more details)

### Contribution checklist (*)

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
