### PR TITLE
Cleanup of getMimeType()

### DIFF
--- a/lib/Varien/Image/Adapter/Abstract.php
+++ b/lib/Varien/Image/Adapter/Abstract.php
@@ -154,13 +154,18 @@ abstract class Varien_Image_Adapter_Abstract
 
     public function getMimeType()
     {
-        if( $this->_fileType ) {
-            return $this->_fileType;
-        } else {
-            list($this->_imageSrcWidth, $this->_imageSrcHeight, $this->_fileType, ) = getimagesize($this->_fileName);
-            $this->_fileMimeType = image_type_to_mime_type($this->_fileType);
+        if($this->_fileMimeType){
             return $this->_fileMimeType;
         }
+        $imageInfo = @getimagesize($this->_fileName);
+        if($imageInfo === false){
+            throw new RuntimeException('Failed to read image at ' . $this->_fileName);
+        }
+        $this->_imageSrcWidth = $imageInfo[0];
+        $this->_imageSrcHeight = $imageInfo[1];
+        $this->_fileType = $imageInfo[2];
+        $this->_fileMimeType = $imageInfo['mime'];
+        return $this->_fileMimeType;
     }
 
     /**


### PR DESCRIPTION
### Description (*)

- Removed unneeded call to image_type_to_mime_type() because the mime type is already determined by getimagesize()
- Removed returning $this->_fileType. This is NOT the mime type and not in use anywhere, so safe to remove.
- More readable code
- New exception if image is unreadable

If you prefer, I can move this to 20.x as well, but should not be an issue I believe.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
