### PR TITLE
Fix wrong payment info template paths

### DIFF
--- a/app/code/core/Mage/Payment/Block/Info.php
+++ b/app/code/core/Mage/Payment/Block/Info.php
@@ -74,7 +74,7 @@ class Mage_Payment_Block_Info extends Mage_Core_Block_Template
      */
     public function toPdf()
     {
-        $this->setTemplate('payment/info/pdf/default.phtml');
+        $this->setTemplate('payment/info/default.phtml');
         return $this->toHtml();
     }
 

--- a/app/code/core/Mage/Payment/Block/Info/Checkmo.php
+++ b/app/code/core/Mage/Payment/Block/Info/Checkmo.php
@@ -92,7 +92,7 @@ class Mage_Payment_Block_Info_Checkmo extends Mage_Payment_Block_Info
      */
     public function toPdf()
     {
-        $this->setTemplate('payment/info/pdf/checkmo.phtml');
+        $this->setTemplate('payment/info/checkmo.phtml');
         return $this->toHtml();
     }
 }

--- a/app/code/core/Mage/Payment/Block/Info/Purchaseorder.php
+++ b/app/code/core/Mage/Payment/Block/Info/Purchaseorder.php
@@ -38,7 +38,7 @@ class Mage_Payment_Block_Info_Purchaseorder extends Mage_Payment_Block_Info
      */
     public function toPdf()
     {
-        $this->setTemplate('payment/info/pdf/purchaseorder.phtml');
+        $this->setTemplate('payment/info/purchaseorder.phtml');
         return $this->toHtml();
     }
 }


### PR DESCRIPTION
# Description (*)
 In some Payment block classes the 'toPdf' function sets a wrong template path. These templates are present in another folder.

### Manual testing scenarios (*)
1. Create order/invoice
2. Make sure the email is being sent with pdf attached
3. Check if payment info is added to attached pdf, and no logs about invalid template files are created.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
