### PR TITLE
Grid range filter - optimize SQL query when from === to

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -303,7 +303,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
      * Add column to grid
      *
      * @param   string $columnId
-     * @param   array || Varien_Object $column
+     * @param   array $column
      * @return  Mage_Adminhtml_Block_Widget_Grid
      */
     public function addColumn($columnId, $column)
@@ -423,7 +423,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
      * Retrieve grid column by column id
      *
      * @param   string $columnId
-     * @return  Mage_Adminhtml_Block_Widget_Grid_Column|Varien_Object|false
+     * @return  Mage_Adminhtml_Block_Widget_Grid_Column|false
      */
     public function getColumn($columnId)
     {

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -313,9 +313,6 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
                 ->setData($column)
                 ->setGrid($this);
         }
-        /*elseif ($column instanceof Varien_Object) {
-            $this->_columns[$columnId] = $column;
-        }*/
         else {
             throw new Exception(Mage::helper('adminhtml')->__('Wrong column format.'));
         }
@@ -426,7 +423,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
      * Retrieve grid column by column id
      *
      * @param   string $columnId
-     * @return  Varien_Object || false
+     * @return  Mage_Adminhtml_Block_Widget_Grid_Column|Varien_Object|false
      */
     public function getColumn($columnId)
     {
@@ -439,13 +436,18 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
     /**
      * Retrieve all grid columns
      *
-     * @return array
+     * @return Mage_Adminhtml_Block_Widget_Grid_Column[]
      */
     public function getColumns()
     {
         return $this->_columns;
     }
 
+    /**
+     * @param array $data
+     *
+     * @return $this
+     */
     protected function _setFilterValues($data)
     {
         foreach ($this->getColumns() as $columnId => $column) {
@@ -1286,7 +1288,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
      * @param   mixed $default
      * @return  mixed
      */
-    public function getParam($paramName, $default=null)
+    public function getParam($paramName, $default = null)
     {
         $session = Mage::getSingleton('adminhtml/session');
         $sessionParamName = $this->getId().$paramName;

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
@@ -353,6 +353,9 @@ class Mage_Adminhtml_Block_Widget_Grid_Column extends Mage_Adminhtml_Block_Widge
         return $filterClass;
     }
 
+    /**
+     * @return Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Abstract|false
+     */
     public function getFilter()
     {
         if (!$this->_filter) {

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
@@ -51,11 +51,15 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Range extends Mage_Adminhtm
         }
         return null;
     }
-    
 
     public function getCondition()
     {
         $value = $this->getValue();
+
+        if (isset($value['from']) && isset($value['to']) && $value['from'] === $value['to']) {
+            return ['eq' => $value['from']];
+        }
+
         return $value;
     }
 


### PR DESCRIPTION
### Description (*)
Optimalize SQL query in grid, when you filter same values in range field (number range) + added some docs & type hints.

#### SQL before
```sql
SELECT `main_table`.* 
FROM `sometable` AS `main_table` 
WHERE (`sid` >= '31233' AND `sid` <= '31233') ORDER BY sid DESC LIMIT 20
```
![image](https://user-images.githubusercontent.com/9967016/119406453-1b817880-bce3-11eb-9c95-2527c73b205b.png)


#### SQL after
```sql
SELECT `main_table`.* 
FROM `sometable` AS `main_table` 
WHERE (`sid` = '31233') ORDER BY sid DESC LIMIT 20
```
![image](https://user-images.githubusercontent.com/9967016/119406490-2c31ee80-bce3-11eb-8018-a305da351546.png)


Special thanks to: original idea from @midlan 

### Manual testing scenarios (*)
1. Put same values to `from` and `to` in grid and check SQL query 
![image](https://user-images.githubusercontent.com/9967016/119405938-5636e100-bce2-11eb-9498-571634e58538.png)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
