### PR TITLE
Update report.php

### DIFF
--- a/errors/report.php
+++ b/errors/report.php
@@ -24,6 +24,8 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+if ($_SERVER['SCRIPT_FILENAME'] == __FILE__ && (!isset($_GET['id']) || strlen($_GET['id']) == 0)) die("Missing parameter: id");
+
 require_once 'processor.php';
 
 $processor = new Error_Processor();


### PR DESCRIPTION
This should improve https://github.com/OpenMage/magento-lts/issues/1581

If checks that parameter $_GET['id'] is passed (it's then casted to int by processor.php) but ONLY if the report.php script is called directly.
This first part of the check is necessary because report.php is included in Mage::printException()

I know that a "die" is maybe not the best option but... in the contest of this specific script, I think it's the only way.