### PR TITLE
Improve Developer Mode

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -122,6 +122,12 @@
     RewriteRule .* - [L,R=405]
 
 <IfModule mod_setenvif.c>
+
+############################################
+## Enable Developer Mode based on OS environment variable
+
+    SetEnvIfExpr "osenv('MAGE_IS_DEVELOPER_MODE') == '1'" MAGE_IS_DEVELOPER_MODE=1
+
     <IfModule mod_headers.c>
 
         ############################################

--- a/api.php
+++ b/api.php
@@ -49,12 +49,6 @@ if (!Mage::isInstalled()) {
     exit;
 }
 
-if (isset($_SERVER['MAGE_IS_DEVELOPER_MODE'])) {
-    Mage::setIsDeveloperMode(true);
-}
-
-#ini_set('display_errors', 1);
-
 Mage::$headersSentThrowsException = false;
 Mage::init('admin');
 Mage::app()->loadAreaPart(Mage_Core_Model_App_Area::AREA_GLOBAL, Mage_Core_Model_App_Area::PART_EVENTS);

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -30,7 +30,7 @@ define('BP', dirname(dirname(__FILE__)));
 
 Mage::register('original_include_path', get_include_path());
 
-if ( ! empty($_SERVER['MAGE_IS_DEVELOPER_MODE']) || ! empty($_ENV['MAGE_IS_DEVELOPER_MODE'])) {
+if (!empty($_SERVER['MAGE_IS_DEVELOPER_MODE']) || !empty($_ENV['MAGE_IS_DEVELOPER_MODE'])) {
     Mage::setIsDeveloperMode(true);
     ini_set('display_errors', 1);
 }

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -30,6 +30,11 @@ define('BP', dirname(dirname(__FILE__)));
 
 Mage::register('original_include_path', get_include_path());
 
+if ( ! empty($_SERVER['MAGE_IS_DEVELOPER_MODE']) || ! empty($_ENV['MAGE_IS_DEVELOPER_MODE'])) {
+    Mage::setIsDeveloperMode(true);
+    ini_set('display_errors', 1);
+}
+
 /**
  * Set include path
  */

--- a/dev/openmage/README.md
+++ b/dev/openmage/README.md
@@ -50,6 +50,8 @@ You can override some defaults using environment variables defined in a file tha
 - `ADMIN_EMAIL`
 - `ADMIN_USERNAME`
 - `ADMIN_PASSWORD`
+- `MAGE_IS_DEVELOPER_MODE`
+  - Set to 1 by default, set to 0 to disable
 
 Wiping
 ---

--- a/dev/openmage/docker-compose.yml
+++ b/dev/openmage/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       - ENABLE_SENDMAIL=true
       - XDEBUG_CONFIG=remote_connect_back=1 remote_enable=1 idekey=phpstorm
+      - MAGE_IS_DEVELOPER_MODE=1
     links:
       - mysql
 

--- a/index.php
+++ b/index.php
@@ -61,12 +61,6 @@ require_once $mageFilename;
 
 #Varien_Profiler::enable();
 
-if (isset($_SERVER['MAGE_IS_DEVELOPER_MODE'])) {
-    Mage::setIsDeveloperMode(true);
-}
-
-#ini_set('display_errors', 1);
-
 umask(0);
 
 /* Store or website code */

--- a/index.php.sample
+++ b/index.php.sample
@@ -54,12 +54,6 @@ require_once $mageFilename;
 
 #Varien_Profiler::enable();
 
-if (isset($_SERVER['MAGE_IS_DEVELOPER_MODE'])) {
-    Mage::setIsDeveloperMode(true);
-}
-
-#ini_set('display_errors', 1);
-
 umask(0);
 
 $mageRunCode = isset($_SERVER['MAGE_RUN_CODE']) ? $_SERVER['MAGE_RUN_CODE'] : '';


### PR DESCRIPTION
This allows developer mode to easily be controlled by an environment variable, for example set in the docker container and moves the logic to Mage.php so it can work from any script (index.php, api.php, get.php, cron.php, custom scripts). It is enabled by default in the bundled docker-based environment.