### PR TITLE
Use mb_substr to split the postcode

### DIFF
--- a/app/code/core/Mage/Tax/Model/Resource/Calculation.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation.php
@@ -222,16 +222,16 @@ class Mage_Tax_Model_Resource_Calculation extends Mage_Core_Model_Resource_Db_Ab
     protected function _createSearchPostCodeTemplates($postcode)
     {
         $len = Mage::helper('tax')->getPostCodeSubStringLength();
-        $strlen = strlen($postcode);
+        $strlen = mb_strlen($postcode);
         if ($strlen > $len) {
-            $postcode = substr($postcode, 0, $len);
+            $postcode = mb_substr($postcode, 0, $len);
             $strlen = $len;
         }
 
         $strArr = array((string)$postcode, $postcode . '*');
         if ($strlen > 1) {
             for ($i = 1; $i < $strlen; $i++) {
-                $strArr[] = sprintf('%s*', substr($postcode, 0, - $i));
+                $strArr[] = sprintf('%s*', mb_substr($postcode, 0, - $i));
             }
         }
 


### PR DESCRIPTION
### Description
This PR fix illegal mix collation when user postcode contains accented characters.
OpenMage 20.0.4 / PHP 7.4.6 - 8.0.0

### Manual testing scenarios
1. Set your local.xml to use utf8mb4 (#1036 #430)
2. Try to set the postcode "00-5éé" in your shipping address on the checkout

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
