### PR TITLE
Mage_Core_Model_Abstract: Fix rollback when Throwable is thrown in save/delete method

### DIFF
--- a/app/code/core/Mage/Core/Model/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Abstract.php
@@ -310,6 +310,7 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
      * Save object data
      *
      * @return $this
+     * @throws Throwable
      */
     public function save()
     {
@@ -334,10 +335,10 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
                 ->commit();
             $this->_hasDataChanges = false;
             $dataCommited = true;
-        } catch (Throwable $t) {
+        } catch (Throwable $e) {
             $this->_getResource()->rollBack();
             $this->_hasDataChanges = true;
-            throw $t;
+            throw $e;
         }
         if ($dataCommited) {
             $this->_afterSaveCommit();
@@ -483,6 +484,7 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
      * Delete object from database
      *
      * @return $this
+     * @throws Throwable
      */
     public function delete()
     {
@@ -493,7 +495,7 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
             $this->_afterDelete();
 
             $this->_getResource()->commit();
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $this->_getResource()->rollBack();
             throw $e;
         }

--- a/app/code/core/Mage/Core/Model/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Abstract.php
@@ -334,10 +334,10 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
                 ->commit();
             $this->_hasDataChanges = false;
             $dataCommited = true;
-        } catch (Exception $e) {
+        } catch (Throwable $t) {
             $this->_getResource()->rollBack();
             $this->_hasDataChanges = true;
-            throw $e;
+            throw $t;
         }
         if ($dataCommited) {
             $this->_afterSaveCommit();


### PR DESCRIPTION
### Description (*)
When you throw some child of `Error` class (or `Error` class) in `_beforeSave` or in `_afterSave` methods - Magento do not rollback started transaction and it is provide error: 
![image](https://user-images.githubusercontent.com/9967016/109885311-9ad05480-7c7e-11eb-9b1f-9e3953f95b98.png)

PHP implementation:
`Error implements Throwable`
`Exception implements Throwable`

### Manual testing scenarios (*)

Consider this code:
```
class Namespace_Module_Model_Foo extends Mage_Core_Model_Abstract {
    protected function _beforeSave()
    {
        parent::_beforeSave();

        throw new Error('error from some specifiec reason');
    }
}

Mage::getModel('namespace_module/foo')->save();
```


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
