### PR TITLE
 Support saving static attributes

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Abstract.php
@@ -1604,7 +1604,7 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
 
             $adapter->commit();
         } catch (Exception $e) {
-            $adapter->rollback();
+            $adapter->rollBack();
             throw $e;
         }
 

--- a/app/code/core/Mage/Eav/Model/Entity/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Abstract.php
@@ -1454,7 +1454,16 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
         try {
             $adapter = $this->_getWriteAdapter();
             foreach ($this->_attributeValuesToSave as $table => $data) {
-                $adapter->insertOnDuplicate($table, $data, array('value'));
+                $eavValueSuffixes = ['int','varchar','text','decimal','datetime'];
+                $words = explode('_', $table);
+                $lastWord = $words[count($words) - 1];
+                if(in_array($lastWord, $eavValueSuffixes, true)){
+                    // Saving an EAV value
+                    $adapter->insertOnDuplicate($table, $data, array('value'));
+                }else{
+                    // Saving a static attribute value in the entity table
+                    $adapter->insertOnDuplicate($table, $data);
+                }
             }
 
             foreach ($this->_attributeValuesToDelete as $table => $valueIds) {


### PR DESCRIPTION
### Description (*)
Magento's resource models only allow saving of EAV attributes that are non-static. However, static attributes make sense in a lot of ways to increase performance + to have an actual unique key on DB level.

My client has a huge catalog and is moving attributes around to increase storage efficiency and speed.

All unique + global attributes benefit from becoming static + receiving a unique DB key.

Magento's own uniqueness is a joke and not really unique.

This PR allows static attributes to be saved as you would expect any attribute to save through the resource layer.
Existing logic is not effected, so there should be no danger.

Upon merge, please squash these commits.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
