### PR TITLE
Throwing Exception when column not exists in resource model

### DIFF
--- a/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
@@ -403,7 +403,7 @@ abstract class Mage_Core_Model_Resource_Db_Abstract extends Mage_Core_Model_Reso
         $fields = $this->_getReadAdapter()->describeTable($this->getMainTable());
 
         if (!isset($fields[$field])) {
-            throw new Exception("Column \"{$field}\" does not exists in table \"{$this->getMainTable()}\"");
+            throw new Exception("Column \"{$field}\" does not exist in table \"{$this->getMainTable()}\"");
         }
 
         $value  = $this->_getReadAdapter()->prepareColumnValue($fields[$field], $value);

--- a/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
@@ -248,7 +248,7 @@ abstract class Mage_Core_Model_Resource_Db_Abstract extends Mage_Core_Model_Reso
     /**
      * Get table name for the entity, validated by db adapter
      *
-     * @param string $entityName
+     * @param string|array $entityName
      * @return string
      */
     public function getTable($entityName)
@@ -396,10 +396,16 @@ abstract class Mage_Core_Model_Resource_Db_Abstract extends Mage_Core_Model_Reso
      * @param mixed $value
      * @param Mage_Core_Model_Abstract $object
      * @return Varien_Db_Select
+     * @throws Exception
      */
     protected function _getLoadSelect($field, $value, $object)
     {
         $fields = $this->_getReadAdapter()->describeTable($this->getMainTable());
+
+        if (!isset($fields[$field])) {
+            throw new Exception("Column \"{$field}\" does not exists in table \"{$this->getMainTable()}\"");
+        }
+
         $value  = $this->_getReadAdapter()->prepareColumnValue($fields[$field], $value);
         $field  = $this->_getReadAdapter()->quoteIdentifier(sprintf('%s.%s', $this->getMainTable(), $field));
         $select = $this->_getReadAdapter()->select()


### PR DESCRIPTION
### Description / Manual testing scenarios
Consider following code:

```php
Mage::getModel('catalog/product')->load('value', 'unexisting_column');
```

Now is show following error:
![113858340-e6a57a80-97a3-11eb-88ac-f77031d4842d](https://user-images.githubusercontent.com/9967016/114203111-2745f500-9958-11eb-9b5f-858ad28ad781.png)


After change is thrown `Exception` with info, which column does not exist.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
