### PR TITLE
Ascending alphabetical sort for Attribute Set Name

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main.php
@@ -246,6 +246,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Attribute_Set_Main extends Mage_Admin
         $attributes = Mage::getResourceModel('catalog/product_attribute_collection')
             ->setAttributesExcludeFilter($attributesIds)
             ->addVisibleFilter()
+            ->setOrder('attribute_code', 'asc')
             ->load();
 
         foreach ($attributes as $child) {

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formset.php
@@ -66,6 +66,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Attribute_Set_Main_Formset extends Ma
             $sets = Mage::getModel('eav/entity_attribute_set')
                 ->getResourceCollection()
                 ->setEntityTypeFilter(Mage::registry('entityType'))
+                ->setOrder('attribute_set_name', 'asc')
                 ->load()
                 ->toOptionArray();
 

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Settings.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Settings.php
@@ -60,6 +60,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Settings extends Mage_Adminh
             'value' => $entityType->getDefaultAttributeSetId(),
             'values'=> Mage::getResourceModel('eav/entity_attribute_set_collection')
                 ->setEntityTypeFilter($entityType->getId())
+                ->setOrder('attribute_set_name', 'asc')
                 ->load()
                 ->toOptionArray()
         ));

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
@@ -177,6 +177,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
 
         $sets = Mage::getResourceModel('eav/entity_attribute_set_collection')
             ->setEntityTypeFilter(Mage::getModel('catalog/product')->getResource()->getTypeId())
+            ->setOrder('attribute_set_name', 'asc')
             ->load()
             ->toOptionHash();
 


### PR DESCRIPTION
A first modification allows the ascending alphabetical order of the list containing the attribute sets on the [Attrib. Set Name] column in Magento Backend -> Catalog -> Manage Products page.

It is useful for those who have a long list of sets of attributes. Magento sorts them by default as they were created, so it's very difficult to identify a particular set in a long list, especially since there is no possibility to filter the column.

Here is the result in production this store has almost 120 attributes sets:

![screenshot_new](https://user-images.githubusercontent.com/8360474/105629810-e3aa1780-5e4d-11eb-9525-c5c9f4fe83ab.jpg)

Another modification is useful when creating a New Product. The attribute sets list is sorted too. 

![2](https://user-images.githubusercontent.com/8360474/105629867-3d124680-5e4e-11eb-92c8-32d977a8fdd5.jpg)

The third modification sorts Attribute Sets lists when creating a new attribute set:

![3](https://user-images.githubusercontent.com/8360474/105629871-41d6fa80-5e4e-11eb-8c5d-db90ebf2a687.jpg)

And finally this modification sorts Unassigned Attributes list in Edit Attribute Page:

![screenshot2](https://user-images.githubusercontent.com/8360474/105613684-c719cb00-5dcc-11eb-89f2-f68c62922920.jpg)