### PR TITLE
Prevent duplicate entry when updating salesrule_coupon_usage

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
@@ -62,16 +62,19 @@ class Mage_SalesRule_Model_Resource_Coupon_Usage extends Mage_Core_Model_Resourc
         $timesUsed = $read->fetchOne($select, array(':coupon_id' => $couponId, ':customer_id' => $customerId));
 
         if ($timesUsed !== false) {
-            $this->_getWriteAdapter()->update(
-                $this->getMainTable(),
-                array(
-                    'times_used' => $timesUsed + ($decrement ? -1 : 1)
-                ),
-                array(
-                    'coupon_id = ?' => $couponId,
-                    'customer_id = ?' => $customerId,
-                )
-            );
+            $timesUsed += ($decrement ? -1 : 1);
+            if($timesUsed >= 0) {
+                $this->_getWriteAdapter()->update(
+                    $this->getMainTable(),
+                    array(
+                        'times_used' => $timesUsed
+                    ),
+                    array(
+                        'coupon_id = ?' => $couponId,
+                        'customer_id = ?' => $customerId,
+                    )
+                );
+            }
         } else {
             $this->_getWriteAdapter()->insert(
                 $this->getMainTable(),

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
@@ -61,7 +61,7 @@ class Mage_SalesRule_Model_Resource_Coupon_Usage extends Mage_Core_Model_Resourc
 
         $timesUsed = $read->fetchOne($select, array(':coupon_id' => $couponId, ':customer_id' => $customerId));
 
-        if ($timesUsed !== false && $timesUsed > 0) {
+        if ($timesUsed !== false) {
             $this->_getWriteAdapter()->update(
                 $this->getMainTable(),
                 array(


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
If you cancel a customer order with a promo code and try to place an order with the same promo code it fails because of an Integrity constraint violation: 1062 Duplicate entry on salesrule_coupon_usage since times_used goes to 0 when the order is canceled. I removed the check for $timesUsed > 0 so that it will run as an update instead of an insert.

### Related Pull Requests
<!-- related pull request placeholder -->
#1031 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#1116

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Log in to customer account
2. Place an order with a promo code
3. Cancel the order
4. While still logged in, place another order with the same promo code (This failed before making this change.)
