### PR TITLE
Do not startEnvironmentEmulation for current store

### DIFF
--- a/app/code/core/Mage/Core/Model/Template.php
+++ b/app/code/core/Mage/Core/Model/Template.php
@@ -71,7 +71,7 @@ abstract class Mage_Core_Model_Template extends Mage_Core_Model_Abstract
         $store = $designConfig->getStore();
         $storeId = is_object($store) ? $store->getId() : $store;
         $area = $designConfig->getArea();
-        if (!is_null($storeId)) {
+        if (!is_null($storeId) && ($storeId != Mage::app()->getStore()->getId())) {
             $appEmulation = Mage::getSingleton('core/app_emulation');
             $this->_initialEnvironmentInfo = $appEmulation->startEnvironmentEmulation($storeId, $area);
         }

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -1404,7 +1404,7 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
         }
 
         // Stop store emulation process
-        if (isset($initialEnvironmentInfo)) {
+        if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
             $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
         }
 

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -1404,7 +1404,7 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
         }
 
         // Stop store emulation process
-        if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
+        if (isset($appEmulation, $initialEnvironmentInfo)) {
             $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
         }
 

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -1383,9 +1383,11 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
         $copyMethod = Mage::getStoreConfig(self::XML_PATH_EMAIL_COPY_METHOD, $storeId);
 
         // Start store emulation process
-        /** @var Mage_Core_Model_App_Emulation $appEmulation */
-        $appEmulation = Mage::getSingleton('core/app_emulation');
-        $initialEnvironmentInfo = $appEmulation->startEnvironmentEmulation($storeId);
+        if ($storeId != Mage::app()->getStore()->getId()) {
+            /** @var Mage_Core_Model_App_Emulation $appEmulation */
+            $appEmulation = Mage::getSingleton('core/app_emulation');
+            $initialEnvironmentInfo = $appEmulation->startEnvironmentEmulation($storeId);
+        }
 
         try {
             // Retrieve specified view block from appropriate design package (depends on emulated store)
@@ -1393,14 +1395,18 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
                 ->setIsSecureMode(true);
             $paymentBlock->getMethod()->setStore($storeId);
             $paymentBlockHtml = $paymentBlock->toHtml();
-        } catch (Exception $exception) {
+        } catch (Exception $e) {
             // Stop store emulation process
-            $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
-            throw $exception;
+            if (isset($initialEnvironmentInfo)) {
+                $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
+            }
+            throw $e;
         }
 
         // Stop store emulation process
-        $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
+        if (isset($initialEnvironmentInfo)) {
+            $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
+        }
 
         // Retrieve corresponding email template id and customer name
         if ($this->getCustomerIsGuest()) {

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -1397,7 +1397,7 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
             $paymentBlockHtml = $paymentBlock->toHtml();
         } catch (Exception $e) {
             // Stop store emulation process
-            if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
+            if (isset($appEmulation, $initialEnvironmentInfo)) {
                 $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
             }
             throw $e;

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -1397,7 +1397,7 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
             $paymentBlockHtml = $paymentBlock->toHtml();
         } catch (Exception $e) {
             // Stop store emulation process
-            if (isset($initialEnvironmentInfo)) {
+            if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
                 $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
             }
             throw $e;

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
@@ -782,7 +782,7 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
             $paymentBlockHtml = $paymentBlock->toHtml();
         } catch (Exception $e) {
             // Stop store emulation process
-            if (isset($initialEnvironmentInfo)) {
+            if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
                 $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
             }
             throw $e;

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
@@ -789,7 +789,7 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
         }
 
         // Stop store emulation process
-        if (isset($initialEnvironmentInfo)) {
+        if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
             $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
         }
 

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
@@ -789,7 +789,7 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
         }
 
         // Stop store emulation process
-        if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
+        if (isset($appEmulation, $initialEnvironmentInfo)) {
             $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
         }
 

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
@@ -769,8 +769,10 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
         }
 
         // Start store emulation process
-        $appEmulation = Mage::getSingleton('core/app_emulation');
-        $initialEnvironmentInfo = $appEmulation->startEnvironmentEmulation($storeId);
+        if ($storeId != Mage::app()->getStore()->getId()) {
+            $appEmulation = Mage::getSingleton('core/app_emulation');
+            $initialEnvironmentInfo = $appEmulation->startEnvironmentEmulation($storeId);
+        }
 
         try {
             // Retrieve specified view block from appropriate design package (depends on emulated store)
@@ -778,14 +780,18 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
                 ->setIsSecureMode(true);
             $paymentBlock->getMethod()->setStore($storeId);
             $paymentBlockHtml = $paymentBlock->toHtml();
-        } catch (Exception $exception) {
+        } catch (Exception $e) {
             // Stop store emulation process
-            $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
-            throw $exception;
+            if (isset($initialEnvironmentInfo)) {
+                $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
+            }
+            throw $e;
         }
 
         // Stop store emulation process
