### PR TITLE
Fixed method addExpressionFieldToSelect to use Zend_Db_Expr

### DIFF
--- a/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
@@ -354,7 +354,7 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends Varien_Da
             $fullExpression = str_replace('{{' . $fieldKey . '}}', $fieldItem, $fullExpression);
         }
 
-        $this->getSelect()->columns(array($alias=>$fullExpression));
+        $this->getSelect()->columns(array($alias=>new Zend_Db_Expr($fullExpression)));
 
         return $this;
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed method `addExpressionFieldToSelect` to use always `Zend_Db_Expr`. The problem is, when you have more complex expression, it does not match `Zend_Db_Select::REGEX_COLUMN_EXPR` and is not converted `Zend_Db_Expr` automatically inside `Zend_Db_Select`.

Since the method name is `add`**`Expression`**`FieldToSelect`, converting it to `Zend_Db_Expr` always makes sense for me.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Call the method with some not-trivial expression. E.g.
```php
$collection->addExpressionFieldToSelect(
                'total',
                "SUM({{price}}) + SUM({{tax}})",
                array('price' => $price, 'tax' => $tax)
            );
```


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
