### PR TITLE
Fix call_user_func_array arguments for PHP 8

### DIFF
--- a/app/code/core/Mage/Core/Model/Layout.php
+++ b/app/code/core/Mage/Core/Model/Layout.php
@@ -346,7 +346,7 @@ class Mage_Core_Model_Layout extends Varien_Simplexml_Config
             }
 
             $this->_translateLayoutNode($node, $args);
-            call_user_func_array(array($block, $method), $args);
+            call_user_func_array(array($block, $method), array_values($args));
         }
 
         Varien_Profiler::stop($_profilerKey);

--- a/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
@@ -121,7 +121,7 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
             $cookieParams['domain'] = $cookie->getDomain();
         }
 
-        call_user_func_array('session_set_cookie_params', $cookieParams);
+        call_user_func_array('session_set_cookie_params', array_values($cookieParams));
 
         if (!empty($sessionName)) {
             $this->setSessionName($sessionName);


### PR DESCRIPTION
### Description
Changes second argument of call_user_func_array() from associative to indexed array. Before PHP 8 both types of arrays work the same but on PHP 8 associative arrays are interpreted as "named parameters". In our case this causes code to break.

OpenMage 20.0.3 / PHP 8.0.0-beta3
From https://github.com/joomla/joomla-cms/pull/30608.

### Manual testing scenarios
1. Install PHP 8.0.0
2. Open any page of OpenMage in your browser

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
