### PR TITLE
Better error handling for issues during bulk attribute update

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
@@ -188,9 +188,11 @@ class Mage_Adminhtml_Catalog_Product_Action_AttributeController extends Mage_Adm
             $this->_getSession()->addError($attributeName . ': ' . $e->getMessage());
         }
         catch (Mage_Core_Exception $e) {
+            Mage::logException($e);
             $this->_getSession()->addError($e->getMessage());
         }
-        catch (Exception $e) {
+        catch (Throwable $e) {
+            Mage::logException($e);
             $this->_getSession()->addException($e, $this->__('An error occurred while updating the product(s) attributes.'));
         }
 

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
@@ -192,7 +192,7 @@ class Mage_Adminhtml_Catalog_Product_Action_AttributeController extends Mage_Adm
         }
         catch (Throwable $e) {
             Mage::logException($e);
-            $this->_getSession()->addException($e, $this->__('An error occurred while updating the product(s) attributes.'));
+            $this->_getSession()->addError($this->__('An error occurred while updating the product(s) attributes.'));
         }
 
         $this->_redirect('*/catalog_product/', array('store'=>$this->_getHelper()->getSelectedStoreId()));

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
@@ -188,7 +188,6 @@ class Mage_Adminhtml_Catalog_Product_Action_AttributeController extends Mage_Adm
             $this->_getSession()->addError($attributeName . ': ' . $e->getMessage());
         }
         catch (Mage_Core_Exception $e) {
-            Mage::logException($e);
             $this->_getSession()->addError($e->getMessage());
         }
         catch (Throwable $e) {


### PR DESCRIPTION
If something goes wrong during mass product attribute update, the admin gets a generic message and there is no error in the log, making it harder to debug this issue.