### PR TITLE
Avoids multiplying all price adjustments by the number of websites

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Configurable.php
@@ -172,7 +172,7 @@ class Mage_Catalog_Model_Resource_Product_Indexer_Price_Configurable extends Mag
             )
             ->where('le.required_options=0')
             ->group(array('l.parent_id', 'i.customer_group_id', 'i.website_id', 'l.product_id'));
-        $this->_addWebsiteJoinToSelect($select, true);
+        $this->_addWebsiteJoinToSelect($select, true, 'i.website_id');
         $this->_addProductWebsiteJoinToSelect($select, 'cw.website_id', 'le.entity_id');
 
         $priceExpression = $write->getCheckSql('apw.value_id IS NOT NULL', 'apw.pricing_value', 'apd.pricing_value');


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR ensures that when Magento indexes the price of a configurable product, the price adjustments do not get multiplied by the number of websites configured in Magento.
The bug makes so that, for example, if a Magento installation has 6 websites and one sets a fixed +5€ price adjustment for some configurable options, the index will indicate that the maximum price of the product is `price + (5€ * 6)`.
The cause is a `CROSS JOIN` with the `core_website table`. Since the query in the file changed by this PR executes a `GROUP BY` and uses the `SUM()` function to aggregate the values, this cross join effectively multiplies the computed values by the number of websites. The end result is that the `catalog_product_index_price` table will report weird values for the `min_price` and `max_price` columns (and possibly others too), which in turn could cause strange prices to be displayed whenever those values are used.

The fix is to ensure that the reindex query only considers each website once, by turning the `CROSS JOIN` into an `INNER JOIN` and specifying the join condition.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
There is no open issue about this, at least none that I could find

### Manual testing scenarios (*)
* Install Magento and configure at least two websites;
* Set all indexes to "update on save";
* Create a configurable product with at least one configurable attribute and at least two subproducts. Make sure it's properly configured (active, visible, associated with at least one website... Basically everything needed to see the product in the frontend);
* Set the configurable price to 10
* Check the table `catalog_product_index_price`. The `price`, `final_price`, `min_price` and `max_price` columns should all contain the value 10;
* Set a fixed price adjustment of 2 for only one of the configurability options, then save the configurable.
* Check the `catalog_product_index_price` table again. One would expect to see the same values as before, except for the `max_price` column that should contain 12 (the base price of 10 plus the adjustment of 2). Instead `max_price` contains `10 + (2 * number of websites)`;
* Go back to the configurable product admin page and replace the previous fixed adjustment with a percent price adjustment of -10%, then save;
* In the DB table one would expect to find all columns set to 10, save for the `min_price` columns that should contain 10 - 10% = 9. Instead the value in `min_price` is `10 - (10 * number of websites)%`;
* The same tests after applying the PR should yield the expected values.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
