### PR TITLE
End the request and close the session before core_app_run_after event

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Most important changes will be listed here, all other changes since `19.4.0` can
 ### New Events
 - `adminhtml_sales_order_create_save_before`
 - `checkout_cart_product_add_before`
+- `core_app_run_after`
 - `sitemap_cms_pages_generating_before`
 - `sitemap_urlset_generating_before`
 

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -380,6 +380,23 @@ class Mage_Core_Model_App
 
             $this->getFrontController()->dispatch();
         }
+
+        // Finish the request explicitly, no output allowed beyond this point
+        if (php_sapi_name() == 'fpm-fcgi' && function_exists('fastcgi_finish_request')) {
+            fastcgi_finish_request();
+        } else {
+            flush();
+        }
+        if (isset($_SESSION)) {
+            session_write_close();
+        }
+
+        try {
+            Mage::dispatchEvent('core_app_run_after', ['app' => $this]);
+        } catch (Throwable $e) {
+            Mage::logException($e);
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
### Description (*)

This PR does two things:

1. Explicitly ends the request and closes the session after the app has completed rendering.
2. Adds `core_app_run_after` event to allow events to occur after response is sent.

With this PR you can add an event observer for `core_app_run_after` which can do something which will not add any time to the response even if it is long-running (e.g. `sleep(3);`).

### Related Pull Requests

Closes #113

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
