### PR TITLE
Fix Coupon related cancel order bug if the uses are equal to 0

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Observer.php
+++ b/app/code/core/Mage/SalesRule/Model/Observer.php
@@ -152,15 +152,20 @@ class Mage_SalesRule_Model_Observer
                 $coupon->setTimesUsed($coupon->getTimesUsed() - 1);
                 $coupon->save();
 
-
                 if ($customerId = $order->getCustomerId()) {
                     // Decrement coupon_usage times_used
                     Mage::getResourceModel('salesrule/coupon_usage')->updateCustomerCouponTimesUsed($customerId, $coupon->getId(), true);
 
                     // Decrement rule times_used
                     if ($customerCoupon = Mage::getModel('salesrule/rule_customer')->loadByCustomerRule($customerId, $coupon->getRuleId())) {
-                        $customerCoupon->setTimesUsed($customerCoupon->getTimesUsed() - 1);
-                        $customerCoupon->save();
+                        $customerTimesUsed = $customerCoupon->getTimesUsed() - 1;
+
+                        if ($customerTimesUsed < 1) {
+                            $customerCoupon->delete();
+                        } else {
+                            $customerCoupon->setTimesUsed($customerTimesUsed);
+                            $customerCoupon->save();
+                        }
                     }
                 }
             }

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
@@ -56,8 +56,8 @@ class Mage_SalesRule_Model_Resource_Coupon_Usage extends Mage_Core_Model_Resourc
         $read = $this->_getReadAdapter();
         $select = $read->select();
         $select->from($this->getMainTable(), array('times_used'))
-          ->where('coupon_id = :coupon_id')
-          ->where('customer_id = :customer_id');
+                ->where('coupon_id = :coupon_id')
+                ->where('customer_id = :customer_id');
 
         $timesUsed = $read->fetchOne($select, array(':coupon_id' => $couponId, ':customer_id' => $customerId));
 
@@ -66,32 +66,32 @@ class Mage_SalesRule_Model_Resource_Coupon_Usage extends Mage_Core_Model_Resourc
 
             if ($newTimesUsed < 1) {
                 $this->_getWriteAdapter()->delete(
-                  $this->getMainTable(),
-                  array(
-                    'coupon_id = ?' => $couponId,
-                    'customer_id = ?' => $customerId,
-                  )
+                    $this->getMainTable(),
+                    array(
+                        'coupon_id = ?' => $couponId,
+                        'customer_id = ?' => $customerId,
+                    )
                 );
             } else {
                 $this->_getWriteAdapter()->update(
-                  $this->getMainTable(),
-                  array(
-                    'times_used' => $newTimesUsed
-                  ),
-                  array(
-                    'coupon_id = ?' => $couponId,
-                    'customer_id = ?' => $customerId,
-                  )
+                    $this->getMainTable(),
+                    array(
+                        'times_used' => $newTimesUsed,
+                    ),
+                    array(
+                        'coupon_id = ?' => $couponId,
+                        'customer_id = ?' => $customerId,
+                    )
                 );
             }
         } else {
             $this->_getWriteAdapter()->insert(
-              $this->getMainTable(),
-              array(
-                'coupon_id' => $couponId,
-                'customer_id' => $customerId,
-                'times_used' => 1
-              )
+                $this->getMainTable(),
+                array(
+                    'coupon_id' => $couponId,
+                    'customer_id' => $customerId,
+                    'times_used' => 1
+                )
             );
         }
     }

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
@@ -56,30 +56,42 @@ class Mage_SalesRule_Model_Resource_Coupon_Usage extends Mage_Core_Model_Resourc
         $read = $this->_getReadAdapter();
         $select = $read->select();
         $select->from($this->getMainTable(), array('times_used'))
-                ->where('coupon_id = :coupon_id')
-                ->where('customer_id = :customer_id');
+          ->where('coupon_id = :coupon_id')
+          ->where('customer_id = :customer_id');
 
         $timesUsed = $read->fetchOne($select, array(':coupon_id' => $couponId, ':customer_id' => $customerId));
 
         if ($timesUsed !== false && $timesUsed > 0) {
-            $this->_getWriteAdapter()->update(
-                $this->getMainTable(),
-                array(
-                    'times_used' => $timesUsed + ($decrement ? -1 : 1)
-                ),
-                array(
+            $newTimesUsed = $timesUsed + ($decrement ? -1 : 1);
+
+            if ($newTimesUsed < 1) {
+                $this->_getWriteAdapter()->delete(
+                  $this->getMainTable(),
+                  array(
                     'coupon_id = ?' => $couponId,
                     'customer_id = ?' => $customerId,
-                )
-            );
+                  )
+                );
+            } else {
+                $this->_getWriteAdapter()->update(
+                  $this->getMainTable(),
+                  array(
+                    'times_used' => $newTimesUsed
+                  ),
+                  array(
+                    'coupon_id = ?' => $couponId,
+                    'customer_id = ?' => $customerId,
+                  )
+                );
+            }
         } else {
             $this->_getWriteAdapter()->insert(
-                $this->getMainTable(),
-                array(
-                    'coupon_id' => $couponId,
-                    'customer_id' => $customerId,
-                    'times_used' => 1
-                )
+              $this->getMainTable(),
+              array(
+                'coupon_id' => $couponId,
+                'customer_id' => $customerId,
+                'times_used' => 1
+              )
             );
         }
     }


### PR DESCRIPTION
### Description (*)
If the use of the coupon is equal to 0, the record must be deleted in order not to create SQL errors at the next use of the coupon.


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create an order using a coupon (1 use). Cancel the order and try again to place an order with the same COUPON. You will get a SQL error in the "salesrule_coupon_usage" table.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
