### PR TITLE
Mark invoice as last when dummy items included

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -726,6 +726,11 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
     public function isLast()
     {
         foreach ($this->getAllItems() as $item) {
+            $orderItem = $item->getOrderItem();
+            if ($orderItem->isDummy()) {
+                continue;
+            }
+
             if (!$item->isLast()) {
                 return false;
             }


### PR DESCRIPTION
This commit fixes invoice generation when an order contains configurable or bundled items.

This is a [backported fix](https://github.com/magento/magento2/pull/31472) from Magento 2, as this bug exists in M1 as well. When a configurable or dummy item is included on an order, and custom tax collectors are used the tax total is off due to `$invoice->isLast()` being false and the code choosing the tax total of only items+shipping (in `Mage_Sales_Model_Order_Invoice_Total_Tax`). This has been testing with multiple-invoiced orders as well and works as expected.

Thanks!