### PR TITLE
Add Events around Zend_Email

### DIFF
--- a/app/code/core/Mage/Core/Model/Email.php
+++ b/app/code/core/Mage/Core/Model/Email.php
@@ -127,6 +127,7 @@ class Mage_Core_Model_Email extends Varien_Object
         }
 
         $mail = new Zend_Mail('utf-8');
+        $transport = new Varien_Object();
 
         if (strtolower($this->getType()) == 'html') {
             $mail->setBodyHtml($this->getBody());
@@ -137,7 +138,25 @@ class Mage_Core_Model_Email extends Varien_Object
         $mail->setFrom($this->getFromEmail(), $this->getFromName())
             ->addTo($this->getToEmail(), $this->getToName())
             ->setSubject($this->getSubject());
-        $mail->send();
+
+        Mage::dispatchEvent('email_send_before', [
+            'mail'      => $mail,
+            'template'  => $this->getTemplate(),
+            'transport' => $transport,
+            'variables' => $this->getTemplateVars()
+        ]);
+
+        if ($transport->getTransport()) {
+            $mail->send($transport->getTransport());
+        } else {
+            $mail->send();
+        }
+
+        Mage::dispatchEvent('email_send_after', [
+            'to'         => $this->getToEmail(),
+            'subject'    => $this->getSubject(),
+            'email_body' => $this->getBody()
+        ]);
 
         return $this;
     }

--- a/app/code/core/Mage/Core/Model/Email.php
+++ b/app/code/core/Mage/Core/Model/Email.php
@@ -126,7 +126,7 @@ class Mage_Core_Model_Email extends Varien_Object
             return $this;
         }
 
-        $mail = new Zend_Mail();
+        $mail = new Zend_Mail('utf-8');
 
         if (strtolower($this->getType()) == 'html') {
             $mail->setBodyHtml($this->getBody());

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -241,6 +241,8 @@
 | model_save_after | 1.9.4.5 |
 | model_save_before | 1.9.4.5 |
 | model_save_commit_after | 1.9.4.5 |
+| newsletter_send_before | 19.4.18 |
+| newsletter_send_after | 19.4.18 |
 | on_view_report | 1.9.4.5 |
 | order_cancel_after | 1.9.4.5 |
 | page_block_html_topmenu_gethtml_after | 1.9.4.5 |

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -215,6 +215,12 @@
 | customer_registration_is_allowed | 1.9.4.5 |
 | customer_session_init | 1.9.4.5 |
 | eav_collection_abstract_load_before | 1.9.4.5 |
+| email_queue_send_before | 19.4.18 |
+| email_queue_send_after | 19.4.18 |
+| email_send_before | 19.4.18 |
+| email_send_after | 19.4.18 |
+| email_template_send_before | 19.4.18 |
+| email_template_send_after | 19.4.18 |
 | end_index_events_[getEventTypeName] | 1.9.4.5 |
 | end_process_event_[getEventTypeName] | 1.9.4.5 |
 | gift_options_prepare_items | 1.9.4.5 |


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

Current we have several ways of sending email - `Email`, `Template`, `Newsletter` and `Queue`.

There are no events around any of these ways of sending email. 
There is no way to send to authenticated SMTP servers.

Currently only way to send via SMTP is to rewrite core via third party extensions - there are many extensions that do this (paid, free, open-source etc). These extensions often conflict with each other and are sometimes bundled with packages.

Events are useful for a number of use-cases, for example:

1. Using a different Transport (SMTP, API)
2. Logging of outgoing emails
3. Manipulating emails before they're sent (such as automatic attachments)

Configuration in `System Configuration -> Advanced -> System -> Mail Sending Settings` includes support for `Host` and `Port` but these configuration elements have comments saying they're "for Windows servers only". These configuration values are used for PHP's `ini_set` method to configure PHP's [`mail`](https://www.php.net/manual/en/mail.configuration.php) extension.

`Zend_Mail` handles mail sending, which supports `Transports` to take care of the actual delivery. However no transport is configured, which defaults to passing to PHP's [`mail()`](https://www.php.net/manual/en/function.mail.php) function that tries to use `sendmail` installed on Linux servers (or SMTP on windows). Having `sendmail` installed and configured on Linux servers is often not possible these days especially in shared hosting environments.

<!--- Please provide a general summary of the Pull Request in the Title above -->

This PR:

1.  Adds the following events (which should cover every instance of `Zend_Mail`):

* `email_send_before` / `email_send_after`
* `email_queue_send_before` / `email_queue_send_after`
* `email_template_send_before` / `email_template_send_after`
* `newsletter_send_before` / `newsletter_send_after`

2. Uses `utf-8` for `Mage_Core_Model_Email` (`utf-8` is used for every other email type but this one seems to have been forgotten).

3. Instantiates a `Zend_Mail_Transport` and passes this to the relevant `before` event. This transport is used for sending if it is set by the event.

This allows developers to hook these events and set transports or manipulate the `Zend_Mail` object without rewriting core.

Nothing is done with these events - they're merely dispatched.

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#1366 (use utf-8 for `Zend_Mail`)

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. I have written an extension to use a SMTP transport for each of the email sending models via the `before` events https://github.com/icecubenz-open-mage/Icecube_CustomEmailServer (this also includes example code for the `after` events). This extension provides a way to configure a SMTP server then send a test email from each model via system configuration.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

I have modelled these events after the popular [`SMTP Pro`](https://github.com/aschroder/Magento-SMTP-Pro-Email-Extensio) Extension,


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
