### PR TITLE
don't redirect to "downloader" (which doesn't exists)

### DIFF
--- a/index.php
+++ b/index.php
@@ -42,15 +42,6 @@ define('MAGENTO_ROOT', getcwd());
 $mageFilename = MAGENTO_ROOT . '/app/Mage.php';
 $maintenanceFile = 'maintenance.flag';
 
-if (!file_exists($mageFilename)) {
-    if (is_dir('downloader')) {
-        header("Location: downloader");
-    } else {
-        echo $mageFilename." was not found";
-    }
-    exit;
-}
-
 if (file_exists($maintenanceFile)) {
     include_once dirname(__FILE__) . '/errors/503.php';
     exit;


### PR DESCRIPTION
In the main index.php there's a check for the app/Mage.php (which is 99.9% useless) and a redirect to the "magento downloader".

Downloader was removed with https://github.com/OpenMage/magento-lts/pull/952 so it's useless to redirect to the downloader subdir. Also, I think the purpose of checkin if the MAGENTO_ROOT . '/app/Mage.php' is useless, one file check for every request while magento wouldn't work at all if it didn't exist, I think that check has to be removed, there's no point in executing it.