### PR TITLE
Fix getId() on bool when primary billing address is null

### DIFF
--- a/app/code/core/Mage/Customer/Model/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Customer.php
@@ -654,7 +654,7 @@ class Mage_Customer_Model_Customer extends Mage_Core_Model_Abstract
 
         $primaryShipping = $this->getPrimaryShippingAddress();
         if ($primaryShipping) {
-            if ($primaryBilling->getId() == $primaryShipping->getId()) {
+            if ($primaryBilling && $primaryBilling->getId() == $primaryShipping->getId()) {
                 $primaryBilling->setIsPrimaryShipping(true);
             } else {
                 $primaryShipping->setIsPrimaryShipping(true);


### PR DESCRIPTION
### Description (*)
![image](https://user-images.githubusercontent.com/9967016/101774547-8b61c500-3aee-11eb-8348-5b31f3f478c9.png)

If I have `$primaryShipping` and I do not have `$primaryBilling`, code ends with Fatal error: `Call to a member function getId() on bool`


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
