### PR TITLE
Add weight for API salesOrderShipmentAddTrack

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Api.php
@@ -175,7 +175,7 @@ class Mage_Sales_Model_Order_Shipment_Api extends Mage_Sales_Model_Api_Resource
      * @param string $trackNumber
      * @return int
      */
-    public function addTrack($shipmentIncrementId, $carrier, $title, $trackNumber)
+    public function addTrack($shipmentIncrementId, $carrier, $title, $trackNumber, $weight = null)
     {
         $shipment = Mage::getModel('sales/order_shipment')->loadByIncrementId($shipmentIncrementId);
 
@@ -193,6 +193,10 @@ class Mage_Sales_Model_Order_Shipment_Api extends Mage_Sales_Model_Api_Resource
                     ->setNumber($trackNumber)
                     ->setCarrierCode($carrier)
                     ->setTitle($title);
+
+        if (!empty($weight)) {
+            $track->setWeight($weight);
+        }
 
         $shipment->addTrack($track);
 

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Api.php
@@ -173,6 +173,7 @@ class Mage_Sales_Model_Order_Shipment_Api extends Mage_Sales_Model_Api_Resource
      * @param string $carrier
      * @param string $title
      * @param string $trackNumber
+     * @param null|float $weight
      * @return int
      */
     public function addTrack($shipmentIncrementId, $carrier, $title, $trackNumber, $weight = null)

--- a/app/code/core/Mage/Sales/etc/wsdl.xml
+++ b/app/code/core/Mage/Sales/etc/wsdl.xml
@@ -843,6 +843,7 @@
         <part name="carrier" type="xsd:string" />
         <part name="title" type="xsd:string" />
         <part name="trackNumber" type="xsd:string" />
+        <part name="weight" type="xsd:double" minOccurs="0" />
     </message>
     <message name="salesOrderShipmentAddTrackResponse">
         <part name="result" type="xsd:int" />

--- a/app/code/core/Mage/Sales/etc/wsi.xml
+++ b/app/code/core/Mage/Sales/etc/wsi.xml
@@ -881,6 +881,7 @@
                         <xsd:element minOccurs="1" maxOccurs="1" name="carrier" type="xsd:string" />
                         <xsd:element minOccurs="1" maxOccurs="1" name="title" type="xsd:string" />
                         <xsd:element minOccurs="1" maxOccurs="1" name="trackNumber" type="xsd:string" />
+                        <xsd:element minOccurs="0" maxOccurs="1" name="weight" type="xsd:double" />
                     </xsd:sequence>
                 </xsd:complexType>
             </xsd:element>


### PR DESCRIPTION
### Description
This PR add the possibility to specify a weight when adding a tracking number to a shipment.

[API doc1](https://r-martins.github.io/m1docs/guides/m1x/api/soap/sales/salesOrderShipment/sales_order_shipment.addTrack.html) [API doc2](https://devdocs-openmage.org/guides/m1x/api/soap/sales/salesOrderShipment/sales_order_shipment.addTrack.html)
```
Type | Name | Description
string | sessionId | Session ID
string | shipmentIncrementId | Shipment increment ID
string | carrier | Carrier code (ups, usps, dhl, fedex, or dhlint)
string | title | Tracking title
string | trackNumber | Tracking number
double | weight | Weight of the shipment (optional)
```

OpenMage 20.0.10 / PHP 7.4.11 and 8.0.5

### Manual testing scenarios
Update and run:
```php
$proxy = new SoapClient('https://.../api/soap/?wsdl');
$sessionId = $proxy->login('login', 'pass');
var_dump($proxy->call($sessionId, 'sales_order_shipment.addTrack',
    ['shipment_id', 'custom', 'test', 'trackingNumber', 5]));
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
