### PR TITLE
Fix Coments in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,7 +5,7 @@
 
 ## you might also need to add this line to php.ini
 ##     cgi.fix_pathinfo = 1
-## if it still doesn't work, rename php.ini to php5.ini
+## if it still doesn't work, rename php.ini to php7.ini
 
 ############################################
 ## default index file
@@ -13,7 +13,7 @@
     DirectoryIndex index.php
 
 ############################################
-## php5 settings
+## php7 settings
 
 <IfModule mod_php7.c>
 


### PR DESCRIPTION
fixing https://github.com/OpenMage/magento-lts/issues/1419

in the htaccess there are some php7 related settings, but the comments right above them have the  "php5" title.

just a couple of typo fixed, not super useful but still