### PR TITLE
fixed twitter share link, issue 1595

### DIFF
--- a/app/design/frontend/rwd/default/template/catalog/product/view/sharing.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/sharing.phtml
@@ -44,7 +44,7 @@
         </a>
     </li>
     <li>
-        <a href="<?php echo 'http://twitter.com/home?status=' . $_productName . '+' . $_productUrl; ?>" target="_blank" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Share on Twitter')) ?>" class="link-twitter"><?php echo $this->__('Share on Twitter') ?></a>
+        <a href="<?php echo 'http://twitter.com/intent/tweet?text=' . $_productName . '+' . $_productUrl; ?>" target="_blank" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Share on Twitter')) ?>" class="link-twitter"><?php echo $this->__('Share on Twitter') ?></a>
     </li>
 </ul>
 

--- a/app/design/frontend/rwd/default/template/catalog/product/view/sharing.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/sharing.phtml
@@ -44,7 +44,7 @@
         </a>
     </li>
     <li>
-        <a href="<?php echo 'http://twitter.com/intent/tweet?text=' . $_productName . '+' . $_productUrl; ?>" target="_blank" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Share on Twitter')) ?>" class="link-twitter"><?php echo $this->__('Share on Twitter') ?></a>
+        <a href="<?php echo 'http://twitter.com/intent/tweet?text=' . $_productName . '&url=' . $_productUrl; ?>" target="_blank" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Share on Twitter')) ?>" class="link-twitter"><?php echo $this->__('Share on Twitter') ?></a>
     </li>
 </ul>
 


### PR DESCRIPTION
This PR should fix https://github.com/OpenMage/magento-lts/issues/1595
It's done in a slightly different way (to keep the product name in the shared tweet) compared to the one suggested by the original reporter.