### PR TITLE
Do not load captcha.js when disabled

### DIFF
--- a/app/design/frontend/base/default/layout/captcha.xml
+++ b/app/design/frontend/base/default/layout/captcha.xml
@@ -32,7 +32,7 @@
             <block type="core/text_list" name="form.additional.info">
                 <block type="captcha/captcha" name="captcha">
                     <reference name="head">
-                        <action method="addJs"><file>mage/captcha.js</file></action>
+                        <action method="addJs" ifconfig="customer/captcha/enable"><file>mage/captcha.js</file></action>
                     </reference>
                     <action method="setFormId"><formId>user_login</formId></action>
                     <action method="setImgWidth"><width>230</width></action>
@@ -46,7 +46,7 @@
             <block type="core/text_list" name="form.additional.info">
                 <block type="captcha/captcha" name="captcha">
                     <reference name="head">
-                        <action method="addJs"><file>mage/captcha.js</file></action>
+                        <action method="addJs" ifconfig="customer/captcha/enable"><file>mage/captcha.js</file></action>
                     </reference>
                     <action method="setFormId"><formId>user_forgotpassword</formId></action>
                     <action method="setImgWidth"><width>230</width></action>
@@ -60,7 +60,7 @@
             <block type="core/text_list" name="form.additional.info">
                 <block type="captcha/captcha" name="captcha">
                     <reference name="head">
-                        <action method="addJs"><file>mage/captcha.js</file></action>
+                        <action method="addJs" ifconfig="customer/captcha/enable"><file>mage/captcha.js</file></action>
                     </reference>
                     <action method="setFormId"><formId>user_create</formId></action>
                     <action method="setImgWidth"><width>230</width></action>
@@ -74,7 +74,7 @@
             <block type="core/text_list" name="form.additional.info">
                 <block type="captcha/captcha" name="captcha">
                     <reference name="head">
-                        <action method="addJs"><file>mage/captcha.js</file></action>
+                        <action method="addJs" ifconfig="customer/captcha/enable"><file>mage/captcha.js</file></action>
                     </reference>
                     <action method="setFormId"><formId>user_login</formId></action>
                     <action method="setImgWidth"><width>230</width></action>
@@ -86,7 +86,7 @@
             <block type="core/text_list" name="form.additional.info">
                 <block type="captcha/captcha" name="captcha.guest.checkout">
                     <reference name="head">
-                        <action method="addJs"><file>mage/captcha.js</file></action>
+                        <action method="addJs" ifconfig="customer/captcha/enable"><file>mage/captcha.js</file></action>
                     </reference>
                     <action method="setFormId"><formId>guest_checkout</formId></action>
                     <action method="setImgWidth"><width>230</width></action>
@@ -94,7 +94,7 @@
                 </block>
                 <block type="captcha/captcha" name="captcha.register.during.checkout">
                     <reference name="head">
-                        <action method="addJs"><file>mage/captcha.js</file></action>
+                        <action method="addJs" ifconfig="customer/captcha/enable"><file>mage/captcha.js</file></action>
                     </reference>
                     <action method="setFormId"><formId>register_during_checkout</formId></action>
                     <action method="setImgWidth"><width>230</width></action>
@@ -108,7 +108,7 @@
             <block type="core/text_list" name="wishlist.sharing.form.additional.info">
                 <block type="captcha/captcha" name="captcha">
                     <reference name="head">
-                        <action method="addJs"><file>mage/captcha.js</file></action>
+                        <action method="addJs" ifconfig="customer/captcha/enable"><file>mage/captcha.js</file></action>
                     </reference>
                     <action method="setFormId"><formId>wishlist_sharing</formId></action>
                     <action method="setImgWidth"><width>230</width></action>
@@ -122,7 +122,7 @@
             <block type="core/text_list" name="sendfriend.send.form.additional.info">
                 <block type="captcha/captcha" name="captcha">
                     <reference name="head">
-                        <action method="addJs"><file>mage/captcha.js</file></action>
+                        <action method="addJs" ifconfig="customer/captcha/enable"><file>mage/captcha.js</file></action>
                     </reference>
                     <action method="setFormId"><formId>sendfriend_send</formId></action>
                     <action method="setImgWidth"><width>230</width></action>


### PR DESCRIPTION
### Description

When captcha is not enabled on front (login page...), _mage/captcha.js_ is loaded.
This PR check the configuration to load or not the file.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
