### PR TITLE
Removed unnecessary replacing of variable from parent

### DIFF
--- a/app/code/core/Mage/Directory/Model/Resource/Country/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Country/Collection.php
@@ -30,6 +30,8 @@
  * @category    Mage
  * @package     Mage_Directory
  * @author      Magento Core Team <core@magentocommerce.com>
+ *
+ * @property Mage_Directory_Model_Country[] $_items
  */
 class Mage_Directory_Model_Resource_Country_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {

--- a/app/code/core/Mage/Directory/Model/Resource/Country/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Country/Collection.php
@@ -34,11 +34,6 @@
 class Mage_Directory_Model_Resource_Country_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {
     /**
-     * @var Mage_Directory_Model_Country[]
-     */
-    protected $_items;
-
-    /**
      * Define main table
      */
     protected function _construct()


### PR DESCRIPTION
### Description (*)

`Mage_Directory_Model_Resource_Country_Collection` extending `Varien_Data_Collection` where is `$_items` already defined:
```
    /**
     * Collection items
     *
     * @var array
     */
    protected $_items = array();

```
And there was diferrent initial value.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
