### PR TITLE
Enhancement for categories management and products grids

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Product.php
@@ -82,7 +82,8 @@ class Mage_Adminhtml_Block_Catalog_Category_Tab_Product extends Mage_Adminhtml_B
                 'position',
                 'product_id=entity_id',
                 'category_id=' . (int) $this->getRequest()->getParam('id', 0),
-                'left')
+                'left'
+            )
             ->joinAttribute('name', 'catalog_product/name', 'entity_id', null, 'left', $store)
             ->joinAttribute('price', 'catalog_product/price', 'entity_id', null, 'left', $store)
             ->joinAttribute('status', 'catalog_product/status', 'entity_id', null, 'left', $store)

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php
@@ -55,7 +55,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Wid
                         'class'   => 'back'
                     ])
             );
-        } else if (!$this->getRequest()->getParam('popin')) {
+        } elseif (!$this->getRequest()->getParam('popin')) {
             $this->setChild(
                 'back_button',
                 $this->getLayout()->createBlock('adminhtml/widget_button')

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php
@@ -50,9 +50,19 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Wid
                 'back_button',
                 $this->getLayout()->createBlock('adminhtml/widget_button')
                     ->setData([
-                        'label'     => Mage::helper('catalog')->__('Back'),
-                        'onclick'   => Mage::helper('core/js')->getSetLocationJs($this->getUrl('*/*/', ['store' => $this->getRequest()->getParam('store', 0)])),
-                        'class'     => 'back'
+                        'label'   => Mage::helper('catalog')->__('Back'),
+                        'onclick' => Mage::helper('core/js')->getSetLocationJs($this->getUrl('*/*/', ['store' => $this->getRequest()->getParam('store', 0)])),
+                        'class'   => 'back'
+                    ])
+            );
+        } else if (!$this->getRequest()->getParam('popin')) {
+            $this->setChild(
+                'back_button',
+                $this->getLayout()->createBlock('adminhtml/widget_button')
+                    ->setData([
+                        'label'   => Mage::helper('catalog')->__('Close Window'),
+                        'onclick' => 'window.close()',
+                        'class'   => 'cancel'
                     ])
             );
         } else {
@@ -60,9 +70,9 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Wid
                 'back_button',
                 $this->getLayout()->createBlock('adminhtml/widget_button')
                     ->setData([
-                        'label'     => Mage::helper('catalog')->__('Close Window'),
-                        'onclick'   => 'window.close()',
-                        'class'     => 'cancel'
+                        'label'   => Mage::helper('catalog')->__('Close Window'),
+                        'onclick' => 'window.parent.superProduct.closePopup()',
+                        'class'   => 'cancel'
                     ])
             );
         }
@@ -72,8 +82,8 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Wid
                 'reset_button',
                 $this->getLayout()->createBlock('adminhtml/widget_button')
                     ->setData([
-                        'label'     => Mage::helper('catalog')->__('Reset'),
-                        'onclick'   => Mage::helper('core/js')->getSetLocationJs($this->getUrl('*/*/*', ['_current' => true]))
+                        'label'   => Mage::helper('catalog')->__('Reset'),
+                        'onclick' => Mage::helper('core/js')->getSetLocationJs($this->getUrl('*/*/*', ['_current' => true]))
                     ])
             );
 
@@ -81,9 +91,9 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Wid
                 'save_button',
                 $this->getLayout()->createBlock('adminhtml/widget_button')
                     ->setData([
-                        'label'     => Mage::helper('catalog')->__('Save'),
-                        'onclick'   => 'productForm.submit()',
-                        'class'     => 'save'
+                        'label'   => Mage::helper('catalog')->__('Save'),
+                        'onclick' => 'productForm.submit()',
+                        'class'   => 'save'
                     ])
             );
         }
@@ -94,9 +104,9 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Wid
                     'save_and_edit_button',
                     $this->getLayout()->createBlock('adminhtml/widget_button')
                         ->setData([
-                            'label'     => Mage::helper('catalog')->__('Save and Continue Edit'),
-                            'onclick'   => Mage::helper('core/js')->getSaveAndContinueEditJs($this->getSaveAndContinueUrl()),
-                            'class'     => 'save'
+                            'label'   => Mage::helper('catalog')->__('Save and Continue Edit'),
+                            'onclick' => Mage::helper('core/js')->getSaveAndContinueEditJs($this->getSaveAndContinueUrl()),
+                            'class'   => 'save'
                         ])
                 );
             }
@@ -105,9 +115,9 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Wid
                     'delete_button',
                     $this->getLayout()->createBlock('adminhtml/widget_button')
                         ->setData([
-                            'label'     => Mage::helper('catalog')->__('Delete'),
-                            'onclick'   => Mage::helper('core/js')->getConfirmSetLocationJs($this->getDeleteUrl()),
-                            'class'     => 'delete'
+                            'label'   => Mage::helper('catalog')->__('Delete'),
+                            'onclick' => Mage::helper('core/js')->getConfirmSetLocationJs($this->getDeleteUrl()),
+                            'class'   => 'delete'
                         ])
                 );
             }
@@ -117,9 +127,9 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Wid
                     'duplicate_button',
                     $this->getLayout()->createBlock('adminhtml/widget_button')
                     ->setData([
-                        'label'     => Mage::helper('catalog')->__('Duplicate'),
-                        'onclick'   => Mage::helper('core/js')->getSetLocationJs($this->getDuplicateUrl()),
-                        'class'     => 'add'
+                        'label'   => Mage::helper('catalog')->__('Duplicate'),
+                        'onclick' => Mage::helper('core/js')->getSetLocationJs($this->getDuplicateUrl()),
+                        'class'   => 'add'
                     ])
                 );
             }

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid.php
@@ -260,13 +260,13 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Super_Config_Grid extends Ma
             [
                 'header'    => Mage::helper('catalog')->__('Action'),
                 'type'      => 'action',
-                'getter'     => 'getId',
+                'getter'    => 'getId',
                 'actions'   => [
                     [
                         'caption' => Mage::helper('catalog')->__('Edit'),
                         'url'     => $this->getEditParamsForAssociated(),
                         'field'   => 'id',
-                        'onclick'  => 'superProduct.createPopup(this.href);return false;'
+                        'onclick' => 'superProduct.createPopup(this.href);return false;'
                     ]
                 ],
                 'filter'    => false,
@@ -283,10 +283,12 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Super_Config_Grid extends Ma
     public function getEditParamsForAssociated()
     {
         return [
-            'base'      =>  '*/*/edit',
-            'params'    =>  [
+            'base'      => '*/*/edit',
+            'params'    => [
                 'required' => $this->_getRequiredAttributesIds(),
+                'store'    => (int) $this->getRequest()->getParam('store', 0),
                 'popup'    => 1,
+                'popin'    => 0,
                 'product'  => $this->_getProduct()->getId()
             ]
         ];

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/CategoryController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/CategoryController.php
@@ -101,7 +101,7 @@ class Mage_Adminhtml_Catalog_CategoryController extends Mage_Adminhtml_Controlle
         $_prevStoreId = Mage::getSingleton('admin/session')
             ->getLastViewedStore(true);
 
-        if (!empty($_prevStoreId) && !$this->getRequest()->getQuery('isAjax')) {
+        if (is_numeric($_prevStoreId) && !$this->getRequest()->getQuery('isAjax')) {
             $params['store'] = $_prevStoreId;
             $redirect = true;
         }
@@ -164,7 +164,7 @@ class Mage_Adminhtml_Catalog_CategoryController extends Mage_Adminhtml_Controlle
             }
 
             Mage::getSingleton('admin/session')
-                ->setLastViewedStore($this->getRequest()->getParam('store'));
+                ->setLastViewedStore($storeId);
             Mage::getSingleton('admin/session')
                 ->setLastEditedCategory($category->getId());
             $this->loadLayout();
@@ -423,6 +423,7 @@ class Mage_Adminhtml_Catalog_CategoryController extends Mage_Adminhtml_Controlle
         }
         $this->getResponse()->setBody(
             $this->getLayout()->createBlock('adminhtml/catalog_category_tab_product', 'category.product.grid')
+                ->setProductsCategory($this->getRequest()->getPost('selected_products', []))
                 ->toHtml()
         );
     }

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
@@ -281,6 +281,14 @@ class Mage_Adminhtml_Catalog_ProductController extends Mage_Adminhtml_Controller
             $block->setStoreId($product->getStoreId());
         }
 
