### PR TITLE
steamClose doenst void this->_streamHandler in php8

### DIFF
--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -252,6 +252,7 @@ class Varien_Io_File extends Varien_Io_Abstract
             $this->streamUnlock();
         }
         @fclose($this->_streamHandler);
+        $this->_streamHandler = null;
         $this->chmod($this->_streamFileName, $this->_streamChmod);
         return true;
     }


### PR DESCRIPTION
This PR solves https://github.com/OpenMage/magento-lts/issues/1617

The problem is actually caused by the "register_shutdown_function" which closes "again" the open streams, and this happens because nobody resets the $this->_streamHandler variable after the fclose.