### PR TITLE
advertise firegento_logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ There are some new or changed translations, if you want add them to your locale 
 - `Mage_Xmlconnect`
 - `Phoenix_Moneybookers`
 
+### Suggested Modules
+- [FireGento_Logger](https://github.com/firegento/firegento-logger)
+
 ## Development Environment with ddev
 - Install [ddev](https://ddev.com/get-started/)
 - Clone the repository as described in Installation -> Using Git


### PR DESCRIPTION
As per https://github.com/OpenMage/magento-lts/issues/569 let's help people find a better logging solution.

It's not in composer suggest but I (now) think this is the best (and less intrusive, and more easily findable) way to advertise important 3rd party modules
