### PR TITLE
Make the attribute note translatable in Adminhtml

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
@@ -197,7 +197,7 @@ class Mage_Adminhtml_Block_Widget_Form extends Mage_Adminhtml_Block_Widget
                         'label'     => $attribute->getFrontend()->getLabel(),
                         'class'     => $attribute->getFrontend()->getClass(),
                         'required'  => $attribute->getIsRequired(),
-                        'note'      =>  $this->__($this->escapeHtml($attribute->getNote()))
+                        'note'      => $this->__($this->escapeHtml($attribute->getNote()))
                     )
                 )
                 ->setEntityAttribute($attribute);

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
@@ -197,7 +197,7 @@ class Mage_Adminhtml_Block_Widget_Form extends Mage_Adminhtml_Block_Widget
                         'label'     => $attribute->getFrontend()->getLabel(),
                         'class'     => $attribute->getFrontend()->getClass(),
                         'required'  => $attribute->getIsRequired(),
-                        'note'      => $this->escapeHtml($attribute->getNote()),
+                        'note'      =>  $this->__($this->escapeHtml($attribute->getNote()))
                     )
                 )
                 ->setEntityAttribute($attribute);


### PR DESCRIPTION
### Description (*)
Make the attribute note translatable in Adminhtml.

### Manual testing scenarios (*)
1. Enter a note in an eav attribute, for example the firstname customer / address attribute.
2. Translate the string;
3. Go to edit address in any customer from Adminhtml;

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
