### PR TITLE
#1167 - do not connect to write adapter when getting the read adapter

### DIFF
--- a/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
@@ -325,17 +325,29 @@ abstract class Mage_Core_Model_Resource_Db_Abstract extends Mage_Core_Model_Reso
     }
 
     /**
+     * @param string $connectionName
+     * @return bool
+     */
+    public function hasConnection($connectionName)
+    {
+        return isset($this->_connections[$connectionName]);
+    }
+
+    /**
      * Retrieve connection for read data
      *
-     * @return Magento_Db_Adapter_Pdo_Mysql
+     * @return Varien_Db_Adapter_Interface
      */
     protected function _getReadAdapter()
     {
-        $writeAdapter = $this->_getWriteAdapter();
-        if ($writeAdapter && $writeAdapter->getTransactionLevel() > 0) {
-            // if transaction is started we should use write connection for reading
-            return $writeAdapter;
+        if ($this->hasConnection('write')) {
+            $writeAdapter = $this->_getWriteAdapter();
+            if ($writeAdapter && $writeAdapter->getTransactionLevel() > 0) {
+                // if transaction is started we should use write connection for reading
+                return $writeAdapter;
+            }
         }
+
         return $this->_getConnection('read');
     }
 

--- a/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
@@ -336,7 +336,7 @@ abstract class Mage_Core_Model_Resource_Db_Abstract extends Mage_Core_Model_Reso
     /**
      * Retrieve connection for read data
      *
-     * @return Varien_Db_Adapter_Interface
+     * @return Magento_Db_Adapter_Pdo_Mysql
      */
     protected function _getReadAdapter()
     {


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Do not connect to the write adapter when getting the read adapter. We get the write adapter to check if there are any transactions. This causes it to have to connect to the write connection to do so. Most requests don't actually need that write connection.

### Related Pull Requests
None

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#1167

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Test if it works - Place a break point in Mage_Core_Model_Resource::_newConnection()
2. Test if the read adapter is still fetched by going to really any page that is not cached
3. Test that transactions work by going to a page that does any writes

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
