### PR TITLE
Fixes catalog pricerules with dates in conditions, closes #433

### DIFF
--- a/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Product.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Product.php
@@ -114,7 +114,10 @@ class Mage_CatalogRule_Model_Rule_Condition_Product extends Mage_Rule_Model_Cond
     protected function _prepareDatetimeValue($value, $object)
     {
         $attribute = $object->getResource()->getAttribute($this->getAttribute());
-        if ($attribute && $attribute->getBackendType() == 'datetime') {
+        if ($attribute && $attribute->getBackendType() === 'datetime') {
+            if (!$value) {
+                return null;
+            }
             $value = strtotime($value);
         }
         return $value;


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

> I must create an additional catalogrule discount on products that have special_from_date attribute set. This is the interesting part of my rule:
> 
> My problem is: this rule doesn't work in a reliable way: sometime it does, sometime it doesn't.
> 
> I think I tracked down the issue in a apple-to-orange comparison in shop/app/code/core/Mage/Rule/Model/Condition/Abstract.php#614.
> 
> As you can see in this debugging session, the function Mage_CatalogRule_Model_Rule_Condition_Product::validateAttribute() is comparing $validatedValue <= $value, where the former ia a unix timestamp (1504310400) and the latter is a plain date 2018-01-18.
> 
> The former is coming from the special_from_date attribute, the latter is the date set in the rule
> 

### Related Pull Requests
<!-- related pull request placeholder -->

- https://github.com/OpenMage/magento-lts/pull/434#pullrequestreview-95444322

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
- Fixes OpenMage/magento-lts#433

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
- please read https://magento.stackexchange.com/questions/210006/catalog-price-rules-with-date-as-conditions-cannot-possibly-work-due-to-strtotim

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

This has been heavily tested, but please check it yourself.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
