### PR TITLE
Allow BASE_URL to be overridden by environment.

### DIFF
--- a/dev/openmage/install.sh
+++ b/dev/openmage/install.sh
@@ -17,7 +17,7 @@ done
 
 HOST_PORT=":${HOST_PORT:-80}"
 test "$HOST_PORT" = ":80" && HOST_PORT=""
-BASE_URL="http://${HOST_NAME:-openmage-7f000001.nip.io}${HOST_PORT}/"
+BASE_URL=${BASE_URL:-"http://${HOST_NAME:-openmage-7f000001.nip.io}${HOST_PORT}/"}
 ADMIN_EMAIL="${ADMIN_EMAIL:-admin@example.com}"
 ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
 ADMIN_PASSWORD="${ADMIN_PASSWORD:-veryl0ngpassw0rd}"


### PR DESCRIPTION
Refs #1704

### Description (*)

If `BASE_URL` is already set in the environment it will be used as-is rather than assembled from HOST_PORT and HOST_DOMAIN. This allows the listened port to be different from the URL and should make it much easier to integrate with Gitpod.io
