### PR TITLE
Fix: Integrity constraint violation: Duplicate key

### DIFF
--- a/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
+++ b/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
@@ -561,7 +561,7 @@ class Mage_CatalogRule_Model_Action_Index_Refresh
                     new Zend_Db_Expr($this->_connection->getUnixTimestamp('dates.rule_date') . " <= to_time")
                 )
             )
-            ->group(array('customer_group_id', 'product_id', 'dates.rule_date'));
+            ->group(array('customer_group_id', 'product_id', 'dates.rule_date', 'website_id'));
 
         return $select;
     }
@@ -590,7 +590,9 @@ class Mage_CatalogRule_Model_Action_Index_Refresh
         $this->_connection->query(
             $this->_connection->insertFromSelect(
                 $this->_prepareIndexSelect($website, $time),
-                $this->_resource->getTable('catalogrule/rule_product_price')
+                $this->_resource->getTable('catalogrule/rule_product_price'),
+                [],
+                Varien_Db_Adapter_Interface::INSERT_IGNORE
             )
         );
     }


### PR DESCRIPTION
Fix: Integrity constraint violation: 1062 Duplicate entry for key 'UNQ_CATRULE_PRD_PRICE_RULE_DATE_WS_ID_CSTR_GROUP_ID_PRD_ID'

<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fix for:
Integrity constraint violation: 1062 Duplicate entry for key 'UNQ_CATRULE_PRD_PRICE_RULE_DATE_WS_ID_CSTR_GROUP_ID_PRD_ID'

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#1241

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. magerun sys:cron:run catalogrule_apply_all
2. Run Mage_CatalogRule_Model_Observer::dailyCatalogUpdate **done**

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
