### PR TITLE
Revert update to Prototype serialize method that breaks OpenMage functionality. Fixes #1549

### DIFF
--- a/js/prototype/prototype.js
+++ b/js/prototype/prototype.js
@@ -6331,16 +6331,8 @@ var Form = {
       };
     } else {
       initial = '';
-      accumulator = function(result, key, values) {
-        if (!Object.isArray(values)) {values = [values];}
-        if (!values.length) {return result;}
-        var encodedKey = encodeURIComponent(key).gsub(/%20/, '+');
-        return result + (result ? "&" : "") + values.map(function (value) {
-          value = value.gsub(/(\r)?\n/, '\r\n');
-          value = encodeURIComponent(value);
-          value = value.gsub(/%20/, '+');
-          return encodedKey + "=" + value;
-        }).join("&");
+      accumulator = function(result, key, value) {
+        return result + (result ? '&' : '') + encodeURIComponent(key) + '=' + encodeURIComponent(value);
       };
     }
 


### PR DESCRIPTION
OpenMage depends on the old behavior of Prototype form serialization so this reverts that part back while keeping all of the other Prototype updates.

See #1549 