### PR TITLE
Fix #1190 - Fix the "$_FILES array is empty" exception when assiging products to a category or creating a category with the XMLRPC-API

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Image.php
@@ -43,6 +43,9 @@ class Mage_Catalog_Model_Category_Attribute_Backend_Image extends Mage_Eav_Model
     public function afterSave($object)
     {
         $value = $object->getData($this->getAttribute()->getName());
+        if (empty($value) && empty($_FILES)) {
+            return $this;
+        }
 
         if (is_array($value) && !empty($value['delete'])) {
             $object->setData($this->getAttribute()->getName(), '');


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR is to fix the issue #1190 

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#1190

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Use the testing procedure provided in the issue
2. Apply the fix
3. Enjoy the exception not being thrown anymore.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
This bug fix was taken directly from Magento 2.0 before they entirely refactored this file in the last versions.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
