### PR TITLE
Fixes PHP7.4 deprecated nested ternary operators

### DIFF
--- a/lib/Zend/Service/Console/Command.php
+++ b/lib/Zend/Service/Console/Command.php
@@ -220,8 +220,8 @@ class Zend_Service_Console_Command
 
 			for ($hi = 0; $hi < count($handlers); $hi++) {
 				$handler = $handlers[$hi];
-				$handlerDescription = isset($handlerDescriptions[$hi]) ? $handlerDescriptions[$hi] : isset($handlerDescriptions[0]) ? $handlerDescriptions[0] : '';
-				$handlerDescription = str_replace('\r\n', "\r\n", $handlerDescription);
+                $handlerDescription = ($handlerDescriptions[$hi] ?? isset($handlerDescriptions[0])) ? $handlerDescriptions[0] : '';
+                $handlerDescription = str_replace('\r\n', "\r\n", $handlerDescription);
 				$handlerDescription = str_replace('\n', "\n", $handlerDescription);
 
 				$handlerModel = (object)array(

--- a/lib/Zend/Service/Console/Command.php
+++ b/lib/Zend/Service/Console/Command.php
@@ -220,7 +220,7 @@ class Zend_Service_Console_Command
 
 			for ($hi = 0; $hi < count($handlers); $hi++) {
 				$handler = $handlers[$hi];
-                $handlerDescription = ($handlerDescriptions[$hi] ?? isset($handlerDescriptions[0])) ? $handlerDescriptions[0] : '';
+                $handlerDescription = $handlerDescriptions[$hi] ?? $handlerDescriptions[0] ?? '';
                 $handlerDescription = str_replace('\r\n', "\r\n", $handlerDescription);
 				$handlerDescription = str_replace('\n', "\n", $handlerDescription);
 


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Fixes:

PHP Deprecated:  Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` in ./lib/Zend/Service/Console/Command.php on line 223

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. https://github.com/OpenMage/magento-lts/pull/1392/checks?check_run_id=1692086971 (PHP7.4)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
