### PR TITLE
Optimize the indexing catalog query and remove the always true condition(1=1)

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
@@ -116,10 +116,10 @@ class Mage_Catalog_Model_Resource_Product_Indexer_Eav_Source extends Mage_Catalo
             )
             ->joinLeft(
                 array('d' => $this->getValueTable('catalog/product', 'int')),
-                '1 = 1 AND d.store_id = 0',
+                'd.store_id = 0',
                 array('entity_id', 'attribute_id', 'value')
             )
-            ->where('s.store_id != 0');
+            ->where('s.store_id != 0 AND d.`value` IS NOT NULL');
 
         $statusCond = $adapter->quoteInto(' = ?', Mage_Catalog_Model_Product_Status::STATUS_ENABLED);
         $this->_addAttributeToSelect($subSelect, 'status', 'd.entity_id', 's.store_id', $statusCond);


### PR DESCRIPTION
### Description (*)
There is an always true condition in of the joins of product indexer, so I removed it.
Also I realized that if we check whether d.value is not null in the where clause of **FROM** , the query execution time could be very faster, and you can see the difference by explaining the query and compare them after and before this change.
In my benchmark, it is **4600% faster** than before.
I believe this condition (AND d.`value` IS NOT NULL) has not any effect in the result of the query because as you can see we have been already filtering this query by d.value in the line of 147 

### Fixed Issues (if relevant)
1. remove extra condition, which is always true (1=1)
2. add a condition to one of the where clauses to increase the query

### Manual testing scenarios (*)
1. Reindex the produducts
2. check the results and counts
3. checkout to my branch
4. reindex the products again
5. check the results and counts
6. both of them should be the same and the index execution should be faster

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
