### PR TITLE
Throw exception when editing an order and the old order could not be cancelled.

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
@@ -1549,6 +1549,10 @@ class Mage_Adminhtml_Model_Sales_Order_Create extends Varien_Object implements M
             $service->setOrderData($orderData);
 
             $oldOrder->cancel();
+
+            if(!$oldOrder->isCanceled()){
+                Mage::throwException('Could not cancel the old order during order edit.');
+            }
         }
 
         /** @var Mage_Sales_Model_Order $order */


### PR DESCRIPTION
Throw exception when editing an order and the old order could not be cancelled.

This is to avoid having 2 open orders.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
