### PR TITLE
Fix for currency symbol not saved with fatal PHP error

### DIFF
--- a/app/code/core/Mage/CurrencySymbol/controllers/Adminhtml/System/CurrencysymbolController.php
+++ b/app/code/core/Mage/CurrencySymbol/controllers/Adminhtml/System/CurrencysymbolController.php
@@ -69,7 +69,7 @@ class Mage_CurrencySymbol_Adminhtml_System_CurrencysymbolController extends Mage
 
         try {
             Mage::getModel('currencysymbol/system_currencysymbol')->setCurrencySymbolsData($symbolsDataArray);
-            Mage::getSingleton('connect/session')->addSuccess(
+            Mage::getSingleton('adminhtml/session')->addSuccess(
                 Mage::helper('currencysymbol')->__('Custom currency symbols were applied successfully.')
             );
         } catch (Exception $e) {


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Fix for Currency symbol not saved with fatal PHP error
Replace  Mage::getSingleton('connect/session') with Mage::getSingleton('adminhtml/session') in CurrencysymbolController

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#1318

### Manual testing scenarios (*)
1. Login to backend and navigate to System > Manage Currency > Symbols
2. Click on Save Currency Symbols button
3. Ensure that currency symbol is saved and green success "Custom currency symbols were applied successfully." notice is shown.



### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
