### PR TITLE
Invalidate reset password token when user changes password.

### DIFF
--- a/app/code/core/Mage/Customer/controllers/AccountController.php
+++ b/app/code/core/Mage/Customer/controllers/AccountController.php
@@ -1020,6 +1020,11 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
                          */
                         $customer->setPassword($newPass);
                         $customer->setPasswordConfirmation($confPass);
+
+                        // Invalidate reset password token when user changes password
+                        $customer->setRpToken(null);
+                        $customer->setRpTokenCreatedAt(null);
+                        $customer->setRpCustomerId(null);
                     } else {
                         $errors[] = $this->__('New password field cannot be empty.');
                     }


### PR DESCRIPTION
As reported by Jaimaakali on HackerOne, the reset password token should be reset when the user changes their password.