### PR TITLE
bugfix: don't cast min_sale_qty to int as it can be below 1

### DIFF
--- a/app/design/adminhtml/default/default/template/catalog/product/tab/inventory.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/tab/inventory.phtml
@@ -77,7 +77,7 @@
 
         <tr>
             <td class="label"><label for="inventory_min_sale_qty"><?php echo Mage::helper('catalog')->__('Minimum Qty Allowed in Shopping Cart') ?></label></td>
-            <td class="value"><input type="text" class="input-text validate-number" id="inventory_min_sale_qty" name="<?php echo $this->getFieldSuffix() ?>[stock_data][min_sale_qty]" value="<?php echo (bool)$this->getProduct()->getId() ? (int)$this->getFieldValue('min_sale_qty') : Mage::helper('catalog/product')->getDefaultProductValue('min_sale_qty', $this->getProduct()->getTypeId()) ?>" <?php echo $_readonly ?>/>
+            <td class="value"><input type="text" class="input-text validate-number" id="inventory_min_sale_qty" name="<?php echo $this->getFieldSuffix() ?>[stock_data][min_sale_qty]" value="<?php echo (bool)$this->getProduct()->getId() ? $this->getFieldValue('min_sale_qty')*1 : Mage::helper('catalog/product')->getDefaultProductValue('min_sale_qty', $this->getProduct()->getTypeId()) ?>" <?php echo $_readonly ?>/>
 
             <?php $_checked = ($this->getFieldValue('use_config_min_sale_qty') || $this->IsNew()) ? 'checked="checked"' : '' ?>
             <input type="checkbox" id="inventory_use_config_min_sale_qty" name="<?php echo $this->getFieldSuffix() ?>[stock_data][use_config_min_sale_qty]" value="1" <?php echo $_checked ?> onclick="toggleValueElements(this, this.parentNode);" class="checkbox" <?php echo $_readonly;?> />


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
With Magento 1.9.4.2 there was a small change in 
app/design/adminhtml/default/default/template/catalog/product/tab/inventory.phtml.

When selling products with is_qty_decimal set to true, it is possible to sell units lower than one.

Here an example from an actual product in frontend
![image](https://user-images.githubusercontent.com/1145186/93027871-407c0280-f610-11ea-966e-b72bed920acd.png)

Backend when creating product
![image](https://user-images.githubusercontent.com/1145186/93027802-c8add800-f60f-11ea-9caf-12c389e47a68.png)

When creating a product in backend, this will first be save correctly. 
![image](https://user-images.githubusercontent.com/1145186/93027810-d7948a80-f60f-11ea-8b62-d98571d22385.png)

With next edit it will be casted to integer and the decimal part will be cutted of. A min_sale_qty with 0.25 for example will be casted to 0.
![image](https://user-images.githubusercontent.com/1145186/93027828-f09d3b80-f60f-11ea-8c83-66153b36a8f3.png)

With this fix the old version will be introduced again.


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. enable is_qty_decimal in product
2. enter qty of 1.5
3. set min_sale_qty to 0.25
4. save and continue edit
5. min_sale_qty now is still 0.25 (instead of 0)


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
