### PR TITLE
Fix Varien_File_Uploader ignored errors with try catch

### DIFF
--- a/lib/Varien/File/Uploader.php
+++ b/lib/Varien/File/Uploader.php
@@ -151,10 +151,10 @@ class Varien_File_Uploader
      */
     protected $_result;
 
-    function __construct($fileId)
+    public function __construct($fileId)
     {
         $this->_setUploadFileId($fileId);
-        if(!file_exists($this->_file['tmp_name'])) {
+        if (empty($this->_file['tmp_name']) || !file_exists($this->_file['tmp_name'])) {
             $code = empty($this->_file['tmp_name']) ? self::TMP_NAME_EMPTY : 0;
             throw new Exception('File was not uploaded.', $code);
         } else {


### PR DESCRIPTION
### Description

This fix a Varien/Io/Uploader.php ignored error with try catch.
- Trying to access array offset on value of type null

I hope it's good.

OpenMage 20.0.10 / PHP 7.4.6 and 8.0.5

### Manual testing scenarios
- Install OpenMage
- Install https://github.com/getsentry/magento-amg-sentry-extension
- Configure the installed module, go to System → Configuration → Advanced → Developer → AMG Sentry
- Go to a category, select a category, and save it (without adding a new image)
- Go to your Sentry instance, and read error:
![image](https://user-images.githubusercontent.com/31816829/96845342-e103e480-1450-11eb-84df-ecb954d5e05e.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)