### PR TITLE
Old inactive quotes are now actually purged from the database

### DIFF
--- a/app/code/core/Mage/Checkout/etc/system.xml
+++ b/app/code/core/Mage/Checkout/etc/system.xml
@@ -80,6 +80,7 @@
                     <fields>
                         <delete_quote_after translate="label">
                             <label>Quote Lifetime (days)</label>
+                            <validate>validate-not-negative-number</validate>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>


### PR DESCRIPTION

### Description (*)

Since the beggining of Magento, only quotes converted to orders can be deleted by `sales_clean_quotes` cron because quote collection filter on `is_active=0` ​

---
Show quotes group by year
```
select YEAR(updated_at), count('*')
from sales_flat_quote
GROUP BY YEAR(updated_at)
```

| YEAR\(updated\_at\) | count\('\*'\) |
| :--- | :--- |
| 2018 | 1014080 |
| 2019 | 404537 |
| 2020 | 159526 |
| 2021 | 46765 |

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
