### PR TITLE
mark trigger_recollect before collectTotals

### DIFF
--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -2037,7 +2037,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
     {
         // collect totals and save me, if required
         if (1 == $this->getData('trigger_recollect')) {
-            $this->setData('trigger_recollect', 0)->save();
+            $this->setTriggerRecollect(0)->getResource()->save($this);
             $this->collectTotals()->save();
         }
         return parent::_afterLoad();

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -2037,6 +2037,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
     {
         // collect totals and save me, if required
         if (1 == $this->getData('trigger_recollect')) {
+            $this->setData('trigger_recollect', 0)->save();
             $this->collectTotals()->save();
         }
         return parent::_afterLoad();


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fix issue that causing the loop if any 3rd party payment/shipping method attempt to reloading the quote before collectTotals is ended
### Related Pull Requests
<!-- related pull request placeholder -->
https://github.com/OpenMage/magento-lts/pull/1244
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
