### PR TITLE
modified nav-bar padding to prevent the search box hiding menu items

### DIFF
--- a/skin/adminhtml/default/openmage/menu.css
+++ b/skin/adminhtml/default/openmage/menu.css
@@ -18,7 +18,7 @@
 
 .nav-bar {
   background: #202856;
-  padding: 0 70px;
+  padding: 0 350px 0 70px;
 }
 .nav-bar:after {
   content: ".";

--- a/skin/adminhtml/default/openmage/scss/menu.scss
+++ b/skin/adminhtml/default/openmage/scss/menu.scss
@@ -7,7 +7,7 @@
 
 .nav-bar {
   background: $color_dorado_approx;
-  padding: 0 70px;
+  padding: 0 350px 0 70px;
 
   &:after {
     content: ".";


### PR DESCRIPTION
Isse #1214 mentions that additional menu entries in first level are hidden behind the search-box. This commit adjusts the right padding of the nav-bar to prevent this in most cases.

### Fixed Issues
1. Fixes OpenMage/magento-lts#1214

### Manual testing scenarios
resize your browser window to a size where the menu breaks and check if menu entries are all visible 

### Questions or comments
This is a shot fix to make the new theme usable in unusual conditions. Some styling optimizations may follow like a condensed menu font or replacing the search-box with a magnification glas icon.

