### PR TITLE
Set proper HTTP response code on error

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -969,6 +969,7 @@ final class Mage
     public static function printException(Throwable $e, $extra = '')
     {
         if (self::$_isDeveloperMode) {
+            @http_response_code(500);
             print '<pre>';
 
             if (!empty($extra)) {


### PR DESCRIPTION
### Description (*)
I was doing some AJAX work in DEV mode and discovered that Magento returns a status 200 for uncaught exceptions. This single line fixes it.

Since the request breaks, we don't want a status 200, because it can have unintended consequences in JavaScript (i.e. run a success callback instead of an error callback in JS).


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
