### PR TITLE
Remove useless item options save

### DIFF
--- a/app/code/core/Mage/Sales/Model/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item.php
@@ -776,22 +776,6 @@ class Mage_Sales_Model_Quote_Item extends Mage_Sales_Model_Quote_Item_Abstract
     }
 
     /**
-     * Save model plus its options
-     * Ensures saving options in case when resource model was not changed
-     */
-    public function save()
-    {
-        $hasDataChanges = $this->hasDataChanges();
-        $this->_flagOptionsSaved = false;
-
-        parent::save();
-
-        if ($hasDataChanges && !$this->_flagOptionsSaved) {
-            $this->_saveItemOptions();
-        }
-    }
-
-    /**
      * Save item options after item saved
      *
      * @inheritDoc


### PR DESCRIPTION
Hello,

Because the `_afterSave()` function already calls `_saveItemOptions()` everytime a quote item is saved, the override of `save()` function to add `_saveItemOptions()` in case of data changes is useless.

What do you think about this modification?
