### PR TITLE
Expected PayPal (Express) field not found in NVP Response: AMT

### DIFF
--- a/app/code/core/Mage/Paypal/Model/Api/Nvp.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Nvp.php
@@ -521,7 +521,7 @@ class Mage_Paypal_Model_Api_Nvp extends Mage_Paypal_Model_Api_Abstract
      */
     protected $_requiredResponseParams = array(
         self::DO_DIRECT_PAYMENT             => array('ACK', 'CORRELATIONID', 'AMT'),
-        self::DO_EXPRESS_CHECKOUT_PAYMENT   => array('ACK', 'CORRELATIONID', 'AMT'),
+        self::DO_EXPRESS_CHECKOUT_PAYMENT   => array('ACK', 'CORRELATIONID'),
     );
 
     /**


### PR DESCRIPTION
### Description

This PR fix #1010. 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
