### PR TITLE
Add attribute note to sales_order address edit

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Abstract.php
@@ -151,6 +151,7 @@ abstract class Mage_Adminhtml_Block_Sales_Order_Create_Form_Abstract
                     'label'     => $this->__($attribute->getStoreLabel()),
                     'class'     => $attribute->getFrontend()->getClass(),
                     'required'  => $attribute->getIsRequired(),
+                    'note'      => $this->__($this->escapeHtml($attribute->getNote()))
                 ));
                 if ($inputType == 'multiline') {
                     $element->setLineCount($attribute->getMultilineCount());


### PR DESCRIPTION
### Description (*)
Make the attribute note translatable in Adminhtml.

### Manual testing scenarios (*)
1. Enter a note in a eav attribute, for example the firstname customer / address attribute.
2. Translate the string;
3. Go to edit address in any sales order from Adminhtml;

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)