### PR TITLE
Move orig data to abstract model (according to Magento 2.x)

### DIFF
--- a/app/code/core/Mage/Core/Model/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Abstract.php
@@ -59,6 +59,13 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
     protected $_eventObject = 'object';
 
     /**
+     * Original data that was loaded
+     *
+     * @var array
+     */
+    protected $_origData;
+
+    /**
      * Name of the resource model
      *
      * @var string
@@ -112,6 +119,51 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
     protected function _init($resourceModel)
     {
         $this->_setResourceModel($resourceModel);
+    }
+
+    /**
+     * Get object loaded data (original data)
+     *
+     * @param string $key
+     * @return mixed
+     */
+    public function getOrigData($key = null)
+    {
+        if (is_null($key)) {
+            return $this->_origData;
+        }
+        return isset($this->_origData[$key]) ? $this->_origData[$key] : null;
+    }
+
+    /**
+     * Initialize object original data
+     *
+     * @param string $key
+     * @param mixed $data
+     * @return $this
+     */
+    public function setOrigData($key = null, $data = null)
+    {
+        if (is_null($key)) {
+            $this->_origData = $this->_data;
+        } else {
+            $this->_origData[$key] = $data;
+        }
+        return $this;
+    }
+
+    /**
+     * Compare object data with original data
+     *
+     * @param string $field
+     * @return boolean
+     */
+    public function dataHasChangedFor($field)
+    {
+        $newData = $this->getData($field);
+        $origData = $this->getOrigData($field);
+
+        return $newData != $origData;
     }
 
     /**

--- a/lib/Varien/Object.php
+++ b/lib/Varien/Object.php
@@ -47,13 +47,6 @@ class Varien_Object implements ArrayAccess
     protected $_hasDataChanges = false;
 
     /**
-    * Original data that was loaded
-    *
-    * @var array
-    */
-    protected $_origData;
-
-    /**
      * Name of object id field
      *
      * @var string
@@ -747,50 +740,6 @@ class Varien_Object implements ArrayAccess
         }
         $res = implode($fieldSeparator, $data);
         return $res;
-    }
-
-    /**
-     * Get object loaded data (original data)
-     *
-     * @param string $key
-     * @return mixed
-     */
-    public function getOrigData($key=null)
-    {
-        if (is_null($key)) {
-            return $this->_origData;
-        }
-        return isset($this->_origData[$key]) ? $this->_origData[$key] : null;
-    }
-
-    /**
-     * Initialize object original data
-     *
-     * @param string $key
-     * @param mixed $data
-     * @return $this
-     */
-    public function setOrigData($key=null, $data=null)
-    {
-        if (is_null($key)) {
-            $this->_origData = $this->_data;
-        } else {
-            $this->_origData[$key] = $data;
-        }
-        return $this;
-    }
-
-    /**
-     * Compare object data with original data
-     *
-     * @param string $field
-     * @return boolean
-     */
-    public function dataHasChangedFor($field)
-    {
-        $newData = $this->getData($field);
-        $origData = $this->getOrigData($field);
-        return $newData!=$origData;
     }
 
     /**


### PR DESCRIPTION
### Description (*)
Move `origData` property and related methods to `mage_Core_Model_Abstract` according to Magento 2.x.

Related M2 file: https://github.com/magento/magento2/blob/fbfac3e51730abe2b79c6072544bc9742fcf7606/lib/internal/Magento/Framework/Model/AbstractModel.php#L56

**These methods are not used in any direct child of `Varien_Object`:**
`$ grep -R -B10000 -A10000 -P 'OrigData|dataHasChangedFor' . | grep -F "extends Varien_Object"`

**Output:**
`./app/code/core/Mage/Core/Model/Abstract.php-abstract class Mage_Core_Model_Abstract extends Varien_Object`


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)