### PR TITLE
fix cancel order bug

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Observer.php
+++ b/app/code/core/Mage/SalesRule/Model/Observer.php
@@ -158,7 +158,7 @@ class Mage_SalesRule_Model_Observer
                     Mage::getResourceModel('salesrule/coupon_usage')->updateCustomerCouponTimesUsed($customerId, $coupon->getId(), true);
 
                     // Decrement rule times_used
-                    if ($customerCoupon = Mage::getModel('salesrule/rule_customer')->loadByCustomerRule($customerId, $coupon->getId())) {
+                    if ($customerCoupon = Mage::getModel('salesrule/rule_customer')->loadByCustomerRule($customerId, $coupon->getRuleId())) {
                         $customerCoupon->setTimesUsed($customerCoupon->getTimesUsed() - 1);
                         $customerCoupon->save();
                     }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When trying to cancel an order I was getting an error related to changes in pull request #1031. When trying to decrement times_used in salesrule_customer, you need to use rule_id and not the id of the coupon.

### Related Pull Requests
#1031
