### PR TITLE
Inventory saving improvement

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
@@ -124,6 +124,7 @@ class Mage_Adminhtml_Catalog_Product_Action_AttributeController extends Mage_Adm
                 /** @var $stockItem Mage_CatalogInventory_Model_Stock_Item */
                 $stockItem = Mage::getModel('cataloginventory/stock_item');
                 $stockItem->setProcessIndexEvents(false);
+                $stockItem->setProcessIndexLogs(false);
                 $stockItemSaved = false;
                 $changedProductIds = array();
 

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
@@ -160,6 +160,13 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
      */
     protected $_processIndexEvents = true;
 
+     /**
+     * Whether index events should be logged immediately
+     *
+     * @var bool
+     */
+    protected $_processIndexLogs = true;
+
     /**
      * Initialize resource model
      *
@@ -938,6 +945,18 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
     }
 
     /**
+     * Set whether index events should be logged immediately
+     *
+     * @param bool $process
+     * @return $this
+     */
+    public function setProcessIndexLogs($process = true)
+    {
+        $this->_processIndexLogs = $process;
+        return $this;
+    }
+
+    /**
      * Callback function which called after transaction commit in resource model
      *
      * @return $this
@@ -951,7 +970,7 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
 
         if ($this->_processIndexEvents) {
             $indexer->processEntityAction($this, self::ENTITY, Mage_Index_Model_Event::TYPE_SAVE);
-        } else {
+        } elseif ($this->_processIndexLogs) {
             $indexer->logEvent($this, self::ENTITY, Mage_Index_Model_Event::TYPE_SAVE);
         }
         return $this;


### PR DESCRIPTION
### Description (*)
If I perform mass actions in the inventory, in addition to not wanting to trigger the reindex at each save I don't want an index process log to be saved, since a manual index will be done later.
This significantly improves performance during mass action.

### Manual testing scenarios (*)
Send a massaction on many products by updating inventory attributes.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
