### PR TITLE
Improved VAT number validation

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Vatnumberformat.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Vatnumberformat.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * OpenMage
+ *
+ * @category    Mage
+ * @package     Mage_Adminhtml
+ * @copyright   Copyright (c) 2009-2021 OpenMage (https://www.openmage.org/)
+ */
+class Mage_Adminhtml_Model_System_Config_Source_Customer_Vatnumberformat
+{
+    /**
+     * Options getter
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return array(
+            array('value' => 0, 'label'=>Mage::helper('adminhtml')->__('Without country code')),
+            array('value' => 1, 'label'=>Mage::helper('adminhtml')->__('With country code')),
+            array('value' => 2, 'label'=>Mage::helper('adminhtml')->__('With and without country code')),
+        );
+    }
+
+    /**
+     * Get options in "key-value" format
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array(
+            0 => Mage::helper('adminhtml')->__('Without country code'),
+            1 => Mage::helper('adminhtml')->__('With country code'),
+            2 => Mage::helper('adminhtml')->__('With and without country code'),
+        );
+    }
+}

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/System/Config/ValidatevatController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/System/Config/ValidatevatController.php
@@ -40,10 +40,16 @@ class Mage_Adminhtml_Customer_System_Config_ValidatevatController extends Mage_A
      */
     protected function _validate()
     {
-        return Mage::helper('customer')->checkVatNumber(
-            $this->getRequest()->getParam('country'),
-            $this->getRequest()->getParam('vat')
-        );
+        /** @var Mage_Customer_Model_Vies $vies */
+        $vies = Mage::getModel('customer/vies');
+
+        // Prepare vies check
+        $vies->enableVatNumberCheckForNorthernIreland()
+            ->setVatNumber($this->getRequest()->getParam('vat'))
+            ->setCountryCode($this->getRequest()->getParam('country'))
+            ->setPostcode($this->getRequest()->getParam('postcode'));
+
+        return $vies->checkVatNumber();
     }
 
     /**

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -52,6 +52,7 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
      * Config pathes to merchant country code and merchant VAT number
      */
     const XML_PATH_MERCHANT_COUNTRY_CODE = 'general/store_information/merchant_country';
+    const XML_PATH_MERCHANT_POSTCODE = 'general/store_information/merchant_postcode';
     const XML_PATH_MERCHANT_VAT_NUMBER = 'general/store_information/merchant_vat_number';
     const XML_PATH_EU_COUNTRIES_LIST = 'general/country/eu_countries';
 
@@ -911,6 +912,17 @@ XML;
     public function getMerchantCountryCode($store = null)
     {
         return (string) Mage::getStoreConfig(self::XML_PATH_MERCHANT_COUNTRY_CODE, $store);
+    }
+
+    /**
+     * Retrieve merchant postcode
+     *
+     * @param Mage_Core_Model_Store|string|int|null $store
+     * @return string
+     */
+    public function getMerchantPostcode($store = null)
+    {
+        return (string) Mage::getStoreConfig(self::XML_PATH_MERCHANT_POSTCODE, $store);
     }
 
     /**

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -917,6 +917,14 @@
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
                         </merchant_country>
+                        <merchant_postcode translate="label">
+                            <label>Postcode</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </merchant_postcode>
                         <merchant_vat_number translate="label">
                             <label>VAT Number</label>
                             <frontend_type>text</frontend_type>

--- a/app/code/core/Mage/Customer/Model/Observer.php
+++ b/app/code/core/Mage/Customer/Model/Observer.php
@@ -155,8 +155,18 @@ class Mage_Customer_Model_Observer
             /** @var Mage_Customer_Helper_Data $customerHelper */
             $customerHelper = Mage::helper('customer');
 
+            /** @var Mage_Customer_Model_Vies $vies */
+            $vies = Mage::getModel('customer/vies');
+
+            // Prepare vies check
+            $vies->setStore($store)
+                ->setVatNumber($customerAddress->getVatId())
+                ->setCountryCode($customerAddress->getCountryId())
+                ->setPostcode($customerAddress->getPostcode());
+
             if ($customerAddress->getVatId() == ''
-                || !Mage::helper('core')->isCountryInEU($customerAddress->getCountry())) {
+                || !$vies->shouldValidateVatNumber()
+            ) {
                 $defaultGroupId = $customerHelper->getDefaultCustomerGroupId($customer->getStore());
 
                 if (!$customer->getDisableAutoGroupChange() && $customer->getGroupId() != $defaultGroupId) {
@@ -164,10 +174,7 @@ class Mage_Customer_Model_Observer
                     $customer->save();
                 }
             } else {
-                $result = $customerHelper->checkVatNumber(
-                    $customerAddress->getCountryId(),
-                    $customerAddress->getVatId()
-                );
+                $result = $vies->checkVatNumber();
 
                 $newGroupId = $customerHelper->getCustomerGroupIdBasedOnVatNumber(
                     $customerAddress->getCountryId(),

--- a/app/code/core/Mage/Customer/Model/Vies.php
+++ b/app/code/core/Mage/Customer/Model/Vies.php
@@ -1,0 +1,363 @@
+<?php
+/**
+ * OpenMage
+ *
+ * @category    Mage
+ * @package     Mage_Customer
+ * @copyright   Copyright (c) 2009-2021 OpenMage (https://www.openmage.org/)
+ */
+class Mage_Customer_Model_Vies extends Varien_Object
+{
+    /**
+     * WSDL of VAT validation service
+     */
+    const VAT_VALIDATION_WSDL_URL = 'https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl';
+
+    /**
+     * Config paths to VAT related customer groups
+     */
+    const XML_PATH_CUSTOMER_VIV_VAT_NUMBER_FORMAT = 'customer/create_account/viv_vat_number_format';
+    const XML_PATH_CUSTOMER_VIV_FOR_NORTHERN_IRELAND = 'customer/create_account/viv_for_northern_ireland';
+
+    /**
+     * Flag for Northern Ireland VAT number check
+     *
+     * @var boolean
+     */
+    protected $checkNorthernIreland;
+
+    /**
+     * Send request to VAT validation service and return validation result
+     *
+     * @return Varien_Object
+     */
+    public function checkVatNumber()
+    {
+        // Default response
+        $gatewayResponse = new Varien_Object(array(
+            'is_valid' => false,
+            'request_date' => '',
+            'request_identifier' => '',
+            'request_success' => false
+        ));
+
+        if (!extension_loaded('soap')) {
+            Mage::logException(Mage::exception(
+                'Mage_Core',
+                Mage::helper('core')->__('PHP SOAP extension is required.')
+            ));
+            return $gatewayResponse;
+        }
+
+        if (empty($this->getCountryCode())) {
+            return $gatewayResponse;
+        }
+
+        if (empty($this->getVatNumber())) {
+            return $gatewayResponse;
+        }
+
+        if ($this->getValidationType() == 1 // With country code
+            && !$this->vatNumberContainsCountryCode($this->getVatNumber(), $this->getCountryCode())
+        ) {
+            // No valid vat number because not the right countrycode is used
+            return $gatewayResponse;
+        }
+
+        if (!$this->canCheckVatNumber()) {
+            return $gatewayResponse;
+        }
+
+        try {
+            $soapClient = $this->createVatNumberValidationSoapClient();
+
+            $requestParams = array();
+            $requestParams['countryCode'] = $this->getViesCountryCode();
+            $requestParams['vatNumber'] = $this->getViesVatNumber();
+            $requestParams['requesterCountryCode'] = $this->getViesRequesterCountryCode();
+            $requestParams['requesterVatNumber'] = $this->getViesRequesterVatNumber();
+
+            // Send request to service
+            $result = $soapClient->checkVatApprox($requestParams);
+
+            $gatewayResponse->setIsValid((boolean) $result->valid);
+            $gatewayResponse->setRequestDate((string) $result->requestDate);
+            $gatewayResponse->setRequestIdentifier((string) $result->requestIdentifier);
+            $gatewayResponse->setRequestSuccess(true);
+        } catch (Exception $exception) {
+            $gatewayResponse->setIsValid(false);
+            $gatewayResponse->setRequestDate('');
+            $gatewayResponse->setRequestIdentifier('');
+        }
+
+        return $gatewayResponse;
+    }
+
+    /**
+     * Check if vat number should be validated
+     *
+     * @return boolean
+     */
+    public function shouldValidateVatNumber()
+    {
+        if (Mage::helper('core')->isCountryInEU($this->getCountryCode())) {
+            return true;
+        }
+
+        if ($this->getCountryCode() == 'GB'
+            && $this->validNorthernIrelandPostcode($this->getPostcode())
+            && $this->checkVatNumberForNorthernIreland()
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Enable / disable vat validation for Northern Ireland
+     *
+     * @param boolean $flag
+     * @return $this
+     */
+    public function enableVatNumberCheckForNorthernIreland($flag = true)
+    {
+        $this->checkNorthernIreland = $flag;
+
+        return $this;
+    }
+
+    /**
+     * Set vat number to validate
+     *
+     * @param string $vatNumber
+     * @return $this
+     */
+    public function setVatNumber($vatNumber)
+    {
+        return $this->setData('vat_number', str_replace(array(' ', '-'), array('', ''), $vatNumber));
+    }
+
+    /**
+     * Set requester vat number
+     *
+     * @param string $vatNumber
+     * @return $this
+     */
+    public function setRequesterVatNumber($vatNumber)
+    {
+        return $this->setData('requester_vat_number', str_replace(array(' ', '-'), array('', ''), $vatNumber));
+    }
+
+    /**
+     * Get requester country code
+     *
+     * @return string
+     */
+    public function getRequesterCountryCode()
+    {
+        $countryCode = $this->getData('requester_country_code');
+        if (is_null($countryCode)) {
+            return '';
+        }
+
+        return (string) $countryCode;
+    }
+
+    /**
+     * Get requester vat number
+     *
+     * @return string
+     */
+    public function getRequesterVatNumber()
+    {
+        $vatNumber = $this->getData('requester_vat_number');
+        if (is_null($vatNumber)) {
+            return '';
+        }
+
+        return (string) $vatNumber;
+    }
+
+    /**
+     * Check if postcode is valid for Northern Ireland
+     *
+     * @param  string $postcode
+     * @return boolean
+     */
+    protected function validNorthernIrelandPostcode($postcode)
+    {
+        if (empty($postcode)) {
+            return false;
+        }
+
+        preg_match("/^BT\d{1,2}\s?[0-9][A-Z]{2}$/i", trim($postcode), $matches);
+
+        return is_array($matches) && count($matches);
+    }
+
+    /**
+     * Check if vat number contains country code
+     *
+     * @param  string $vatNumber
+     * @param  string $countryCode
+     * @return boolean
+     */
+    protected function vatNumberContainsCountryCode($vatNumber, $countryCode)
+    {
+        $vatNumberCountryCode = substr(strtoupper($vatNumber), 0, 2);
+        if ($vatNumberCountryCode == 'XI') {
+            $vatNumberCountryCode = 'GB';
+        } elseif($vatNumberCountryCode == 'EL') {
+            $vatNumberCountryCode = 'GR';
+        }
+
+        return $vatNumberCountryCode === $countryCode;
+    }
+
+    /**
+     * Check if vat validation for Northern Ireland is enabled
+     *
+     * @return boolean
+     */
+    protected function checkVatNumberForNorthernIreland()
+    {
+        if (!is_bool($this->checkNorthernIreland)) {
+            $this->checkNorthernIreland = (bool) (int) Mage::getStoreConfig(
+                self::XML_PATH_CUSTOMER_VIV_FOR_NORTHERN_IRELAND, $this->getStore()
+            );
+        }
+
+        return $this->checkNorthernIreland;
+    }
+
+    /**
+     * Get vat validation type
+     *
+     * @return int
+     */
+    protected function getValidationType()
+    {
+        return (int) Mage::getStoreConfig(self::XML_PATH_CUSTOMER_VIV_VAT_NUMBER_FORMAT, $this->getStore());
+    }
+
+    /**
+     * Get formatted vat number for vies check
+     *
+     * @return string
+     */
+    protected function getViesVatNumber()
+    {
+        // Remove country code from vat number to make vies check work
+        if (in_array($this->getValidationType(), [1,2])
+            && $this->vatNumberContainsCountryCode($this->getVatNumber(), $this->getCountryCode())
+        ) {
+            return substr($this->getVatNumber(), strlen($this->getCountryCode()));
+        }
+
+        return (string) $this->getVatNumber();
+    }
+
+    /**
+     * Get formatted vat number for vies check
+     *
+     * @return string
+     */
+    protected function getViesRequesterVatNumber()
+    {
+        // Remove country code from vat number to make vies check work
+        if ($this->vatNumberContainsCountryCode($this->getRequesterVatNumber(), $this->getRequesterCountryCode())) {
+            return substr($this->getRequesterVatNumber(), strlen($this->getRequesterCountryCode()));
+        }
+
+        return (string) $this->getRequesterVatNumber();
+    }
+
+    /**
+     * Get country code for vies check
+     *
+     * @return string
+     */
+    protected function getViesCountryCode()
+    {
+        // Fix for Greece
+        if($this->getCountryCode() == 'GR') {
+            return 'EL';
+        }
+
+        // Fix for Northern Ireland
+        if ($this->getCountryCode() == 'GB'
+            && $this->validNorthernIrelandPostcode($this->getPostcode())
+            && $this->checkVatNumberForNorthernIreland()
+        ) {
+            return 'XI';
+        }
+
+        return (string) $this->getCountryCode();
+    }
+
+    /**
+     * Get vies version of requester country code
+     *
+     * @return string
+     */
+    protected function getViesRequesterCountryCode()
+    {
+        if ($this->getRequesterCountryCode() == 'GB'
+            && $this->validNorthernIrelandPostcode($this->getRequesterPostcode())
+        ) {
+            return 'XI';
+        } elseif($this->getRequesterCountryCode() == 'GR') {
+            return 'EL';
+        }
+
+        return (string) $this->getRequesterCountryCode();
+    }
+
+    /**
+     * Check if parameters are valid to send to VAT validation service
+     *
+     * @return boolean
+     */
+    protected function canCheckVatNumber()
+    {
+        /** @var $coreHelper Mage_Core_Helper_Data */
+        $coreHelper = Mage::helper('core');
+
+        if (!is_string($this->getCountryCode())
+            || !is_string($this->getVatNumber())
+            || !is_string($this->getRequesterCountryCode())
+            || !is_string($this->getRequesterVatNumber())
+            || empty($this->getCountryCode())
+            || !(
+                    $coreHelper->isCountryInEU($this->getCountryCode(), $this->getStore())
+                    || $this->getViesCountryCode() == 'XI' // Northern Ireland
+                )
+            || empty($this->getVatNumber())
+            || (empty($this->getRequesterCountryCode()) && !empty($this->getRequesterVatNumber()))
+            || (!empty($this->getRequesterCountryCode()) && empty($this->getRequesterVatNumber()))
+            || (
+                !empty($this->getRequesterCountryCode())
+                && !(
+                    $coreHelper->isCountryInEU($this->getRequesterCountryCode(), $this->getStore())
+                    || $this->getViesRequesterCountryCode() == 'XI' // Northern Ireland
+                )
+            )
+        ) {
+            return false;
+        }
+
+        return true;;
+    }
+
+    /**
+     * Create SOAP client based on VAT validation service WSDL
+     *
+     * @param boolean $trace
+     * @return SoapClient
+     */
+    protected function createVatNumberValidationSoapClient($trace = false)
+    {
+        return new SoapClient(self::VAT_VALIDATION_WSDL_URL, array('trace' => $trace));
+    }
+}

--- a/app/code/core/Mage/Customer/etc/config.xml
+++ b/app/code/core/Mage/Customer/etc/config.xml
@@ -527,6 +527,8 @@
                 <email_confirmation_template>customer_create_account_email_confirmation_template</email_confirmation_template>
                 <email_confirmed_template>customer_create_account_email_confirmed_template</email_confirmed_template>
                 <vat_frontend_visibility>0</vat_frontend_visibility>
+                <viv_vat_number_format>0</viv_vat_number_format>
+                <viv_for_northern_ireland>0</viv_for_northern_ireland>
             </create_account>
             <changed_account>
                 <password_or_email_identity>general</password_or_email_identity>

--- a/app/code/core/Mage/Customer/etc/system.xml
+++ b/app/code/core/Mage/Customer/etc/system.xml
@@ -108,6 +108,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </tax_calculation_address_type>
+                        <viv_vat_number_format translate="label">
+                            <label>VAT number validation type</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_customer_vatnumberformat</source_model>
+                            <sort_order>11</sort_order>
+                            <depends><auto_group_assign>1</auto_group_assign></depends>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </viv_vat_number_format>
                         <default_group translate="label">
                             <label>Default Group</label>
                             <frontend_type>select</frontend_type>
@@ -167,11 +177,21 @@
                             <show_in_store>1</show_in_store>
                             <depends><auto_group_assign>1</auto_group_assign></depends>
                         </viv_on_each_transaction>
+                        <viv_for_northern_ireland translate="label comment">
+                            <label>Validate Northern Ireland VAT ID</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>57</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment><![CDATA[Enable VIES check for Northern Ireland based on postcode.]]></comment>
+                        </viv_for_northern_ireland>
                         <viv_disable_auto_group_assign_default translate="label">
                             <label>Default Value for Disable Automatic Group Changes Based on VAT ID</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>57</sort_order>
+                            <sort_order>58</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
@@ -180,7 +200,7 @@
                             <label>Show VAT Number on Frontend</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>58</sort_order>
+                            <sort_order>59</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>

--- a/app/design/adminhtml/default/default/template/customer/system/config/validatevat.phtml
+++ b/app/design/adminhtml/default/default/template/customer/system/config/validatevat.phtml
@@ -36,6 +36,7 @@
 
         params = {
             country: $('general_store_information_merchant_country').value,
+            postcode: $('general_store_information_merchant_postcode').value,
             vat: $('general_store_information_merchant_vat_number').value
         };
 


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Improved VAT number validation (VIES):
- added validation for Greece and Northern Ireland
- added validation option for accepting VAT numbers including country code

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#1486

### Manual testing scenarios (*)
1. Setup tax rules for Europe (for Northern Ireland use the "United Kingdom" as country and "BT*" for the postcode)
2. Make sure you have configured a VAT number for another EU country for your store and all settings for the Intra Union functionality to work (let me know if you need help with this).
3. Buy a product and use a valid VAT number for Greece (this is a VAT number starting with EL) or Northern Ireland (this is a VAT number starting with XI) but only submit the part after the EL or XI (this is how Magento always worked).
4. If you test for Northern Ireland you also have to provide a valid postcode for the Northern Ireland (starting with BT).
5. The tax should be set to 0.
6. Set the config value for customer/create_account/viv_vat_number_format to 1 (With country code)
7. Repeat step 3 to 5 but now you have to use the whole VAT number including the "country" code prefix.
9. Set the config value for customer/create_account/viv_vat_number_format to 2 (With and without country code)
10. Repeat step 3 to 5, now you can use VAT number with or without the "country" code prefix.

### Questions or comments
1. What do we want the copyright comment to be for newly created files? I think the Magento copyright notice is not right for this or is it? For now I added a simple OpenMage comment block.
2. I created a new model for this functionality because I think it is too much functionality to go in a generic helper. For backwards compatibility I changed the old helper method to use the new model. This however will not work for Northern Ireland because there should also be a postcode provided but this is not available in the helper method.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
