### PR TITLE
Fix: Customer with empty DOB can't be saved

### DIFF
--- a/lib/Varien/Data/Form/Filter/Date.php
+++ b/lib/Varien/Data/Form/Filter/Date.php
@@ -71,6 +71,10 @@ class Varien_Data_Form_Filter_Date implements Varien_Data_Form_Filter_Interface
      */
     public function inputFilter($value)
     {
+        if (!$value) {
+            return $value;
+        }
+
         $filterInput = new Zend_Filter_LocalizedToNormalized(array(
             'date_format'   => $this->_dateFormat,
             'locale'        => $this->_locale
@@ -93,6 +97,10 @@ class Varien_Data_Form_Filter_Date implements Varien_Data_Form_Filter_Interface
      */
     public function outputFilter($value)
     {
+        if (!$value) {
+            return $value;
+        }
+
         $filterInput = new Zend_Filter_LocalizedToNormalized(array(
             'date_format'   => Varien_Date::DATE_INTERNAL_FORMAT,
             'locale'        => $this->_locale

--- a/lib/Varien/Data/Form/Filter/Datetime.php
+++ b/lib/Varien/Data/Form/Filter/Datetime.php
@@ -42,6 +42,10 @@ class Varien_Data_Form_Filter_Datetime extends Varien_Data_Form_Filter_Date
      */
     public function inputFilter($value)
     {
+        if (!$value) {
+            return $value;
+        }
+
         $filterInput = new Zend_Filter_LocalizedToNormalized(array(
             'date_format'   => $this->_dateFormat,
             'locale'        => $this->_locale
@@ -64,6 +68,10 @@ class Varien_Data_Form_Filter_Datetime extends Varien_Data_Form_Filter_Date
      */
     public function outputFilter($value)
     {
+        if (!$value) {
+            return $value;
+        }
+
         $filterInput = new Zend_Filter_LocalizedToNormalized(array(
             'date_format'   => Varien_Date::DATETIME_INTERNAL_FORMAT,
             'locale'        => $this->_locale


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

If Date of Birth is enabled when admin creates a customer that has an empty DOB - when that record is saved the save fails without visible error. 

This appears to be because `Mage_Eav_Model_Form` validates and sets default data, including `''` for dates. 
 `Zend_Format`'s date validation doesn't like the default string `''`

This has been encountered in similar code in Magento2: 
https://github.com/magento/magento2/pull/14666
https://github.com/magento/magento2/issues/12146
https://github.com/magento/magento2/issues/13311

To be clear this issue is dates in the `Mage_Eav_Model_Form` and those which extend it - Customer DOB is an easily visible example.

This PR ports the solution from Magento 2 which basically fails fast and bypasses the lengthly validation, parsing and filtering if there is no value set.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Log in to admin
2. Enable Date Of Birth under Customer in System Configuration. It should not be a required value.
3. Create New Customer:
  * Change store to any other than admin (this was required for me to reproduce the issue)
  * Set no DOB
  * Add all other required fields
4. Save will fail without an error (server ajax response shows error with no message)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

I am unsure if this is related to some changes around PHP 7.1+
The Magento 2 issues reference some "A non-numeric value" errors but I haven't seen them.
I am unsure if my locale not being `en_US` (it's `en_NZ`) is significant

I added this to Datetime as well, and output filters. 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
