### PR TITLE
Fix libxml_disable_entity_loader for PHP 8

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -29,6 +29,6 @@
  * @link https://bugs.php.net/bug.php?id=62577
  * @link https://bugs.php.net/bug.php?id=64938
  */
-if (function_exists('libxml_disable_entity_loader')) {
+if ((LIBXML_VERSION < 20900) && function_exists('libxml_disable_entity_loader')) {
     libxml_disable_entity_loader(false);
 }

--- a/app/code/core/Zend/Xml/Security.php
+++ b/app/code/core/Zend/Xml/Security.php
@@ -19,7 +19,7 @@
  * @version    $Id$
  */
 
- 
+
 /**
  * @category   Zend
  * @package    Zend_Xml_SecurityScan
@@ -83,7 +83,9 @@ class Zend_Xml_Security
         }
 
         if (!self::isPhpFpm()) {
-            $loadEntities = libxml_disable_entity_loader(true);
+            if ((LIBXML_VERSION < 20900) && function_exists('libxml_disable_entity_loader')) {
+                $loadEntities = libxml_disable_entity_loader(true);
+            }
             $useInternalXmlErrors = libxml_use_internal_errors(true);
         }
 
@@ -97,7 +99,9 @@ class Zend_Xml_Security
         if (!$result) {
             // Entity load to previous setting
             if (!self::isPhpFpm()) {
-                libxml_disable_entity_loader($loadEntities);
+                if (isset($loadEntities)) {
+                    libxml_disable_entity_loader($loadEntities);
+                }
                 libxml_use_internal_errors($useInternalXmlErrors);
             }
             return false;
@@ -108,7 +112,9 @@ class Zend_Xml_Security
             foreach ($dom->childNodes as $child) {
                 if ($child->nodeType === XML_DOCUMENT_TYPE_NODE) {
                     if (isset($child->entities) && $child->entities->length > 0) {
-                        libxml_disable_entity_loader($loadEntities);
+                        if (isset($loadEntities)) {
+                            libxml_disable_entity_loader($loadEntities);
+                        }
                         libxml_use_internal_errors($useInternalXmlErrors);
 
                         #require_once 'Exception.php';
@@ -120,7 +126,9 @@ class Zend_Xml_Security
 
         // Entity load to previous setting
         if (!self::isPhpFpm()) {
-            libxml_disable_entity_loader($loadEntities);
+            if (isset($loadEntities)) {
+                libxml_disable_entity_loader($loadEntities);
+            }
             libxml_use_internal_errors($useInternalXmlErrors);
         }
 


### PR DESCRIPTION
### Description
This fix function libxml_disable_entity_loader() is deprecated. I hope it's good.

OpenMage 20.0.3 / PHP 8.0.0-beta3

### Manual testing scenarios
1. Install PHP 8.0.0
2. Open any page of OpenMage in your browser

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
