### PR TITLE
Make Curl Client HTTP/2 compatible

### DIFF
--- a/lib/Mage/HTTP/Client/Curl.php
+++ b/lib/Mage/HTTP/Client/Curl.php
@@ -440,8 +440,8 @@ implements Mage_HTTP_IClient
                 list($name, $value) = $out;
             }
 
-            if ('' !== $name) {
-                if ('Set-Cookie' === $name) {
+            if ($name !== '') {
+                if ($name === 'Set-Cookie') {
                     if (!isset($this->_responseHeaders[$name])) {
                         $this->_responseHeaders[$name] = [];
                     }

--- a/lib/Mage/HTTP/Client/Curl.php
+++ b/lib/Mage/HTTP/Client/Curl.php
@@ -464,7 +464,7 @@ implements Mage_HTTP_IClient
      */
     protected function validateHttpVersion(array $line)
     {
-        if ($line[0] === 'HTTP/1.1') {
+        if ($line[0] === 'HTTP/1.0' || $line[0] === 'HTTP/1.1') {
             if (count($line) !== 3) {
                 $this->doError('Invalid response line returned from server: ' . implode(' ', $line));
             }

--- a/lib/Mage/HTTP/Client/Curl.php
+++ b/lib/Mage/HTTP/Client/Curl.php
@@ -421,31 +421,29 @@ implements Mage_HTTP_IClient
      * Parse headers - CURL callback functin
      *
      * @param resource $ch curl handle, not needed
-     * @param string $data
+     * @param string   $data
+     *
      * @return int
      */
-    protected function parseHeaders($ch, $data)
+    protected function parseHeaders($ch, $data): int
     {
-        if($this->_headerCount == 0) {
+        if ($this->_headerCount === 0) {
+            $line = explode(' ', trim($data), 3);
 
-            $line = explode(" ", trim($data), 3);
-            if(count($line) != 3) {
-                return $this->doError("Invalid response line returned from server: ".$data);
-            }
-            $this->_responseStatus = intval($line[1]);
+            $this->validateHttpVersion($line);
+            $this->_responseStatus = (int)$line[1];
         } else {
             //var_dump($data);
             $name = $value = '';
-            $out = explode(": ", trim($data), 2);
-            if(count($out) == 2) {
-                $name = $out[0];
-                $value = $out[1];
+            $out  = explode(': ', trim($data), 2);
+            if (count($out) === 2) {
+                [$name, $value] = $out;
             }
 
-            if(strlen($name)) {
-                if("Set-Cookie" == $name) {
-                    if(!isset($this->_responseHeaders[$name])) {
-                        $this->_responseHeaders[$name] = array();
+            if ('' !== $name) {
+                if ('Set-Cookie' === $name) {
+                    if (!isset($this->_responseHeaders[$name])) {
+                        $this->_responseHeaders[$name] = [];
                     }
                     $this->_responseHeaders[$name][] = $value;
                 } else {
@@ -456,8 +454,32 @@ implements Mage_HTTP_IClient
         }
         $this->_headerCount++;
 
-
         return strlen($data);
+    }
+
+    /**
+     * @param array $line
+     *
+     * @throws Exception
+     */
+    protected function validateHttpVersion(array $line): void
+    {
+        if ($line[0] === 'HTTP/1.1') {
+            if (count($line) !== 3) {
+                $this->doError('Invalid response line returned from server: ' . implode(' ', $line));
+            }
+
+            return;
+        }
+
+        if ($line[0] === 'HTTP/2') {
+            if (!in_array(count($line), [2, 3])) {
+                $this->doError('Invalid response line returned from server: ' . implode(' ', $line));
+            }
+
+            return;
+        }
+        $this->doError('Invalid response line returned from server: ' . $data);
     }
 
     /**

--- a/lib/Mage/HTTP/Client/Curl.php
+++ b/lib/Mage/HTTP/Client/Curl.php
@@ -437,7 +437,7 @@ implements Mage_HTTP_IClient
             $name = $value = '';
             $out  = explode(': ', trim($data), 2);
             if (count($out) === 2) {
-                [$name, $value] = $out;
+                list($name, $value) = $out;
             }
 
             if ('' !== $name) {
@@ -462,7 +462,7 @@ implements Mage_HTTP_IClient
      *
      * @throws Exception
      */
-    protected function validateHttpVersion(array $line): void
+    protected function validateHttpVersion(array $line)
     {
         if ($line[0] === 'HTTP/1.1') {
             if (count($line) !== 3) {


### PR DESCRIPTION
- Refactoring Mage_HTTP_Client_Curl::parseHeaders

### Manual testing scenarios (*)
Before this fails with `Exception: Invalid response line returned from server: HTTP/2 301` after the change it works.
```
$c = new Mage_HTTP_Client_Curl();
$c->get('https://facebook.com');
```
### Questions or comments
- I'm not sure wether HTTP/2 allows Status Codes (line 473)
- this is PHP 7.1 code (not sure what openmage is expecting), list shortcut and return void

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
