### PR TITLE
Handled the case where the coupon no longer exists

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Observer.php
+++ b/app/code/core/Mage/SalesRule/Model/Observer.php
@@ -149,18 +149,20 @@ class Mage_SalesRule_Model_Observer
             if ($code = $order->getCouponCode()) {
                 // Decrement coupon times_used
                 $coupon = Mage::getModel('salesrule/coupon')->loadByCode($code);
-                $coupon->setTimesUsed($coupon->getTimesUsed() - 1);
-                $coupon->save();
 
+                if ($coupon->getId()) {
+                    $coupon->setTimesUsed($coupon->getTimesUsed() - 1);
+                    $coupon->save();
 
-                if ($customerId = $order->getCustomerId()) {
-                    // Decrement coupon_usage times_used
-                    Mage::getResourceModel('salesrule/coupon_usage')->updateCustomerCouponTimesUsed($customerId, $coupon->getId(), true);
+                    if ($customerId = $order->getCustomerId()) {
+                        // Decrement coupon_usage times_used
+                        Mage::getResourceModel('salesrule/coupon_usage')->updateCustomerCouponTimesUsed($customerId, $coupon->getId(), true);
 
-                    // Decrement rule times_used
-                    if ($customerCoupon = Mage::getModel('salesrule/rule_customer')->loadByCustomerRule($customerId, $coupon->getRuleId())) {
-                        $customerCoupon->setTimesUsed($customerCoupon->getTimesUsed() - 1);
-                        $customerCoupon->save();
+                        // Decrement rule times_used
+                        if ($customerCoupon = Mage::getModel('salesrule/rule_customer')->loadByCustomerRule($customerId, $coupon->getRuleId())) {
+                            $customerCoupon->setTimesUsed($customerCoupon->getTimesUsed() - 1);
+                            $customerCoupon->save();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Related Pull Requests
https://github.com/OpenMage/magento-lts/pull/1117
https://github.com/OpenMage/magento-lts/pull/1111
https://github.com/OpenMage/magento-lts/pull/1031

### Description (*)
If you cancel an order where there is a coupon that no longer exists, an SQL error is generated.

### Manual testing scenarios (*)
1. Create a coupon promotion
2. Place it in an order
3. Cancel the promotion
4. Cancel the order

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
