### PR TITLE
Removed unnecessary joins for global attributes

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
@@ -601,6 +601,7 @@ abstract class Mage_Catalog_Model_Resource_Abstract extends Mage_Eav_Model_Entit
         $typedAttributes    = array();
         $staticTable        = null;
         $adapter            = $this->_getReadAdapter();
+        $getPerStore        = false;
 
         foreach ($attribute as $_attribute) {
             /* @var Mage_Catalog_Model_Entity_Attribute $attribute */
@@ -611,6 +612,10 @@ abstract class Mage_Catalog_Model_Resource_Abstract extends Mage_Eav_Model_Entit
             $attributeCode = $_attribute->getAttributeCode();
             $attrTable     = $_attribute->getBackend()->getTable();
             $isStatic      = $_attribute->getBackend()->isStatic();
+
+            if (!$getPerStore && $_attribute->getIsGlobal() != Mage_Catalog_Model_Resource_Eav_Attribute::SCOPE_GLOBAL) {
+                $getPerStore = true;
+            }
 
             if ($isStatic) {
                 $staticAttributes[] = $attributeCode;
@@ -653,7 +658,7 @@ abstract class Mage_Catalog_Model_Resource_Abstract extends Mage_Eav_Model_Entit
                     'entity_id'      => $entityId,
                 );
 
-                if ($store != $this->getDefaultStoreId()) {
+                if ($getPerStore && $store != $this->getDefaultStoreId()) {
                     $valueExpr = $adapter->getCheckSql(
                         'store_value.value IS NULL',
                         'default_value.value',


### PR DESCRIPTION
### Description (*)
If you getting data for global attributes using method `getAttributeRawValue` for specific store, there should not be necessary to check store-scope for this values.

### Manual testing scenarios (*)

#### Database values
![image](https://user-images.githubusercontent.com/9967016/99266094-b411da00-2822-11eb-9b91-c00318662434.png)

#### Code snippet
```        
// global + scope (for specific store)
$data = Mage::getResourceSingleton('catalog/product')->getAttributeRawValue(
    102106,
    ['related_sku', 'battery'],
    2
);
bdump($data);

// global + scope (for default store)
$data = Mage::getResourceSingleton('catalog/product')->getAttributeRawValue(
    102106,
    ['related_sku', 'battery'],
    0
);
bdump($data);

// global + scope (for specific store)
$data = Mage::getResourceSingleton('catalog/product')->getAttributeRawValue(
    102106,
    ['related_sku', 'battery'],
    2
);
bdump($data);

// global + global
$data = Mage::getResourceSingleton('catalog/product')->getAttributeRawValue(
    102106,
    ['related_sku', 'position'],
    2
);
bdump($data);

die();
```

#### Output
Left - before / Right - after
![Screenshot_8](https://user-images.githubusercontent.com/9967016/99265990-98a6cf00-2822-11eb-8c8b-60d46085a200.png)

_"get per store" was my testing string which was been placed inside edited if statement_


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
