### PR TITLE
Fix strpos with non-string needle

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
@@ -43,7 +43,9 @@ class Mage_Eav_Model_Entity_Increment_Numeric extends Mage_Eav_Model_Entity_Incr
     {
         $last = $this->getLastId();
 
-        if (strpos($last, $this->getPrefix()) === 0) {
+        if (empty($last)) {
+            $last = 0;
+        } else if (strpos($last, $this->getPrefix()) === 0) {
             $last = (int)substr($last, strlen($this->getPrefix()));
         } else {
             $last = (int)$last;

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
@@ -45,7 +45,7 @@ class Mage_Eav_Model_Entity_Increment_Numeric extends Mage_Eav_Model_Entity_Incr
 
         if (empty($last)) {
             $last = 0;
-        } else if (strpos($last, $this->getPrefix()) === 0) {
+        } else if (strpos($last, (string)$this->getPrefix()) === 0) {
             $last = (int)substr($last, strlen($this->getPrefix()));
         } else {
             $last = (int)$last;


### PR DESCRIPTION
### Description

This fix: _Deprecated functionality: strpos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior in .../app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php on line 48_

OpenMage 20.0.3 / PHP 7.4.9

### Manual testing scenarios

1. Create a new website with a new store view in backend.
2. Go to frontend on this new store view.
3. Add a product to cart, go to checkout, and try to make the order.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
