### PR TITLE
New event after tabs have been added

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
@@ -189,6 +189,8 @@ class Mage_Adminhtml_Block_Widget_Tabs extends Mage_Adminhtml_Block_Widget
 
     protected function _beforeToHtml()
     {
+        Mage::dispatchEvent('adminhtml_block_widget_tabs_added_after', ['block' => $this]);
+        
         if ($activeTab = $this->getRequest()->getParam('active_tab')) {
             $this->setActiveTab($activeTab);
         } elseif ($activeTabId = Mage::getSingleton('admin/session')->getActiveTabId()) {


### PR DESCRIPTION
### Description (*)
A generic event after tabs have been added, allowing us to add more tabs, edit or remove them without complicating the active tab or sorting of tabs.

Overriding the block is not an option, because the active tab + sorting is handled in the parent class. There is no pretty way to add a tab without ugly copy pasting of code Magento code.

The case where I ran into this was when I wanted to add a tab to `Mage_Adminhtml_Block_Catalog_Product_Attribute_Edit_Tabs`

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
