### PR TITLE
Cm_RedisSession: Fix Notice: Undefined offset: 0

### DIFF
--- a/app/code/community/Cm/RedisSession/Model/Session.php
+++ b/app/code/community/Cm/RedisSession/Model/Session.php
@@ -339,7 +339,7 @@ class Cm_RedisSession_Model_Session extends Mage_Core_Model_Mysql4_Session
         if ($this->_logLevel >= Zend_Log::DEBUG) {
             $timeStart = microtime(true);
         }
-        list($sessionData, $sessionWrites) = $this->_redis->hMGet($sessionId, array('data','writes'));
+        list($sessionData, $sessionWrites) = array_values($this->_redis->hMGet($sessionId, array('data','writes')));
         Varien_Profiler::stop(__METHOD__);
         if ($this->_logLevel >= Zend_Log::DEBUG) {
             $this->_log(sprintf("Data read for ID %s in %.5f seconds", $sessionId, (microtime(true) - $timeStart)));


### PR DESCRIPTION
### Description (*)
After upgrading my local environment to v20.0.12 and setting `<global><session_save>` to `redis`, I could not log in to admin anymore, and would just get invalid form key. On my development box, I have developer mode enabled, and I get this error:
```
Notice: Undefined offset: 0  in /home/www-data/magento-root/htdocs/app/code/community/Cm/RedisSession/Model/Session.php on line 349
```

Previously, I was using this in my composer.json: `"colinmollenhour/magento-redis-session": "^2.3"`, but I removed that and am using the version in this repo.

I am not sure if it is related to the upgrade in particular, or maybe there has always been this problem. I am on PHP 7.4.3. The problem is that hMGet returns an assoc array like `array( 'data' => '', 'writes' => '')` but list is expecting numerical keys.

@colinmollenhour Tagging you just for visibility.

### Related Pull Requests
#1513

**Edit:** This is the same PR: #1254 -- probably was not reproducible for everyone because it requires `Cm_Cache_Backend_Redis` to be installed, see next comment.

### Fixed Issues (if relevant)

### Manual testing scenarios (*)
1. Upgrade to v20.0.12
2. Change local.xml <global><session_save> to redis
3. Configure local.xml redis_session
4. Attempt to login, receive invalid form key
5. Enable developer mode
6. Attempt to login, will receive the notice above

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
