### PR TITLE
Remove invalid branch alias to make the branch importable on packagist.org

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,5 @@
       "email": "github-sr@hotmail.com",
       "role": "Maintainer"
     }
-  ],
-  "extra": {
-    "branch-alias": {
-      "dev-main": "1.9.4.x"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
The invalid branch alias causes the update to fail on packagist.org, and the branch can not be found as a version there https://packagist.org/packages/openmage/magento-lts

Same as #1476 but for the 20.0 branch