### PR TITLE
Associated products are now loaded using the the same store view as the parent

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Type/Grouped.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Grouped.php
@@ -139,6 +139,7 @@ class Mage_Catalog_Model_Product_Type_Grouped extends Mage_Catalog_Model_Product
                 ->addFilterByRequiredOptions()
                 ->setPositionOrder()
                 ->addStoreFilter($this->getStoreFilter($product))
+                ->setStoreId($product->getStoreId())
                 ->addAttributeToFilter('status', array('in' => $this->getStatusFilters($product)));
 
             foreach ($collection as $item) {


### PR DESCRIPTION

### Description (*)

It makes sense that when you need associated products for a given grouped product, the associated products should have data from the same store view. This fixes issues with the associated products being in different languages than the given product.



### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
