### PR TITLE
Product qty is incremented when comment is added on a Credit Memo from SOAP API v2

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api.php
@@ -205,7 +205,8 @@ class Mage_Sales_Model_Order_Creditmemo_Api extends Mage_Sales_Model_Api_Resourc
     {
         $creditmemo = $this->_getCreditmemo($creditmemoIncrementId);
         try {
-            $creditmemo->addComment($comment, $notifyCustomer)->save();
+            $creditmemo->addComment($comment, $notifyCustomer);
+            $creditmemo->getCommentsCollection()->save();
             $creditmemo->sendUpdateEmail($notifyCustomer, ($includeComment ? $comment : ''));
         } catch (Mage_Core_Exception $e) {
             $this->_fault('data_invalid', $e->getMessage());


### PR DESCRIPTION
Adding a comment to a creditmemo keeps "restocking" the products to the inventory, as explained in issue https://github.com/OpenMage/magento-lts/issues/1517

$creditmemo->getCommentsCollection()->save() is used in Mage_Adminhtml_Sales_Order_CreditmemoController::addCommentAction() and works correctly because it doesn't trigger a "save" on the creditmemo, but only on the comments.

### Fixed Issues
1. Fixes https://github.com/OpenMage/magento-lts/issues/1517