### PR TITLE
fix typo in _applyCustomOption() to correctly calculate min/max price

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Default.php
@@ -390,11 +390,6 @@ class Mage_Catalog_Model_Resource_Product_Indexer_Price_Default extends Mage_Cat
                 array()
             )
             ->join(
-                array('cs' => $this->getTable('core/store')),
-                'cs.store_id = csg.default_store_id',
-                array()
-            )
-            ->join(
                 array('o' => $this->getTable('catalog/product_option')),
                 'o.product_id = i.entity_id',
                 array('option_id')
@@ -411,7 +406,7 @@ class Mage_Catalog_Model_Resource_Product_Indexer_Price_Default extends Mage_Cat
             )
             ->joinLeft(
                 array('otps' => $this->getTable('catalog/product_option_type_price')),
-                'otps.option_type_id = otpd.option_type_id AND otps.store_id = cs.store_id',
+                'otps.option_type_id = otpd.option_type_id AND otps.store_id = csg.default_store_id',
                 array()
             )
             ->group(array('i.entity_id', 'i.customer_group_id', 'i.website_id', 'o.option_id'));
@@ -469,11 +464,6 @@ class Mage_Catalog_Model_Resource_Product_Indexer_Price_Default extends Mage_Cat
                 array()
             )
             ->join(
-                array('cs' => $this->getTable('core/store')),
-                'cs.store_id = csg.default_store_id',
-                array()
-            )
-            ->join(
                 array('o' => $this->getTable('catalog/product_option')),
                 'o.product_id = i.entity_id',
                 array('option_id')
@@ -485,7 +475,7 @@ class Mage_Catalog_Model_Resource_Product_Indexer_Price_Default extends Mage_Cat
             )
             ->joinLeft(
                 array('ops' => $this->getTable('catalog/product_option_price')),
-                'ops.option_id = opd.option_id AND ops.store_id = cs.store_id',
+                'ops.option_id = opd.option_id AND ops.store_id = csg.default_store_id',
                 array()
             );
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Default.php
@@ -411,7 +411,7 @@ class Mage_Catalog_Model_Resource_Product_Indexer_Price_Default extends Mage_Cat
             )
             ->joinLeft(
                 array('otps' => $this->getTable('catalog/product_option_type_price')),
-                'otps.option_type_id = otpd.option_type_id AND otpd.store_id = cs.store_id',
+                'otps.option_type_id = otpd.option_type_id AND otps.store_id = cs.store_id',
                 array()
             )
             ->group(array('i.entity_id', 'i.customer_group_id', 'i.website_id', 'o.option_id'));


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
Fix typo in _applyCustomOption() to correctly calculate min/max price per website. 
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Min/Max price of custom options is not calculated correctly per website due to the typo in left join which always return NULLs. Fixed with correcting typo in the join condition, removed unnecessary join to `core_store` table reusing `csg.default_store_id` instead of `core_store.store_id`.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
