### PR TITLE
Remove theme overwrites for backend theme

### DIFF
--- a/app/code/core/Mage/Adminhtml/Controller/Action.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Action.php
@@ -160,11 +160,6 @@ class Mage_Adminhtml_Controller_Action extends Mage_Core_Controller_Varien_Actio
             ->setArea($this->_currentArea)
             ->setPackageName((string)Mage::getConfig()->getNode('stores/admin/design/package/name'))
             ->setTheme((string)$theme);
-        foreach (array('layout', 'template', 'skin', 'locale') as $type) {
-            if ($value = (string)Mage::getConfig()->getNode("stores/admin/design/theme/{$type}")) {
-                Mage::getDesign()->setTheme($type, $value);
-            }
-        }
 
         $this->getLayout()->setArea($this->_currentArea);
 


### PR DESCRIPTION
### Description (*)
This PR is a draft to fix issue #1216 by simply removing the overwrite form backend config.
 
Remove setting layout, template, skin, locale overwrite for backend theme

### Fixed Issues
1. Fixes OpenMage/magento-lts#1216

### Manual testing scenarios
change system/settings/design settings to see if backend theme is affected.