### PR TITLE
Removed redundant if statement

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
@@ -596,14 +596,10 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
             return $this;
         }
         if (is_array($productId)) {
-            if (!empty($productId)) {
-                if ($exclude) {
-                    $condition = array('nin' => $productId);
-                } else {
-                    $condition = array('in' => $productId);
-                }
+            if ($exclude) {
+                $condition = array('nin' => $productId);
             } else {
-                $condition = '';
+                $condition = array('in' => $productId);
             }
         } else {
             if ($exclude) {
@@ -613,6 +609,7 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
             }
         }
         $this->addFieldToFilter('entity_id', $condition);
+
         return $this;
     }
 


### PR DESCRIPTION
### Description (*)
In method `addIdFilter` is redundant if statement and some code is unreachable.

Look at pseudocode below (`#3` is never executed because we evalueate `if (empty($productId)) {` above).

```
function addIdFilter($productId, $exclude = false)
{
    if (empty($productId)) {
        return "#1 (empty)";
    }
    if (is_array($productId)) {
        if (!empty($productId)) {
            return "#2 (not empty)";
        } else {
            return "#3 (empty)";
        }
    } else {
        return "#4 (not array)";
    }
}


var_dump(addIdFilter(123));             // string(14) "#4 (not array)"
var_dump(addIdFilter([123]));           // string(14) "#2 (not empty)"
var_dump(addIdFilter([0]));             // string(14) "#2 (not empty)"
var_dump(addIdFilter(0));               // string(10) "#1 (empty)"
var_dump(addIdFilter(null));            // string(10) "#1 (empty)"
var_dump(addIdFilter(""));              // string(10) "#1 (empty)"
var_dump(addIdFilter("567"));           // string(14) "#4 (not array)"
var_dump(addIdFilter([null]));          // string(14) "#2 (not empty)"
var_dump(addIdFilter(['']));            // string(14) "#2 (not empty)"
var_dump(addIdFilter(array()));         // string(10) "#1 (empty)"
```

### Manual testing scenarios (*)
```
$collection = Mage::getModel('catalog/product')->getCollection()->addIdFilter([10, 20, 30]);
var_dump($collection->getColumnValues('sku'));
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
