### PR TITLE
Fix password creation validation - validation does not fail after pas…

### DIFF
--- a/app/code/core/Mage/Customer/controllers/AccountController.php
+++ b/app/code/core/Mage/Customer/controllers/AccountController.php
@@ -1048,6 +1048,9 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
                 }
                 $this->_redirect('*/*/edit');
                 return $this;
+            } else {
+                // Unset validator data so that user is not logged out after password change
+                unset($_SESSION[Mage_Core_Model_Session_Abstract_Varien::VALIDATOR_KEY][Mage_Core_Model_Session_Abstract_Varien::VALIDATOR_PASSWORD_CREATE_TIMESTAMP]);
             }
 
             try {


### PR DESCRIPTION
…sword is changed.

### Description (*)

Adds session validation information so that when the user changes their password all other sessions for their account become invalidated.

### Fixed Issues (if relevant)

Unreported. Credit goes to Sakshi Patil for reporting via openmage.org email

### Manual testing scenarios (*)

1. Login with two sessions simultaneously (e.g. two different browsers)
2. Change password on session 1

Before:
- Session 2 is not logged out

After:
- Session 2 is logged out

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
