### PR TITLE
Fix special price for bundle products

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
@@ -283,7 +283,7 @@ class Mage_Catalog_Model_Product_Type_Price
      */
     protected function _applySpecialPrice($product, $finalPrice)
     {
-        return self::calculateSpecialPrice(
+        return $this->calculateSpecialPrice(
             $finalPrice,
             $product->getSpecialPrice(),
             $product->getSpecialFromDate(),

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
@@ -283,7 +283,7 @@ class Mage_Catalog_Model_Product_Type_Price
      */
     protected function _applySpecialPrice($product, $finalPrice)
     {
-        return $this->calculateSpecialPrice(
+        return static::calculateSpecialPrice(
             $finalPrice,
             $product->getSpecialPrice(),
             $product->getSpecialFromDate(),


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The bug causes: only on the product detail page and in the cart is the price calculated by interpreting the special_price field, which in the Bundle products is a percentage, as if it were a fixed price.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#1135

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All automated tests passed successfully (all builds are green)
