### PR TITLE
optimize url_rewrite performance

### DIFF
--- a/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite.php
+++ b/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite.php
@@ -63,7 +63,7 @@ class Mage_Catalog_Helper_Category_Url_Rewrite implements Mage_Catalog_Helper_Ca
             "{{table}}.is_system=1 AND " .
                 "{{table}}.store_id='{$storeId}' AND " .
                 "{{table}}.category_id IS NOT NULL AND " .
-                "{{table}}.id_path LIKE 'category/%'",
+                "{{table}}.url_type = 'category'",
             'left'
         );
         return $this;
@@ -83,7 +83,7 @@ class Mage_Catalog_Helper_Category_Url_Rewrite implements Mage_Catalog_Helper_Ca
             'url_rewrite.category_id = main_table.entity_id AND url_rewrite.is_system = 1 ' .
                 ' AND ' . $collection->getConnection()->quoteInto('url_rewrite.store_id = ?', $storeId) .
                 ' AND url_rewrite.category_id IS NOT NULL' .
-                ' AND ' . $collection->getConnection()->quoteInto('url_rewrite.id_path LIKE ?', 'category/%'),
+                ' AND ' . $collection->getConnection()->quoteInto('url_rewrite.url_type = ?', 'category'),
             ['request_path']
         );
         return $this;

--- a/app/code/core/Mage/Catalog/Helper/Product/Url/Rewrite.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Url/Rewrite.php
@@ -82,7 +82,7 @@ class Mage_Catalog_Helper_Product_Url_Rewrite implements Mage_Catalog_Helper_Pro
                     'url_rewrite.category_id IS NULL AND url_rewrite.store_id = ? AND ',
                     (int)$storeId
                 ) .
-                $this->_connection->prepareSqlCondition('url_rewrite.id_path', ['like' => 'product/%']),
+                $this->_connection->prepareSqlCondition('url_rewrite.id_path', ['eq' => 'product']),
             ['request_path' => 'url_rewrite.request_path']
         );
         return $this;

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -271,7 +271,8 @@ class Mage_Catalog_Model_Url
                 'id_path'       => $idPath,
                 'request_path'  => $requestPath,
                 'target_path'   => $targetPath,
-                'is_system'     => 1
+                'is_system'     => 1,
+                'url_type'      => 'category'
             ];
 
             $this->getResource()->saveRewrite($rewriteData, $this->_rewrite);
@@ -342,7 +343,8 @@ class Mage_Catalog_Model_Url
             'id_path'       => $idPath,
             'request_path'  => $requestPath,
             'target_path'   => $targetPath,
-            'is_system'     => 1
+            'is_system'     => 1,
+            'url_type'      => 'product'
         ];
 
         $this->getResource()->saveRewrite($rewriteData, $this->_rewrite);

--- a/app/code/core/Mage/Catalog/etc/config.xml
+++ b/app/code/core/Mage/Catalog/etc/config.xml
@@ -17,7 +17,7 @@
 <config>
     <modules>
         <Mage_Catalog>
-            <version>1.6.0.0.19.1.6</version>
+            <version>1.6.0.0.19.1.7</version>
         </Mage_Catalog>
     </modules>
     <admin>

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.6-1.6.0.0.19.1.7.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.6-1.6.0.0.19.1.7.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   Mage
+ * @package    Mage_Catalog
+ * @copyright  Copyright (c) 2020-2023 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Catalog_Model_Resource_Setup $installer */
+$installer = $this;
+$connection = $installer->getConnection();
+$connection->addColumn($installer->getTable('core_url_rewrite'), 'url_type', 'varchar(50) NULL AFTER `product_id`');
+$installer->run("
+UPDATE `{$installer->getTable('core_url_rewrite')}`
+    SET `url_type`='category' 
+    WHERE `id_path` LIKE 'category/%';
+UPDATE `{$installer->getTable('core_url_rewrite')}`
+    SET `url_type`='product' 
+    WHERE `id_path` LIKE 'product/%';");
+$connection->addIndex($installer->getTable('core_url_rewrite'), 'IDX_CORE_URL_REWRITE_URL_TYPE', array('url_type'));
+$installer->endSetup();


### PR DESCRIPTION
### Description (*)
**The goal of this PR is to optimize url rewrite performance for big catalogs.**

Use of the 'like' operator in sql queries can generate particularly long execution times when the number of records concerned by the query is large.

**Mage_Catalog_Model_Url** defines a new field (url_type) for categories and products $rewriteData array.

SQL queries in **Mage_Catalog_Helper_Category_Url_Rewrite** and **Mage_Catalog_Helper_Product_Url_Rewrite** have been modified **to avoid use of 'like' operator**.
'eq' operator is used instead.

**catalog_setup** has been modified to :
- create '**url_type**' new field in **core_url_rewrite** table and associated index
- update existing core_url_rewrite content to match new behavior

Catalog version now defined as 1.6.0.0.19.1.7

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
