### PR TITLE
Add redis as a valid option for global/session_save

### DIFF
--- a/app/code/community/Cm/RedisSession/etc/config.xml
+++ b/app/code/community/Cm/RedisSession/etc/config.xml
@@ -38,11 +38,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     </modules>
     <global>
         <models>
-            <core_mysql4>
-                <rewrite>
-                    <session>Cm_RedisSession_Model_Session</session>
-                </rewrite>
-            </core_mysql4>
+            <cm_redissession>
+                <class>Cm_RedisSession_Model</class>
+            </cm_redissession>
         </models>
     </global>
 </config>

--- a/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
@@ -71,6 +71,11 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
                 $sessionResource = Mage::getResourceSingleton('core/session');
                 $sessionResource->setSaveHandler();
                 break;
+            case 'redis':
+                /* @var Cm_RedisSession_Model_Session $sessionResource */
+                $sessionResource = Mage::getSingleton('cm_redissession/session');
+                $sessionResource->setSaveHandler();
+                break;
             case 'user':
                 // getSessionSavePath represents static function for custom session handler setup
                 call_user_func($this->getSessionSavePath());

--- a/app/etc/local.xml.additional
+++ b/app/etc/local.xml.additional
@@ -31,7 +31,7 @@ to app/etc/local.xml manually.
 -->
 <config>
     <global>
-        <session_save><![CDATA[]]></session_save> <!-- db / memcache / empty=files -->
+        <session_save><![CDATA[]]></session_save> <!-- db / memcache / redis / empty=files -->
         <session_save_path><![CDATA[]]></session_save_path><!-- e.g. for memcache session save handler tcp://10.0.0.1:11211?persistent=1&weight=2&timeout=10&retry_interval=10 -->
         <session_cache_limiter><![CDATA[]]></session_cache_limiter><!-- see http://php.net/manual/en/function.session-cache-limiter.php#82174 for possible values -->
         <cache>
@@ -119,7 +119,7 @@ to app/etc/local.xml manually.
         </full_page_cache>
 
         <!-- example of redis session storage -->
-        <session_save>db</session_save>
+        <session_save>redis</session_save>
         <redis_session>                                          <!-- All options seen here are the defaults -->
             <host>127.0.0.1</host>                               <!-- Specify an absolute path if using a unix socket -->
             <port>6379</port>

--- a/app/etc/modules/Cm_RedisSession.xml
+++ b/app/etc/modules/Cm_RedisSession.xml
@@ -1,7 +1,7 @@
 <config>
   <modules>
     <Cm_RedisSession>
-      <active>false</active>
+      <active>true</active>
       <codePool>community</codePool>
     </Cm_RedisSession>
   </modules>


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

This is a backwards incompatible change, so I don't think it's a good idea to merge it into 1.9.4.x, however 20.0 perhaps..?

So, this PR:

1. Adds `redis` as an entry in the Core session selection switch statement.
2. Removes the rewrite from `Cm_RedisSession` (to restate `db` when `Cm_RedisSession` is enabled)
3. Enables `Cm_RedisSession`

The impact of this is in `local.xml` `global/session_save` will accept both `db` and `redis` as valid values. 

The reason this is backwards incompatible is `Cm_RedisSession` used to rewrite and replace the `db` handler (if `Cm_RedisSession` was set to enabled/active in its module config.
Thus if merged `Cm_RedisSession` users will revert to DB for session storage.

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This was mentioned here (among other places): https://github.com/OpenMage/magento-lts/issues/379#issuecomment-345328667

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. change local.xml `<global><session_save>` to `redis`
2. configure `local.xml` `redis_session`
3. Create a session with something clearly in it, e.g. add items to the cart and verify they are there after a page load (session is valid)
4. use `redis-cli FLUSHALL` (etc) to drop clear the redis database (this will clear the whole redis db so don't run it on something you care about)
5. Verify session is gone e.g. cart is now empty

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
