### PR TITLE
replace "DEL" Commands with "UNLINK"

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ git add -A && git commit
 
 - PHP 7.0+ (PHP 7.3 and OpenSSL extension strongly recommended)
 - MySQL 5.6+ (8.0+ Recommended)
+- redis 4.0+ (optional)
 
 ## Translations
 

--- a/app/code/community/Cm/RedisSession/Model/Session.php
+++ b/app/code/community/Cm/RedisSession/Model/Session.php
@@ -465,7 +465,7 @@ class Cm_RedisSession_Model_Session extends Mage_Core_Model_Mysql4_Session
         }
         $this->_redis->pipeline();
         if($this->_dbNum) $this->_redis->select($this->_dbNum);
-        $this->_redis->del(self::SESSION_PREFIX.$sessionId);
+        $this->_redis->unlink(self::SESSION_PREFIX.$sessionId);
         $this->_redis->exec();
         Varien_Profiler::stop(__METHOD__);
         return TRUE;

--- a/lib/Cm/Cache/Backend/Redis.php
+++ b/lib/Cm/Cache/Backend/Redis.php
@@ -365,7 +365,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
         $this->_redis->pipeline()->multi();
 
         // Remove data
-        $this->_redis->del(self::PREFIX_KEY.$id);
+        $this->_redis->unlink(self::PREFIX_KEY.$id);
 
         // Remove id from list of all ids
         if($this->_notMatchingTags) {
@@ -393,7 +393,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
             $this->_redis->pipeline()->multi();
 
             // Remove data
-            $this->_redis->del( $this->_preprocessIds($ids));
+            $this->_redis->unlink( $this->_preprocessIds($ids));
 
             // Remove ids from list of all ids
             if($this->_notMatchingTags) {
@@ -415,7 +415,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
             $this->_redis->pipeline()->multi();
 
             // Remove data
-            $this->_redis->del( $this->_preprocessIds($ids));
+            $this->_redis->unlink( $this->_preprocessIds($ids));
 
             // Remove ids from list of all ids
             if($this->_notMatchingTags) {
@@ -439,12 +439,12 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
                     "for i = 1, #KEYS, ARGV[5] do ".
                         "local keysToDel = redis.call('SUNION', unpack(KEYS, i, math.min(#KEYS, i + ARGV[5] - 1))) ".
                         "for _, keyname in ipairs(keysToDel) do ".
-                            "redis.call('DEL', ARGV[1]..keyname) ".
+                            "redis.call('UNLINK', ARGV[1]..keyname) ".
                             "if (ARGV[4] == '1') then ".
                                 "redis.call('SREM', ARGV[3], keyname) ".
                             "end ".
                         "end ".
-                        "redis.call('DEL', unpack(KEYS, i, math.min(#KEYS, i + ARGV[5] - 1))) ".
+                        "redis.call('UNLINK', unpack(KEYS, i, math.min(#KEYS, i + ARGV[5] - 1))) ".
                         "redis.call('SREM', ARGV[2], unpack(KEYS, i, math.min(#KEYS, i + ARGV[5] - 1))) ".
                     "end ".
                     "return true";
@@ -460,7 +460,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
         if($ids)
         {
             // Remove data
-            $this->_redis->del( $this->_preprocessIds($ids));
+            $this->_redis->unlink( $this->_preprocessIds($ids));
 
             // Remove ids from list of all ids
             if($this->_notMatchingTags) {
@@ -469,7 +469,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
         }
 
         // Remove tag id lists
-        $this->_redis->del( $this->_preprocessTagIds($tags));
+        $this->_redis->unlink( $this->_preprocessTagIds($tags));
 
         // Remove tags from list of tags
         $this->_redis->sRem( self::SET_TAGS, $tags);
@@ -526,7 +526,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
                                     "end ".
                                 "end ".
                                 "if (notExpiredCount == 0) then ".
-                                    "redis.call ('DEL', ARGV[4]..tagName) ".
+                                    "redis.call ('UNLINK', ARGV[4]..tagName) ".
                                     "redis.call ('SREM', ARGV[2], tagName) ".
                                 "end ".
                                 "expired = {} ".
@@ -580,7 +580,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
 
             // Remove empty tags or completely expired tags
             if ($numExpired == $numTagMembers) {
-                $this->_redis->del(self::PREFIX_TAG_IDS . $tag);
+                $this->_redis->unlink(self::PREFIX_TAG_IDS . $tag);
                 $this->_redis->sRem(self::SET_TAGS, $tag);
             }
             // Clean up expired ids from tag ids set
@@ -932,7 +932,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
      */
     public function ___expire($id)
     {
-        $this->_redis->del(self::PREFIX_KEY.$id);
+        $this->_redis->unlink(self::PREFIX_KEY.$id);
     }
 
 }


### PR DESCRIPTION
### Description (*)
This PR replaces DEL Command with UNLINK command.

Details about UNLINK can be found here https://redis.io/commands/unlink .

As noticed here redis/redis#1748 (comment) this will not change the behavior.

As there is no check of Redis version included, it will break Redis Versions < 4.0 through.

As Redis 4.0 was released on 2017-07-14 and Redis 3 went EOL with the Redis 5 on 2018-10-17, I don't expect this being an issue.

See also https://github.com/colinmollenhour/Cm_Cache_Backend_Redis/issues/158 for details.


### Related Pull Requests
/

### Fixed Issues (if relevant)
/
### Manual testing scenarios (*)
1. Trigger session deletion

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
