### PR TITLE
Allow changing of posted attribute values by event on mass attribute update

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Action.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Action.php
@@ -63,16 +63,18 @@ class Mage_Catalog_Model_Product_Action extends Mage_Core_Model_Abstract
      */
     public function updateAttributes($productIds, $attrData, $storeId)
     {
+        $attrData = new ArrayObject($attrData);
+
         Mage::dispatchEvent('catalog_product_attribute_update_before', array(
-            'attributes_data' => &$attrData,
+            'attributes_data' => $attrData,
             'product_ids'   => &$productIds,
             'store_id'      => &$storeId
         ));
 
-        $this->_getResource()->updateAttributes($productIds, $attrData, $storeId);
+        $this->_getResource()->updateAttributes($productIds, (array) $attrData, $storeId);
         $this->setData(array(
             'product_ids'       => array_unique($productIds),
-            'attributes_data'   => $attrData,
+            'attributes_data'   => (array) $attrData,
             'store_id'          => $storeId
         ));
 


### PR DESCRIPTION
Passing vars by reference in an event does not work (anymore) in PHP7.
To provide a minimalistic solution, I wrapped the array in an ArrayObject, so not to break anything. Since this is an object, the contents can be changed by listeners.
The other vars could also be changed this way, but it's more invasive and wanted to start with just this.