### PR TITLE
fix ArgumentCountError: array_merge_recursive()

### DIFF
--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
@@ -343,7 +343,7 @@ class Mage_ConfigurableSwatches_Helper_Productimg extends Mage_Core_Helper_Abstr
         }
 
         if (!isset($this->_productImageFilters[$product->getId()])) {
-            $mapping = call_user_func_array("array_merge_recursive", $product->getChildAttributeLabelMapping());
+            $mapping = call_user_func_array("array_merge_recursive", array_values($product->getChildAttributeLabelMapping()));
             $filters = array_unique($mapping['labels']);
             $filters = array_merge($filters, array_map(function ($label) {
                 return $label . Mage_ConfigurableSwatches_Helper_Productimg::SWATCH_LABEL_SUFFIX;


### PR DESCRIPTION
fix ArgumentCountError: array_merge_recursive() does not accept unknown
named parameters


### Description (*)

On a Product containing swatches (with Demo Data: /men/shirts/plaid-cotton-shirt-473.html ) on PHP8

appears the following error:

```
Uncaught ArgumentCountError: array_merge_recursive() does not accept unknown named parameters in 
/var/www/html/src/htdocs/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php:346 Stack trace: #0

```

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
