### PR TITLE
Fixed incorrect regex in Varien_Object _underscore()

### DIFF
--- a/lib/Varien/Object.php
+++ b/lib/Varien/Object.php
@@ -708,7 +708,7 @@ class Varien_Object implements ArrayAccess
             return self::$_underscoreCache[$name];
         }
         #Varien_Profiler::start('underscore');
-        $result = strtolower(preg_replace('/(.)([A-Z])/', "$1_$2", $name));
+        $result = strtolower(preg_replace('/([A-Z])/', "_$1", lcfirst($name)));
         #Varien_Profiler::stop('underscore');
         self::$_underscoreCache[$name] = $result;
         return $result;


### PR DESCRIPTION
### Description (*)

There is a bug in `__call` magic method in `Varien?Object`
Specifically, if you attempt to set/get data that has a letter as a separate word (for example "is_a_weapon") using __call magic method, (`$object->getIsAWeapon()`) regex in method `_underscore()` returns incorrectly parsed string (resulting in $object->getData("is_aweapon")
This is caused by how regexes work, their matches cannot overlap, even if the overlap would be in different subgroups. This is why the current regex `/(.)([A-Z])/` cannot match both capital letters next to each other; the first one is already matched.
Solution: Alter the expression so that it matches all uppercase letters and exclude the first letter in the string by forcing it to be lowercase, instead of checking if there's a character before each capital letter.

### Manual testing scenarios (*)

1. Create a Varient Object instance.
2. Set some data into the object by using syntax `$object->setATestingData()`, with two uppercase letters next to each other in the index.
3. Get the data by using both `$object->getATestingData()` and `$object->getData("a_testing_data")`;
4. Both returned values will be the same as set. Previously, the first would return the value incorrectly set to index "atesting_data" and the second would return null.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
