### PR TITLE
Fix Varien_Io_File ignored errors with error control operator

### DIFF
--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -54,7 +54,9 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
      */
     public function destruct()
     {
-        @imagedestroy($this->_imageHandler);
+        if (is_resource($this->_imageHandler)) {
+            @imagedestroy($this->_imageHandler);
+        }
     }
 
     /**

--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -54,7 +54,7 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
      */
     public function destruct()
     {
-        if (is_resource($this->_imageHandler)) {
+        if (is_resource($this->_imageHandler) || $this->_imageHandler instanceof \GdImage) {
             @imagedestroy($this->_imageHandler);
         }
     }

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -251,12 +251,11 @@ class Varien_Io_File extends Varien_Io_Abstract
         if (!$this->_streamHandler) {
             return false;
         }
+
         if ($this->_streamLocked) {
             $this->streamUnlock();
         }
-        if (is_resource($this->_streamHandler)) {
-            @fclose($this->_streamHandler);
-        }
+        @fclose($this->_streamHandler);
         $this->chmod($this->_streamFileName, $this->_streamChmod);
         return true;
     }

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -251,11 +251,10 @@ class Varien_Io_File extends Varien_Io_Abstract
         if (!$this->_streamHandler) {
             return false;
         }
-
         if ($this->_streamLocked) {
             $this->streamUnlock();
         }
-        if ($this->_streamHandler) {
+        if (is_resource($this->_streamHandler)) {
             @fclose($this->_streamHandler);
         }
         $this->chmod($this->_streamFileName, $this->_streamChmod);

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -134,9 +134,13 @@ class Varien_Io_File extends Varien_Io_Abstract
             ini_set('auto_detect_line_endings', 1);
         }
 
-        @chdir($this->_cwd);
+        if ($this->_cwd) {
+            @chdir($this->_cwd);
+        }
         $this->_streamHandler = @fopen($fileName, $mode);
-        @chdir($this->_iwd);
+        if ($this->_iwd) {
+            @chdir($this->_iwd);
+        }
         if ($this->_streamHandler === false) {
             throw new Exception('Error write to file ' . $this->getFilteredPath($fileName));
         }
@@ -251,7 +255,9 @@ class Varien_Io_File extends Varien_Io_Abstract
         if ($this->_streamLocked) {
             $this->streamUnlock();
         }
-        @fclose($this->_streamHandler);
+        if ($this->_streamHandler) {
+            @fclose($this->_streamHandler);
+        }
         $this->chmod($this->_streamFileName, $this->_streamChmod);
         return true;
     }
@@ -364,7 +370,9 @@ class Varien_Io_File extends Varien_Io_Abstract
             @chdir($this->_cwd);
         }
         $result = self::rmdirRecursive($dir, $recursive);
-        @chdir($this->_iwd);
+        if ($this->_iwd) {
+            @chdir($this->_iwd);
+        }
         return $result;
     }
 
@@ -509,7 +517,9 @@ class Varien_Io_File extends Varien_Io_Abstract
     protected function _isFilenameWriteable($filename)
     {
         $error = false;
-        @chdir($this->_cwd);
+        if ($this->_cwd) {
+            @chdir($this->_cwd);
+        }
         if (file_exists($filename)) {
             if (!is_writeable($filename)) {
                 $error = "File '{$this->getFilteredPath($filename)}' isn't writeable";
@@ -520,7 +530,9 @@ class Varien_Io_File extends Varien_Io_Abstract
                 $error = "Folder '{$this->getFilteredPath($folder)}' isn't writeable";
             }
         }
-        @chdir($this->_iwd);
+        if ($this->_iwd) {
+            @chdir($this->_iwd);
+        }
 
         if ($error) {
             throw new Varien_Io_Exception($error);
@@ -554,29 +566,41 @@ class Varien_Io_File extends Varien_Io_Abstract
      */
     public function filePutContent($filename, $src)
     {
-        @chdir($this->_cwd);
+        if ($this->_cwd) {
+            @chdir($this->_cwd);
+        }
         $result = @file_put_contents($filename, $src);
-        chdir($this->_iwd);
+        if ($this->_iwd) {
+            chdir($this->_iwd);
+        }
 
         return $result;
     }
 
     public function fileExists($file, $onlyFile = true)
     {
-        @chdir($this->_cwd);
+        if ($this->_cwd) {
+            @chdir($this->_cwd);
+        }
         $result = file_exists($file);
         if ($result && $onlyFile) {
             $result = is_file($file);
         }
-        @chdir($this->_iwd);
+        if ($this->_iwd) {
+            @chdir($this->_iwd);
+        }
         return $result;
     }
 
     public function isWriteable($path)
     {
-        @chdir($this->_cwd);
+        if ($this->_cwd) {
+            @chdir($this->_cwd);
+        }
         $result = is_writeable($path);
-        @chdir($this->_iwd);
+        if ($this->_iwd) {
+            @chdir($this->_iwd);
+        }
         return $result;
     }
 
@@ -633,9 +657,13 @@ class Varien_Io_File extends Varien_Io_Abstract
      */
     public function rm($filename)
     {
-        @chdir($this->_cwd);
+        if ($this->_cwd) {
+            @chdir($this->_cwd);
+        }
         $result = @unlink($filename);
-        @chdir($this->_iwd);
+        if ($this->_iwd) {
+            @chdir($this->_iwd);
+        }
         return $result;
     }
 
@@ -648,9 +676,13 @@ class Varien_Io_File extends Varien_Io_Abstract
      */
     public function mv($src, $dest)
     {
-        chdir($this->_cwd);
+        if ($this->_cwd) {
+            chdir($this->_cwd);
+        }
         $result = @rename($src, $dest);
-        chdir($this->_iwd);
+        if ($this->_iwd) {
+            chdir($this->_iwd);
+        }
         return $result;
     }
 
@@ -663,9 +695,13 @@ class Varien_Io_File extends Varien_Io_Abstract
      */
     public function cp($src, $dest)
     {
-        @chdir($this->_cwd);
+        if ($this->_cwd) {
+            @chdir($this->_cwd);
+        }
         $result = @copy($src, $dest);
-        @chdir($this->_iwd);
+        if ($this->_iwd) {
+            @chdir($this->_iwd);
+        }
         return $result;
     }
 
@@ -681,7 +717,7 @@ class Varien_Io_File extends Varien_Io_Abstract
         if ($this->_cwd) {
             chdir($this->_cwd);
         }
-        $result = @chmod($filename, $mode);
+        $result = file_exists($filename) ? @chmod($filename, $mode) : false;
         if ($this->_iwd) {
             chdir($this->_iwd);
         }


### PR DESCRIPTION
### Description

This fix some (perhaps not all) `Varien_Io_File` ignored errors with error control operator.
- `fclose supplied resource is not a valid stream resource`
- `chdir:  No such file or directory (errno 2)`
- `chmod: No such file or directory`

I hope it's good.
OpenMage 20.0.10 - 20.0.13 / PHP 7.4.6 and 8.0.5 - 8.0.14

### Manual testing scenarios
- Install OpenMage
- Install https://github.com/getsentry/magento-amg-sentry-extension
- Configure the installed module, go to System → Configuration → Advanced → Developer → AMG Sentry
- Go to a CMS page or a CMS block, and add a new directory, and upload an image
- Go to your Sentry instance, and read errors:
![image](https://user-images.githubusercontent.com/31816829/96445911-effc5400-1210-11eb-80ab-99aadd68b3de.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)