### PR TITLE
Fixes cloning of a collection by also cloning the internal select object

### DIFF
--- a/lib/Varien/Data/Collection/Db.php
+++ b/lib/Varien/Data/Collection/Db.php
@@ -854,4 +854,16 @@ class Varien_Data_Collection_Db extends Varien_Data_Collection
 
         return $this;
     }
+
+    /**
+     * Magic clone function
+     *
+     * Clone also Zend_Db_Select
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        $this->_select = clone $this->_select;
+    }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Without this fix, the original select object is used and every modification would also affect the original object. A second effect occurs if you clone a collection and use the load function. All the triggers in _beforeLoad function of the collection which add additional filters etc. will be modify the original select object and the select object will be scale up with identical filters and orders.

Here is an SQL example if you use the CSV export in the sales order grid without this patch:

```
SELECT `main_table`.* FROM `sales_flat_order_grid` AS `main_table` ORDER BY created_at DESC LIMIT 1000
SELECT COUNT(*) FROM `sales_flat_order_grid` AS `main_table` 
SELECT `main_table`.* FROM `sales_flat_order_grid` AS `main_table` ORDER BY created_at DESC, created_at DESC LIMIT 1000 OFFSET 1000
SELECT COUNT(*) FROM `sales_flat_order_grid` AS `main_table`
SELECT `main_table`.* FROM `sales_flat_order_grid` AS `main_table` ORDER BY created_at DESC, created_at DESC, created_at DESC LIMIT 1000 OFFSET 2000
SELECT COUNT(*) FROM `sales_flat_order_grid` AS `main_table` 
SELECT `main_table`.* FROM `sales_flat_order_grid` AS `main_table` ORDER BY created_at DESC, created_at DESC, created_at DESC, created_at DESC LIMIT 1000 OFFSET 3000
```
For example, the problem is caused by Mage_Adminhtml_Block_Widget_Grid::_exportIterateCollection starting on line 977 in combination with the while loop.

### Related Pull Requests
none

### Fixed Issues (if relevant)
none

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open admin panel and go to the sales order grid
2. Use the CSV export function with more than 1000 rows.

#### Result without patch
```
SELECT `main_table`.* FROM `sales_flat_order_grid` AS `main_table` ORDER BY created_at DESC LIMIT 1000
SELECT COUNT(*) FROM `sales_flat_order_grid` AS `main_table` 
SELECT `main_table`.* FROM `sales_flat_order_grid` AS `main_table` ORDER BY created_at DESC, created_at DESC LIMIT 1000 OFFSET 1000
SELECT COUNT(*) FROM `sales_flat_order_grid` AS `main_table`
SELECT `main_table`.* FROM `sales_flat_order_grid` AS `main_table` ORDER BY created_at DESC, created_at DESC, created_at DESC LIMIT 1000 OFFSET 2000
```
The issue affects also the where clause and joins.

#### Result with patch
```
SELECT `main_table`.* FROM `sales_flat_order_grid` AS `main_table` ORDER BY created_at DESC LIMIT 1000
SELECT COUNT(*) FROM `sales_flat_order_grid` AS `main_table` 
SELECT `main_table`.* FROM `sales_flat_order_grid` AS `main_table` ORDER BY created_at DESC LIMIT 1000 OFFSET 1000
SELECT COUNT(*) FROM `sales_flat_order_grid` AS `main_table`
SELECT `main_table`.* FROM `sales_flat_order_grid` AS `main_table` ORDER BY created_at DESC LIMIT 1000 OFFSET 2000
```
The select object doesn't scale up and the "order by", where and join conditions are not multiplicated.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
none

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
