### PR TITLE
Unset the "has data changed" flag after loading stock items linked to a product.

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -121,6 +121,14 @@ class Mage_CatalogInventory_Model_Observer
         } else {
             Mage::getModel('cataloginventory/stock_status')->addStockStatusToProducts($productCollection);
         }
+
+        // Stock items don't have any real changes (yet), unset the flag!
+        foreach($productCollection as $product){
+            $stockItem = $product->getStockItem();
+            /* @var $stockItem Mage_CatalogInventory_Model_Stock_Item */
+            $stockItem->setDataChanges(false);
+        }
+        
         return $this;
     }
 


### PR DESCRIPTION
The flag is set incorrectly, because some product data was added to the stock item, making Magento believe there was an actual change, when in fact there wasn't. This is the best way to reset this.