### PR TITLE
Fix the deprecation problem of idn_to_ascii() since php7.2

### DIFF
--- a/app/code/core/Zend/Validate/Hostname.php
+++ b/app/code/core/Zend/Validate/Hostname.php
@@ -2512,7 +2512,12 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
     protected function checkDnsRecords($hostName)
     {
         if (function_exists('idn_to_ascii')) {
-            $result = checkdnsrr(idn_to_ascii($hostName), 'A');
+            if (defined('IDNA_NONTRANSITIONAL_TO_ASCII') && defined('INTL_IDNA_VARIANT_UTS46')) {
+                $toAscii = idn_to_ascii($hostName, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
+            } else {
+                $toAscii = idn_to_ascii($hostName);
+            }
+            $result = checkdnsrr($toAscii, 'A');
         } else {
             $idn = new Net_IDNA2();
             $result = checkdnsrr($idn->encode($hostName), 'A');


### PR DESCRIPTION
idn_to_ascii() php function is deprecated as of php 7.2
However it is still available but you should use INTL_IDNA_VARIANT_UTS46 as a third argument. (see https://www.php.net/manual/en/function.idn-to-ascii.php)
Otherwise you will see the error because INTL_IDNA_VARIANT_2003 is deprecated.
![image](https://user-images.githubusercontent.com/5228893/111969833-f0b84f80-8afa-11eb-9081-f12fff405b50.png)


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
