### PR TITLE
Possibility to disable global search in backend

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/IndexController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/IndexController.php
@@ -104,7 +104,7 @@ class Mage_Adminhtml_IndexController extends Mage_Adminhtml_Controller_Action
         $searchModules = Mage::getConfig()->getNode("adminhtml/global_search");
         $items = array();
 
-        if (!Mage::getStoreConfig('admin/global_search/enable') || !Mage::getSingleton('admin/session')->isAllowed('admin/global_search')) {
+        if (!Mage::getStoreConfigFlag('admin/global_search/enable') || !Mage::getSingleton('admin/session')->isAllowed('admin/global_search')) {
             $items[] = array(
                 'id' => 'error',
                 'type' => Mage::helper('adminhtml')->__('Error'),

--- a/app/code/core/Mage/Adminhtml/controllers/IndexController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/IndexController.php
@@ -104,7 +104,7 @@ class Mage_Adminhtml_IndexController extends Mage_Adminhtml_Controller_Action
         $searchModules = Mage::getConfig()->getNode("adminhtml/global_search");
         $items = array();
 
-        if (!Mage::getSingleton('admin/session')->isAllowed('admin/global_search')) {
+        if (!Mage::getStoreConfig('admin/global_search/enable') || !Mage::getSingleton('admin/session')->isAllowed('admin/global_search')) {
             $items[] = array(
                 'id' => 'error',
                 'type' => Mage::helper('adminhtml')->__('Error'),

--- a/app/code/core/Mage/Adminhtml/etc/config.xml
+++ b/app/code/core/Mage/Adminhtml/etc/config.xml
@@ -238,6 +238,9 @@
             <design>
                 <use_legacy_theme>0</use_legacy_theme>
             </design>
+            <global_search>
+                <enable>1</enable>
+            </global_search>
         </admin>
     </default>
     <stores>

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -1113,6 +1113,25 @@
                     </fields>
                 </design>
 
+                <global_search>
+                    <label>Global Search</label>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>0</show_in_website>
+                    <show_in_store>0</show_in_store>
+                    <sort_order>6</sort_order>
+                    <fields>
+                        <enable translate="label comment">
+                            <label>Enable global search</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>1</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </enable>
+                    </fields>
+                </global_search>
+
                 <emails translate="label">
                     <label>Admin User Emails</label>
                     <frontend_type>text</frontend_type>

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -1120,7 +1120,7 @@
                     <show_in_store>0</show_in_store>
                     <sort_order>6</sort_order>
                     <fields>
-                        <enable translate="label comment">
+                        <enable translate="label">
                             <label>Enable global search</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>

--- a/app/design/adminhtml/default/default/template/page/header.phtml
+++ b/app/design/adminhtml/default/default/template/page/header.phtml
@@ -32,7 +32,7 @@
         <p class="super">
             <?php echo $this->__("Logged in as %s", $this->escapeHtml($this->getUser()->getUsername())) ?><span class="separator">|</span><?php echo $this->formatDate(null, 'full') ?><span class="separator">|</span><a href="<?php echo $this->getLogoutLink() ?>" class="link-logout"><?php echo $this->__('Log Out') ?></a>
         </p>
-        <?php if ( Mage::getStoreConfig('admin/global_search/enable') && Mage::getSingleton('admin/session')->isAllowed('admin/global_search') ): ?>
+        <?php if (Mage::getStoreConfigFlag('admin/global_search/enable') && Mage::getSingleton('admin/session')->isAllowed('admin/global_search')): ?>
         <fieldset>
             <legend>Search</legend>
             <span id="global_search_indicator" class="autocomplete-indicator" style="display: none">

--- a/app/design/adminhtml/default/default/template/page/header.phtml
+++ b/app/design/adminhtml/default/default/template/page/header.phtml
@@ -32,7 +32,7 @@
         <p class="super">
             <?php echo $this->__("Logged in as %s", $this->escapeHtml($this->getUser()->getUsername())) ?><span class="separator">|</span><?php echo $this->formatDate(null, 'full') ?><span class="separator">|</span><a href="<?php echo $this->getLogoutLink() ?>" class="link-logout"><?php echo $this->__('Log Out') ?></a>
         </p>
-        <?php if ( Mage::getSingleton('admin/session')->isAllowed('admin/global_search') ): ?>
+        <?php if ( Mage::getStoreConfig('admin/global_search/enable') && Mage::getSingleton('admin/session')->isAllowed('admin/global_search') ): ?>
         <fieldset>
             <legend>Search</legend>
             <span id="global_search_indicator" class="autocomplete-indicator" style="display: none">

--- a/app/design/adminhtml/default/openmage/template/page/header.phtml
+++ b/app/design/adminhtml/default/openmage/template/page/header.phtml
@@ -49,7 +49,7 @@
 		        </ul>
 		    </li>
 		</ul>
-        <?php if ( Mage::getStoreConfig('admin/global_search/enable') && Mage::getSingleton('admin/session')->isAllowed('admin/global_search') ): ?>
+        <?php if (Mage::getStoreConfigFlag('admin/global_search/enable') && Mage::getSingleton('admin/session')->isAllowed('admin/global_search')): ?>
         <fieldset>
             <legend>Search</legend>
             <span id="global_search_indicator" class="autocomplete-indicator" style="display: none">

--- a/app/design/adminhtml/default/openmage/template/page/header.phtml
+++ b/app/design/adminhtml/default/openmage/template/page/header.phtml
@@ -49,7 +49,7 @@
 		        </ul>
 		    </li>
 		</ul>
-        <?php if ( Mage::getSingleton('admin/session')->isAllowed('admin/global_search') ): ?>
+        <?php if ( Mage::getStoreConfig('admin/global_search/enable') && Mage::getSingleton('admin/session')->isAllowed('admin/global_search') ): ?>
         <fieldset>
             <legend>Search</legend>
             <span id="global_search_indicator" class="autocomplete-indicator" style="display: none">


### PR DESCRIPTION
Global search in the backend can be very resource heavy on big stores, there's an ACL to configure if a user can use it or not but I thought it would be handy to have a global flag to turn it off for everybody (most of the times a lot of backend users have "full on privileges" without a proper ACL configuration) and prevent backend users to potentially run extremely heavy queries.

This is the global search:
<img width="500" alt="Schermata 2021-04-02 alle 21 57 27" src="https://user-images.githubusercontent.com/909743/113453688-6c20d780-93fe-11eb-8631-9c219b6904b0.png">

This is the flag:
<img width="577" alt="Schermata 2021-04-02 alle 21 57 49" src="https://user-images.githubusercontent.com/909743/113453707-79d65d00-93fe-11eb-86eb-e70cf2a96576.png">

Global search is enabled by default (after this PR), so no breaking change is added.

### Manual testing scenarios (*)
1. login to the backend
2. go to "system -> configuration -> advanced -> admin"
3. expand the global search section and disable global search
4. save the configuration and check that the global search isn't visible anymore