### PR TITLE
Do not load product when it is already loaded

### DIFF
--- a/app/code/core/Mage/Review/Block/Form.php
+++ b/app/code/core/Mage/Review/Block/Form.php
@@ -81,6 +81,10 @@ class Mage_Review_Block_Form extends Mage_Core_Block_Template
      */
     public function getProductInfo()
     {
+        $product = Mage::registry('current_product');
+        if (is_object($product) && ($product->getId() == $this->getRequest()->getParam('id')))
+            return $product;
+
         $product = Mage::getModel('catalog/product');
         return $product->load($this->getRequest()->getParam('id'));
     }


### PR DESCRIPTION
### Description

When `review/form` block is added to the product page, without this PR, the product is loaded a second time.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
