### PR TITLE
Remove the need for filter callbacks to be in the same class as the grid. 

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -464,7 +464,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
     {
         if ($this->getCollection()) {
             $field = ( $column->getFilterIndex() ) ? $column->getFilterIndex() : $column->getIndex();
-            if ($column->getFilterConditionCallback() && $column->getFilterConditionCallback()[0] instanceof self) {
+            if ($column->getFilterConditionCallback()) {
                 call_user_func($column->getFilterConditionCallback(), $this->getCollection(), $column);
             } else {
                 $cond = $column->getFilter()->getCondition();


### PR DESCRIPTION
This opens up adding/changing grid columns from observers and having filter callbacks in other places (like in that observer). No need to override the grid each time so a filter callback can be put there.

Some background: I wanted to add a column to a grid from an observer.
The column is a special case that needs a `filter_condition_callback` so filtering can work.

Problem: The callback isn't used if it its not defined in the grid class itself, making it impossible to add this column and forces me to rewrite the grid block. If I have multiple of these columns, I need to extend the grid each time, causing rewrite hell.

Removing this simple check opens up callback to be put anywhere we want, and should not be a problem.