### PR TITLE
Fixes core and lib issues for PHP 8.0 compatibility

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Admin/Page.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Admin/Page.php
@@ -124,7 +124,7 @@ class Mage_Adminhtml_Model_System_Config_Source_Admin_Page
 
         uasort($parentArr, array($this, '_sortMenu'));
 
-        while (list($key, $value) = each($parentArr)) {
+        foreach ($parentArr as $key => $value) {
             $last = $key;
         }
         if (isset($last)) {

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
@@ -718,10 +718,10 @@ class Mage_Catalog_Model_Product_Type_Configurable extends Mage_Catalog_Model_Pr
     {
         $options = parent::getOrderOptions($product);
         $options['attributes_info'] = $this->getSelectedAttributesInfo($product);
-        /** @var Mage_Sales_Model_Quote_Item_Option $simpleOption */
+        /** @var Mage_Sales_Model_Quote_Item_Option|Mage_Catalog_Model_Product_Configuration_Item_Option $simpleOption */
         if ($simpleOption = $this->getProduct($product)->getCustomOption('simple_product')) {
-            $options['simple_name'] = $simpleOption->getProduct($product)->getName();
-            $options['simple_sku']  = $simpleOption->getProduct($product)->getSku();
+            $options['simple_name'] = $simpleOption->getProduct()->getName();
+            $options['simple_sku']  = $simpleOption->getProduct()->getSku();
         }
 
         $options['product_calculations'] = self::CALCULATE_PARENT;
@@ -784,8 +784,8 @@ class Mage_Catalog_Model_Product_Type_Configurable extends Mage_Catalog_Model_Pr
         if ($this->getProduct($product)->hasCustomOptions() &&
             ($simpleProductOption = $this->getProduct($product)->getCustomOption('simple_product'))
         ) {
-            /** @var Mage_Sales_Model_Quote_Item_Option $simpleProductOption */
-            $simpleProduct = $simpleProductOption->getProduct($product);
+            /** @var Mage_Sales_Model_Quote_Item_Option|Mage_Catalog_Model_Product_Configuration_Item_Option $simpleProductOption */
+            $simpleProduct = $simpleProductOption->getProduct();
             if ($simpleProduct) {
                 return $simpleProduct->getWeight();
             }
@@ -837,10 +837,10 @@ class Mage_Catalog_Model_Product_Type_Configurable extends Mage_Catalog_Model_Pr
         /** @var Mage_Sales_Model_Quote_Item_Option $simpleOption */
         $simpleOption = $this->getProduct($product)->getCustomOption('simple_product');
         if ($simpleOption) {
-            $optionProduct = $simpleOption->getProduct($product);
+            $optionProduct = $simpleOption->getProduct();
             $simpleSku = null;
             if ($optionProduct) {
-                $simpleSku =  $simpleOption->getProduct($product)->getSku();
+                $simpleSku =  $simpleOption->getProduct()->getSku();
             }
             $sku = parent::getOptionSku($product, $simpleSku);
         } else {

--- a/lib/Mage/Cache/Backend/File.php
+++ b/lib/Mage/Cache/Backend/File.php
@@ -104,7 +104,7 @@ class Mage_Cache_Backend_File extends Zend_Cache_Backend_File
         }
 
         // Don't use parent constructor
-        while (list($name, $value) = each($options)) {
+        foreach ($options as $name => $value) {
             $this->setOption($name, $value);
         }
 

--- a/lib/Zend/Config/Yaml.php
+++ b/lib/Zend/Config/Yaml.php
@@ -289,7 +289,7 @@ class Zend_Config_Yaml extends Zend_Config
     {
         $config   = array();
         $inIndent = false;
-        while (list($n, $line) = each($lines)) {
+        foreach($lines as $n => $line) {
             $lineno = $n + 1;
 
             $line = rtrim(preg_replace("/#.*$/", "", $line));

--- a/lib/Zend/Feed/Element.php
+++ b/lib/Zend/Feed/Element.php
@@ -193,7 +193,7 @@ class Zend_Feed_Element implements ArrayAccess
         if ($length == 1) {
             return new Zend_Feed_Element($nodes[0]);
         } elseif ($length > 1) {
-            return array_map(create_function('$e', 'return new Zend_Feed_Element($e);'), $nodes);
+            return array_map(function($e) { return new Zend_Feed_Element($e); }, $nodes);
         } else {
             // When creating anonymous nodes for __set chaining, don't
             // call appendChild() on them. Instead we pass the current

--- a/lib/Zend/Http/UserAgent/Features/Adapter/TeraWurfl.php
+++ b/lib/Zend/Http/UserAgent/Features/Adapter/TeraWurfl.php
@@ -88,7 +88,7 @@ class Zend_Http_UserAgent_Features_Adapter_TeraWurfl implements Zend_Http_UserAg
             if (!is_array($group)) {
                 continue;
             }
-            while (list ($key, $value) = each($group)) {
+            foreach($group as $key => $value) {
                 if (is_bool($value)) {
                     // to have the same type than the official WURFL API
                     $features[$key] = ($value ? 'true' : 'false');

--- a/lib/Zend/Xml/Security.php
+++ b/lib/Zend/Xml/Security.php
@@ -167,10 +167,10 @@ class Zend_Xml_Security
     public static function isPhpFpm()
     {
         $isVulnerableVersion = (
-            version_compare(PHP_VERSION, '5.5.22', 'lt')
+            version_compare(PHP_VERSION, '5.5.22', '<')
             || (
-                version_compare(PHP_VERSION, '5.6', 'gte')
-                && version_compare(PHP_VERSION, '5.6.6', 'lt')
+                version_compare(PHP_VERSION, '5.6', '>=')
+                && version_compare(PHP_VERSION, '5.6.6', '<')
             )
         );
 

--- a/lib/Zend/XmlRpc/Value.php
+++ b/lib/Zend/XmlRpc/Value.php
@@ -486,13 +486,15 @@ abstract class Zend_XmlRpc_Value
      */
     protected static function _extractTypeAndValue(SimpleXMLElement $xml, &$type, &$value)
     {
-        list($type, $value) = each($xml);
+        $value = reset($xml);
+        $type = key($xml);
 
         if (!$type and $value === null) {
             $namespaces = array('ex' => 'http://ws.apache.org/xmlrpc/namespaces/extensions');
             foreach ($namespaces as $namespaceName => $namespaceUri) {
                 $namespaceXml = $xml->children($namespaceUri);
-                list($type, $value) = each($namespaceXml);
+                $value = reset($namespaceXml);
+                $type = key($namespaceXml);
                 if ($type !== null) {
                     $type = $namespaceName . ':' . $type;
                     break;

--- a/lib/phpseclib/Crypt/Base.php
+++ b/lib/phpseclib/Crypt/Base.php
@@ -498,7 +498,9 @@ abstract class Base
 
         // Determining whether inline crypting can be used by the cipher
         if ($this->use_inline_crypt !== false) {
-            $this->use_inline_crypt = version_compare(PHP_VERSION, '5.3.0') >= 0 || function_exists('create_function');
+            $this->use_inline_crypt =
+                (version_compare(PHP_VERSION, '5.3.0') >= 0 && version_compare(PHP_VERSION, '8.0.0') < 0)
+                || function_exists('create_function');
         }
     }
 

--- a/lib/phpseclib/Crypt/Base.php
+++ b/lib/phpseclib/Crypt/Base.php
@@ -498,9 +498,7 @@ abstract class Base
 
         // Determining whether inline crypting can be used by the cipher
         if ($this->use_inline_crypt !== false) {
-            $this->use_inline_crypt =
-                (version_compare(PHP_VERSION, '5.3.0') >= 0 && version_compare(PHP_VERSION, '8.0.0') < 0)
-                || function_exists('create_function');
+            $this->use_inline_crypt = version_compare(PHP_VERSION, '5.3.0') >= 0 || function_exists('create_function');
         }
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

1. Adds check for PHP 8 and phpseclib: if it's PHP 8.0+ then disallow inline crypt mode
2. Fixes each() function calls - not available in PHP 8.0 anymore
3. Fixes create_function() function calls - not available in PHP 8.0 anymore
4. Fixes lib/Zend/Xml/Security.php: version_compare doesn't support 'lt' 'gte' 'gt' compare operators anymore in PHP 8.0
5. Inside app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php fixes wrong calls getProduct($product) for objects:

a) Mage_Sales_Model_Quote_Item_Option has getProduct() method which is not taking any parameters!
b) Mage_Catalog_Model_Product_Configuration_Item_Option is Varien_Object derivative, and "product" is just field containing one product data, not a collection inside. (It's causing issue under PHP 8.0 inside Varien_Object::getData() method passing instance of Catalog_Model_Product as $key argument)

### Manual testing scenarios (*)
1. Add to cart some configurable product on frontend under PHP 8.0

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
