### PR TITLE
Improve performance of product category rewrites (disabled product & categories and product_use_categories)

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Seo.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Seo.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magento.com for more information.
+ *
+ * @category    Mage
+ * @package     Mage_Adminhtml
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+
+class Mage_Adminhtml_Model_System_Config_Backend_Seo extends Mage_Core_Model_Config_Data
+{
+    /**
+     * Refresh categories and products url rewrites if configuration was changed
+     */
+    protected function _afterSave()
+    {
+        if ($this->isValueChanged()) {
+            Mage::getModel('index/indexer')
+                ->getProcessByCode(Mage_Catalog_Helper_Category_Flat::CATALOG_CATEGORY_FLAT_PROCESS_CODE)
+                ->changeStatus(Mage_Index_Model_Process::STATUS_REQUIRE_REINDEX);
+
+            Mage::getModel('index/indexer')
+                ->getProcessByCode(Mage_Catalog_Helper_Product_Flat::CATALOG_FLAT_PROCESS_CODE)
+                ->changeStatus(Mage_Index_Model_Process::STATUS_REQUIRE_REINDEX);
+        }
+        return $this;
+    }
+}

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Seo.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Seo.php
@@ -18,10 +18,10 @@
  * versions in the future. If you wish to customize Magento for your
  * needs please refer to http://www.magento.com for more information.
  *
- * @category    Mage
- * @package     Mage_Adminhtml
+ * @category   Mage
+ * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
- * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
 

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Seo/Product.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Seo/Product.php
@@ -27,12 +27,18 @@
 class Mage_Adminhtml_Model_System_Config_Backend_Seo_Product extends Mage_Core_Model_Config_Data
 {
     /**
-     * Refresh category url rewrites if configuration was changed
+     * Refresh products url rewrites if configuration was changed
      *
      * @return $this
      */
     protected function _afterSave()
     {
+        if ($this->isValueChanged()) {
+            Mage::getModel('index/indexer')
+                ->getProcessByCode(Mage_Catalog_Helper_Product_Flat::CATALOG_FLAT_PROCESS_CODE)
+                ->changeStatus(Mage_Index_Model_Process::STATUS_REQUIRE_REINDEX);
+        }
+
         return $this;
     }
 }

