### PR TITLE
Last login date in wrong in backend

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
@@ -113,7 +113,8 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_View
     {
         $date = $this->getCustomerLog()->getLoginAtTimestamp();
         if ($date) {
-            return Mage::helper('core')->formatDate($date, Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true);
+            $date = Mage::app()->getLocale()->utcDate($this->getCustomer()->getStoreId(), $date, true);
+            return $this->formatDate($date, Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true);
         }
         return Mage::helper('customer')->__('Never');
     }


### PR DESCRIPTION
In "adminhtml -> customers -> manage customers" if you click on a customer sheet and check the "last login" section, sometimes you get a weird situation like this:

<img width="402" alt="Schermata 2021-05-07 alle 12 32 07" src="https://user-images.githubusercontent.com/909743/117444710-bb908100-af31-11eb-8582-22cc7f31f9b3.png">

the "login date" for the store timezone is correct while the UTC one is not, that is because, in the code, the formatDate function expects a "date", not a "timestamp".

After the patch, this is the result:
<img width="405" alt="Schermata 2021-05-07 alle 12 54 57" src="https://user-images.githubusercontent.com/909743/117446042-70776d80-af33-11eb-804f-bb78c51f0d85.png">

### Manual testing scenarios (*)
Insert "2021-05-07 07:12:18" as "login_at" column in the "log_customer" table, for the user you want to test.