### PR TITLE
Improved global search performance by using only prefix matching.

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/Search/Order.php
+++ b/app/code/core/Mage/Adminhtml/Model/Search/Order.php
@@ -53,12 +53,10 @@ class Mage_Adminhtml_Model_Search_Order extends Varien_Object
                 ['attribute' => 'billing_firstname',  'like' => $query . '%'],
                 ['attribute' => 'billing_lastname',   'like' => $query . '%'],
                 ['attribute' => 'billing_telephone',  'like' => $query . '%'],
-                ['attribute' => 'billing_postcode',   'like' => $query . '%'],
 
                 ['attribute' => 'shipping_firstname', 'like' => $query . '%'],
                 ['attribute' => 'shipping_lastname',  'like' => $query . '%'],
                 ['attribute' => 'shipping_telephone', 'like' => $query . '%'],
-                ['attribute' => 'shipping_postcode',  'like' => $query . '%'],
             ])
             ->setCurPage($this->getStart())
             ->setPageSize($this->getLimit())

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Search/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Search/Collection.php
@@ -115,7 +115,7 @@ class Mage_CatalogSearch_Model_Resource_Search_Collection extends Mage_Catalog_M
 
         /** @var Mage_Core_Model_Resource_Helper_Abstract $resHelper */
         $resHelper = Mage::getResourceHelper('core');
-        $likeOptions = ['position' => 'any'];
+        $likeOptions = ['position' => 'start'];
 
         /**
          * Collect tables and attribute ids of attributes with string values


### PR DESCRIPTION
This removes the postcode search (with a large store searching by postcode will be useless) and uses only prefix match for catalog search.

I don't have a large instance handy to test with, if someone does and can profile the database queries to identify which ones are slow and provide an "explain" that would be helpful.

Refs #134 