### PR TITLE
Fix class name and filename for case sensitive filesystems

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cookie/Samesite.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cookie/Samesite.php
@@ -1,6 +1,6 @@
 <?php
 
-class Mage_Adminhtml_Model_System_Config_Source_Cookie_SameSite
+class Mage_Adminhtml_Model_System_Config_Source_Cookie_Samesite
 {
     /**
      * @return array[]


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Adds support for "SameSite" cookie property #1246 is throwing some errors on case-sensitive file systems. This PR fixes this.

### Related Pull Requests

- https://github.com/OpenMage/magento-lts/pull/1246

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Fixes compatibility with case sensitive file systems see https://github.com/OpenMage/magento-lts/pull/1246

### Manual testing scenarios (*)
In the backend, on General > Web, Magento's autoloader attempts to load Mage_Adminhtml_Model_System_Config_Source_Cookie_Samesite , while the class file is named "SameSite.php" (with an upper "Site" in it). The file is not auto-loaded on case sensitive filesystems, and causes wild errors.
(Taken from @ansgarbecker in the linked PR) 

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
