### PR TITLE
Reduce getId calls

### DIFF
--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Mediafallback.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Mediafallback.php
@@ -322,9 +322,10 @@ class Mage_ConfigurableSwatches_Helper_Mediafallback extends Mage_Core_Helper_Ab
 
         $newMediaGalleryImages = array();
         $configurableImages = array();
+        $productId = $product->getId();
 
         foreach ($mediaGallery['images'] as $mediaGalleryImage) {
-            if ($mediaGalleryImage['product_id'] == $product->getId()) {
+            if ($mediaGalleryImage['product_id'] == $productId) {
                 $newMediaGalleryImages[] = $mediaGalleryImage;
             } else {
                 $configurableImages[] = $mediaGalleryImage;
@@ -368,7 +369,8 @@ class Mage_ConfigurableSwatches_Helper_Mediafallback extends Mage_Core_Helper_Ab
 
         $relationship = array();
         foreach ($products as $product) {
-            $relationship[$product->getId()] = $product->getId();
+            $productId = $product->getId();
+            $relationship[$productId] = $productId;
 
             if (!is_array($product->getChildrenProducts())) {
                 continue;
@@ -376,13 +378,12 @@ class Mage_ConfigurableSwatches_Helper_Mediafallback extends Mage_Core_Helper_Ab
 
             /* @var Mage_Catalog_Model_Product $childProduct */
             foreach ($product->getChildrenProducts() as $childProduct) {
-                $relationship[$childProduct->getId()] = $product->getId();
+                $relationship[$childProduct->getId()] = $productId;
             }
         }
 
         foreach ($images as $image) {
-            $productId = $image['product_id'];
-            $realProductId = $relationship[$productId];
+            $realProductId = $relationship[$image['product_id']];
             $product = $products[$realProductId];
 
             if (is_null($image['label'])) {


### PR DESCRIPTION
### Description

This PR reduce calls for `getId`.
On a category page with ~80 products, this change remove the following result from BlackFire:

![getid](https://user-images.githubusercontent.com/31816829/116221258-bbcc9780-a74d-11eb-9fb0-b4fb3996908e.png)

OpenMage 20.0.8 / PHP 7.4.6

### Manual testing scenarios

Go to any pages where product are visible.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
