### PR TITLE
New event "order_status_changed_before_save"

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -2355,6 +2355,11 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
         }
 
         $this->setData('protect_code', substr(md5(uniqid(mt_rand(), true) . ':' . microtime(true)), 5, 6));
+
+        if ($this->getStatus() !== $this->getOrigData('status')) {
+            Mage::dispatchEvent('order_status_changed_before_save', ['order' => $this]);
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
### Description (*)
New event "sales_order_state_change" allows custom modules to detect an order state/status change and trigger appropriate actions. I've seen modules rewrite the order model because this was missing.

Very handy improvement.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
