### PR TITLE
Fixed stock status update from SOAP API V2

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item/Api/V2.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item/Api/V2.php
@@ -35,14 +35,15 @@ class Mage_CatalogInventory_Model_Stock_Item_Api_V2 extends Mage_CatalogInventor
         $idBySku = $product->getIdBySku($productId);
         $productId = $idBySku ? $idBySku : $productId;
 
-        $product->setStoreId($this->_getStoreId())
-            ->load($productId);
+        /** @var Mage_CatalogInventory_Model_Stock_Item $stockItem */
+        $stockItem = Mage::getModel('cataloginventory/stock_item')
+            ->setStoreId($this->_getStoreId())
+            ->loadByProduct($productId);
 
-        if (!$product->getId()) {
+        if (!$stockItem->getId()) {
             $this->_fault('not_exists');
         }
 
-        $stockItem = $product->getStockItem();
         $stockData = array_replace($stockItem->getData(), (array)$data);
         $stockItem->setData($stockData);
 


### PR DESCRIPTION
### Description (*)
This change will fix an issue where updating the stock status from "Out of Stock" to "In Stock" from the SOAP API V2, with `Display Out of Stock Products` set to `No`, does not make the product show in front and vice-versa.
This is because in the method `Mage_CatalogInventory_Model_Stock_Item_Api_V2::update` the stock item is obtained from the call to `$product->getStockItem()` and so `$stockItem->getProduct()` returns the associated product. Because the stock indexer is expecting `$stockItem->getProduct()` to be `null` (see snippet below) this leads the product prices to not be indexed and therefore causes issues with product visibility in front.

https://github.com/OpenMage/magento-lts/blob/d078657d88e7758f4b6bd1b7046751197f063bc1/app/code/core/Mage/CatalogInventory/Model/Indexer/Stock.php#L272

### Fixed Issues
1. Fixes OpenMage/magento-lts#1634

### Manual testing scenarios (*)
Can be found in the linked issue.
