### PR TITLE
Fix retrun type of getColumn in Column_Renderer_Interface

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Interface.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Interface.php
@@ -47,7 +47,7 @@ interface Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Interface
      * Returns row associated with the renderer
      *
      * @abstract
-     * @return Mage_Adminhtml_Block_Widget_Grid
+     * @return Mage_Adminhtml_Block_Widget_Grid_Column
      */
     public function getColumn();
 

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Interface.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Interface.php
@@ -38,7 +38,7 @@ interface Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Interface
      * Set column for renderer
      *
      * @abstract
-     * @param $column
+     * @param Mage_Adminhtml_Block_Widget_Grid_Column $column
      * @return void
      */
     public function setColumn($column);

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Interface.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Interface.php
@@ -47,7 +47,7 @@ interface Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Interface
      * Returns row associated with the renderer
      *
      * @abstract
-     * @return void
+     * @return Mage_Adminhtml_Block_Widget_Grid
      */
     public function getColumn();
 


### PR DESCRIPTION
Fixes multiple issues spotted by phpstan

### Description (*)
When running phpstan on the project, I've got several errors like:
```
Result of method Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract::getColumn() (void) is used.
```

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
