### PR TITLE
Properly set timestamp for catalogrule on non GMT install Fix #1191

### DIFF
--- a/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
+++ b/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
@@ -116,9 +116,7 @@ class Mage_CatalogRule_Model_Action_Index_Refresh
     {
         $this->_app->dispatchEvent('catalogrule_before_apply', array('resource' => $this->_resource));
 
-        /** @var Mage_Core_Model_Date $coreDate */
-        $coreDate  = $this->_factory->getModel('core/date');
-        $timestamp = Mage::app()->getLocale()->date(null, null, null, true)->get(Zend_Date::TIMESTAMP);
+        $timestamp = Mage::app()->getLocale()->storeTimeStamp();
 
         foreach ($this->_app->getWebsites(false) as $website) {
             /** @var Mage_Core_Model_Website $website */

--- a/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
+++ b/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
@@ -118,7 +118,7 @@ class Mage_CatalogRule_Model_Action_Index_Refresh
 
         /** @var Mage_Core_Model_Date $coreDate */
         $coreDate  = $this->_factory->getModel('core/date');
-        $timestamp = $coreDate->gmtTimestamp('Today');
+        $timestamp = Mage::app()->getLocale()->date(null, null, null, true)->get(Zend_Date::TIMESTAMP);
 
         foreach ($this->_app->getWebsites(false) as $website) {
             /** @var Mage_Core_Model_Website $website */


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fix the issue #1191 

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#1191

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Setup the testing procedure from the issue
2. Apply the fix
3. Enjoy the rule still working after midnight.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
