### PR TITLE
Fix notice when there are no sales rules for a given situation

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Validator.php
+++ b/app/code/core/Mage/SalesRule/Model/Validator.php
@@ -140,7 +140,7 @@ class Mage_SalesRule_Model_Validator extends Mage_Core_Model_Abstract
     protected function _getRules()
     {
         $key = $this->getWebsiteId() . '_' . $this->getCustomerGroupId() . '_' . $this->getCouponCode();
-        return $this->_rules[$key];
+        return isset($this->_rules[$key]) ? $this->_rules[$key] :  null;
     }
 
     /**

--- a/app/code/core/Mage/SalesRule/Model/Validator.php
+++ b/app/code/core/Mage/SalesRule/Model/Validator.php
@@ -140,7 +140,7 @@ class Mage_SalesRule_Model_Validator extends Mage_Core_Model_Abstract
     protected function _getRules()
     {
         $key = $this->getWebsiteId() . '_' . $this->getCustomerGroupId() . '_' . $this->getCouponCode();
-        return isset($this->_rules[$key]) ? $this->_rules[$key] :  null;
+        return $this->_rules[$key] ?? null;
     }
 
     /**


### PR DESCRIPTION
### Description (*)

When there are no sales rules for a given combination of website, customer group and coupon code, a notice is generated. This checks more carefully to not emit the notice and just return null.

### Manual testing scenarios (*)

I'm not sure how to trigger the code path without third party extension code.

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
