### PR TITLE
Reinstate getters and setters for $_pageHelpUrl which some third party modules still use

### DIFF
--- a/app/code/core/Mage/Adminhtml/Helper/Data.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Data.php
@@ -44,6 +44,7 @@ class Mage_Adminhtml_Helper_Data extends Mage_Adminhtml_Helper_Help_Mapping
     /**
      * Get mapped help pages url
      *
+     * @deprecated
      * @param null|string $url
      * @return mixed
      */

--- a/app/code/core/Mage/Adminhtml/Helper/Data.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Data.php
@@ -59,6 +59,7 @@ class Mage_Adminhtml_Helper_Data extends Mage_Adminhtml_Helper_Help_Mapping
     /**
      * Set help page url
      *
+     * @deprecated
      * @param null|string $url
      * @return $this
      */

--- a/app/code/core/Mage/Adminhtml/Helper/Data.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Data.php
@@ -39,6 +39,34 @@ class Mage_Adminhtml_Helper_Data extends Mage_Adminhtml_Helper_Help_Mapping
     const XML_PATH_CUSTOM_ADMIN_PATH            = 'default/admin/url/custom_path';
     const XML_PATH_ADMINHTML_SECURITY_USE_FORM_KEY = 'admin/security/use_form_key';
 
+    protected $_pageHelpUrl;
+
+    /**
+     * Get mapped help pages url
+     *
+     * @param null|string $url
+     * @return mixed
+     */
+    public function getPageHelpUrl($url = null)
+    {
+        if (!$this->_pageHelpUrl) {
+            $this->setPageHelpUrl($url);
+        }
+        return $this->_pageHelpUrl;
+    }
+
+    /**
+     * Set help page url
+     *
+     * @param null|string $url
+     * @return $this
+     */
+    public function setPageHelpUrl($url = null)
+    {
+        $this->_pageHelpUrl = $url;
+        return $this;
+    }
+
     public static function getUrl($route='', $params=array())
     {
         return Mage::getModel('adminhtml/url')->getUrl($route, $params);

--- a/app/code/core/Mage/Adminhtml/Helper/Data.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Data.php
@@ -39,6 +39,7 @@ class Mage_Adminhtml_Helper_Data extends Mage_Adminhtml_Helper_Help_Mapping
     const XML_PATH_CUSTOM_ADMIN_PATH            = 'default/admin/url/custom_path';
     const XML_PATH_ADMINHTML_SECURITY_USE_FORM_KEY = 'admin/security/use_form_key';
 
+    /** @deprecated */
     protected $_pageHelpUrl;
 
     /**


### PR DESCRIPTION
Hello,

After updating OpenMage to latest version noticed PR #1536  creates a a fatal error  if a third party module is using the tooltip functionality. e.g. https://github.com/m2epro/magento1-extension/blob/master/app/code/community/Ess/M2ePro/Observer/Order/View/After.php#L46

I've re-instated the $_pageHelpUrl and recreated basic setters and getters with the Magento help specific code removed.  

Ref #1374 