### PR TITLE
Trim values from XML so auto-formatting our XML does not break the autoloader.

### DIFF
--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -1288,6 +1288,8 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
                 }
             }
         }
+        
+        $className = trim($className);
 
         // Second - if entity is not rewritten then use class prefix to form class name
         if (empty($className)) {


### PR DESCRIPTION
If you auto-format an XML file (like in PHPStorm), the value/class name can end up on a new line. This breaks the loading of the class, because Magento tries to create a class that starts with a newline and spaces. This simple trim avoids formatting issues.