### PR TITLE
Add a word-break to list items to keep the layout intact

### DIFF
--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -333,7 +333,7 @@ table.form-edit                         { width:100%; }
 .entry-edit .entry-edit-head a          { color:#fff; font-size:1em; line-height:18px; min-height:0; font-weight:bold}
 .entry-edit .content                    { margin-left:0 !important; padding:10px 15px; }
 .entry-edit fieldset li,
-.entry-edit .fieldset li                { margin:4px 0; }
+.entry-edit .fieldset li                { margin:4px 0; word-break: break-all; }
 .entry-edit fieldset span.form_row,
 .entry-edit .fieldset span.form_row,
 .entry-edit fieldset .field-row .hint,

--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -553,10 +553,18 @@ td.divider              { font-size:1px; line-height:0; }
 
 
 /**/
-.note-list { width:100%; overflow:hidden; }
-.note-list li { border-top:1px solid #e3e3e3; margin-top:9px !important; background:url(images/icon_note_list.gif) no-repeat 0 4px; padding-bottom:9px; padding-left:18px; }
-
-
+.note-list {
+    width:100%;
+    overflow:hidden;
+}
+.note-list li {
+    border-top: 1px solid #e3e3e3;
+    margin-top: 9px !important;
+    background: url(images/icon_note_list.gif) no-repeat 0 4px;
+    padding-bottom: 9px;
+    padding-left: 18px;
+    word-break: break-all;
+}
 
 /******************************************************************************/
 /********************************** STRUCTURE *********************************/


### PR DESCRIPTION
Long words (like URLs from payment modules) mess up the order notes layout like this:

Before:
![image](https://user-images.githubusercontent.com/7300472/100254787-0cdc2380-2f43-11eb-9786-fb67bc7575da.png)

A `word-break` fixes it and although it does break the word at the end of the box, it does not take away any information.

After:

![image](https://user-images.githubusercontent.com/7300472/100254820-12d20480-2f43-11eb-9599-f90e9fa7987b.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
