### PR TITLE
Allow min pass length to 5 during login

### DIFF
--- a/app/design/frontend/base/default/template/customer/form/login.phtml
+++ b/app/design/frontend/base/default/template/customer/form/login.phtml
@@ -61,7 +61,7 @@
                         <li>
                             <label for="pass" class="required"><em>*</em><?php echo $this->__('Password') ?></label>
                             <div class="input-box">
-                                <input type="password" name="login[password]" class="input-text required-entry validate-password" id="pass" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Password')) ?>" />
+                                <input type="password" name="login[password]" class="input-text required-entry validate-password min-pass-length-5" id="pass" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Password')) ?>" />
                             </div>
                         </li>
                         <?php echo $this->getChildHtml('form.additional.info'); ?>

--- a/app/design/frontend/base/default/template/oauth/authorize/form/login.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/form/login.phtml
@@ -52,7 +52,7 @@ $rejectJs = "document.location.href='{$this->getRejectUrl()}';";
                             <li>
                                 <label for="pass"><?php echo $this->__('Password') ?></label>
                                 <div class="input-box">
-                                    <input type="password" name="login[password]" class="input-text required-entry validate-password" id="pass" title="<?php echo $this->__('Password') ?>" />
+                                    <input type="password" name="login[password]" class="input-text required-entry validate-password min-pass-length-5" id="pass" title="<?php echo $this->__('Password') ?>" />
                                 </div>
                             </li>
                         </ul>

--- a/app/design/frontend/default/iphone/template/customer/form/login.phtml
+++ b/app/design/frontend/default/iphone/template/customer/form/login.phtml
@@ -54,7 +54,7 @@
                         <li>
                             <label for="pass" class="required"><em>*</em><?php echo $this->__('Password') ?></label>
                             <div class="input-box">
-                                <input type="password" name="login[password]" class="input-text required-entry validate-password" id="pass" title="<?php echo $this->__('Password') ?>" />
+                                <input type="password" name="login[password]" class="input-text required-entry validate-password min-pass-length-5" id="pass" title="<?php echo $this->__('Password') ?>" />
                             </div>
                         </li>
                         <li class="note">

--- a/app/design/frontend/default/iphone/template/persistent/customer/form/login.phtml
+++ b/app/design/frontend/default/iphone/template/persistent/customer/form/login.phtml
@@ -53,7 +53,7 @@
                         <li>
                             <label for="pass" class="required"><em>*</em><?php echo $this->__('Password') ?></label>
                             <div class="input-box">
-                                <input type="password" name="login[password]" class="input-text required-entry validate-password" id="pass" title="<?php echo $this->__('Password') ?>" />
+                                <input type="password" name="login[password]" class="input-text required-entry validate-password min-pass-length-5" id="pass" title="<?php echo $this->__('Password') ?>" />
                             </div>
                         </li>
                         <li class="note">


### PR DESCRIPTION

### Description (*)

Allow customer to login with a password of 5 characters. It will avoid to have some customers who cannot login because their current password is less than 7 characters.

### Related Pull Requests

No related pull request found.

### Fixed Issues (if relevant)

1. Fixes OpenMage/magento-lts#855  

### Manual testing scenarios (*)

1. Try to login with a password with less than 7 characters but more than 5.
2. You will not have the JS validation which tells you that your password is too short.

### Questions or comments

We can decrease the limit of 5 characters if necessary. I don't know the old minimum password length.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