-        $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
+        if (isset($initialEnvironmentInfo)) {
+            $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
+        }
 
         // Retrieve corresponding email template id and customer name
         if ($order->getCustomerIsGuest()) {

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
@@ -782,7 +782,7 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
             $paymentBlockHtml = $paymentBlock->toHtml();
         } catch (Exception $e) {
             // Stop store emulation process
-            if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
+            if (isset($appEmulation, $initialEnvironmentInfo)) {
                 $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
             }
             throw $e;

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -817,7 +817,7 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
             $paymentBlockHtml = $paymentBlock->toHtml();
         } catch (Exception $e) {
             // Stop store emulation process
-            if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
+            if (isset($appEmulation, $initialEnvironmentInfo)) {
                 $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
             }
             throw $e;

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -817,7 +817,7 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
             $paymentBlockHtml = $paymentBlock->toHtml();
         } catch (Exception $e) {
             // Stop store emulation process
-            if (isset($initialEnvironmentInfo)) {
+            if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
                 $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
             }
             throw $e;

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -804,8 +804,10 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
         }
 
         // Start store emulation process
-        $appEmulation = Mage::getSingleton('core/app_emulation');
-        $initialEnvironmentInfo = $appEmulation->startEnvironmentEmulation($storeId);
+        if ($storeId != Mage::app()->getStore()->getId()) {
+            $appEmulation = Mage::getSingleton('core/app_emulation');
+            $initialEnvironmentInfo = $appEmulation->startEnvironmentEmulation($storeId);
+        }
 
         try {
             // Retrieve specified view block from appropriate design package (depends on emulated store)
@@ -813,14 +815,18 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
                 ->setIsSecureMode(true);
             $paymentBlock->getMethod()->setStore($storeId);
             $paymentBlockHtml = $paymentBlock->toHtml();
-        } catch (Exception $exception) {
+        } catch (Exception $e) {
             // Stop store emulation process
-            $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
-            throw $exception;
+            if (isset($initialEnvironmentInfo)) {
+                $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
+            }
+            throw $e;
         }
 
         // Stop store emulation process
-        $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
+        if (isset($initialEnvironmentInfo)) {
+            $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
+        }
 
         // Retrieve corresponding email template id and customer name
         if ($order->getCustomerIsGuest()) {

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -824,7 +824,7 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
         }
 
         // Stop store emulation process
-        if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
+        if (isset($appEmulation, $initialEnvironmentInfo)) {
             $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
         }
 

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -824,7 +824,7 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
         }
 
         // Stop store emulation process
-        if (isset($initialEnvironmentInfo)) {
+        if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
             $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
         }
 

--- a/app/code/core/Mage/Sales/Model/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment.php
@@ -464,7 +464,7 @@ class Mage_Sales_Model_Order_Shipment extends Mage_Sales_Model_Abstract
         }
 
         // Stop store emulation process
-        if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
+        if (isset($appEmulation, $initialEnvironmentInfo)) {
             $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
         }
 

--- a/app/code/core/Mage/Sales/Model/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment.php
@@ -457,7 +457,7 @@ class Mage_Sales_Model_Order_Shipment extends Mage_Sales_Model_Abstract
             $paymentBlockHtml = $paymentBlock->toHtml();
         } catch (Exception $e) {
             // Stop store emulation process
-            if (isset($initialEnvironmentInfo)) {
+            if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
                 $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
             }
             throw $e;

--- a/app/code/core/Mage/Sales/Model/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment.php
@@ -464,7 +464,7 @@ class Mage_Sales_Model_Order_Shipment extends Mage_Sales_Model_Abstract
         }
 
         // Stop store emulation process
-        if (isset($initialEnvironmentInfo)) {
+        if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
             $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
         }
 

--- a/app/code/core/Mage/Sales/Model/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment.php
@@ -457,7 +457,7 @@ class Mage_Sales_Model_Order_Shipment extends Mage_Sales_Model_Abstract
             $paymentBlockHtml = $paymentBlock->toHtml();
         } catch (Exception $e) {
             // Stop store emulation process
-            if (isset($appEmulation) && isset($initialEnvironmentInfo)) {
+            if (isset($appEmulation, $initialEnvironmentInfo)) {
                 $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
             }
             throw $e;


### PR DESCRIPTION
### Description

This PR do not run `startEnvironmentEmulation` when the targeted store is the current store.
I don't know if this is the best way, for now our emails seem to keep working.

When a customer place an order, the new order email is sent.
To do that, `startEnvironmentEmulation` is triggered.

Three screenshots from BlackFire, before:
![a1](https://user-images.githubusercontent.com/31816829/116668478-c1b8b780-a99d-11eb-88e5-d09aeb56b946.png)
![a2](https://user-images.githubusercontent.com/31816829/116668485-c3827b00-a99d-11eb-90ae-e2f2c8db5016.png)
After:
![b2](https://user-images.githubusercontent.com/31816829/116668494-c54c3e80-a99d-11eb-81ae-4d5a92124744.png)

OpenMage 20.0.10 / PHP 7.4.6

### Manual testing scenarios

- Front: place an order, check new order email sent
- Back: go to any order / invoice / shipment / credit memo, click on send email button, check emails sent

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
