### PR TITLE
Clean up empty directories created when file requested does not exist in remote storage.

### DIFF
--- a/get.php
+++ b/get.php
@@ -141,6 +141,9 @@ if (!$mediaDirectory) {
 if (0 !== stripos($pathInfo, $mediaDirectory . '/')) {
     sendNotFoundPage();
 }
+if (substr_count($relativeFilename, '/') > 10) {
+    sendNotFoundPage();
+}
 
 $localStorage = Mage::getModel('core/file_storage_file');
 $remoteStorage = Mage::getModel('core/file_storage_database');

--- a/get.php
+++ b/get.php
@@ -152,7 +152,7 @@ try {
         try {
             $remoteStorage->loadByFilename($relativeFilename);
         } catch (Exception $e) {
-            // Ignore errors
+            Mage::logException($e);
         }
         if ($remoteStorage->getId()) {
             $localStorage->saveFile($remoteStorage, false);


### PR DESCRIPTION
Quick fix for #1334 

### Description (*)

Cleans up empty directories created in the same process.

### Related Pull Requests

#601 

### Fixed Issues (if relevant)

1. Fixes OpenMage/magento-lts#1334

### Manual testing scenarios (*)

1. Make a request for a file in a directory that does not exist (`/media/foo/bar/baz`)
2. Check that no empty directories persist as a result of step 1

### Questions or comments

Not a perfect solution since a large number of simultaneous requests with the same subdirectories could still result in some directories being persisted. The random cleanup job (1 in 1000) uses exec and "find" so will only work on Linux with "find" available.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