+        /** @var Mage_Adminhtml_Block_Page $root */
+        if ($this->getRequest()->getParam('popin')) {
+            $root = $this->getLayout()->getBlock('root');
+            if ($root) {
+                $root->addBodyClass('popup-nohead-nofoot');
+            }
+        }
+
         $this->renderLayout();
     }
 

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
@@ -281,8 +281,8 @@ class Mage_Adminhtml_Catalog_ProductController extends Mage_Adminhtml_Controller
             $block->setStoreId($product->getStoreId());
         }
 
-        /** @var Mage_Adminhtml_Block_Page $root */
         if ($this->getRequest()->getParam('popin')) {
+            /** @var Mage_Adminhtml_Block_Page $root */
             $root = $this->getLayout()->getBlock('root');
             if ($root) {
                 $root->addBodyClass('popup-nohead-nofoot');

--- a/app/design/adminhtml/default/default/template/catalog/category/edit.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/edit.phtml
@@ -25,23 +25,25 @@
 <script type="text/javascript">
 //<![CDATA[
 
-    function categoryReset(url,useAjax){
-        if(useAjax){
-            var params = {active_tab_id:false};
+    function categoryReset(url, useAjax)
+    {
+        if (useAjax) {
+            var params = {active_tab_id: false};
             updateContent(url, params);
-        }else{
+        } else {
             location.href = url;
         }
     }
 
     /**
-    * Delete some category
-    * This routine get categoryId explicitly, so even if currently selected tree node is out of sync
-    * with this form, we surely delete same category in the tree and at backend
-    */
-    function categoryDelete(url, useAjax, categoryId) {
-        if (confirm('<?php echo Mage::helper('core')->jsQuoteEscape(Mage::helper('catalog')->__('Are you sure you want to delete this category?')) ?>')){
-            if (useAjax){
+     * Delete some category
+     * This routine get categoryId explicitly, so even if currently selected tree node is out of sync
+     * with this form, we surely delete same category in the tree and at backend
+     */
+    function categoryDelete(url, useAjax, categoryId)
+    {
+        if (confirm("<?php echo Mage::helper('core')->jsQuoteEscape(Mage::helper('catalog')->__('Are you sure you want to delete this category?')) ?>")) {
+            if (useAjax) {
                 tree.nodeForDelete = categoryId;
                 updateContent(url, {}, true);
             } else {
@@ -53,7 +55,8 @@
     /**
      * Update category content area
      */
-    function updateContent(url, params, refreshTree) {
+    function updateContent(url, params, refreshTree)
+    {
         if (!params) {
             params = {};
         }
@@ -63,11 +66,10 @@
 
         toolbarToggle.stop();
 
-       /*if(params.node_name)
-       {
-           var currentNode = tree.getNodeById(tree.currentNodeId);
-           currentNode.setText(params.node_name);
-       }*/
+        /*if (params.node_name) {
+            var currentNode = tree.getNodeById(tree.currentNodeId);
+            currentNode.setText(params.node_name);
+        }*/
 
         var categoryContainer = $('category-edit-container');
         var messagesContainer = $('messages');
@@ -80,7 +82,7 @@
                  * This func depends on variables, that came in response, and were eval'ed in onSuccess() callback.
                  * Since prototype's Element.update() evals javascripts in 10 msec, we should exec our func after it.
                  */
-                setTimeout(function() {
+                setTimeout(function () {
                     try {
                         if (refreshTree) {
                             thisObj.refreshTreeArea();
@@ -91,7 +93,7 @@
                     };
                 }, 25);
             },
-            onSuccess: function(transport) {
+            onSuccess: function (transport) {
                 try {
                     if (transport.responseText.isJSON()) {
                         var response = transport.responseText.evalJSON();
@@ -100,23 +102,22 @@
                             alert(response.message);
                             needUpdate = false;
                         }
-                        if(response.ajaxExpired && response.ajaxRedirect) {
+                        if (response.ajaxExpired && response.ajaxRedirect) {
                             setLocation(response.ajaxRedirect);
                             needUpdate = false;
                         }
-                        if (needUpdate){
-                            if (response.content){
+                        if (needUpdate) {
+                            if (response.content) {
                                 $(categoryContainer).update(response.content);
                             }
-                            if (response.messages){
+                            if (response.messages) {
                                 $(messagesContainer).update(response.messages);
                             }
                         }
                     } else {
                         $(categoryContainer).update(transport.responseText);
                     }
-                }
-                catch (e) {
+                } catch (e) {
                     $(categoryContainer).update(transport.responseText);
                 }
             }
@@ -155,8 +156,8 @@
                     } else {
                         var timer;
                         parent.expand();
-                        var f = function(){
-                            if(parent.expanded){ // done expanding
+                        var f = function () {
+                            if (parent.expanded) { // done expanding
                                 clearInterval(timer);
                                 tree.selectCurrentNode();
                             }

--- a/app/design/adminhtml/default/default/template/catalog/category/edit/form.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/edit/form.phtml
@@ -15,23 +15,25 @@
 ?>
 
 <div class="content-header">
-        <h3 class="icon-head head-categories"><?php echo $this->escapeHtml($this->getHeader()) . ($this->getCategoryId() ? ' (' . Mage::helper('catalog')->__('ID: %s', $this->getCategoryId()) . ')' : '') ?></h3>
-        <p class="content-buttons form-buttons">
-            <?php echo $this->getResetButtonHtml() ?>
-            <?php if($this->getCategoryId()): ?>
-                    <?php echo $this->getDeleteButtonHtml() ?>
-            <?php endif ?>
-            <?php echo $this->getAdditionalButtonsHtml(); ?>
-            <?php echo $this->getSaveButtonHtml() ?>
-        </p>
+    <h3 class="icon-head head-categories"><?php echo $this->escapeHtml($this->getHeader()) . ($this->getCategoryId() ? ' (' . Mage::helper('catalog')->__('ID: %s', $this->getCategoryId()) . ')' : '') ?></h3>
+    <p class="content-buttons form-buttons">
+        <?php echo $this->getResetButtonHtml() ?>
+        <?php if ($this->getCategoryId()): ?>
+                <?php echo $this->getDeleteButtonHtml() ?>
+        <?php endif ?>
+        <?php echo $this->getAdditionalButtonsHtml(); ?>
+        <?php echo $this->getSaveButtonHtml() ?>
+    </p>
 </div>
-<?php if($this->hasStoreRootCategory()): ?>
+
+<?php if ($this->hasStoreRootCategory()): ?>
     <?php echo $this->getTabsHtml() ?>
 <?php else: ?>
-<div class="messages warning-msg">
-    <?php echo Mage::helper('catalog')->__('Set root category for this store in the <a href="%s">configuration</a>', $this->getStoreConfigurationUrl()) ?>
-</div>
+    <div class="messages warning-msg">
+        <?php echo Mage::helper('catalog')->__('Set root category for this store in the <a href="%s">configuration</a>', $this->getStoreConfigurationUrl()) ?>
+    </div>
 <?php endif ?>
+
 <iframe name="iframeSave" style="display:none; width:100%;" src="<?php echo $this->getJsUrl() ?>blank.html"></iframe>
 <form target="iframeSave" id="category_edit_form" action="<?php echo $this->getSaveUrl() ?>" method="post" enctype="multipart/form-data">
     <div class="no-display">
@@ -42,6 +44,7 @@
     </div>
     <div id="category_tab_content"></div>
 </form>
+
 <script type="text/javascript">
 //<![CDATA[
     categoryForm = new varienForm('category_edit_form');
@@ -51,7 +54,7 @@
         this.canShowError = true;
         this.submitUrl = url;
         if (this.validator && this.validator.validate()) {
-            if(this.validationUrl){
+            if (this.validationUrl) {
                 this._validate();
             }
             else{
@@ -89,12 +92,12 @@
         };
 
         new Ajax.Request(
-                '<?php echo $this->getRefreshPathUrl() ?>',
-                {
-                    method:     'POST',
-                    evalScripts: true,
-                    onSuccess: refreshPathSuccess
-                }
+            '<?php echo $this->getRefreshPathUrl() ?>',
+            {
+                method:     'POST',
+                evalScripts: true,
+                onSuccess: refreshPathSuccess
+            }
         );
 
     };
@@ -114,9 +117,7 @@
         }
     };
 
-    /**
-    * Create/edit some category
-    */
+    // Create/edit some category
     function categorySubmit(url, useAjax) {
         var activeTab = $('active_tab_id');
         if (activeTab) {
@@ -127,7 +128,7 @@
 
         var params = {};
         var fields = $('category_edit_form').getElementsBySelector('input', 'select');
-        for(var i=0;i<fields.length;i++){
+        for(var i=0;i<fields.length;i++) {
             if (!fields[i].name) {
                 continue;
             }
@@ -145,14 +146,14 @@
 
         // Make operations with category tree
         if (isCreating) {
-            /* Some specific tasks for creating category */
+            // Some specific tasks for creating category
             if (!tree.currentNodeId) {
                 // First submit of form - select some node to be current
                 tree.currentNodeId = parentId;
             }
             tree.addNodeTo = parentId;
         } else {
-            /* Some specific tasks for editing category */
+            // Some specific tasks for editing category
             // Maybe change category enabled/disabled style
             if (tree && tree.storeId==0) {
                 var currentNode = tree.getNodeById(categoryId);
@@ -176,51 +177,56 @@
         categoryForm.submit();
     }
 
-<?php if(($block = $this->getLayout()->getBlock('category.product.grid')) && ($_gridJsObject=$block->getJsObjectName())): ?>
+<?php if (($block = $this->getLayout()->getBlock('category.product.grid')) && ($_gridJsObject=$block->getJsObjectName())): ?>
 
     var categoryProducts = $H(<?php echo $this->getProductsJson() ?>);
     $('in_category_products').value = categoryProducts.toQueryString();
 
-    function registerCategoryProduct(grid, element, checked){
-        if(checked){
-            if(element.positionElement){
-                element.positionElement.disabled = false;
-                categoryProducts.set(element.value, element.positionElement.value);
+    function registerCategoryProduct(grid, element, checked) {
+        if (element.getAttribute('type') == 'checkbox') {
+            if (checked) {
+                if (element.positionElement) {
+                    element.positionElement.disabled = false;
+                    categoryProducts.set(element.value, element.positionElement.value);
+                }
             }
-        }
-        else{
-            if(element.positionElement){
-                element.positionElement.disabled = true;
+            else {
+                if (element.positionElement) {
+                    element.positionElement.disabled = true;
+                }
+                categoryProducts.unset(element.value);
             }
-            categoryProducts.unset(element.value);
         }
         $('in_category_products').value = categoryProducts.toQueryString();
         grid.reloadParams = {'selected_products[]':categoryProducts.keys()};
     }
-    function categoryProductRowClick(grid, event){
-        var trElement = Event.findElement(event, 'tr');
-        var isInput   = Event.element(event).tagName == 'INPUT';
-        if(trElement){
-            var checkbox = Element.getElementsBySelector(trElement, 'input');
-            if(checkbox[0]){
-                var checked = isInput ? checkbox[0].checked : !checkbox[0].checked;
-                <?php echo $_gridJsObject ?>.setCheckboxChecked(checkbox[0], checked);
+    function categoryProductRowClick(grid, event) {
+        var tdElement = Event.findElement(event, 'td');
+        if (tdElement) {
+            if (tdElement.down('a')) {
+                return;
+            }
+            var checkbox = tdElement.down('input.checkbox');
+            if (checkbox && !checkbox.disabled) {
+                var isInput = Event.element(event).tagName == 'INPUT';
+                var checked = isInput ? checkbox.checked : !checkbox.checked;
+                <?php echo $_gridJsObject ?>.setCheckboxChecked(checkbox, checked);
             }
         }
     }
-    function positionChange(event){
+    function positionChange(event) {
         var element = Event.element(event);
-        if(element && element.checkboxElement && element.checkboxElement.checked){
+        if (element && element.checkboxElement && element.checkboxElement.checked) {
             categoryProducts.set(element.checkboxElement.value, element.value);
             $('in_category_products').value = categoryProducts.toQueryString();
         }
     }
 
     var tabIndex = 1000;
-    function categoryProductRowInit(grid, row){
+    function categoryProductRowInit(grid, row) {
         var checkbox = $(row).getElementsByClassName('checkbox')[0];
         var position = $(row).getElementsByClassName('input-text')[0];
-        if(checkbox && position){
+        if (checkbox && position) {
             checkbox.positionElement = position;
             position.checkboxElement = checkbox;
             position.disabled = !checkbox.checked;
@@ -229,14 +235,14 @@
         }
     }
 
-
     <?php echo $_gridJsObject ?>.rowClickCallback = categoryProductRowClick;
     <?php echo $_gridJsObject ?>.initRowCallback = categoryProductRowInit;
     <?php echo $_gridJsObject ?>.checkboxCheckCallback = registerCategoryProduct;
     <?php echo $_gridJsObject ?>.rows.each(function(row){categoryProductRowInit(<?php echo $_gridJsObject ?>, row)});
+    <?php echo $_gridJsObject ?>.reloadParams = {'selected_products[]':categoryProducts.keys()};
 
 <?php endif ?>
-<?php if($this->isAjax() && ($block = $this->getLayout()->getBlock('tabs')) && ($_tabsJsObject=$block->getJsObjectName())): ?>
+<?php if ($this->isAjax() && ($block = $this->getLayout()->getBlock('tabs')) && ($_tabsJsObject=$block->getJsObjectName())): ?>
     <?php echo $_tabsJsObject ?>.moveTabContentInDest();
     if (<?php echo $_tabsJsObject ?>.activeTab) {
         $('active_tab_id').value = <?php echo $_tabsJsObject ?>.activeTab.id;

--- a/app/design/adminhtml/default/default/template/catalog/category/tree.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/tree.phtml
@@ -21,7 +21,7 @@
             <?php echo $this->getAddSubButtonHtml() ?>
         <?php endif ?>
     </div>
-    <?php echo $this->getStoreSwitcherHtml();?>
+    <?php echo $this->getStoreSwitcherHtml() ?>
     <div class="tree-actions">
         <?php if($this->getRoot()): ?>
             <a href="#" onclick="tree.collapseTree(); return false;"><?php echo Mage::helper('catalog')->__('Collapse All'); ?></a> <span class="separator">|</span> <a href="#" onclick="tree.expandTree(); return false;"><?php echo Mage::helper('catalog')->__('Expand All'); ?></a>
@@ -36,10 +36,9 @@
 //<![CDATA[
 var tree;
 
-/**
- * Fix ext compatibility with prototype 1.6
- */
-Ext.lib.Event.getTarget = function(e) {
+// Fix ext compatibility with prototype 1.6
+Ext.lib.Event.getTarget = function(e)
+{
     var ee = e.browserEvent || e;
     return ee.target ? Event.element(ee) : null;
 };
@@ -56,9 +55,14 @@ Ext.extend(Ext.tree.TreePanel.Enhanced, Ext.tree.TreePanel, {
         var parameters = config['parameters'];
         var data = config['data'];
 
-        this.storeId = parameters['store_id'];
+        if (!$('store_switcher')) {
+            this.storeId = parameters['store_id'];
+        }
+        else {
+            this.storeId = $('store_switcher').value * 1;
+        }
 
-        if ( this.storeId != 0 && $('add_root_category_button')) {
+        if (this.storeId != 0 && $('add_root_category_button')) {
             $('add_root_category_button').hide();
         }
 
@@ -159,7 +163,7 @@ Ext.extend(Ext.tree.TreePanel.Enhanced, Ext.tree.TreePanel, {
     categoryClick : function(node, e)
     {
         var baseUrl = '<?php echo $this->getEditUrl() ?>';
-        var urlExt = (this.storeId?'store/'+this.storeId+'/':'')+'id/'+node.id+'/';
+        var urlExt = 'store/' + this.storeId + '/id/' + node.id + '/';
         var url = parseSidUrl(baseUrl, urlExt);
 
         this.currentNodeId = node.id;
@@ -180,13 +184,13 @@ function reRenderTree(event, switcher)
     if (tree && event) {
         var obj = event.target;
         var newStoreId = obj.value * 1;
-        var storeParam = newStoreId ? 'store/'+newStoreId + '/' : '';
+        var storeParam = 'store/' + newStoreId + '/';
 
         if (obj.switchParams) {
             storeParam += obj.switchParams;
         }
         if (switcher.useConfirm) {
-            if (!confirm('<?php echo Mage::helper('core')->jsQuoteEscape($this->__('Please confirm site switching. All data that hasn\'t been saved will be lost.')) ?>')){
+            if (!confirm("<?php echo Mage::helper('core')->jsQuoteEscape($this->__('Please confirm site switching. All data that hasn\'t been saved will be lost.')) ?>")) {
                 obj.value = '<?php echo (int) $this->getStoreId() ?>';
                 return false;
             }
@@ -204,11 +208,16 @@ function reRenderTree(event, switcher)
         // retain current selected category id
         storeParam = storeParam + 'id/' + tree.currentNodeId + '/';
         var url = tree.switchTreeUrl + storeParam;
+        var params = {store: newStoreId, form_key: FORM_KEY, isAjax: 1};
+
+        if (category_info_tabsJsTabs.activeTab) {
+            params.active_tab_id = category_info_tabsJsTabs.activeTab.id;
+        }
 
         // load from cache
         // load from ajax
         new Ajax.Request(url, {
-            parameters : {store: newStoreId, form_key: FORM_KEY, isAjax: 1},
+            parameters : params,
             method     : 'post',
             onComplete : function(transport) {
                 var response = transport.responseJSON || transport.responseText.evalJSON(true) || {};
@@ -250,6 +259,15 @@ function _renderNewTree(config, storeParam)
     if (storeParam) {
         url = url + storeParam;
     }
+    else if (tree.storeId && tree.currentNodeId) {
+        url = url + 'store/' + tree.storeId + '/id/' + tree.currentNodeId + '/';
+    }
+    else if (tree.currentNodeId) {
+        url = url + 'id/' + tree.currentNodeId + '/';
+    }
+    else if (tree.storeId) {
+        url = url + 'store/' + tree.storeId + '/';
+    }
     <?php if ($this->isClearEdit()):?>
     if (selectedNode) {
         url = url + 'id/' + config.parameters.category_id;
@@ -264,7 +282,8 @@ Ext.onReady(function()
        dataUrl: '<?php echo $this->getLoadTreeUrl() ?>'
     });
 
-    categoryLoader.createNode = function(config) {
+    categoryLoader.createNode = function(config)
+    {
         var node;
         var _node = Object.clone(config);
         if (config.children && !config.children.length) {
@@ -320,7 +339,8 @@ Ext.onReady(function()
         return hash;
     };
 
-    categoryLoader.toArray = function(attributes) {
+    categoryLoader.toArray = function(attributes)
+    {
         var data = {form_key: FORM_KEY};
         for (var key in attributes) {
             var value = attributes[key];
@@ -330,13 +350,15 @@ Ext.onReady(function()
         return data;
     };
 
-    categoryLoader.on("beforeload", function(treeLoader, node) {
+    categoryLoader.on("beforeload", function(treeLoader, node)
+    {
         treeLoader.baseParams.id = node.attributes.id;
         treeLoader.baseParams.store = node.attributes.store;
         treeLoader.baseParams.form_key = FORM_KEY;
     });
 
-    categoryLoader.on("load", function(treeLoader, node, config) {
+    categoryLoader.on("load", function(treeLoader, node, config)
+    {
         varienWindowOnload();
     });
 
@@ -359,7 +381,7 @@ Ext.onReady(function()
 
     defaultLoadTreeParams = {
         parameters : {
-            text        : '<?php echo Mage::helper('core')->jsQuoteEscape(htmlentities($this->getRoot()->getName())) ?>',
+            text        : "<?php echo Mage::helper('core')->jsQuoteEscape(htmlentities($this->getRoot()->getName())) ?>",
             draggable   : false,
             allowDrop   : <?php if ($this->getRoot()->getIsVisible()): ?>true<?php else: ?>false<?php endif ?>,
             id          : <?php echo (int) $this->getRoot()->getId() ?>,

--- a/app/design/adminhtml/default/default/template/catalog/product/created.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/created.phtml
@@ -14,30 +14,32 @@
  */
 ?>
 <script type="text/javascript">
-var added = false;
+var added = false, parent = <?php echo $this->getRequest()->getParam('popin' ) ? 'self.parent' : 'window.opener' ?>;
 function addProduct(closeAfter) {
-    if(window.opener!=null && !added) {
-        <?php if($this->isEdit()): ?>
-        window.opener.superProduct.updateProduct(<?php echo $this->getProductId() ?>, <?php echo $this->getAttributesJson(); ?>);
+    if (parent!=null && !added) {
+        <?php if ($this->isEdit()): ?>
+        parent.superProduct.updateProduct(<?php echo $this->getProductId() ?>, <?php echo $this->getAttributesJson() ?>);
         <?php else: ?>
-        window.opener.superProduct.addNewProduct(<?php echo $this->getProductId() ?>, <?php echo $this->getAttributesJson(); ?>);
-        window.opener.superProduct.showNoticeMessage();
+        parent.superProduct.addNewProduct(<?php echo $this->getProductId() ?>, <?php echo $this->getAttributesJson() ?>);
+        parent.superProduct.showNoticeMessage();
         <?php endif ?>
         added = true;
     }
 
-    if(closeAfter)
-    {
+    if (closeAfter) {
         closeWindow();
     }
 }
 
-function closeWindow()
-{
-    if (window.opener) {
-        window.opener.focus();
+function closeWindow() {
+    if (parent) {
+        parent.focus();
     }
-    window.close();
+    <?php if ($this->getRequest()->getParam('popin')): ?>
+        parent.superProduct.closePopup();
+    <?php else: ?>
+        window.close();
+    <?php endif ?>
 }
 
 addProduct(false);

--- a/js/mage/adminhtml/grid.js
+++ b/js/mage/adminhtml/grid.js
@@ -431,8 +431,8 @@ varienGridMassaction.prototype = {
     },
     onGridRowClick: function(grid, evt) {
 
-        var tdElement = Event.findElement(evt, 'td');
         var trElement = Event.findElement(evt, 'tr');
+        var tdElement = Event.findElement(evt, 'td');
 
         if(!$(tdElement).down('input')) {
             if($(tdElement).down('a') || $(tdElement).down('select')) {
@@ -441,17 +441,18 @@ varienGridMassaction.prototype = {
             if (trElement.title) {
                 setLocation(trElement.title);
             }
-            else{
-                var checkbox = Element.select(trElement, 'input');
-                var isInput  = Event.element(evt).tagName == 'input';
-                var checked = isInput ? checkbox[0].checked : !checkbox[0].checked;
 
-                if(checked) {
-                    this.checkedString = varienStringArray.add(checkbox[0].value, this.checkedString);
+            var checkbox = tdElement.down('input.checkbox');
+            if (checkbox && !checkbox.disabled) {
+                var isInput  = Event.element(evt).tagName == 'input';
+                var checked = isInput ? checkbox.checked : !checkbox.checked;
+
+                if (checked) {
+                    this.checkedString = varienStringArray.add(checkbox.value, this.checkedString);
                 } else {
-                    this.checkedString = varienStringArray.remove(checkbox[0].value, this.checkedString);
+                    this.checkedString = varienStringArray.remove(checkbox.value, this.checkedString);
                 }
-                this.grid.setCheckboxChecked(checkbox[0], checked);
+                this.grid.setCheckboxChecked(checkbox, checked);
                 this.updateCount();
             }
             return;
@@ -832,13 +833,13 @@ serializerController.prototype = {
         this.rowInit(this.grid, row);
     },
     rowClick : function(grid, event) {
-        var trElement = Event.findElement(event, 'tr');
-        var isInput   = Event.element(event).tagName == 'INPUT';
-        if(trElement){
-            var checkbox = Element.select(trElement, 'input');
-            if(checkbox[0] && !checkbox[0].disabled){
-                var checked = isInput ? checkbox[0].checked : !checkbox[0].checked;
-                this.grid.setCheckboxChecked(checkbox[0], checked);
+        var tdElement = Event.findElement(event, 'td');
+        if (tdElement) {
+            var checkbox = tdElement.down('input.checkbox');
+            if (checkbox && !checkbox.disabled) {
+                var isInput = Event.element(event).tagName == 'INPUT';
+                var checked = isInput ? checkbox.checked : !checkbox.checked;
+                this.grid.setCheckboxChecked(checkbox, checked);
             }
         }
         this.getOldCallback('row_click')(grid, event);

--- a/js/mage/adminhtml/product.js
+++ b/js/mage/adminhtml/product.js
@@ -18,19 +18,20 @@ Product.Gallery = Class.create();
 Product.Gallery.prototype = {
     images : [],
     file2id : {
-        'no_selection' :0
+        'no_selection' : 0
     },
-    idIncrement :1,
-    containerId :'',
-    container :null,
+    idIncrement : 1,
+    containerId : '',
+    container : null,
     imageTypes : {},
     initialize : function(containerId, imageTypes) {
-        this.containerId = containerId, this.container = $(this.containerId);
+        this.containerId = containerId;
+        this.container = $(this.containerId);
         this.imageTypes = imageTypes;
 
         document.on('uploader:fileSuccess', function(event) {
             var memo = event.memo;
-            if(memo && this._checkCurrentContainer(memo.containerId)) {
+            if (memo && this._checkCurrentContainer(memo.containerId)) {
                 this.handleUploadComplete([{response: memo.response}]);
             }
         }.bind(this));
@@ -50,7 +51,7 @@ Product.Gallery.prototype = {
     },
     onImageTabMove : function(event) {
         var imagesTab = false;
-        this.container.ancestors().each( function(parentItem) {
+        this.container.ancestors().each(function(parentItem) {
             if (parentItem.tabObject) {
                 imagesTab = parentItem.tabObject;
                 throw $break;
@@ -66,7 +67,7 @@ Product.Gallery.prototype = {
 
     },
     fixParentTable : function() {
-        this.container.ancestors().each( function(parentItem) {
+        this.container.ancestors().each(function(parentItem) {
             if (parentItem.tagName.toLowerCase() == 'td') {
                 parentItem.style.width = '100%';
             }
@@ -84,7 +85,7 @@ Product.Gallery.prototype = {
         this.getElement('uploader').show();
     },
     handleUploadComplete : function(files) {
-        files.each( function(item) {
+        files.each(function(item) {
             if (!item.response.isJSON()) {
                 try {
                     console.log(item.response);
@@ -111,12 +112,10 @@ Product.Gallery.prototype = {
     },
     updateImages : function() {
         this.getElement('save').value = Object.toJSON(this.images);
-        $H(this.imageTypes).each(
-                function(pair) {
-                    this.getFileElement('no_selection',
-                            'cell-' + pair.key + ' input').checked = true;
-                }.bind(this));
-        this.images.each( function(row) {
+        $H(this.imageTypes).each(function(pair) {
+            this.getFileElement('no_selection', 'cell-' + pair.key + ' input').checked = true;
+        }.bind(this));
+        this.images.each(function(row) {
             if (!$(this.prepareId(row.file))) {
                 this.createImageRow(row);
             }
@@ -148,7 +147,7 @@ Product.Gallery.prototype = {
     },
     getNextPosition : function() {
         var maxPosition = 0;
-        this.images.each( function(item) {
+        this.images.each(function(item) {
             if (parseInt(item.position) > maxPosition) {
                 maxPosition = parseInt(item.position);
             }
@@ -194,14 +193,11 @@ Product.Gallery.prototype = {
         this.getFileElement(file, 'cell-position input').value = image.position;
         this.getFileElement(file, 'cell-remove input').checked = (image.removed == 1);
         this.getFileElement(file, 'cell-disable input').checked = (image.disabled == 1);
-        $H(this.imageTypes)
-                .each(
-                        function(pair) {
-                            if (this.imagesValues[pair.key] == file) {
-                                this.getFileElement(file,
-                                        'cell-' + pair.key + ' input').checked = true;
-                            }
-                        }.bind(this));
+        $H(this.imageTypes).each(function(pair) {
+            if (this.imagesValues[pair.key] == file) {
+                this.getFileElement(file, 'cell-' + pair.key + ' input').checked = true;
+            }
+        }.bind(this));
         this.updateState(file);
     },
     updateState : function(file) {
@@ -221,19 +217,17 @@ Product.Gallery.prototype = {
                 alert(selector);
             }
         }
-
         return $$('#' + this.prepareId(file) + ' .' + element)[0];
     },
     getImageByFile : function(file) {
         if (this.getIndexByFile(file) === null) {
             return false;
         }
-
         return this.images[this.getIndexByFile(file)];
     },
     getIndexByFile : function(file) {
         var index;
-        this.images.each( function(item, i) {
+        this.images.each(function(item, i) {
             if (item.file == file) {
                 index = i;
             }
@@ -242,16 +236,12 @@ Product.Gallery.prototype = {
     },
     updateUseDefault : function() {
         if (this.getElement('default')) {
-            this.getElement('default').select('input').each(
-                    function(input) {
-                        $(this.containerId).select(
-                                '.cell-' + input.value + ' input').each(
-                                function(radio) {
-                                    radio.disabled = input.checked;
-                                });
-                    }.bind(this));
+            this.getElement('default').select('input').each(function(input) {
+                $(this.containerId).select('.cell-' + input.value + ' input').each(function(radio) {
+                    radio.disabled = input.checked;
+                });
+            }.bind(this));
         }
-
         if (arguments.length == 0) {
             this.container.setHasChanges();
         }
@@ -265,7 +255,7 @@ Product.Gallery.prototype = {
 };
 
 Product.AttributesBridge = {
-    tabsObject :false,
+    tabsObject : false,
     bindTabs2Attributes : {},
     bind : function(tabId, attributesObject) {
         this.bindTabs2Attributes[tabId] = attributesObject;
@@ -280,7 +270,7 @@ Product.AttributesBridge = {
         return this.tabsObject;
     },
     addAttributeRow : function(data) {
-        $H(data).each( function(item) {
+        $H(data).each(function(item) {
             if (this.getTabsObject().activeTab.name != item.key) {
                 this.getTabsObject().showTabContent($(item.key));
             }
@@ -292,7 +282,7 @@ Product.AttributesBridge = {
 Product.Attributes = Class.create();
 Product.Attributes.prototype = {
     config : {},
-    containerId :null,
+    containerId : null,
     initialize : function(containerId) {
         this.containerId = containerId;
     },
@@ -354,16 +344,10 @@ Product.Configurable.prototype = {
         this.container = $(idPrefix + 'attributes');
 
         /* Listeners */
-        this.onLabelUpdate = this.updateLabel.bindAsEventListener(this); // Update
-                                                                            // attribute
-                                                                            // label
-        this.onValuePriceUpdate = this.updateValuePrice
-                .bindAsEventListener(this); // Update pricing value
-        this.onValueTypeUpdate = this.updateValueType.bindAsEventListener(this); // Update
-                                                                                    // pricing
-                                                                                    // type
-        this.onValueDefaultUpdate = this.updateValueUseDefault
-                .bindAsEventListener(this);
+        this.onLabelUpdate = this.updateLabel.bindAsEventListener(this); // Update attribute label
+        this.onValuePriceUpdate = this.updateValuePrice.bindAsEventListener(this); // Update pricing value
+        this.onValueTypeUpdate = this.updateValueType.bindAsEventListener(this);   // Update pricing type
+        this.onValueDefaultUpdate = this.updateValueUseDefault.bindAsEventListener(this);
 
         /* Grid initialization and attributes initialization */
         this.createAttributes(); // Creation of default attributes
@@ -371,57 +355,54 @@ Product.Configurable.prototype = {
         this.grid = grid;
         this.grid.rowClickCallback = this.rowClick.bind(this);
         this.grid.initRowCallback = this.rowInit.bind(this);
-        this.grid.checkboxCheckCallback = this.registerProduct.bind(this); // Associate/Unassociate
-                                                                            // simple
-                                                                            // product
+        this.grid.checkboxCheckCallback = this.registerProduct.bind(this); // Associate/Unassociate simple product
 
-        this.grid.rows.each( function(row) {
+        this.grid.rows.each(function(row) {
             this.rowInit(this.grid, row);
         }.bind(this));
     },
     createAttributes : function() {
-        this.attributes.each( function(attribute, index) {
-            // var li = Builder.node('li', {className:'attribute'});
-                var li = $(document.createElement('LI'));
-                li.className = 'attribute';
+        this.attributes.each(function(attribute, index) {
+            var li = $(document.createElement('LI'));
+            li.className = 'attribute';
 
-                li.id = this.idPrefix + '_attribute_' + index;
-                attribute.html_id = li.id;
-                if (attribute && attribute.label && attribute.label.blank()) {
-                    attribute.label = '&nbsp;';
-                }
-                var label_readonly = '';
-                var use_default_checked = '';
-                if (attribute.use_default == '1') {
-                    use_default_checked = ' checked="checked"';
-                    label_readonly = ' readonly="readonly"';
-                }
+            li.id = this.idPrefix + '_attribute_' + index;
+            attribute.html_id = li.id;
+            if (attribute && attribute.label && attribute.label.blank()) {
+                attribute.label = '&nbsp;';
+            }
+            var label_readonly = '';
+            var use_default_checked = '';
+            if (attribute.use_default == '1') {
+                use_default_checked = ' checked="checked"';
+                label_readonly = ' readonly="readonly"';
+            }
 
-                var template = this.addAttributeTemplate.evaluate(attribute);
-                template = template.replace(
-                        new RegExp(' readonly="label"', 'ig'), label_readonly);
-                template = template.replace(new RegExp(
-                        ' checked="use_default"', 'ig'), use_default_checked);
-                li.update(template);
-                li.attributeObject = attribute;
+            var template = this.addAttributeTemplate.evaluate(attribute);
+            template = template.replace(
+                    new RegExp(' readonly="label"', 'ig'), label_readonly);
+            template = template.replace(new RegExp(
+                    ' checked="use_default"', 'ig'), use_default_checked);
+            li.update(template);
+            li.attributeObject = attribute;
 
-                this.container.appendChild(li);
-                li.attributeValues = li.down('.attribute-values');
+            this.container.appendChild(li);
+            li.attributeValues = li.down('.attribute-values');
 
-                if (attribute.values) {
-                    attribute.values.each( function(value) {
-                        this.createValueRow(li, value); // Add pricing values
-                        }.bind(this));
-                }
+            if (attribute.values) {
+                attribute.values.each(function(value) {
+                    this.createValueRow(li, value); // Add pricing values
+                }.bind(this));
+            }
 
-                /* Observe label change */
-                Event.observe(li.down('.attribute-label'), 'change',
-                        this.onLabelUpdate);
-                Event.observe(li.down('.attribute-label'), 'keyup',
-                        this.onLabelUpdate);
-                Event.observe(li.down('.attribute-use-default-label'),
-                        'change', this.onLabelUpdate);
-            }.bind(this));
+            /* Observe label change */
+            Event.observe(li.down('.attribute-label'), 'change',
+                    this.onLabelUpdate);
+            Event.observe(li.down('.attribute-label'), 'keyup',
+                    this.onLabelUpdate);
+            Event.observe(li.down('.attribute-use-default-label'),
+                    'change', this.onLabelUpdate);
+        }.bind(this));
         if (!this.readonly) {
             // Creation of sortable for attributes sorting
             Sortable.create(this.container, {
@@ -431,7 +412,6 @@ Product.Configurable.prototype = {
         }
         this.updateSaveInput();
     },
-
     updateLabel : function(event) {
         var li = Event.findElement(event, 'LI');
         var labelEl = li.down('.attribute-label');
@@ -449,7 +429,7 @@ Product.Configurable.prototype = {
         this.updateSaveInput();
     },
     updatePositions : function(param) {
-        this.container.childElements().each( function(row, index) {
+        this.container.childElements().each(function(row, index) {
             row.attributeObject.position = index;
         });
         this.updateSaveInput();
@@ -472,13 +452,28 @@ Product.Configurable.prototype = {
         this.createPopup(this.createNormalUrl);
     },
     createPopup : function(url) {
-        if (this.win && !this.win.closed) {
-            this.win.close();
+        if (url.indexOf('/popin/') > 0) {
+            if (this.win && document.getElementById('edit-popin')) {
+                this.win.remove();
+            }
+            this.win = document.createElement('div');
+            this.win.setAttribute('id', 'edit-popin');
+            this.win.innerHTML = '<iframe src="' + url.replace('/popin/0/', '/popin/1/') + '" class="loading" onload="this.classList.remove(\'loading\');"></iframe>';
+            document.querySelector('body').appendChild(this.win);
+        } else {
+            if (this.win && !this.win.closed && (typeof this.win.close == 'function')) {
+                this.win.close();
+            }
+            this.win = window.open(url, '', 'width=1000,height=700,resizable=1,scrollbars=1');
+            if (this.win) {
+                this.win.focus();
+            }
         }
-
-        this.win = window.open(url, '',
-                'width=1000,height=700,resizable=1,scrollbars=1');
-        this.win.focus();
+    },
+    closePopup : function() {
+        if (this.win && document.getElementById('edit-popin')) {
+            this.win.remove();
+        }
     },
     registerProduct : function(grid, element, checked) {
         if (checked) {
@@ -489,7 +484,7 @@ Product.Configurable.prototype = {
             this.links.unset(element.value);
         }
         this.updateGrid();
-        this.grid.rows.each( function(row) {
+        this.grid.rows.each(function(row) {
             this.revalidateRow(this.grid, row);
         }.bind(this));
         this.updateValues();
@@ -514,22 +509,20 @@ Product.Configurable.prototype = {
     },
     cloneAttributes : function(attributes) {
         var newObj = [];
-        for ( var i = 0, length = attributes.length; i < length; i++) {
+        for (var i = 0, length = attributes.length; i < length; i++) {
             newObj[i] = Object.clone(attributes[i]);
         }
         return newObj;
     },
     rowClick : function(grid, event) {
-        var trElement = Event.findElement(event, 'tr');
-        var isInput = Event.element(event).tagName.toUpperCase() == 'INPUT';
-
-        if ($(Event.findElement(event, 'td')).down('a')) {
-            return;
-        }
-
-        if (trElement) {
-            var checkbox = $(trElement).down('input');
+         var tdElement = Event.findElement(event, 'td');
+         if (tdElement) {
+            if (tdElement.down('a')) {
+                return;
+            }
+            var checkbox = tdElement.down('input');
             if (checkbox && !checkbox.disabled) {
+                var isInput = Event.element(event).tagName.toUpperCase() == 'INPUT';
                 var checked = isInput ? checkbox.checked : !checkbox.checked;
                 grid.setCheckboxChecked(checkbox, checked);
             }
@@ -567,21 +560,20 @@ Product.Configurable.prototype = {
     },
     checkAttributes : function(attributes) {
         var result = true;
-        this.links
-                .each( function(pair) {
-                    var fail = false;
-                    for ( var i = 0; i < pair.value.length && !fail; i++) {
-                        for ( var j = 0; j < attributes.length && !fail; j++) {
-                            if (pair.value[i].attribute_id == attributes[j].attribute_id
-                                    && pair.value[i].value_index != attributes[j].value_index) {
-                                fail = true;
-                            }
-                        }
+        this.links.each(function(pair) {
+            var fail = false;
+            for (var i = 0; i < pair.value.length && !fail; i++) {
+                for (var j = 0; j < attributes.length && !fail; j++) {
+                    if (pair.value[i].attribute_id == attributes[j].attribute_id
+                            && pair.value[i].value_index != attributes[j].value_index) {
+                        fail = true;
                     }
-                    if (!fail) {
-                        result = false;
-                    }
-                });
+                }
+            }
+            if (!fail) {
+                result = false;
+            }
+        });
         return result;
     },
     updateGrid : function() {
@@ -593,8 +585,8 @@ Product.Configurable.prototype = {
     updateValues : function() {
         var uniqueAttributeValues = $H( {});
         /* Collect unique attributes */
-        this.links.each( function(pair) {
-            for ( var i = 0, length = pair.value.length; i < length; i++) {
+        this.links.each(function(pair) {
+            for (var i = 0, length = pair.value.length; i < length; i++) {
                 var attribute = pair.value[i];
                 if (uniqueAttributeValues.keys()
                         .indexOf(attribute.attribute_id) == -1) {
@@ -605,48 +597,45 @@ Product.Configurable.prototype = {
             }
         });
         /* Updating attributes value container */
-        this.container
-                .childElements()
-                .each(
-                        function(row) {
-                            var attribute = row.attributeObject;
-                            for ( var i = 0, length = attribute.values.length; i < length; i++) {
-                                if (uniqueAttributeValues.keys().indexOf(
-                                        attribute.attribute_id) == -1
-                                        || uniqueAttributeValues
-                                                .get(attribute.attribute_id)
-                                                .keys()
-                                                .indexOf(
-                                                        attribute.values[i].value_index) == -1) {
-                                    row.attributeValues
-                                            .childElements()
-                                            .each(
-                                                    function(elem) {
-                                                        if (elem.valueObject.value_index == attribute.values[i].value_index) {
-                                                            elem.remove();
-                                                        }
-                                                    });
-                                    attribute.values[i] = undefined;
+        this.container.childElements().each(function(row) {
+            var attribute = row.attributeObject;
+            for (var i = 0, length = attribute.values.length; i < length; i++) {
+                if (uniqueAttributeValues.keys().indexOf(
+                        attribute.attribute_id) == -1
+                        || uniqueAttributeValues
+                                .get(attribute.attribute_id)
+                                .keys()
+                                .indexOf(
+                                        attribute.values[i].value_index) == -1) {
+                    row.attributeValues
+                            .childElements()
+                            .each(
+                                    function(elem) {
+                                        if (elem.valueObject.value_index == attribute.values[i].value_index) {
+                                            elem.remove();
+                                        }
+                                    });
+                    attribute.values[i] = undefined;
 
-                                } else {
-                                    uniqueAttributeValues.get(
-                                            attribute.attribute_id).unset(
-                                            attribute.values[i].value_index);
-                                }
-                            }
-                            attribute.values = attribute.values.compact();
-                            if (uniqueAttributeValues
-                                    .get(attribute.attribute_id)) {
-                                uniqueAttributeValues.get(
-                                        attribute.attribute_id).each(
-                                        function(pair) {
-                                            attribute.values.push(pair.value);
-                                            this
-                                                    .createValueRow(row,
-                                                            pair.value);
-                                        }.bind(this));
-                            }
+                } else {
+                    uniqueAttributeValues.get(
+                            attribute.attribute_id).unset(
+                            attribute.values[i].value_index);
+                }
+            }
+            attribute.values = attribute.values.compact();
+            if (uniqueAttributeValues
+                    .get(attribute.attribute_id)) {
+                uniqueAttributeValues.get(
+                        attribute.attribute_id).each(
+                        function(pair) {
+                            attribute.values.push(pair.value);
+                            this
+                                    .createValueRow(row,
+                                            pair.value);
                         }.bind(this));
+            }
+        }.bind(this));
         this.updateSaveInput();
         this.updateSimpleForm();
     },
@@ -666,7 +655,6 @@ Product.Configurable.prototype = {
         }
         this.valueAutoIndex++;
 
-        // var li = $(Builder.node('li', {className:'attribute-value'}));
         var li = $(document.createElement('LI'));
         li.className = 'attribute-value';
         li.id = templateVariables.get('html_id');
@@ -756,10 +744,10 @@ Product.Configurable.prototype = {
             return;
         }
 
-        $(this.idPrefix + 'simple_form').select('td.value').each( function(td) {
-            var adviceContainer = $(Builder.node('div'));
+        $(this.idPrefix + 'simple_form').select('td.value').each(function(td) {
+            var adviceContainer = $(document.createElement('div'));
             td.appendChild(adviceContainer);
-            td.select('input', 'select').each( function(element) {
+            td.select('input', 'select').each(function(element) {
                 element.advaiceContainer = adviceContainer;
             });
         });
@@ -769,7 +757,7 @@ Product.Configurable.prototype = {
         this.initializeAdvicesForSimpleForm();
         $(this.idPrefix + 'simple_form').removeClassName('ignore-validate');
         var validationResult = $(this.idPrefix + 'simple_form').select('input',
-                'select', 'textarea').collect( function(elm) {
+                'select', 'textarea').collect(function(elm) {
             return Validation.validate(elm, {
                 useTitle :false,
                 onElementValidate : function() {
@@ -800,20 +788,17 @@ Product.Configurable.prototype = {
             if (result.error.fields) {
                 $(this.idPrefix + 'simple_form').removeClassName(
                         'ignore-validate');
-                $H(result.error.fields)
-                        .each(
-                                function(pair) {
-                                    $('simple_product_' + pair.key).value = pair.value;
-                                    $('simple_product_' + pair.key + '_autogenerate').checked = false;
-                                    toggleValueElements(
-                                            $('simple_product_' + pair.key + '_autogenerate'),
-                                            $('simple_product_' + pair.key + '_autogenerate').parentNode);
-                                    Validation.ajaxError(
-                                            $('simple_product_' + pair.key),
-                                            result.error.message);
-                                });
-                $(this.idPrefix + 'simple_form')
-                        .addClassName('ignore-validate');
+                $H(result.error.fields).each(function (pair) {
+                    $('simple_product_' + pair.key).value = pair.value;
+                    $('simple_product_' + pair.key + '_autogenerate').checked = false;
+                    toggleValueElements(
+                            $('simple_product_' + pair.key + '_autogenerate'),
+                            $('simple_product_' + pair.key + '_autogenerate').parentNode);
+                    Validation.ajaxError(
+                            $('simple_product_' + pair.key),
+                            result.error.message);
+                });
+                $(this.idPrefix + 'simple_form').addClassName('ignore-validate');
             } else {
                 if (result.error.message) {
                     alert(result.error.message);
@@ -827,7 +812,7 @@ Product.Configurable.prototype = {
         }
 
         result.attributes
-                .each( function(attribute) {
+                .each(function(attribute) {
                     var attr = this.getAttributeById(attribute.attribute_id);
                     if (!this.getValueByIndex(attr, attribute.value_index)
                             && result.pricing
@@ -839,7 +824,7 @@ Product.Configurable.prototype = {
                     }
                 }.bind(this));
 
-        this.attributes.each( function(attribute) {
+        this.attributes.each(function(attribute) {
             if ($('simple_product_' + attribute.attribute_code)) {
                 $('simple_product_' + attribute.attribute_code).value = '';
             }
@@ -852,20 +837,17 @@ Product.Configurable.prototype = {
     },
     checkCreationUniqueAttributes : function() {
         var attributes = [];
-        this.attributes
-                .each( function(attribute) {
-                    attributes
-                            .push( {
-                                attribute_id :attribute.attribute_id,
-                                value_index :$('simple_product_' + attribute.attribute_code).value
-                            });
-                }.bind(this));
-
+        this.attributes.each(function(attribute) {
+            attributes.push({
+                attribute_id :attribute.attribute_id,
+                value_index :$('simple_product_' + attribute.attribute_code).value
+            });
+        }.bind(this));
         return this.checkAttributes(attributes);
     },
     getAttributeByCode : function(attributeCode) {
         var attribute = null;
-        this.attributes.each( function(item) {
+        this.attributes.each(function(item) {
             if (item.attribute_code == attributeCode) {
                 attribute = item;
                 throw $break;
@@ -875,7 +857,7 @@ Product.Configurable.prototype = {
     },
     getAttributeById : function(attributeId) {
         var attribute = null;
-        this.attributes.each( function(item) {
+        this.attributes.each(function(item) {
             if (item.attribute_id == attributeId) {
                 attribute = item;
                 throw $break;
@@ -885,7 +867,7 @@ Product.Configurable.prototype = {
     },
     getValueByIndex : function(attribute, valueIndex) {
         var result = null;
-        attribute.values.each( function(value) {
+        attribute.values.each(function(value) {
             if (value.value_index == valueIndex) {
                 result = value;
                 throw $break;
@@ -977,7 +959,7 @@ Product.Configurable.prototype = {
         }
     },
     updateSimpleForm : function() {
-        this.attributes.each( function(attribute) {
+        this.attributes.each(function(attribute) {
             if ($('simple_product_' + attribute.attribute_code)) {
                 this.showPricing(
                         $('simple_product_' + attribute.attribute_code),
@@ -989,6 +971,23 @@ Product.Configurable.prototype = {
         $('assign_product_warrning').show();
     }
 };
+
+Product.EditWin = Class.create(Product.Configurable, {
+    initialize : function(grid, data) {
+        this.links = data;
+        this.grid = grid;
+    },
+    createAttributes : function() {},
+    updateSaveInput : function() {},
+    updateSimpleForm : function() {},
+    updateValues : function() {},
+    updateGrid : function() {},
+    updateProduct : function() {
+        this.updateGrid();
+        this.updateValues();
+        this.grid.reload(null);
+    }
+});
 
 var onInitDisableFieldsList = [];
 
@@ -1019,7 +1018,7 @@ function initDisableFields(fieldContainer) {
 }
 
 function onCompleteDisableInited() {
-    onInitDisableFieldsList.each( function(item) {
+    onInitDisableFieldsList.each(function(item) {
         disableFieldEditMode(item);
     });
 }

--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -49,6 +49,37 @@
 /**************************** WIDGETS *****************************/
 /******************************************************************/
 
+.adminhtml-catalog-product-created #anchor-content {
+    height:100vh;
+    box-sizing:border-box;
+}
+
+.popup-nohead-nofoot .wrapper > .header,
+.popup-nohead-nofoot .footer {
+    display:none;
+}
+
+#edit-popin {
+    position:fixed;
+    top:0;
+    right:0;
+    left:0;
+    bottom:0;
+    width:100% !important;
+    height:100% !important;
+    z-index:5000000;
+    background:rgba(0,0,0,0.6);
+}
+#edit-popin iframe {
+    margin:5vh 5vw 7vh;
+    width:calc(100% - 10vw);
+    height:calc(100% - 12vh);
+    background:#ccc;
+    border:0;
+}
+#edit-popin iframe.loading {
+    cursor:wait;
+}
 
 /* LOADING INDICATOR
 *******************************************************************/
@@ -65,21 +96,23 @@
     font-weight:bold;
     text-align:center;
     z-index:501;
-    }
+}
 #loading-mask {
-    background:url(images/blank.gif) repeat;
-    position:absolute;
+    position:fixed;
     top:0;
     right:0;
     bottom:0;
     left:0;
+    width:100% !important;
+    height:100% !important;
+    background:rgba(255,255,255,0.6);
     color:#d85909;
     font-size:1.1em;
     font-weight:bold;
     text-align:center;
-    opacity:0.80;
     z-index:1000;
-    }
+    cursor:wait;
+}
 #loading-mask .loader {
     position:fixed;
     top:45%;
@@ -92,10 +125,10 @@
     color:#d85909;
     font-weight:bold;
     text-align:center;
-    z-index:1000;
-    }
+    z-index:1001;
+}
 
-#message-popup-window-mask { position:absolute; top:0; right:0; bottom:0; left:0; width:100%; height:100%; z-index:1980; background-color:#efefef; opacity:.5; }
+#message-popup-window-mask { position:absolute; top:0; right:0; bottom:0; left:0; width:100%; height:100%; z-index:1980; background-color:rgba(255,255,255,0.6); }
 .message-popup { position:absolute; z-index:1990; width:407px; top:-9999em; left:50%; margin:0 0 0 -203px; background:#f3bf8f; padding:0 4px 4px; }
 .message-popup.show { top:280px; }
 .message-popup .message-popup-head { padding:1px 0; }


### PR DESCRIPTION
### Description

It allow to keep current selected tab on store switch, and to keep current category and current store on refresh in categories management. It prevents to add a new category without a parent category.

It add columns to products grid in categories (status, visibility, action).

![image](https://user-images.githubusercontent.com/31816829/137367890-e10e76db-0887-4af0-85b0-31353271e268.png)

It open product edit in a popin (without header and footer) with the current selected store in categories and in associated products of configurable products. You can also open the edit page in a new tab or in a new window.

![image](https://user-images.githubusercontent.com/31816829/137368143-df771ced-da72-4acf-8a88-2d5153ab86a9.png)

It allow to check or uncheck products only when clicking on the checkbox or in the td that contain the checkbox for all grids (products in categories ; related, upsell, crosssell, associated (for grouped and configurable products)).

OpenMage 20.0.13 / PHP 7.4.11 - 8.0.11

### Manual testing scenarios

**TEST 1**
Go to Catalog / Categories.

- Try to create a new subcategory without selecting a parent. This is not possible.
- You can check or uncheck products only when clicking on td input.
- New columns "Status", "Visibility" and "Action".
- The edit link opens product edit page in popup (with the current store).
- You can open the [Edit] link in a new browser tab (middle click or right click "Open in a new tab/window").
- Use Name, Price, Status and Visibility values from selected store.

**TEST 2**
Go to Catalog > Categories the select any category.
Go to Category Products tab.

- Select another store with store switcher.  The current tab is not lost.
- Press F5 or refresh the page. The current category and the current store are not lost.
- Uncheck all products then reset filter or filter or sort or page change. After AJAX all products are unchecked.


**TEST 3**
Go to Catalog > Products and choose any configurable product. For Associated Products grid.

- You can check or uncheck products only when clicking on td input.
- The [Edit] link opens product edit page in popup (with the current store)
- You can open the [Edit] link on a new tab (middle click or right click open in a new tab/window)

**TEST 4**
Go to Catalog > Products and choose any product.
For Related, Up-sells and Cross-sells, Associated (for grouped products) grids.

- Uncheck all products then reset filter or filter or sort or page change. After AJAX all products are unchecked.
- Check some products then reset filter or filter or sort or page change. After AJAX selected products are checked.
- You can check check or uncheck products only when clicking on td input.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list