### PR TITLE
Enforce specific PNG compression level of 9

### DIFF
--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -205,14 +205,7 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
         // set quality param for PNG file type
         if (!is_null($this->quality()) && $this->_fileType == IMAGETYPE_PNG)
         {
-            $quality = round(($this->quality() / 100) * 10);
-            if ($quality < 1) {
-                $quality = 1;
-            } elseif ($quality > 10) {
-                $quality = 10;
-            }
-            $quality = 10 - $quality;
-            $functionParameters[] = $quality;
+            $functionParameters[] = 9;
         }
 
         call_user_func_array($this->_getCallback('output'), $functionParameters);


### PR DESCRIPTION
### Description (*)
Currently, Magento calculates the compression level for PNG images based on the desired image quality. For higher image qualities the compresseion is lowered or even disabled completely. This doesn't makes sense because PNG compression is lossless. Higher compression levels don't degrade image quality.  Even worse, for the default quality of 90 a compression level of 1 is calculated. This is the lowest possible compression. If you increase the quality to 95, a compression level of 0 is calculated which disables PNG compression completely.

My pull request changes that so PNG compression is not calculated from image quality anymore. Instead, PNG compression is now defined in system configuration. As default value I set 9 (highest possible compression) because images are usually only resized compressed once and then cached on disk.

### Manual testing scenarios (*)
Assign a PNG image as a product image. Change the image quality in Mage_Catalog_Model_Product_Image and look how the file size of the resized image changes.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
