### PR TITLE
make Mage::getOpenMageVersionInfo() more stable for the release process

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -212,6 +212,24 @@ final class Mage
      */
     public static function getOpenMageVersionInfo()
     {
+        $majorVersion = 19;
+
+        /**
+         * This code construct is to make merging for forward porting of changes easier.
+         * By having the version numbers of different branches in own lines, they do not provoke a merge conflict
+         * also as releases are usually done together, this could in theory be done at once.
+         * The major Version then needs to be only changed once per branch.
+         */
+        if ($majorVersion === 20) {
+            return array(
+                'major'     => '20',
+                'minor'     => '0',
+                'patch'     => '6',
+                'stability' => '', // beta,alpha,rc
+                'number'    => '', // 1,2,3,0.3.7,x.7.z.92 @see https://semver.org/#spec-item-9
+            );
+        }
+
         return array(
             'major'     => '19',
             'minor'     => '4',


### PR DESCRIPTION
This code construct is to make merging for forward porting of changes easier.
By having the version numbers of different branches in own lines, they do not provoke a merge conflict
also as releases are usually done together, this could in theory be done at once.
The major Version then needs to be only changed once per branch.

to visualize the current situation, this is the diff view of v20.0.6

```
Tags: v20.0.6
Parent: f7b3c521d9b8d0243aaf2d28cd07650442aec345 (Merge tag 'v19.4.9' into 20.0)
Parent: f0b8bba9820b6f21e9eca4f1563f08c40b5a8c45 (bump version)
Branch: 
Follows: 
Precedes: 

    Merge tag 'v19.4.10' into 20.0

--------------------------------- app/Mage.php ---------------------------------
index 3b07c4ee1d,bbc002b021..7eda7547dd
@@@ -210,15 -210,15 +210,15 @@@ final class Mag
       *
       * @return array
       */
      public static function getOpenMageVersionInfo()
      {
          return array(
 -            'major'     => '19',
 -            'minor'     => '4',
 -            'patch'     => '10',
 +            'major'     => '20',
 +            'minor'     => '0',
-             'patch'     => '5',
++            'patch'     => '6',
              'stability' => '', // beta,alpha,rc
              'number'    => '', // 1,2,3,0.3.7,x.7.z.92 @see https://semver.org/#spec-item-9
          );
      }
  
      /**
```


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
