### PR TITLE
Fix getChildren must be compatible with SimpleXMLElement with PHP 8

### DIFF
--- a/app/code/core/Mage/Api/Model/Wsdl/Config/Element.php
+++ b/app/code/core/Mage/Api/Model/Wsdl/Config/Element.php
@@ -176,7 +176,7 @@ class Mage_Api_Model_Wsdl_Config_Element extends Varien_Simplexml_Element
      * @param Varien_Simplexml_Element $source
      * @return array
      */
-    public function getChildren($source)
+    public function getChildren($source = null)
     {
         $children = array();
         $namespaces = $source->getNamespaces(true);


### PR DESCRIPTION
### Description

This PR fix the following error with PHP 8 (#1602):
```
Fatal error: Declaration of Mage_Api_Model_Wsdl_Config_Element::getChildren($source)
 must be compatible with SimpleXMLElement::getChildren() in
 [...]/app/code/core/Mage/Api/Model/Wsdl/Config/Element.php on line 179
```

OpenMage 20.0.10 / PHP 8.0.5

### Manual testing scenarios

```php
$proxy = new SoapClient('https://.../api/v2_soap/?wsdl', ['user_agent' => 'Local/Test']);
$sessionId = $proxy->login('...', '...');
$products = $proxy->catalogProductList($sessionId, [], 1);
foreach ($products as $product)
	echo $product->product_id,' ',$product->name,"\n";
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
