### PR TITLE
New event "adminhtml_sales_order_create_save_before" when editing an order.

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
@@ -1565,6 +1565,9 @@ class Mage_Adminhtml_Model_Sales_Order_Create extends Varien_Object implements M
         if ($oldOrder->getId()) {
             $oldOrder->setRelationChildId($order->getId());
             $oldOrder->setRelationChildRealId($order->getIncrementId());
+
+            Mage::dispatchEvent('order_edited_save_before', ['new_order' => $order, 'old_order' => $oldOrder]);
+
             $oldOrder->save();
             $order->save();
         }

--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
@@ -1566,7 +1566,7 @@ class Mage_Adminhtml_Model_Sales_Order_Create extends Varien_Object implements M
             $oldOrder->setRelationChildId($order->getId());
             $oldOrder->setRelationChildRealId($order->getIncrementId());
 
-            Mage::dispatchEvent('order_edited_save_before', ['new_order' => $order, 'old_order' => $oldOrder]);
+            Mage::dispatchEvent('adminhtml_sales_order_create_save_before', ['new_order' => $order, 'old_order' => $oldOrder]);
 
             $oldOrder->save();
             $order->save();


### PR DESCRIPTION
New event for when you're editing an order in Magento Admin and need to make changes to the old and/or new order before save.