### PR TITLE
Fixed incorrect datetime in block.

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
@@ -78,11 +78,9 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_View
      */
     public function getCreateDate()
     {
-        if ( ! $this->getCustomer()->getCreatedAt()) {
-            return null;
-        }
-        return $this->_getCoreHelper()->formatDate($this->getCustomer()->getCreatedAt(),
-            Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true);
+        return ($date = $this->getCustomer()->getCreatedAt())
+            ? $this->formatDate($date, Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true, false)
+            : null;
     }
 
     public function getStoreCreateDate()
@@ -111,11 +109,9 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_View
      */
     public function getLastLoginDate()
     {
-        $date = $this->getCustomerLog()->getLoginAtTimestamp();
-        if ($date) {
-            return Mage::helper('core')->formatDate($date, Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true);
-        }
-        return Mage::helper('customer')->__('Never');
+        return ($date = $this->getCustomerLog()->getLoginAtTimestamp())
+            ? $this->formatDate($date, Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true, false)
+            : Mage::helper('customer')->__('Never');
     }
 
     public function getStoreLastLoginDate()
@@ -218,6 +214,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_View
     }
 
     /**
+     * @deprecated
      * Return instance of core helper
      *
      * @return Mage_Core_Helper_Data

--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -1128,11 +1128,12 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      * @param   string $date
      * @param   string $format
      * @param   bool $showTime
+     * @param   bool $useTimezone
      * @return  string
      */
-    public function formatDate($date = null, $format = Mage_Core_Model_Locale::FORMAT_TYPE_SHORT, $showTime = false)
+    public function formatDate($date = null, $format = Mage_Core_Model_Locale::FORMAT_TYPE_SHORT, $showTime = false, $useTimezone = true)
     {
-        return $this->helper('core')->formatDate($date, $format, $showTime);
+        return $this->helper('core')->formatDate($date, $format, $showTime, $useTimezone);
     }
 
     /**

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -155,30 +155,32 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Format date using current locale options and time zone.
      *
-     * @param   string|Zend_Date|null $date
+     * @param   string|Zend_Date|null $date If empty, return current datetime.
      * @param   string              $format   See Mage_Core_Model_Locale::FORMAT_TYPE_* constants
      * @param   bool                $showTime Whether to include time
+     * @param   bool                $useTimezone Convert to local datetime?
      * @return  string
      */
-    public function formatDate($date = null, $format = Mage_Core_Model_Locale::FORMAT_TYPE_SHORT, $showTime = false)
+    public function formatDate($date = null, $format = Mage_Core_Model_Locale::FORMAT_TYPE_SHORT, $showTime = false, $useTimezone = true)
     {
         if (!in_array($format, $this->_allowedFormats, true)) {
             return $date;
         }
-        if (!($date instanceof Zend_Date) && $date && !strtotime($date)) {
-            return '';
-        }
-        if (is_null($date)) {
-            $date = Mage::app()->getLocale()->date(Mage::getSingleton('core/date')->gmtTimestamp(), null, null);
+        if (empty($date)) {
+            $date = Mage::app()->getLocale()->date(Mage::getSingleton('core/date')->gmtTimestamp(), null, null, $useTimezone);
+        } elseif (is_int($date)) {
+            $date = Mage::app()->getLocale()->date($date, null, null, $useTimezone);
         } elseif (!$date instanceof Zend_Date) {
-            $date = Mage::app()->getLocale()->date(strtotime($date), null, null);
+            if ($time = strtotime($date)) {
+                $date = Mage::app()->getLocale()->date($time, null, null, $useTimezone);
+            } else {
+                return '';
+            }
         }
 
-        if ($showTime) {
-            $format = Mage::app()->getLocale()->getDateTimeFormat($format);
-        } else {
-            $format = Mage::app()->getLocale()->getDateFormat($format);
-        }
+        $format = $showTime
+            ? Mage::app()->getLocale()->getDateTimeFormat($format)
+            : Mage::app()->getLocale()->getDateFormat($format);
 
         return $date->toString($format);
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixes 2 issues:
1. Incorrect datetime in backend customer page, see issue #466.
2. Enable the ability to `formatDate()` in the block without converting to store timezone. A use case is when a datetime is stored in the DB in local timezone (or a date such as birthdate, which is independent of timezone), the method `formatDate()` would convert the datetime and couldn't be used for rendering. This PR fixes that. Now, the same method can be used.


### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#466

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
After:
![image](https://user-images.githubusercontent.com/1106470/113652741-f1d6a880-96c6-11eb-9dd9-e592c96bf466.png)


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
