### PR TITLE
Prevent backend_type from being changed automatically on attribute save without the admin realizing

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
@@ -275,7 +275,7 @@ class Mage_Adminhtml_Catalog_Product_AttributeController extends Mage_Adminhtml_
                 $data['is_filterable_in_search'] = 0;
             }
 
-            if (is_null($model->getIsUserDefined()) || $model->getIsUserDefined() != 0) {
+            if (!$model->getBackendType() && (is_null($model->getIsUserDefined()) || $model->getIsUserDefined() != 0)) {
                 $data['backend_type'] = $model->getBackendTypeByInput($data['frontend_input']);
             }
 

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Api.php
@@ -169,7 +169,7 @@ class Mage_Catalog_Model_Product_Attribute_Api extends Mage_Catalog_Model_Api_Re
 
         $data['source_model'] = $helper->getAttributeSourceModelByInputType($data['frontend_input']);
         $data['backend_model'] = $helper->getAttributeBackendModelByInputType($data['frontend_input']);
-        if (is_null($model->getIsUserDefined()) || $model->getIsUserDefined() != 0) {
+        if (!$model->getBackendType() && (is_null($model->getIsUserDefined()) || $model->getIsUserDefined() != 0)) {
             $data['backend_type'] = $model->getBackendTypeByInput($data['frontend_input']);
         }
 


### PR DESCRIPTION
### Description (*)

If an attribute is user defined, the backend type is automatically set every time you save the attribute. If another backend_type was in use before, this breaks the attribute without the admin realizing it. We cannot have a different backend_type unless we also make the attribute is_user_defined = 0. Making the attribute non-user defined, might seam as the solution, but if you do this, the attribute becomes locked in the set and it cannot be removed anymore, so you're stuck with either e locked attribute that must remain in the set, or an attribute that will change backend_type on every save.
My code change prevents the auto-changing of the backend_type. Only if there wasn't a backend_type before, will it now be auto-detected.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
