### PR TITLE
Add php-74 to static tests

### DIFF
--- a/.github/workflows/static-code-analyses.yml
+++ b/.github/workflows/static-code-analyses.yml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 5
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.0', '7.1', '7.2', '7.3']
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
     steps:
       - uses: actions/checkout@v1
       - name: Setup PHP
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4', '8.0']
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
     steps:
       - uses: actions/checkout@v1
       - name: Setup PHP
@@ -54,7 +54,7 @@ jobs:
         run: php -v
       - name: Check .php files
         continue-on-error: true
-        run: '! find . -not \( -path ./.phpstorm.meta.php -prune \) -not \( -path ./lib/PEAR -prune \) -not \( -path ./lib/phpseclib -prune \) -not \( -path ./lib/Zend -prune \) -type f -name "*.php" -exec php -d error_reporting=32767 -l {} \; 2>&1 1> /dev/null | grep "^"'
+        run: '! find . -not \( -path ./.phpstorm.meta.php -prune \) -type f -name "*.php" -exec php -d error_reporting=32767 -l {} \; 2>&1 1> /dev/null | grep "^"'
       - name: Check .phtml files
         continue-on-error: true
         run: '! find app/design -type f -name "*.phtml" -exec php -d error_reporting=32767 -l {} \; 2>&1 1> /dev/null | grep "^"'


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

`composer.json` allows PHP7.0-7.4, so we should also cover 7.4 with static tests.

- should be merged after #1181, #1182
- made 7.4 non-experimental
- added 7.0-7.3 experimental tests, with included lib-directories (PEAR maybe will be removed, not sure about phpseclib, but lib/Zend should be covered)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
