### PR TITLE
Fix protect code changing on order save

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -2354,7 +2354,9 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
             $this->unsShippingAddressId();
         }
 
-        $this->setData('protect_code', substr(md5(uniqid(mt_rand(), true) . ':' . microtime(true)), 5, 6));
+        if (!$this->getId()) {
+            $this->setData('protect_code', substr(md5(uniqid(mt_rand(), true) . ':' . microtime(true)), 5, 6));
+        }
         return $this;
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Upon saving an order, the protectCode is regenerated. This PR checks to see if a protectCode was already set before generating a new one.

I am not sure where this bug would present itself on a default installation. I only see protectCode being used at `app/code/core/Mage/Sales/controllers/GuestController.php`, and I'm not sure that magento will ever trigger a re-save of the order object. 

My case presents itself with a custom API for retrieving order info (with an order id and protect code passed) and a custom action that lets users register after checkout (changing the customer id, etc).

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Run the following PHP code, the protect code changes.
```
$order = Mage::getModel('sales/order')->load(1);

var_dump($order->getProtectCode());

$order->setCustomerEmail('foo@example.com');
$order->save();

var_dump($order->getProtectCode());
```


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
