### PR TITLE
Ensure there are no emails without recipient in email queue

### DIFF
--- a/app/code/core/Mage/Core/Model/Email/Queue.php
+++ b/app/code/core/Mage/Core/Model/Email/Queue.php
@@ -95,7 +95,7 @@ class Mage_Core_Model_Email_Queue extends Mage_Core_Model_Abstract
      */
     protected function _beforeSave()
     {
-        if (empty($this->_recipients) || !is_array($this->_recipients)) {
+        if (empty($this->_recipients) || !is_array($this->_recipients) || empty($this->_recipients[0])) { // additional check of recipients information (email address)
             Mage::throwException(Mage::helper('core')->__('Message recipients data must be set.'));
         }
         return parent::_beforeSave();
@@ -238,13 +238,13 @@ class Mage_Core_Model_Email_Queue extends Mage_Core_Model_Abstract
 
                 try {
                     $mailer->send();
+                    unset($mailer);
+                    $message->setProcessedAt(Varien_Date::formatDate(true));
+                    $message->save(); // save() is throwing exception when recipient is not set
                 } catch (Exception $e) {
                     Mage::logException($e);
                 }
 
-                unset($mailer);
-                $message->setProcessedAt(Varien_Date::formatDate(true));
-                $message->save();
             }
         }
 


### PR DESCRIPTION
Additional check of email recipients in order to ensure there are no invalid emails without recipient in queue

### Description (*)
It appeared several times that there are emails without recipients in the emails queue - even if the email address is mandatory for checkout. This pull request is not fixing the origin issue but it ensures that this one wrongly added email is not blocking all queued emails which is leading to unsatisfied customers.
Consider it more as a security improvement to keep the shop running.

### Manual testing scenarios (*)
There is no known test scenario but it is solving issues that happens once every 2000 orders.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
