### PR TITLE
Fixed bug on incorrect category store_id when set with store code in …

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Category.php
@@ -470,13 +470,13 @@ class Mage_Catalog_Model_Category extends Mage_Catalog_Model_Abstract
     /**
      * Set store id
      *
-     * @param integer $storeId
+     * @param string|int|Mage_Core_Model_Store $storeId
      * @return $this
      */
     public function setStoreId($storeId)
     {
         if (!is_numeric($storeId)) {
-            $storeId = Mage::app($storeId)->getStore()->getId();
+            $storeId = Mage::app()->getStore($storeId)->getId();
         }
         $this->setData('store_id', $storeId);
         $this->getResource()->setStoreId($storeId);


### PR DESCRIPTION
…setStoreId.

<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
In a multiple stores setup, I discovered this bug when trying to get product collection in a store from a category with `setStoreId($storeCode)`, the returned products are always from the default store.

This is because `Mage::app($storeId)->getStore()->getId();` in line 479
https://github.com/OpenMage/magento-lts/blob/8b0c0b9c9ec629826a19d1c07547e2a62b8a4fd7/app/code/core/Mage/Catalog/Model/Category.php#L476-L484

will return the store that was previously set, for example, in root's `index.php`. See

https://github.com/OpenMage/magento-lts/blob/8b0c0b9c9ec629826a19d1c07547e2a62b8a4fd7/app/Mage.php#L675-L690

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
```php
$storeCode = 'not_default_store_code'; // take a code that is different from Mage::app()->getStore()->getCode();
$store = Mage::app()->getStore($storeCode);
$category = Mage::getModel('catalog/category');
$category->setStoreId($storeCode);
$categoryStoreId = $category->getStoreId(); // Is different from $store->getId().
```

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
