### PR TITLE
Modernize setCategoryIds()

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -579,22 +579,22 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     }
 
     /**
-     * Set assigned category IDs array to product
+     * Replace product's category ID(s)
      *
-     * @param array|int|string $ids
+     * @param array|int|string $ids the ID(s) as int, comma-separated string or array of ints
      * @return $this
      */
     public function setCategoryIds($ids)
     {
         if (is_string($ids) === true) {
             $ids = explode(',', $ids);
-            $ids = array_map('intval', $ids);
         } elseif (is_int($ids) === true) {
             $ids = (array) $ids;
         } elseif (is_array($ids) === false) {
             Mage::throwException(Mage::helper('catalog')->__('Invalid category IDs.'));
         }
-
+        
+        $ids = array_map('intval', $ids);
         $this->setData('category_ids', array_filter($ids));
         return $this;
     }

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -593,7 +593,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
         } elseif (is_array($ids) === false) {
             Mage::throwException(Mage::helper('catalog')->__('Invalid category IDs.'));
         }
-        $ids = array_filter(array_map('intval', $ids)));
+        $ids = array_filter(array_map('intval', $ids));
         $this->setData('category_ids', $ids);
         return $this;
     }

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -579,7 +579,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     }
 
     /**
-     * Replace product's category ID(s)
+     * Set assigned category IDs array to product
      *
      * @param array|int|string $ids the ID(s) as int, comma-separated string or array of ints
      * @return $this
@@ -590,7 +590,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
             $ids = explode(',', $ids);
         } elseif (is_int($ids)) {
             $ids = (array) $ids;
-        } elseif (is_array($ids) === false) {
+        } elseif (!is_array($ids)) {
             Mage::throwException(Mage::helper('catalog')->__('Invalid category IDs.'));
         }
         $ids = array_filter(array_map('intval', $ids));

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -588,7 +588,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     {
         if (is_string($ids)) {
             $ids = explode(',', $ids);
-        } elseif (is_int($ids) === true) {
+        } elseif (is_int($ids)) {
             $ids = (array) $ids;
         } elseif (is_array($ids) === false) {
             Mage::throwException(Mage::helper('catalog')->__('Invalid category IDs.'));

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -593,9 +593,8 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
         } elseif (is_array($ids) === false) {
             Mage::throwException(Mage::helper('catalog')->__('Invalid category IDs.'));
         }
-        
-        $ids = array_map('intval', $ids);
-        $this->setData('category_ids', array_filter($ids));
+        $ids = array_filter(array_map('intval', $ids)));
+        $this->setData('category_ids', $ids);
         return $this;
     }
 

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -586,7 +586,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
      */
     public function setCategoryIds($ids)
     {
-        if (is_string($ids) === true) {
+        if (is_string($ids)) {
             $ids = explode(',', $ids);
         } elseif (is_int($ids) === true) {
             $ids = (array) $ids;

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -581,23 +581,21 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     /**
      * Set assigned category IDs array to product
      *
-     * @param array|string $ids
+     * @param array|int|string $ids
      * @return $this
      */
     public function setCategoryIds($ids)
     {
-        if (is_string($ids)) {
+        if (is_string($ids) === true) {
             $ids = explode(',', $ids);
-        } elseif (!is_array($ids)) {
+            $ids = array_map('trim', $ids);
+        } elseif (is_int($ids) === true) {
+            $ids = (array) $ids;
+        } elseif (is_array($ids) === false) {
             Mage::throwException(Mage::helper('catalog')->__('Invalid category IDs.'));
         }
-        foreach ($ids as $i => $v) {
-            if (empty($v)) {
-                unset($ids[$i]);
-            }
-        }
 
-        $this->setData('category_ids', $ids);
+        $this->setData('category_ids', array_filter($ids));
         return $this;
     }
 

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -588,7 +588,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     {
         if (is_string($ids) === true) {
             $ids = explode(',', $ids);
-            $ids = array_map('trim', $ids);
+            $ids = array_map('intval', $ids);
         } elseif (is_int($ids) === true) {
             $ids = (array) $ids;
         } elseif (is_array($ids) === false) {


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This function needlessly rejects `integer` input. Modernized a couple of other things as well, as a proposal.

`array_filter()` is valid since category IDs start at `1`, hence `0` will not happen (`array_filter` would remove a `0`).

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
