### PR TITLE
Fix PHP 7.4 deprecation: array/string curly braces access

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Alphanum.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Alphanum.php
@@ -77,7 +77,7 @@ class Mage_Eav_Model_Entity_Increment_Alphanum extends Mage_Eav_Model_Entity_Inc
                 $p = 0;
                 $bumpNextChar = true;
             }
-            $nextId = $chars{$p}.$nextId;
+            $nextId = $chars[$p] . $nextId;
         }
 
         return $this->format($nextId);

--- a/app/code/core/Mage/Eav/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Setup.php
@@ -1231,14 +1231,14 @@ class Mage_Eav_Model_Entity_Setup extends Mage_Core_Model_Resource_Setup
                 if (!empty($attr['frontend'])) {
                     if ('_' === $attr['frontend']) {
                         $attr['frontend'] = $frontendPrefix;
-                    } elseif ('_' === $attr['frontend']{0}) {
+                    } elseif ('_' === $attr['frontend'][0]) {
                         $attr['frontend'] = $frontendPrefix.$attr['frontend'];
                     }
                 }
                 if (!empty($attr['source'])) {
                     if ('_' === $attr['source']) {
                         $attr['source'] = $sourcePrefix;
-                    } elseif ('_' === $attr['source']{0}) {
+                    } elseif ('_' === $attr['source'][0]) {
                         $attr['source'] = $sourcePrefix . $attr['source'];
                     }
                 }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Fixes php-74 array/string curly braces access deprection warning.

### Related Pull Requests

1. OpenMage/magento-lts#859

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. see https://github.com/OpenMage/magento-lts/pull/1181/checks?check_run_id=1067053140

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

Should we change php-74 syntax check to non-experimental (and include lib/Zend)?

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
