### PR TITLE
Resolves the PHP 7 error: Declaration of Mage_Tag_Model_Api_V2::items...

### DIFF
--- a/app/code/core/Mage/Tag/Model/Api/V2.php
+++ b/app/code/core/Mage/Tag/Model/Api/V2.php
@@ -40,7 +40,7 @@ class Mage_Tag_Model_Api_V2 extends Mage_Tag_Model_Api
      * @param string|int $store
      * @return array
      */
-    public function items($productId, $store)
+    public function items($productId, $store = null)
     {
         $result = parent::items($productId, $store);
         foreach ($result as $key => $tag) {


### PR DESCRIPTION
### Description (*)
Resolves the PHP 7 error:
`Declaration of Mage_Tag_Model_Api_V2::items($productId, $store) should be compatible with Mage_Tag_Model_Api::items($productId, $store = NULL)`

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
