### PR TITLE
Fix undefined offset on redis session

### DIFF
--- a/app/code/community/Cm/RedisSession/Model/Session.php
+++ b/app/code/community/Cm/RedisSession/Model/Session.php
@@ -339,7 +339,7 @@ class Cm_RedisSession_Model_Session extends Mage_Core_Model_Mysql4_Session
         if ($this->_logLevel >= Zend_Log::DEBUG) {
             $timeStart = microtime(true);
         }
-        list($sessionData, $sessionWrites) = $this->_redis->hMGet($sessionId, array('data','writes'));
+        list($sessionData, $sessionWrites) = array_values($this->_redis->hMGet($sessionId, array('data','writes')));
         Varien_Profiler::stop(__METHOD__);
         if ($this->_logLevel >= Zend_Log::DEBUG) {
             $this->_log(sprintf("Data read for ID %s in %.5f seconds", $sessionId, (microtime(true) - $timeStart)));


### PR DESCRIPTION
### Description
In most cases it will never be a problem, but in test environments with the highest error level it will not work.
list() wants numeric arrays

### Manual testing scenarios
1. Visit a page

### Questions or comments
**Prerequisite**
- Run php with error_reporting = E_ALL
- Configure redis as session backend

**ENV**
- PHP 7.3.22
- Redis 6.05

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
