### PR TITLE
Fixed Zend Lib  Deprecated Notice PHP8

### DIFF
--- a/lib/Zend/Gdata/YouTube.php
+++ b/lib/Zend/Gdata/YouTube.php
@@ -799,8 +799,8 @@ class Zend_Gdata_YouTube extends Zend_Gdata_Media
      *         Zend_Gdata_YouTube_Inbox_Entry representing the sent message.
      *
      */
-    public function sendVideoMessage($body, $videoEntry = null,
-        $videoId = null, $recipientUserName)
+    public function sendVideoMessage($body, $videoEntry,
+        $videoId, $recipientUserName)
     {
         if (!$videoId && !$videoEntry) {
             #require_once 'Zend/Gdata/App/InvalidArgumentException.php';

--- a/lib/Zend/Pdf/Element/Reference.php
+++ b/lib/Zend/Pdf/Element/Reference.php
@@ -88,7 +88,7 @@ class Zend_Pdf_Element_Reference extends Zend_Pdf_Element
      * @param Zend_Pdf_ElementFactory $factory
      * @throws Zend_Pdf_Exception
      */
-    public function __construct($objNum, $genNum = 0, Zend_Pdf_Element_Reference_Context $context, Zend_Pdf_ElementFactory $factory)
+    public function __construct($objNum, $genNum, Zend_Pdf_Element_Reference_Context $context, Zend_Pdf_ElementFactory $factory)
     {
         if ( !(is_integer($objNum) && $objNum > 0) ) {
             #require_once 'Zend/Pdf/Exception.php';

--- a/lib/Zend/Service/WindowsAzure/CommandLine/Certificate.php
+++ b/lib/Zend/Service/WindowsAzure/CommandLine/Certificate.php
@@ -143,7 +143,7 @@ class Zend_Service_WindowsAzure_CommandLine_Certificate
 	 * @command-example Get certificate for service name "phptest":
 	 * @command-example Get -sid:"<your_subscription_id>" -cert:"mycert.pem" -sn:"phptest" --CertificateThumbprint:"<thumbprint>" --CertificateAlgorithm:"sha1"
 	 */
-	public function getCertificatePropertyCommand($subscriptionId, $certificate, $certificatePassphrase, $serviceName, $thumbprint, $algorithm = "sha1", $property)
+	public function getCertificatePropertyCommand($subscriptionId, $certificate, $certificatePassphrase, $serviceName, $thumbprint, $algorithm, $property)
 	{
 		$client = new Zend_Service_WindowsAzure_Management_Client($subscriptionId, $certificate, $certificatePassphrase);
 		$result = $client->getCertificate($serviceName, $algorithm, $thumbprint);

--- a/lib/Zend/Service/WindowsAzure/CommandLine/Deployment.php
+++ b/lib/Zend/Service/WindowsAzure/CommandLine/Deployment.php
@@ -79,7 +79,7 @@ class Zend_Service_WindowsAzure_CommandLine_Deployment
 	 * @command-example --PackageUrl:"http://acct.blob.core.windows.net/pkgs/service.cspkg"
 	 * @command-example --ServiceConfigLocation:".\ServiceConfiguration.cscfg" --StartImmediately --WaitFor
 	 */
-	public function createFromStorageCommand($subscriptionId, $certificate, $certificatePassphrase, $serviceName, $deploymentName, $label, $staging = false, $production = false, $packageUrl, $serviceConfigurationLocation, $startImmediately = true, $warningsAsErrors = false, $waitForOperation = false)
+	public function createFromStorageCommand($subscriptionId, $certificate, $certificatePassphrase, $serviceName, $deploymentName, $label, $staging , $production , $packageUrl, $serviceConfigurationLocation, $startImmediately = true, $warningsAsErrors = false, $waitForOperation = false)
 	{
 		$deploymentSlot = 'staging';
 		if (!$staging && !$production) {
@@ -90,12 +90,13 @@ class Zend_Service_WindowsAzure_CommandLine_Deployment
 			$deploymentSlot = 'production';
 		}
 
-		$client->createDeployment($serviceName, $deploymentSlot, $deploymentName, $label, $packageUrl, $serviceConfigurationLocation, $startImmediately, $warningsAsErrors);
+		// $client was never set probably dead code
+		/*$client->createDeployment($serviceName, $deploymentSlot, $deploymentName, $label, $packageUrl, $serviceConfigurationLocation, $startImmediately, $warningsAsErrors);
 
 		if ($waitForOperation) {
 			$client->waitForOperation();
 		}
-		echo $client->getLastRequestId();
+		echo $client->getLastRequestId();*/
 	}
 
 	/**
@@ -123,7 +124,7 @@ class Zend_Service_WindowsAzure_CommandLine_Deployment
 	 * @command-example --ServiceConfigLocation:".\ServiceConfiguration.cscfg" --StorageAccount:"mystorage"
 	 * @command-example --StartImmediately --WaitFor
 	 */
-	public function createFromLocalCommand($subscriptionId, $certificate, $certificatePassphrase, $serviceName, $deploymentName, $label, $staging = false, $production = false, $packageLocation, $serviceConfigurationLocation, $storageAccount, $startImmediately = true, $warningsAsErrors = false, $waitForOperation = false)
+	public function createFromLocalCommand($subscriptionId, $certificate, $certificatePassphrase, $serviceName, $deploymentName, $label, $staging , $production, $packageLocation, $serviceConfigurationLocation, $storageAccount, $startImmediately = true, $warningsAsErrors = false, $waitForOperation = false)
 	{
 		$deploymentSlot = 'staging';
 		if (!$staging && !$production) {

--- a/lib/Zend/Service/WindowsAzure/Diagnostics/Manager.php
+++ b/lib/Zend/Service/WindowsAzure/Diagnostics/Manager.php
@@ -209,7 +209,7 @@ class Zend_Service_WindowsAzure_Diagnostics_Manager
 	 * @param Zend_Service_WindowsAzure_Diagnostics_ConfigurationInstance $configuration Configuration to apply
 	 * @throws Zend_Service_WindowsAzure_Diagnostics_Exception
 	 */
-	public function setConfigurationForRoleInstance($roleInstance = null, Zend_Service_WindowsAzure_Diagnostics_ConfigurationInstance $configuration)
+	public function setConfigurationForRoleInstance($roleInstance, Zend_Service_WindowsAzure_Diagnostics_ConfigurationInstance $configuration)
 	{
 		if (is_null($roleInstance)) {
 			#require_once 'Zend/Service/WindowsAzure/Diagnostics/Exception.php';

--- a/lib/Zend/Service/WindowsAzure/Storage/Queue.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/Queue.php
@@ -519,7 +519,7 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 	 * @param Zend_Service_WindowsAzure_Storage_QueueMessage $message Message to delete from queue. A message retrieved using "peekMessages" can NOT be deleted!
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	public function deleteMessage($queueName = '', Zend_Service_WindowsAzure_Storage_QueueMessage $message)
+	public function deleteMessage($queueName, Zend_Service_WindowsAzure_Storage_QueueMessage $message)
 	{
 		if ($queueName === '') {
 			#require_once 'Zend/Service/WindowsAzure/Exception.php';


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
bugfix(zend) Deprecated: Required parameter $A follows optional parameter $B (example) 


### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#1271

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

Only one function was call from another one. 

public function deleteMessage
/lib/Zend/Service/WindowsAzure/Storage/Queue.php:522


Deprecated: Required parameter $packageUrl follows optional parameter $staging in ./Service/WindowsAzure/CommandLine/Deployment.php on line 82
Deprecated: Required parameter $serviceConfigurationLocation follows optional parameter $staging in ./Service/WindowsAzure/CommandLine/Deployment.php on line 82
Deprecated: Required parameter $packageLocation follows optional parameter $staging in ./Service/WindowsAzure/CommandLine/Deployment.php on line 126
Deprecated: Required parameter $serviceConfigurationLocation follows optional parameter $staging in ./Service/WindowsAzure/CommandLine/Deployment.php on line 126
Deprecated: Required parameter $storageAccount follows optional parameter $staging in ./Service/WindowsAzure/CommandLine/Deployment.php on line 126
Deprecated: Required parameter $property follows optional parameter $algorithm in ./Service/WindowsAzure/CommandLine/Certificate.php on line 146
Deprecated: Required parameter $message follows optional parameter $queueName in ./Service/WindowsAzure/Storage/Queue.php on line 522
Deprecated: Required parameter $configuration follows optional parameter $roleInstance in ./Service/WindowsAzure/Diagnostics/Manager.php on line 212
Deprecated: Required parameter $context follows optional parameter $genNum in ./Pdf/Element/Reference.php on line 91
Deprecated: Required parameter $factory follows optional parameter $genNum in ./Pdf/Element/Reference.php on line 91
Deprecated: Required parameter $recipientUserName follows optional parameter $videoEntry in ./Gdata/YouTube.php on line 802

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
