### PR TITLE
Fix phpDoc for set/getStepData in Checkout

### DIFF
--- a/app/code/core/Mage/Checkout/Model/Session.php
+++ b/app/code/core/Mage/Checkout/Model/Session.php
@@ -323,9 +323,13 @@ class Mage_Checkout_Model_Session extends Mage_Core_Model_Session_Abstract
     }
 
     /**
-     * @param array $step
-     * @param array $data
-     * @param string $value
+     * Set step data for given checkout step (e.g. "billing").
+     * By providing the two parameters data and value, the data will be added to existing step data.
+     * By providing an associative array [data => value, ...] the existing step data will be replaced.
+     * 
+     * @param string $step
+     * @param array|string $data
+     * @param mixed|null $value
      * @return $this
      */
     public function setStepData($step, $data, $value = null)
@@ -349,9 +353,12 @@ class Mage_Checkout_Model_Session extends Mage_Core_Model_Session_Abstract
     }
 
     /**
-     * @param array $step
-     * @param array $data
-     * @return array|false
+     * Returns existing step data for all steps ($step = null) or the provided checkout step.
+     * By providing $data only this data of the given step will be returned, or false if not set.
+     *
+     * @param string|null $step
+     * @param string|null $data
+     * @return array|mixed|false
      */
     public function getStepData($step = null, $data = null)
     {


### PR DESCRIPTION
### Description (*)
Fixed the phpDoc so it matches the function code

### Fixed Issues (if relevant)
setStepData & getStepData:
According to the function code, $step must not be an array as previously stated. It has to be either string or int. Since strings are used to identify checkout steps (like "billing"), I assumed this to be the correct type.

setStepData only:
The function does not perform any type check on $value, thus it can be of any type. Leaving out $value and calling the function with an array [data => value] is also possible and now reflected in the phpdoc comments.

getStepData only:
$step can be null and will return all steps' data (multi-dimensional array) or all of the given step's data (array) or the defined data from the given step (mixed), false otherwise.
I know that "array" is part of "mixed", but since it seems like a different context, i mentioned that additionally.

### Manual testing scenarios (*)
Either in separate file (requiring app/Mage.php) or a module:
1. Mage::getSingleton('checkout/session')->getStepData();
2. Mage::getSingleton('checkout/session')->getStepData('billing');
3. Mage::getSingleton('checkout/session')->setStepData('billing', 'allow', true);
4. Mage::getSingleton('checkout/session')->getStepData('billing', 'allow');

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All automated tests passed successfully (all builds are green)