--- a/app/code/core/Mage/Catalog/Model/Indexer/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Indexer/Url.php
@@ -47,7 +47,8 @@ class Mage_Catalog_Model_Indexer_Url extends Mage_Index_Model_Indexer_Abstract
      */
     protected $_matchedEntities = [
         Mage_Catalog_Model_Product::ENTITY => [
-            Mage_Index_Model_Event::TYPE_SAVE
+            Mage_Index_Model_Event::TYPE_SAVE,
+            Mage_Index_Model_Event::TYPE_MASS_ACTION
         ],
         Mage_Catalog_Model_Category::ENTITY => [
             Mage_Index_Model_Event::TYPE_SAVE
@@ -180,13 +181,36 @@ class Mage_Catalog_Model_Indexer_Url extends Mage_Index_Model_Indexer_Abstract
     protected function _registerProductEvent(Mage_Index_Model_Event $event)
     {
         $product = $event->getDataObject();
-        $dataChange = $product->dataHasChangedFor('url_key')
-            || $product->dataHasChangedFor('status')
-            || $product->getIsChangedCategories()
-            || $product->getIsChangedWebsites();
+        $dataChange = false;
+        $products = [];
 
-        if (!$product->getExcludeUrlRewrite() && $dataChange) {
-            $event->addNewData('rewrite_product_ids', [$product->getId()]);
+        if (is_a($product, Mage_Catalog_Model_Product_Action::class)) {
+            $attributesData = $product->getData('attributes_data');
+            $productsIds = $product->getData('product_ids');
+            $dataChange = isset($attributesData['status']) && isset($productsIds) && count($productsIds) > 0;
+            if ($dataChange) {
+                $products = Mage::getModel('catalog/product')->getCollection()
+                    ->addFieldToFilter('entity_id', array('in'=> $productsIds));
+            } else {
+                return;
+            }
+        }
+
+        if (is_a($product, Mage_Catalog_Model_Product::class)) {
+            $dataChange =
+                (
+                    $product->dataHasChangedFor('url_key')
+                    || $product->dataHasChangedFor('status')
+                    || $product->getIsChangedCategories()
+                    || $product->getIsChangedWebsites()
+                ) && !$product->getExcludeUrlRewrite();
+            $products = [$product];
+        }
+
+        if ($dataChange) {
+            foreach ($products as $product) {
+                $event->addNewData('rewrite_product_ids', [$product->getId()]);
+            }
         }
     }
 

--- a/app/code/core/Mage/Catalog/Model/Indexer/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Indexer/Url.php
@@ -181,6 +181,7 @@ class Mage_Catalog_Model_Indexer_Url extends Mage_Index_Model_Indexer_Abstract
     {
         $product = $event->getDataObject();
         $dataChange = $product->dataHasChangedFor('url_key')
+            || $product->dataHasChangedFor('status')
             || $product->getIsChangedCategories()
             || $product->getIsChangedWebsites();
 
@@ -198,7 +199,11 @@ class Mage_Catalog_Model_Indexer_Url extends Mage_Index_Model_Indexer_Abstract
     {
         $category = $event->getDataObject();
         if (!$category->getInitialSetupFlag() && $category->getLevel() > 1) {
-            if ($category->dataHasChangedFor('url_key') || $category->getIsChangedProductList()) {
+            if (
+                $category->dataHasChangedFor('url_key')
+                || $category->getIsChangedProductList()
+                || $category->dataHasChangedFor('is_active')
+            ) {
                 $event->addNewData('rewrite_category_ids', [$category->getId()]);
             }
             /**

--- a/app/code/core/Mage/Catalog/Model/Indexer/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Indexer/Url.php
@@ -184,19 +184,19 @@ class Mage_Catalog_Model_Indexer_Url extends Mage_Index_Model_Indexer_Abstract
         $dataChange = false;
         $products = [];
 
-        if (is_a($product, Mage_Catalog_Model_Product_Action::class)) {
+        if ($product instanceof Mage_Catalog_Model_Product_Action) {
             $attributesData = $product->getData('attributes_data');
             $productsIds = $product->getData('product_ids');
             $dataChange = isset($attributesData['status']) && isset($productsIds) && count($productsIds) > 0;
             if ($dataChange) {
                 $products = Mage::getModel('catalog/product')->getCollection()
-                    ->addFieldToFilter('entity_id', array('in'=> $productsIds));
+                    ->addFieldToFilter('entity_id', ['in'=> $productsIds]);
             } else {
                 return;
             }
         }
 
-        if (is_a($product, Mage_Catalog_Model_Product::class)) {
+        if ($product instanceof Mage_Catalog_Model_Product) {
             $dataChange =
                 (
                     $product->dataHasChangedFor('url_key')

--- a/app/code/core/Mage/Catalog/Model/Resource/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Url.php
@@ -1054,6 +1054,8 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
     public function clearCategoryProduct($storeId)
     {
         $adapter = $this->_getWriteAdapter();
+
+        $productUseCategories = Mage::getStoreConfigFlag('catalog/seo/product_use_categories');
         $select = $adapter->select()
             ->from(['tur' => $this->getMainTable()], $this->getIdFieldName())
             ->joinLeft(
@@ -1063,8 +1065,11 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             )
             ->where('tur.store_id = :store_id')
             ->where('tur.category_id IS NOT NULL')
-            ->where('tur.product_id IS NOT NULL')
-            ->where('tcp.category_id IS NULL');
+            ->where('tur.product_id IS NOT NULL');
+
+        if ($productUseCategories) {
+            $select->where('tcp.category_id IS NULL');
+        }
         $rewriteIds = $adapter->fetchCol($select, ['store_id' => $storeId]);
         if ($rewriteIds) {
             $where = [$this->getIdFieldName() . ' IN(?)' => $rewriteIds];

--- a/app/code/core/Mage/Catalog/Model/Resource/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Url.php
@@ -1102,7 +1102,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
 
         $rewriteIds = $adapter->fetchCol($select, $bind);
         if ($rewriteIds) {
-            $where = array($this->getIdFieldName() . ' IN(?)' => $rewriteIds);
+            $where = [$this->getIdFieldName() . ' IN(?)' => $rewriteIds];
             $adapter->delete($this->getMainTable(), $where);
         }
 
@@ -1137,7 +1137,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
 
         $adapter = $this->_getWriteAdapter();
 
-        $table = $this->getTable(array('catalog/category', 'int'));
+        $table = $this->getTable(['catalog/category', 'int']);
         $select = $adapter->select()
             ->from(['tur' => $this->getMainTable()], $this->getIdFieldName())
             ->joinLeft(
@@ -1186,7 +1186,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
 
         $bind = ['store_id' => $storeId];
         $select = $adapter->select()
-            ->from(array('tur' => $this->getMainTable()), $this->getIdFieldName())
+            ->from(['tur' => $this->getMainTable()], $this->getIdFieldName())
             ->where('tur.store_id = :store_id')
             ->where('tur.is_system = 1');
 
@@ -1200,31 +1200,31 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             // (either to other category or deleted), so rewrite "category_id-product_id" is invalid
             if ($productUseCategories) {
                 $select->joinLeft(
-                        array('tcp' => $this->getTable('catalog/category_product')),
+                        ['tcp' => $this->getTable('catalog/category_product')],
                         'tur.category_id = tcp.category_id AND tur.product_id = tcp.product_id',
-                        array()
+                        []
                     )
                     ->where('tcp.category_id IS NULL');
             }
 
         } else {
             // Find products, cartegories and cartegory/product rewrites for disabled products or cartegories
-            $productTable = $this->getTable(array('catalog/product', 'int'));
-            $categoryTable = $this->getTable(array('catalog/category', 'int'));
+            $productTable = $this->getTable(['catalog/product', 'int']);
+            $categoryTable = $this->getTable(['catalog/category', 'int']);
             $select->joinLeft(
                 ['cpei' => $productTable],
                 'cpei.entity_id = tur.product_id AND cpei.attribute_id = :product_status_attribute_id',
                 []
                 )
                 ->joinLeft(
-                    array('ccei1' => $categoryTable),
+                    ['ccei1' => $categoryTable],
                     'ccei1.attribute_id = :is_active_category_attribute_id AND ccei1.store_id = 0 AND ccei1.entity_id = tur.category_id',
-                    array()
+                    []
                 )
                 ->joinLeft(
-                    array('ccei2' => $categoryTable),
+                    ['ccei2' => $categoryTable],
                     'ccei2.attribute_id = :is_active_category_attribute_id AND ccei2.store_id = :store_id AND ccei2.entity_id = tur.category_id',
-                    array()
+                    []
             );
             $productStatusAttributeId = Mage::getSingleton('eav/config')
                 ->getAttribute(Mage_Catalog_Model_Product::ENTITY, 'status');
@@ -1241,9 +1241,9 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             if ($productUseCategories) {
                 $select
                     ->joinLeft(
-                        array('tcp' => $this->getTable('catalog/category_product')),
+                        ['tcp' => $this->getTable('catalog/category_product')],
                         'tcp.category_id = tur.category_id AND tcp.product_id = tur.product_id',
-                        array()
+                        []
                     );
                 // product_is_disabled OR (category is disabled) OR (cartegory/product rewrite AND product were moved away from the category)
                 $where ='(cpei.value = 2 OR (IF(ccei2.value_id > 0, ccei2.value, ccei1.value) = 0) OR (tur.category_id IS NOT NULL AND tur.product_id IS NOT NULL AND tcp.category_id IS NULL))';

--- a/app/code/core/Mage/Catalog/Model/Resource/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Url.php
@@ -80,7 +80,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
     protected function _construct()
     {
         $this->_init('core/url_rewrite', 'url_rewrite_id');
-        $this->_productEntityTypeId = Mage::getModel('eav/entity')->setType(Mage_Catalog_Model_Product::ENTITY)->getTypeId();
+        $this->_productEntityTypeId = Mage::getSingleton('eav/config')->getEntityType(Mage_Catalog_Model_Product::ENTITY)->getId();
         $this->_statusAttributeId = Mage::getModel('catalog/resource_eav_attribute')
             ->loadByCode($this->_productEntityTypeId, 'status')->getId();
     }

--- a/app/code/core/Mage/Catalog/Model/Resource/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Url.php
@@ -28,10 +28,6 @@
  */
 class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstract
 {
-    const PRODUCT_ENTITY_TYPE_ID = 4;
-    const STATUS_ATTRIBUTE_ID = 96;
-    const DISABLED_PRODUCT_STATUS = 2;
-
     /**
      * Stores configuration array
      *
@@ -68,12 +64,25 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
     protected $_rootChildrenIds             = [];
 
     /**
+     * @var int
+     */
+    protected $_productEntityTypeId;
+
+    /**
+     * @var int
+     */
+    protected $_statusAttributeId;
+
+    /**
      * Load core Url rewrite model
      *
      */
     protected function _construct()
     {
         $this->_init('core/url_rewrite', 'url_rewrite_id');
+        $this->_productEntityTypeId = Mage::getModel('eav/entity')->setType(Mage_Catalog_Model_Product::ENTITY)->getTypeId();
+        $this->_statusAttributeId = Mage::getModel('catalog/resource_eav_attribute')
+            ->loadByCode($this->_productEntityTypeId, 'status')->getId();
     }
 
     /**
@@ -978,10 +987,10 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
         if (!$withDisabled) {
             $select->join(
                 ['cpei' => 'catalog_product_entity_int'],
-                'cpei.entity_id = e.entity_id AND cpei.entity_type_id = ' . self::PRODUCT_ENTITY_TYPE_ID . ' AND cpei.attribute_id = ' . self::STATUS_ATTRIBUTE_ID,
+                'cpei.entity_id = e.entity_id AND cpei.entity_type_id = ' . $this->_productEntityTypeId . ' AND cpei.attribute_id = ' . $this->_statusAttributeId,
                 []
             );
-            $select->where('cpei.value <> ' . self::DISABLED_PRODUCT_STATUS);
+            $select->where('cpei.value <> ' . Mage_Catalog_Model_Product_Status::STATUS_DISABLED);
         }
 
         $rowSet = $adapter->fetchAll($select, $bind);

--- a/app/code/core/Mage/Catalog/Model/Resource/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Url.php
@@ -1105,7 +1105,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
      * catalog/seo/create_url_for_disabled is set as false
      *
      * @param int $categoryId
-     * @param int|null $storeId
+     * @param int|Mage_Core_Model_Store|null $storeId
      * @return $this
      */
     public function clearDisabledCategory($categoryId, $storeId = null)
@@ -1119,6 +1119,11 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
                 $this->clearDisabledCategory($categoryId, $store);
             }
             return $this;
+        }
+        if ($storeId instanceof Mage_Core_Model_Store) {
+            $storeId = $storeId->getStoreId();
+        } elseif (!is_int($storeId)) {
+            throw new Exception('StoreId must by int or Mage_Core_Model_Store');
         }
 
         $adapter = $this->_getWriteAdapter();

--- a/app/code/core/Mage/Catalog/Model/Resource/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Url.php
@@ -28,6 +28,10 @@
  */
 class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstract
 {
+    const PRODUCT_ENTITY_TYPE_ID = 4;
+    const STATUS_ATTRIBUTE_ID = 96;
+    const DISABLED_PRODUCT_STATUS = 2;
+
     /**
      * Stores configuration array
      *
@@ -685,9 +689,10 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
      * @param int|array $categoryIds
      * @param int $storeId
      * @param string $path
+     * @param bool $withDisabled
      * @return array
      */
-    protected function _getCategories($categoryIds, $storeId = null, $path = null)
+    protected function _getCategories($categoryIds, $storeId = null, $path = null, $withDisabled = true)
     {
         $isActiveAttribute = Mage::getSingleton('eav/config')
             ->getAttribute(Mage_Catalog_Model_Category::ENTITY, 'is_active');
@@ -735,6 +740,10 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             $rootCategoryPath = $this->getStores($storeId)->getRootCategoryPath();
             $rootCategoryPathLength = strlen($rootCategoryPath);
         }
+        if (!$withDisabled) {
+            $select->where('IF(c.value_id > 0, c.value, d.value) = 1');
+        }
+
         $bind = [
             'attribute_id' => (int)$isActiveAttribute->getId(),
             'store_id'     => (int)$storeId
@@ -802,15 +811,16 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
      *
      * @param int|array $categoryIds
      * @param int $storeId
+     * @param bool $withDisabled
      * @return Mage_Catalog_Model_Category[]|false
      */
-    public function getCategories($categoryIds, $storeId)
+    public function getCategories($categoryIds, $storeId, $withDisabled = true)
     {
         if (!$categoryIds || !$storeId) {
             return false;
         }
 
-        return $this->_getCategories($categoryIds, $storeId);
+        return $this->_getCategories($categoryIds, $storeId, null, $withDisabled);
     }
 
     /**
@@ -933,9 +943,11 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
      * @param int $storeId
      * @param int $entityId
      * @param int $lastEntityId
+     * @param bool $withDisabled
      * @return array
+     * @throws Mage_Core_Model_Store_Exception
      */
-    protected function _getProducts($productIds, $storeId, $entityId, &$lastEntityId)
+    protected function _getProducts($productIds, $storeId, $entityId, &$lastEntityId, $withDisabled = true)
     {
         $products   = [];
         $websiteId  = Mage::app()->getStore($storeId)->getWebsiteId();
@@ -962,6 +974,14 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             ->limit($this->_productLimit);
         if ($productIds !== null) {
             $select->where('e.entity_id IN(?)', $productIds);
+        }
+        if (!$withDisabled) {
+            $select->join(
+                ['cpei' => 'catalog_product_entity_int'],
+                'cpei.entity_id = e.entity_id AND cpei.entity_type_id = ' . self::PRODUCT_ENTITY_TYPE_ID . ' AND cpei.attribute_id = ' . self::STATUS_ATTRIBUTE_ID,
+                []
+            );
+            $select->where('cpei.value <> ' . self::DISABLED_PRODUCT_STATUS);
         }
 
         $rowSet = $adapter->fetchAll($select, $bind);
@@ -1007,9 +1027,11 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
      *
      * @param int $productId
      * @param int $storeId
+     * @param bool $withDisabled
      * @return Varien_Object|false
+     * @throws Mage_Core_Model_Store_Exception
      */
-    public function getProduct($productId, $storeId)
+    public function getProduct($productId, $storeId, $withDisabled = true)
     {
         $entityId = 0;
         $products = $this->_getProducts($productId, $storeId, 0, $entityId);
@@ -1021,11 +1043,12 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
      *
      * @param int $storeId
      * @param int $lastEntityId
+     * @param bool $withDisabled
      * @return Mage_Catalog_Model_Product[]
      */
-    public function getProductsByStore($storeId, &$lastEntityId)
+    public function getProductsByStore($storeId, &$lastEntityId, $withDisabled = true)
     {
-        return $this->_getProducts(null, $storeId, $lastEntityId, $lastEntityId);
+        return $this->_getProducts(null, $storeId, $lastEntityId, $lastEntityId, $withDisabled);
     }
 
     /**
@@ -1045,38 +1068,180 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
     }
 
     /**
-     * Find and remove unused products rewrites - a case when products were moved away from the category
-     * (either to other category or deleted), so rewrite "category_id-product_id" is invalid
+     * Unused function. Left for backward compatibility
      *
      * @param int $storeId
      * @return $this
      */
     public function clearCategoryProduct($storeId)
     {
+        return $this->clearRewrites($storeId);
+    }
+
+    /**
+     * Find and remove unused rewrites a case when
+     * - products were moved away from the category (either to other category or deleted), so rewrite "category_id-product_id" is invalid
+     * - category
+     *
+     * @param int $storeId
+     * @return $this
+     */
+    public function clearRewrites($storeId)
+    {
+        $adapter = $this->_getWriteAdapter();
+        list($select, $bind) = $this->getSelectToClearRewrites($adapter, $storeId);
+
+        $rewriteIds = $adapter->fetchCol($select, $bind);
+        if ($rewriteIds) {
+            $where = array($this->getIdFieldName() . ' IN(?)' => $rewriteIds);
+            $adapter->delete($this->getMainTable(), $where);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Find and remove unused category rewrites - a case when category is disabled and in config field
+     * catalog/seo/create_url_for_disabled is set as false
+     *
+     * @param int $categoryId
+     * @param int|null $storeId
+     * @return $this
+     */
+    public function clearDisabledCategory($categoryId, $storeId = null)
+    {
+        if (Mage::getStoreConfigFlag('catalog/seo/create_url_for_disabled')) {
+            return $this;
+        }
+
+        if (is_null($storeId)) {
+            foreach ($this->getStores() as $store) {
+                $this->clearDisabledCategory($categoryId, $store);
+            }
+            return $this;
+        }
+
         $adapter = $this->_getWriteAdapter();
 
-        $productUseCategories = Mage::getStoreConfigFlag('catalog/seo/product_use_categories');
+        $table = $this->getTable(array('catalog/category', 'int'));
         $select = $adapter->select()
             ->from(['tur' => $this->getMainTable()], $this->getIdFieldName())
             ->joinLeft(
-                ['tcp' => $this->getTable('catalog/category_product')],
-                'tur.category_id = tcp.category_id AND tur.product_id = tcp.product_id',
+                ['ccei1' => $table],
+                'ccei1.attribute_id = :is_active_category_attribute_id AND ccei1.store_id = 0 AND ccei1.entity_id = tur.category_id',
                 []
             )
+            ->joinLeft(
+                ['ccei2' => $table],
+                'ccei2.attribute_id = :is_active_category_attribute_id AND ccei2.store_id = :store_id AND ccei2.entity_id = tur.category_id',
+                []
+            )
+            ->where('IF(ccei2.value_id > 0, ccei2.value, ccei1.value) = 0')
             ->where('tur.store_id = :store_id')
-            ->where('tur.category_id IS NOT NULL')
-            ->where('tur.product_id IS NOT NULL');
+            ->where('tur.category_id = :category_id');
 
-        if ($productUseCategories) {
-            $select->where('tcp.category_id IS NULL');
-        }
-        $rewriteIds = $adapter->fetchCol($select, ['store_id' => $storeId]);
+        $isActiveCategoryAttribute = Mage::getSingleton('eav/config')
+            ->getAttribute(Mage_Catalog_Model_Category::ENTITY, 'is_active');
+        $bind = [
+            'store_id' => $storeId,
+            'is_active_category_attribute_id' => $isActiveCategoryAttribute->getId(),
+            'category_id' => $categoryId
+        ];
+
+        $rewriteIds = $adapter->fetchCol($select, $bind);
         if ($rewriteIds) {
             $where = [$this->getIdFieldName() . ' IN(?)' => $rewriteIds];
             $adapter->delete($this->getMainTable(), $where);
         }
 
         return $this;
+    }
+
+    /**
+     * Prepare select to find unused rewrites
+     * as set in configuration fields catalog/seo/product_use_categories and catalog/seo/create_url_for_disabled
+     *
+     * @param Magento_Db_Adapter_Pdo_Mysql $adapter
+     * @param int $storeId
+     * @return array
+     */
+    protected function getSelectToClearRewrites($adapter, $storeId)
+    {
+        $productUseCategories = Mage::getStoreConfigFlag('catalog/seo/product_use_categories');
+        $createUrlForDisabled = Mage::getStoreConfigFlag('catalog/seo/create_url_for_disabled');
+
+        $bind = ['store_id' => $storeId];
+        $select = $adapter->select()
+            ->from(array('tur' => $this->getMainTable()), $this->getIdFieldName())
+            ->where('tur.store_id = :store_id')
+            ->where('tur.is_system = 1');
+
+        if ($createUrlForDisabled) {
+
+            // Find rewrites for cartegory/product
+            $select->where('tur.category_id IS NOT NULL')
+                ->where('tur.product_id IS NOT NULL');
+
+            // Find unused products rewrites - a case when products were moved away from the category
+            // (either to other category or deleted), so rewrite "category_id-product_id" is invalid
+            if ($productUseCategories) {
+                $select->joinLeft(
+                        array('tcp' => $this->getTable('catalog/category_product')),
+                        'tur.category_id = tcp.category_id AND tur.product_id = tcp.product_id',
+                        array()
+                    )
+                    ->where('tcp.category_id IS NULL');
+            }
+
+        } else {
+            // Find products, cartegories and cartegory/product rewrites for disabled products or cartegories
+            $productTable = $this->getTable(array('catalog/product', 'int'));
+            $categoryTable = $this->getTable(array('catalog/category', 'int'));
+            $select->joinLeft(
+                ['cpei' => $productTable],
+                'cpei.entity_id = tur.product_id AND cpei.attribute_id = :product_status_attribute_id',
+                []
+                )
+                ->joinLeft(
+                    array('ccei1' => $categoryTable),
+                    'ccei1.attribute_id = :is_active_category_attribute_id AND ccei1.store_id = 0 AND ccei1.entity_id = tur.category_id',
+                    array()
+                )
+                ->joinLeft(
+                    array('ccei2' => $categoryTable),
+                    'ccei2.attribute_id = :is_active_category_attribute_id AND ccei2.store_id = :store_id AND ccei2.entity_id = tur.category_id',
+                    array()
+            );
+            $productStatusAttributeId = Mage::getSingleton('eav/config')
+                ->getAttribute(Mage_Catalog_Model_Product::ENTITY, 'status');
+            $bind['product_status_attribute_id'] = $productStatusAttributeId->getId();
+
+                $isActiveCategoryAttribute = Mage::getSingleton('eav/config')
+                    ->getAttribute(Mage_Catalog_Model_Category::ENTITY, 'is_active');
+                $bind['is_active_category_attribute_id'] = $isActiveCategoryAttribute->getId();
+
+            // product_is_disabled OR (category is disabled) OR (cartegory/product rewrite)
+            $where = '(cpei.value = 2 OR (IF(ccei2.value_id > 0, ccei2.value, ccei1.value) = 0) OR (tur.category_id IS NOT NULL AND tur.product_id IS NOT NULL) )';
+
+            // Find products, categories and cartegory/product rewrites for disabled products or categories
+            if ($productUseCategories) {
+                $select
+                    ->joinLeft(
+                        array('tcp' => $this->getTable('catalog/category_product')),
+                        'tcp.category_id = tur.category_id AND tcp.product_id = tur.product_id',
+                        array()
+                    );
+                // product_is_disabled OR (category is disabled) OR (cartegory/product rewrite AND product were moved away from the category)
+                $where ='(cpei.value = 2 OR (IF(ccei2.value_id > 0, ccei2.value, ccei1.value) = 0) OR (tur.category_id IS NOT NULL AND tur.product_id IS NOT NULL AND tcp.category_id IS NULL))';
+            }
+            $select->where($where);
+        }
+        $select->group('url_rewrite_id');
+
+        return [
+            $select,
+            $bind
+        ];
     }
 
     /**

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -499,7 +499,7 @@ class Mage_Catalog_Model_Url
         $product = $this->getResource()->getProduct($productId, $storeId, $this->createForDisabled);
         if (!$product) {
             // Product doesn't belong to this store - clear all its url rewrites including root one
-            $this->getResource()->clearProductRewrites($productId, $storeId, array());
+            $this->getResource()->clearProductRewrites($productId, $storeId, []);
             return $this;
         }
 

--- a/app/code/core/Mage/Catalog/etc/config.xml
+++ b/app/code/core/Mage/Catalog/etc/config.xml
@@ -809,6 +809,7 @@
                 <product_url_suffix>.html</product_url_suffix>
                 <category_url_suffix>.html</category_url_suffix>
                 <product_use_categories>1</product_use_categories>
+                <create_url_for_disabled>1</create_url_for_disabled>
                 <save_rewrites_history>1</save_rewrites_history>
                 <title_separator>-</title_separator>
                 <category_canonical_tag>0</category_canonical_tag>

--- a/app/code/core/Mage/Catalog/etc/system.xml
+++ b/app/code/core/Mage/Catalog/etc/system.xml
@@ -263,6 +263,7 @@
                         </product_url_suffix>
                         <product_use_categories translate="label">
                             <label>Use Categories Path for Product URLs</label>
+                            <comment>Changing this option requires full reindex of "catalog_url"</comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <backend_model>adminhtml/system_config_backend_seo_product</backend_model>
@@ -271,6 +272,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </product_use_categories>
+                        <create_url_for_disabled translate="label">
+                            <label>Generate URL rewrites for disabled categories and products</label>
+                            <comment>Changing this option requires full reindex of "catalog_url"</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>4</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </create_url_for_disabled>
                         <save_rewrites_history translate="label">
                             <label>Create Permanent Redirect for URLs if URL Key Changed</label>
                             <frontend_type>select</frontend_type>

--- a/app/code/core/Mage/Catalog/etc/system.xml
+++ b/app/code/core/Mage/Catalog/etc/system.xml
@@ -263,7 +263,6 @@
                         </product_url_suffix>
                         <product_use_categories translate="label">
                             <label>Use Categories Path for Product URLs</label>
-                            <comment>Changing this option requires full reindex of "catalog_url"</comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <backend_model>adminhtml/system_config_backend_seo_product</backend_model>
@@ -274,9 +273,9 @@
                         </product_use_categories>
                         <create_url_for_disabled translate="label">
                             <label>Generate URL rewrites for disabled categories and products</label>
-                            <comment>Changing this option requires full reindex of "catalog_url"</comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <backend_model>adminhtml/system_config_backend_seo</backend_model>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
1. I fixed issues when it was set not to use „Categories Path for Product URLs” (product_use_categories) in configuration (Catalog → Catalog → Search Engine Optimizations) and yet they can be found in URL Rewrite Management (commit bfe932992f8498a1edbb9221a989f7da98f5c06e)
2. I added field in configuration to set whether or not to generate rewrites for disabled categories and products (commit 9163a4d468ab93f42024c3677c251f1e5825a97a)

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#931
2. Fixes OpenMage/magento-lts#932

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Screenplay:
1. Present situation
a.) Set field product_use_categories in configuration to „yes”
b.) Set field create_url_for_disabled in configuration to „yes”
c.) In Index Management reindex „Catalog URL Rewrites”
d.) In URL Rewrite Management check if there are rewrites for products with categories path, or in DB check if in table core_url_rewrite there are rows with set columns category_id and product_id.
e.) In URL Rewrite Management check if there are rewrites for disabled products and categories.

2. Products rewrites with categories path, but not for disabled products and categories.
a.) In URL Rewrite Management check if there are rewrites for products with categories path, or in DB check if in table core_url_rewrite are row with set fields category_id and product_id.
b.) In URL Rewrite Management check if there are rewrites for disabled products and categories.
c.) Set field create_url_for_disabled in configuration to „no”
d.) In Index Management reindex „Catalog URL Rewrites”
e.) Check if rewrites checked in a. still exist.
f.) Check if rewrites checked in b. were removed.

3. Products rewrites with categories path, but not for disabled categories.
a.) Choose active category.
b.) In URL Rewrite Management check if there are rewrites for products with this category path, or in DB check if in table core_url_rewrite there are rows with set columns product_id and this category id in category_id column.
c.) In URL Rewrite Management check if there are rewrite for this category.
d.) Set field create_url_for_disabled in configuration to „no”.
e.) Disable chosen category.
f.) Check if rewrites checked in b. and c. were removed.

4. Product rewrites with categories path, but not for disabled products.
a.) Choose active product.
b.) In URL Rewrite Management check if there are rewrites for this product.
c.) Set field create_url_for_disabled in configuration to „no”.
d.) Disable chosen product.
e.) Check if rewrites checked in b. were removed.

5. Product rewrites without categories path and for disabled products and categories.
a.) In URL Rewrite Management check if there are rewrites for products with categories path, or in DB check if in table core_url_rewrite there are rows with set columns category_id and product_id.
b.) In URL Rewrite Management check if there are rewrites for disabled products and categories.
c.) Set field product_use_categories in configuration to „no”
d.) In Index Management reindex „Catalog URL Rewrites”
e.) Check if rewrites checked in a. were removed.
f.) Check if rewrites checked in b. still exist.

6.  Product rewrites without categories path and not for disabled products and categories.
a.) In URL Rewrite Management check if there are rewrites for products with categories path, or in DB check if in table core_url_rewrite are rows with set columns category_id and product_id.
b.) In URL Rewrite Management check if there are rewrites for disabled products and categories.
c.) Set field product_use_categories in configuration to „no”
d.) Set field create_url_for_disabled in configuration to „no”.
e.) In Index Management reindex „Catalog URL Rewrites”
f.) Check if rewrites checked in a. and b. were removed.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
The time it takes for a full reindex on shop with 16802 products and 542 categories:

#### 1. At present (before my changes):

First execute (when empty table core_url_rewrite):
1 – 56s
2 – 54s 
3 – 55s
4 – 57s
5 – 55s

Another execute:
1 – 1m 4s
2 – 1m 1s
3 – 1m 3s
4 – 1m 3s
5 – 1m 1s


#### 2. After changes

Configuration:

**a.) product_use_categories = true and create_url_for_disabled = true (1. screenplay)**

65614 - rewrites

First execute:
1 – 59s
2 – 56s
3 – 56s
4 – 57s
5 – 57s

Another execute:
1 – 1m 6s
2 – 1m 8s
3 – 1m 5s
4 – 1m 5s
5 – 1m 4s


**b.) product_use_categories = true and create_url_for_disabled = false (2. screenplay)**

47360 – rewrites

First execute:
1 – 50s
2 – 42s
3 – 40s
4 – 45s
5 – 43s

Another execute:
1 – 48s
2 – 50s
3 – 47s
4 – 51s
5 – 52s

From configuration a to b
1 – 47s
2 – 46s
3 – 48s
4 – 46s
5 – 46s


**c.)  product_use_categories = false and create_url_for_disabled = true (5. screenplay)**

17342 -  rewrites

First execute:
1 – 15s
2 – 15s
3 – 15s
4 – 15s
5 – 15s

Another execute:
1 – 17s
2 – 17s
3 – 17s
4 – 17s
5 – 17s

From configuration a. to c.
1 – 22s
2 – 21s
3 – 22s
4 – 21s
5 – 21s


**d.) product_use_categories = false and create_url_for_disabled = false (6. screenplay)**

14715 - rewrites

First execute:
1 – 13s
2 – 13s
3 – 13s
4 – 13s
5 – 13s

Another execute:
1 – 14s
2 – 14s
3 – 14s
4 – 14s
5 – 14s

From configuration a. to d.
1 – 18s
2 – 17s
3 – 17s
4 – 17s
5 – 17s


#### DB select to find rewrites to remove (app/code/core/Mage/Catalog/Model/Resource/Url.php::clearRewrites):

**1. Configuration a.**

```sql
SELECT `tur`.`url_rewrite_id` FROM `core_url_rewrite` AS `tur`
LEFT JOIN `catalog_category_product` AS `tcp` ON tur.category_id = tcp.category_id AND tur.product_id = tcp.product_id
WHERE (tur.store_id = :store_id) AND (tur.is_system = 1) 
**// product rewrites with categories path and not connected with this category**
AND (tur.category_id IS NOT NULL) AND (tur.product_id IS NOT NULL) AND (tcp.category_id IS NULL) 
GROUP BY `url_rewrite_id`
```

**2. Configuration b.**

```sql
SELECT `tur`.`url_rewrite_id` FROM `core_url_rewrite` AS `tur`
LEFT JOIN `catalog_product_entity_int` AS `cpei` ON cpei.entity_id = tur.product_id AND cpei.attribute_id = :product_status_attribute_id
LEFT JOIN `catalog_category_entity_int` AS `ccei1` ON ccei1.attribute_id = :is_active_category_attribute_id AND ccei1.store_id = 0 AND ccei1.entity_id = tur.category_id
LEFT JOIN `catalog_category_entity_int` AS `ccei2` ON ccei2.attribute_id = :is_active_category_attribute_id AND ccei2.store_id = :store_id AND ccei2.entity_id = tur.category_id
LEFT JOIN `catalog_category_product` AS `tcp` ON tcp.category_id = tur.category_id AND tcp.product_id = tur.product_id
WHERE (tur.store_id = :store_id) AND (tur.is_system = 1) 
AND (
	(
	**// rewrites for disabled products**
	cpei.value = 2
	**// rewrites for categories disabled in this store or in general store**
	 OR (IF(ccei2.value_id > 0, ccei2.value, ccei1.value) = 0) 
	**// product rewrites with categories path and not connected with this category**
	 OR (tur.category_id IS NOT NULL AND tur.product_id IS NOT NULL AND tcp.category_id IS NULL)
	)
)
GROUP BY `url_rewrite_id`
```

**3. Configuration c.**
db select to remove rewrites:

```sql‌
SELECT `tur`.`url_rewrite_id` FROM `core_url_rewrite` AS `tur`
WHERE (tur.store_id = :store_id) AND (tur.is_system = 1) 
**// product rewrites with categories path** 
AND (tur.category_id IS NOT NULL) AND (tur.product_id IS NOT NULL) 
GROUP BY `url_rewrite_id`
```

**_4. Configuration d._**

```sql
SELECT `tur`.`url_rewrite_id` FROM `core_url_rewrite` AS `tur`
LEFT JOIN `catalog_product_entity_int` AS `cpei` ON cpei.entity_id = tur.product_id AND cpei.attribute_id = :product_status_attribute_id
LEFT JOIN `catalog_category_entity_int` AS `ccei1` ON ccei1.attribute_id = :is_active_category_attribute_id AND ccei1.store_id = 0 AND ccei1.entity_id = tur.category_id
LEFT JOIN `catalog_category_entity_int` AS `ccei2` ON ccei2.attribute_id = :is_active_category_attribute_id AND ccei2.store_id = :store_id AND ccei2.entity_id = tur.category_id 
WHERE (tur.store_id = :store_id) AND (tur.is_system = 1) 
AND (
	(
	**// rewrites for disabled products**
	cpei.value = 2 
	**// rewrites for categories disabled in this store or in general store**
	OR (IF(ccei2.value_id > 0, ccei2.value, ccei1.value) = 0)
	**// product rewrites with categories path** 
	OR (tur.category_id IS NOT NULL AND tur.product_id IS NOT NULL) 
	)
) 
GROUP BY `url_rewrite_id`
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
