### PR TITLE
Do not save customer addresses when there are no changes

### DIFF
--- a/app/code/core/Mage/Customer/Model/Address.php
+++ b/app/code/core/Mage/Customer/Model/Address.php
@@ -68,6 +68,8 @@ class Mage_Customer_Model_Address extends Mage_Customer_Model_Address_Abstract
     {
         $this->setParentId($id);
         $this->setData('customer_id', $id);
+        if (empty($this->getOrigData('customer_id')))
+            $this->setOrigData('customer_id', $id);
         return $this;
     }
 

--- a/app/code/core/Mage/Customer/Model/Address.php
+++ b/app/code/core/Mage/Customer/Model/Address.php
@@ -68,8 +68,6 @@ class Mage_Customer_Model_Address extends Mage_Customer_Model_Address_Abstract
     {
         $this->setParentId($id);
         $this->setData('customer_id', $id);
-        if (empty($this->getOrigData('customer_id')))
-            $this->setOrigData('customer_id', $id);
         return $this;
     }
 

--- a/app/code/core/Mage/Customer/Model/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Customer.php
@@ -422,9 +422,11 @@ class Mage_Customer_Model_Customer extends Mage_Core_Model_Abstract
         if ($this->_addressesCollection === null) {
             $this->_addressesCollection = $this->getAddressCollection()
                 ->setCustomerFilter($this)
-                ->addAttributeToSelect('*');
+                ->addAttributeToSelect('*')
+                ->setOrder('entity_id', 'desc');
             foreach ($this->_addressesCollection as $address) {
                 $address->setCustomer($this);
+                $address->setDataChanges(false);
             }
         }
 

--- a/app/code/core/Mage/Customer/Model/Resource/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Customer.php
@@ -134,8 +134,8 @@ class Mage_Customer_Model_Resource_Customer extends Mage_Eav_Model_Entity_Abstra
      */
     protected function _saveAddresses(Mage_Customer_Model_Customer $customer)
     {
-        $defaultBillingId   = $customer->getData('default_billing');
-        $defaultShippingId  = $customer->getData('default_shipping');
+        $defaultBillingId  = $customer->getData('default_billing');
+        $defaultShippingId = $customer->getData('default_shipping');
         foreach ($customer->getAddresses() as $address) {
             if ($address->getData('_deleted')) {
                 if ($address->getId() == $defaultBillingId) {
@@ -146,10 +146,18 @@ class Mage_Customer_Model_Resource_Customer extends Mage_Eav_Model_Entity_Abstra
                 }
                 $address->delete();
             } else {
-                $address->setParentId($customer->getId())
-                    ->setStoreId($customer->getStoreId())
-                    ->setIsCustomerSaveTransaction(true)
-                    ->save();
+                if ($address->getParentId() != $customer->getId())
+                    $address->setParentId($customer->getId());
+
+                if ($address->hasDataChanges()) {
+                    $address->setStoreId($customer->getStoreId())
+                        ->setIsCustomerSaveTransaction(true)
+                        ->save();
+                } else {
+                    $address->setStoreId($customer->getStoreId())
+                        ->setIsCustomerSaveTransaction(true);
+                }
+
                 if (($address->getIsPrimaryBilling() || $address->getIsDefaultBilling())
                     && $address->getId() != $defaultBillingId
                 ) {

--- a/app/code/core/Mage/Customer/Model/Resource/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Customer.php
@@ -146,8 +146,9 @@ class Mage_Customer_Model_Resource_Customer extends Mage_Eav_Model_Entity_Abstra
                 }
                 $address->delete();
             } else {
-                if ($address->getParentId() != $customer->getId())
+                if ($address->getParentId() != $customer->getId()) {
                     $address->setParentId($customer->getId());
+                }
 
                 if ($address->hasDataChanges()) {
                     $address->setStoreId($customer->getStoreId())


### PR DESCRIPTION
### Description

This PR do not save ALL customer addresses when the customer place an order.
I also change the sort order of customer addresses, last added address is displayed first.

OpenMage 20.0.13 / PHP 7.4.6, 8.0.11, 8.0.18

### Manual testing scenarios

First, you need a customer with addresses.

- Add in `app/code/core/Mage/Customer/Model/Address.php`:
```php
    protected function _beforeSave()
    {
        Mage::log('! _beforeSave '.$this->getId());
        return parent::_beforeSave();
    }
```
- Place an order, check logs.
- Apply the PR and try again.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)