### PR TITLE
New event "init_form_values_after" after data set on a form

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
@@ -143,6 +143,7 @@ class Mage_Adminhtml_Block_Widget_Form extends Mage_Adminhtml_Block_Widget
     {
         $this->_prepareForm();
         $this->_initFormValues();
+        Mage::dispatchEvent('init_form_values_after', ['form' => $this]);
         return parent::_beforeToHtml();
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
@@ -143,7 +143,13 @@ class Mage_Adminhtml_Block_Widget_Form extends Mage_Adminhtml_Block_Widget
     {
         $this->_prepareForm();
         $this->_initFormValues();
-        Mage::dispatchEvent('init_form_values_after', ['form' => $this]);
+        Mage::dispatchEvent(
+            'adminhtml_block_widget_form_init_form_values_after',
+            [
+                'block' => $this,
+                'form' => $this->getForm()
+            ]
+        );
         return parent::_beforeToHtml();
     }
 


### PR DESCRIPTION
Magento does not have a common event after data is set on a form.
This new event allows us to change the form, the elements and the values once data is entered, giving full flexibility.
I needed this event in a special case where I needed to change the options of a select, to include the current value that was not in the existing options list.
There was no other way to do this without overriding many forms 1 by 1.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
