### PR TITLE
Fix PHP8 Deprecated: Required parameter $A follows optional parameter 

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Container.php
@@ -131,11 +131,11 @@ class Mage_Adminhtml_Block_Widget_Container extends Mage_Adminhtml_Block_Templat
      * Update specified button property
      *
      * @param string $id
-     * @param string|null $key
+     * @param string $key
      * @param mixed $data
      * @return $this
      */
-    protected function _updateButton($id, $key=null, $data)
+    protected function _updateButton($id, $key, $data)
     {
         foreach ($this->_buttons as $level => $buttons) {
             if (isset($buttons[$id])) {
@@ -162,11 +162,11 @@ class Mage_Adminhtml_Block_Widget_Container extends Mage_Adminhtml_Block_Templat
      * Public wrapper for protected _updateButton method
      *
      * @param string $id
-     * @param string|null $key
+     * @param string $key
      * @param mixed $data
      * @return $this
      */
-    public function updateButton($id, $key=null, $data)
+    public function updateButton($id, $key, $data)
     {
         return $this->_updateButton($id, $key, $data);
     }

--- a/app/code/core/Mage/Bundle/Model/Product/Price.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Price.php
@@ -117,11 +117,11 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
     /**
      * Get product final price
      *
-     * @param   double $qty
-     * @param   Mage_Catalog_Model_Product $product
+     * @param float|null $qty
+     * @param Mage_Catalog_Model_Product $product
      * @return  double
      */
-    public function getFinalPrice($qty = null, $product)
+    public function getFinalPrice($qty, $product)
     {
         if (is_null($qty) && !is_null($product->getCalculatedFinalPrice())) {
             return $product->getCalculatedFinalPrice();
@@ -688,11 +688,11 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
     /**
      * Get product tier price by qty
      *
-     * @param   float $qty
-     * @param   Mage_Catalog_Model_Product $product
+     * @param float|null $qty
+     * @param Mage_Catalog_Model_Product $product
      * @return  float|array
      */
-    public function getTierPrice($qty = null, $product)
+    public function getTierPrice($qty, $product)
     {
         $allGroups = Mage_Customer_Model_Group::CUST_GROUP_ALL;
         $prices = $product->getData('tier_price');

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Price.php
@@ -36,11 +36,11 @@ class Mage_Catalog_Model_Product_Type_Configurable_Price extends Mage_Catalog_Mo
     /**
      * Get product final price
      *
-     * @param   double $qty
-     * @param   Mage_Catalog_Model_Product $product
+     * @param float|null $qty
+     * @param Mage_Catalog_Model_Product $product
      * @return  double
      */
-    public function getFinalPrice($qty = null, $product)
+    public function getFinalPrice($qty, $product)
     {
         if (is_null($qty) && !is_null($product->getCalculatedFinalPrice())) {
             return $product->getCalculatedFinalPrice();

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Grouped/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Grouped/Price.php
@@ -36,11 +36,11 @@ class Mage_Catalog_Model_Product_Type_Grouped_Price extends Mage_Catalog_Model_P
     /**
      * Returns product final price depending on options chosen
      *
-     * @param   double $qty
-     * @param   Mage_Catalog_Model_Product $product
+     * @param float|null $qty
+     * @param Mage_Catalog_Model_Product $product
      * @return  double
      */
-    public function getFinalPrice($qty = null, $product)
+    public function getFinalPrice($qty, $product)
     {
         if (is_null($qty) && !is_null($product->getCalculatedFinalPrice())) {
             return $product->getCalculatedFinalPrice();

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
@@ -74,7 +74,7 @@ class Mage_Catalog_Model_Product_Type_Price
      * @param Mage_Catalog_Model_Product $product
      * @return float
      */
-    public function getFinalPrice($qty = null, $product)
+    public function getFinalPrice($qty, $product)
     {
         if (is_null($qty) && !is_null($product->getCalculatedFinalPrice())) {
             return $product->getCalculatedFinalPrice();
@@ -181,11 +181,11 @@ class Mage_Catalog_Model_Product_Type_Price
     /**
      * Get product tier price by qty
      *
-     * @param   float $qty
-     * @param   Mage_Catalog_Model_Product $product
+     * @param float|null $qty
+     * @param Mage_Catalog_Model_Product $product
      * @return  float|array
      */
-    public function getTierPrice($qty = null, $product)
+    public function getTierPrice($qty, $product)
     {
         $allGroups = Mage_Customer_Model_Group::CUST_GROUP_ALL;
         $prices = $product->getData('tier_price');
@@ -307,11 +307,11 @@ class Mage_Catalog_Model_Product_Type_Price
     /**
      * Get formatted by currency tier price
      *
-     * @param   float $qty
-     * @param   Mage_Catalog_Model_Product $product
+     * @param float|null $qty
+     * @param Mage_Catalog_Model_Product $product
      * @return  array|float
      */
-    public function getFormatedTierPrice($qty = null, $product)
+    public function getFormatedTierPrice($qty, $product)
     {
         $price = $product->getTierPrice($qty);
         if (is_array($price)) {

--- a/app/code/core/Mage/Centinel/Model/Api/Client.php
+++ b/app/code/core/Mage/Centinel/Model/Api/Client.php
@@ -34,7 +34,7 @@ include_once '3Dsecure/CentinelClient.php';
  */
 class Mage_Centinel_Model_Api_Client extends CentinelClient
 {
-    public function sendHttp($url, $connectTimeout = "", $timeout)
+    public function sendHttp($url, $connectTimeout, $timeout)
     {
         // verify that the URL uses a supported protocol.
         if ((strpos($url, "http://") === 0) || (strpos($url, "https://") === 0)) {

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
@@ -178,8 +178,8 @@ class Mage_ConfigurableSwatches_Helper_Productimg extends Mage_Core_Helper_Abstr
     public function getSwatchUrl(
         $product,
         $value,
-        $width = self::SWATCH_DEFAULT_WIDTH,
-        $height = self::SWATCH_DEFAULT_HEIGHT,
+        $width,
+        $height,
         &$swatchType,
         $fallbackFileExt = null
     ) {

--- a/app/code/core/Mage/Core/Model/Locale.php
+++ b/app/code/core/Mage/Core/Model/Locale.php
@@ -575,7 +575,7 @@ class Mage_Core_Model_Locale
      * @param null|string $format
      * @return Zend_Date
      */
-    public function utcDate($store = null, $date, $includeTime = false, $format = null)
+    public function utcDate($store, $date, $includeTime = false, $format = null)
     {
         $dateObj = $this->storeDate($store, $date, $includeTime);
         $dateObj->set($date, $format);

--- a/app/code/core/Mage/Downloadable/Model/Product/Price.php
+++ b/app/code/core/Mage/Downloadable/Model/Product/Price.php
@@ -36,11 +36,11 @@ class Mage_Downloadable_Model_Product_Price extends Mage_Catalog_Model_Product_T
     /**
      * Retrieve product final price
      *
-     * @param integer $qty
+     * @param integer|null $qty
      * @param Mage_Catalog_Model_Product $product
      * @return float
      */
-    public function getFinalPrice($qty = null, $product)
+    public function getFinalPrice($qty, $product)
     {
         if (is_null($qty) && !is_null($product->getCalculatedFinalPrice())) {
             return $product->getCalculatedFinalPrice();

--- a/app/code/core/Mage/Eav/Model/Convert/Adapter/Entity.php
+++ b/app/code/core/Mage/Eav/Model/Convert/Adapter/Entity.php
@@ -201,7 +201,7 @@ class Mage_Eav_Model_Convert_Adapter_Entity extends Mage_Dataflow_Model_Convert_
      * @param string $name
      * @return array|bool
      */
-    protected function getFieldValue($fields = array(), $name)
+    protected function getFieldValue($fields = array(), $name = '')
     {
         $result = array();
         if ($fields && $name) {

--- a/app/code/core/Mage/Rule/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Abstract.php
@@ -197,16 +197,16 @@ abstract class Mage_Rule_Model_Resource_Abstract extends Mage_Core_Model_Resourc
      *
      * @return Mage_Rule_Model_Resource_Abstract
      */
-    public function unbindRuleFromEntity($ruleIds = array(), $entityIds = array(), $entityType)
+    public function unbindRuleFromEntity($ruleIds, $entityIds, $entityType)
     {
         $writeAdapter = $this->_getWriteAdapter();
-        $entityInfo   = $this->_getAssociatedEntityInfo($entityType);
+        $entityInfo = $this->_getAssociatedEntityInfo($entityType);
 
         if (!is_array($entityIds)) {
-            $entityIds = array((int) $entityIds);
+            $entityIds = array((int)$entityIds);
         }
         if (!is_array($ruleIds)) {
-            $ruleIds = array((int) $ruleIds);
+            $ruleIds = array((int)$ruleIds);
         }
 
         $where = array();

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -1681,7 +1681,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
      * @param array $params
      * @return $this
      */
-    public function removeErrorInfosByParams($type = 'error', $params)
+    public function removeErrorInfosByParams($type, $params)
     {
         if ($type && !isset($this->_errorInfoGroups[$type])) {
             return $this;
@@ -1724,7 +1724,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
      * @param string $text
      * @return $this
      */
-    public function removeMessageByText($type = 'error', $text)
+    public function removeMessageByText($type, $text)
     {
         $messages = $this->getData('messages');
         if (is_null($messages)) {

--- a/app/code/core/Mage/Tag/Model/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Tag/Relation.php
@@ -103,13 +103,13 @@ class Mage_Tag_Model_Tag_Relation extends Mage_Core_Model_Abstract
     /**
      * Load relation by Product (optional), tag, customer and store
      *
-     * @param int $productId
+     * @param int|null $productId
      * @param int $tagId
      * @param int $customerId
-     * @param int $storeId
+     * @param int|null $storeId
      * @return $this
      */
-    public function loadByTagCustomer($productId = null, $tagId, $customerId, $storeId = null)
+    public function loadByTagCustomer($productId, $tagId, $customerId, $storeId = null)
     {
         $this->setProductId($productId);
         $this->setTagId($tagId);

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Admin/Login.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Admin/Login.php
@@ -61,7 +61,7 @@ class Login extends Form
      * @param Mapper $mapper
      * @param BrowserInterface $browser
      * @param SequenceSorterInterface $sequenceSorter
-     * @param array $config [optional]
+     * @param array $config
      * @param Dashboard $dashboard
      */
     public function __construct(
@@ -70,7 +70,7 @@ class Login extends Form
         Mapper $mapper,
         BrowserInterface $browser,
         SequenceSorterInterface $sequenceSorter,
-        array $config = [],
+        array $config,
         Dashboard $dashboard
     ) {
         parent::__construct($element, $blockFactory, $mapper, $browser, $sequenceSorter, $config);

--- a/lib/3Dsecure/CentinelClient.php
+++ b/lib/3Dsecure/CentinelClient.php
@@ -48,61 +48,63 @@
 		}
 
 
-		/////////////////////////////////////////////////////////////////////////////////////////////
-		// Function getRequestXml(name)
-		//
-		// Serialize all elements of the request collection into a XML message, and format the required
-		// form payload according to the Centinel XML Message APIs. The form payload is returned from
-		// the function.
-		/////////////////////////////////////////////////////////////////////////////////////////////
+        /////////////////////////////////////////////////////////////////////////////////////////////
+        // Function getRequestXml(name)
+        //
+        // Serialize all elements of the request collection into a XML message, and format the required
+        // form payload according to the Centinel XML Message APIs. The form payload is returned from
+        // the function.
+        /////////////////////////////////////////////////////////////////////////////////////////////
 
 
-		function getRequestXml(){
-			$queryString = "<CardinalMPI>";
-			foreach ($this->request as $name => $value) {
-				$queryString = $queryString."<".($name).">".($value)."</".($name).">" ;
-			}
-			$queryString = $queryString."</CardinalMPI>";
-			return "cmpi_msg=".urlencode($queryString);
-		}
+        function getRequestXml()
+        {
+            $queryString = "<CardinalMPI>";
+            foreach ($this->request as $name => $value) {
+                $queryString = $queryString . "<" . ($name) . ">" . ($value) . "</" . ($name) . ">";
+            }
+            $queryString = $queryString . "</CardinalMPI>";
+            return "cmpi_msg=" . urlencode($queryString);
+        }
 
-	    /////////////////////////////////////////////////////////////////////////////////////////////
-		// Function sendHttp(url, "", $timeout)
-		//
-		// HTTP POST the form payload to the url using cURL.
-		// form payload according to the Centinel XML Message APIs. The form payload is returned from
-		// the function.
-		/////////////////////////////////////////////////////////////////////////////////////////////
+        /////////////////////////////////////////////////////////////////////////////////////////////
+        // Function sendHttp(url, "", $timeout)
+        //
+        // HTTP POST the form payload to the url using cURL.
+        // form payload according to the Centinel XML Message APIs. The form payload is returned from
+        // the function.
+        /////////////////////////////////////////////////////////////////////////////////////////////
 
-		function sendHttp($url, $connectTimeout="", $timeout) {
+        function sendHttp($url, $connectTimeout, $timeout)
+        {
 
-		    // verify that the URL uses a supported protocol.
+            // verify that the URL uses a supported protocol.
 
-			if( (strpos($url, "http://")=== 0) || (strpos($url, "https://")=== 0) ) {
+            if ((strpos($url, "http://") === 0) || (strpos($url, "https://") === 0)) {
 
-				//Construct the payload to POST to the url.
+                //Construct the payload to POST to the url.
 
-				$data = $this->getRequestXml();
-				// create a new cURL resource
+                $data = $this->getRequestXml();
+                // create a new cURL resource
 
-				$ch = curl_init($url);
+                $ch = curl_init($url);
 
-				// set URL and other appropriate options
-				curl_setopt($ch, CURLOPT_POST,1);
-				curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
-				curl_setopt($ch, CURLOPT_SSL_VERIFYHOST,  2);
-				curl_setopt($ch, CURLOPT_RETURNTRANSFER,1);
-				curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
-				curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
+                // set URL and other appropriate options
+                curl_setopt($ch, CURLOPT_POST, 1);
+                curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+                curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+                curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+                curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
+                curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
 
-				// Execute the request.
+                // Execute the request.
 
-				$result = curl_exec($ch);
-				$succeeded  = curl_errno($ch) == 0 ? true : false;
+                $result = curl_exec($ch);
+                $succeeded = curl_errno($ch) == 0 ? true : false;
 
-				// close cURL resource, and free up system resources
+                // close cURL resource, and free up system resources
 
-				curl_close($ch);
+                curl_close($ch);
 
 				// If Communication was not successful set error result, otherwise
 

--- a/lib/Varien/Data/Tree.php
+++ b/lib/Varien/Data/Tree.php
@@ -87,7 +87,7 @@ class Varien_Data_Tree
      * @param Varien_Data_Tree_Node $prevNode
      * @return Varien_Data_Tree_Node
      */
-    public function appendChild($data=array(), $parentNode, $prevNode=null)
+    public function appendChild($data, $parentNode, $prevNode = null)
     {
         if (is_array($data)) {
             $node = $this->addNode(

--- a/lib/Varien/Data/Tree/Db.php
+++ b/lib/Varien/Data/Tree/Db.php
@@ -191,16 +191,16 @@ class Varien_Data_Tree_Db extends Varien_Data_Tree
      * @return Varien_Data_Tree_Node
      * @throws Zend_Db_Adapter_Exception
      */
-    public function appendChild($data=array(), $parentNode, $prevNode=null)
+    public function appendChild($data, $parentNode, $prevNode = null)
     {
         $orderSelect = $this->_conn->select();
-        $orderSelect->from($this->_table, new Zend_Db_Expr('MAX('.$this->_conn->quoteIdentifier($this->_orderField).')'))
-            ->where($this->_conn->quoteIdentifier($this->_parentField).'='.$parentNode->getId());
+        $orderSelect->from($this->_table, new Zend_Db_Expr('MAX(' . $this->_conn->quoteIdentifier($this->_orderField) . ')'))
+            ->where($this->_conn->quoteIdentifier($this->_parentField) . '=' . $parentNode->getId());
 
         $order = $this->_conn->fetchOne($orderSelect);
         $data[$this->_parentField] = $parentNode->getId();
-        $data[$this->_levelField]  = $parentNode->getData($this->_levelField)+1;
-        $data[$this->_orderField]  = $order+1;
+        $data[$this->_levelField] = $parentNode->getData($this->_levelField) + 1;
+        $data[$this->_orderField] = $order + 1;
 
         $this->_conn->insert($this->_table, $data);
         $data[$this->_idField] = $this->_conn->lastInsertId();

--- a/lib/Varien/Db/Tree/Node.php
+++ b/lib/Varien/Db/Tree/Node.php
@@ -41,8 +41,14 @@ class Varien_Db_Tree_Node {
     public $hasChild = false;
     public $numChild = 0;
 
-
-    function __construct($nodeData = array(), $keys) {
+    /**
+     * Varien_Db_Tree_Node constructor.
+     * @param array $nodeData
+     * @param array $keys
+     * @throws Varien_Db_Tree_Node_Exception
+     */
+    function __construct($nodeData, $keys)
+    {
         if (empty($nodeData)) {
             throw new Varien_Db_Tree_Node_Exception('Empty array of node information');
         }
@@ -50,13 +56,13 @@ class Varien_Db_Tree_Node {
             throw new Varien_Db_Tree_Node_Exception('Empty keys array');
         }
 
-        $this->id    = $nodeData[$keys['id']];
-        $this->pid   = $nodeData[$keys['pid']];
-        $this->left  = $nodeData[$keys['left']];
+        $this->id = $nodeData[$keys['id']];
+        $this->pid = $nodeData[$keys['pid']];
+        $this->left = $nodeData[$keys['left']];
         $this->right = $nodeData[$keys['right']];
         $this->level = $nodeData[$keys['level']];
 
-        $this->data  = $nodeData;
+        $this->data = $nodeData;
         $a = $this->right - $this->left;
         if ($a > 1) {
             $this->hasChild = true;


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Should fix all "Required parameter $A follows optional parameter $B warnings.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. https://github.com/OpenMage/magento-lts/pull/1391/checks?check_run_id=1688556992

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
