### PR TITLE
Fix array_key_exists on objects (deprecated notice or fatal error)

### DIFF
--- a/app/code/core/Mage/Catalog/Helper/Product.php
+++ b/app/code/core/Mage/Catalog/Helper/Product.php
@@ -552,8 +552,8 @@ class Mage_Catalog_Helper_Product extends Mage_Core_Helper_Url
     {
         $fieldData = $this->getFieldset($fieldName) ? (array) $this->getFieldset($fieldName) : null;
         if (
-            count($fieldData)
-            && array_key_exists($productType, $fieldData['product_type'])
+            !empty($fieldData)
+            && ((is_array($fieldData['product_type']) && array_key_exists($productType, $fieldData['product_type'])) || (is_object($fieldData['product_type']) && property_exists($fieldData['product_type'], $productType)))
             && (bool)$fieldData['use_config']
         ) {
             return $fieldData['inventory'];


### PR DESCRIPTION
### Description

This fix a notice or a fatal error when creating a new product in backend, I hope it's good.

PHP 7.4.6
`array_key_exists(): Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead`

PHP 8.0.0-rc2
`Fatal error:  Uncaught TypeError: array_key_exists(): Argument #2 ($array) must be of type array, Mage_Core_Model_Config_Element given`

OpenMage 20.0.5 / PHP 7.4.6 and 8.0.1

### Manual testing scenarios
1. Install PHP 7.4 or 8.0
2. Go to, Catalog → Manage products
3. Create a new product
4. Press continue button

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
