### PR TITLE
Fixed phpdoc of Mage_Core_Model_Resource_Db_Collection_Abstract::addExpressionFieldToSelect

### DIFF
--- a/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
@@ -333,13 +333,13 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends Varien_Da
 
     /**
      * Add attribute expression (SUM, COUNT, etc)
-     * Example: ('sub_total', 'SUM({{attribute}})', 'revenue')
+     * Example: ('sub_total', 'SUM({{attribute}})', array('attribute' => 'revenue'))
      * Example: ('sub_total', 'SUM({{revenue}})', 'revenue')
      * For some functions like SUM use groupByAttribute.
      *
      * @param string $alias
      * @param string $expression
-     * @param array $fields
+     * @param array|string $fields
      * @return $this
      */
     public function addExpressionFieldToSelect($alias, $expression, $fields)


### PR DESCRIPTION
Fixed phpdoc of Mage_Core_Model_Resource_Db_Collection_Abstract::addExpressionFieldToSelect

<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed wrong phpdoc parameter datatype and usage example.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. go to your IDE, call collection method addExpressionFieldToSelect with third parameter string. It should not be highlighted as datatype mismatch.
2. test examples  mentioned in `Example:` section

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
