### PR TITLE
Reload admin ACL

### DIFF
--- a/app/code/core/Mage/Admin/Model/Resource/User.php
+++ b/app/code/core/Mage/Admin/Model/Resource/User.php
@@ -221,13 +221,11 @@ class Mage_Admin_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstrac
     public function _saveRelations(Mage_Core_Model_Abstract $user)
     {
         $rolesIds = $user->getRoleIds();
-
         if (!is_array($rolesIds) || count($rolesIds) == 0) {
             return $user;
         }
 
         $adapter = $this->_getWriteAdapter();
-
         $adapter->beginTransaction();
 
         try {
@@ -239,22 +237,27 @@ class Mage_Admin_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstrac
             foreach ($rolesIds as $rid) {
                 $rid = intval($rid);
                 if ($rid > 0) {
-                    $row = Mage::getModel('admin/role')->load($rid)->getData();
+                    $role = Mage::getModel('admin/role')->load($rid);
                 } else {
-                    $row = ['tree_level' => 0];
+                    $role = new Varien_Object(['tree_level' => 0]);
                 }
 
                 $data = new Varien_Object([
-                    'parent_id'     => $rid,
-                    'tree_level'    => $row['tree_level'] + 1,
-                    'sort_order'    => 0,
-                    'role_type'     => 'U',
-                    'user_id'       => $user->getId(),
-                    'role_name'     => $user->getFirstname()
+                    'parent_id'  => $rid,
+                    'tree_level' => $role->getTreeLevel() + 1,
+                    'sort_order' => 0,
+                    'role_type'  => Mage_Admin_Model_Acl::ROLE_TYPE_USER,
+                    'user_id'    => $user->getId(),
+                    'role_name'  => $user->getFirstname()
                 ]);
 
                 $insertData = $this->_prepareDataForTable($data, $this->getTable('admin/role'));
                 $adapter->insert($this->getTable('admin/role'), $insertData);
+            }
+
+            if ($user->getId() > 0) {
+                // reload acl on next user http request
+                $this->saveReloadAclFlag($user, 1);
             }
             $adapter->commit();
         } catch (Mage_Core_Exception $e) {
@@ -280,10 +283,9 @@ class Mage_Admin_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstrac
             return [];
         }
 
-        $table  = $this->getTable('admin/role');
-        $adapter   = $this->_getReadAdapter();
-
-        $select = $adapter->select()
+        $table   = $this->getTable('admin/role');
+        $adapter = $this->_getReadAdapter();
+        $select  = $adapter->select()
                     ->from($table, [])
                     ->joinLeft(
                         ['ar' => $table],
@@ -314,37 +316,38 @@ class Mage_Admin_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstrac
     public function add(Mage_Core_Model_Abstract $user)
     {
         $dbh = $this->_getWriteAdapter();
-
         $aRoles = $this->hasAssigned2Role($user);
         if (count($aRoles)) {
             foreach ($aRoles as $idx => $data) {
-                $conditions = [
-                    'role_id = ?' => $data['role_id'],
-                ];
-
-                $dbh->delete($this->getTable('admin/role'), $conditions);
+                $dbh->delete(
+                    $this->getTable('admin/role'),
+                    ['role_id = ?' => $data['role_id']]
+                );
             }
         }
 
         if ($user->getId() > 0) {
             $role = Mage::getModel('admin/role')->load($user->getRoleId());
         } else {
-            $role = new Varien_Object();
-            $role->setTreeLevel(0);
+            $role = new Varien_Object(['tree_level' => 0]);
         }
 
         $data = new Varien_Object([
             'parent_id'  => $user->getRoleId(),
-            'tree_level' => ($role->getTreeLevel() + 1),
+            'tree_level' => $role->getTreeLevel() + 1,
             'sort_order' => 0,
-            'role_type'  => 'U',
+            'role_type'  => Mage_Admin_Model_Acl::ROLE_TYPE_USER,
             'user_id'    => $user->getUserId(),
             'role_name'  => $user->getFirstname()
         ]);
 
         $insertData = $this->_prepareDataForTable($data, $this->getTable('admin/role'));
-
         $dbh->insert($this->getTable('admin/role'), $insertData);
+
+        if ($user->getId() > 0) {
+            // reload acl on next user http request
+            $this->saveReloadAclFlag($user, 1);
+        }
 
         return $this;
     }
@@ -412,7 +415,7 @@ class Mage_Admin_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstrac
     public function userExists(Mage_Core_Model_Abstract $user)
     {
         $adapter = $this->_getReadAdapter();
-        $select = $adapter->select();
+        $select  = $adapter->select();
 
         $binds = [
             'username' => $user->getUsername(),
@@ -462,6 +465,13 @@ class Mage_Admin_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstrac
                 ['reload_acl_flag' => $flag],
                 ['user_id = ?' => (int) $object->getId()]
             );
+            if ($flag) {
+                // refresh cache menu
+                Mage::app()->getCache()->clean(
+                    Zend_Cache::CLEANING_MODE_MATCHING_TAG,
+                    [Mage_Adminhtml_Block_Page_Menu::CACHE_TAGS]
+                );
+            }
         }
 
         return $this;

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/RoleController.php
@@ -83,7 +83,6 @@ class Mage_Adminhtml_Permissions_RoleController extends Mage_Adminhtml_Controlle
 
     /**
      * Show grid with roles existing in systems
-     *
      */
     public function indexAction()
     {
@@ -92,13 +91,11 @@ class Mage_Adminhtml_Permissions_RoleController extends Mage_Adminhtml_Controlle
              ->_title($this->__('Roles'));
 
         $this->_initAction();
-
         $this->renderLayout();
     }
 
     /**
      * Action for ajax request from grid
-     *
      */
     public function roleGridAction()
     {
@@ -108,7 +105,6 @@ class Mage_Adminhtml_Permissions_RoleController extends Mage_Adminhtml_Controlle
 
     /**
      * Edit role action
-     *
      */
     public function editRoleAction()
     {
@@ -143,7 +139,6 @@ class Mage_Adminhtml_Permissions_RoleController extends Mage_Adminhtml_Controlle
 
     /**
      * Remove role action
-     *
      */
     public function deleteAction()
     {
@@ -177,9 +172,9 @@ class Mage_Adminhtml_Permissions_RoleController extends Mage_Adminhtml_Controlle
 
         try {
             $role->delete();
-
             Mage::getSingleton('adminhtml/session')->addSuccess($this->__('The role has been deleted.'));
         } catch (Exception $e) {
+            Mage::logException($e);
             Mage::getSingleton('adminhtml/session')->addError($this->__('An error occurred while deleting this role.'));
         }
 
@@ -188,7 +183,6 @@ class Mage_Adminhtml_Permissions_RoleController extends Mage_Adminhtml_Controlle
 
     /**
      * Role form submit action to save or create new role
-     *
      */
     public function saveRoleAction()
     {
@@ -243,7 +237,7 @@ class Mage_Adminhtml_Permissions_RoleController extends Mage_Adminhtml_Controlle
                 ->setResources($resource)
                 ->saveRel();
 
-            foreach($oldRoleUsers as $oUid) {
+            foreach ($oldRoleUsers as $oUid) {
                 $this->_deleteUserFromRole($oUid, $role->getId());
             }
 
@@ -251,21 +245,19 @@ class Mage_Adminhtml_Permissions_RoleController extends Mage_Adminhtml_Controlle
                 $this->_addUserToRole($nRuid, $role->getId());
             }
 
-            $rid = $role->getId();
             Mage::getSingleton('adminhtml/session')->addSuccess($this->__('The role has been successfully saved.'));
         } catch (Mage_Core_Exception $e) {
             Mage::getSingleton('adminhtml/session')->addError($e->getMessage());
         } catch (Exception $e) {
+            Mage::logException($e);
             Mage::getSingleton('adminhtml/session')->addError($this->__('An error occurred while saving this role.'));
         }
 
-        //$this->getResponse()->setRedirect($this->getUrl("*/*/editrole/rid/$rid"));
         $this->_redirect('*/*/');
     }
 
     /**
      * Action for ajax request from assigned users grid
-     *
      */
     public function editrolegridAction()
     {
@@ -307,7 +299,7 @@ class Mage_Adminhtml_Permissions_RoleController extends Mage_Adminhtml_Controlle
         $user = Mage::getModel('admin/user')->load($userId);
         $user->setRoleId($roleId)->setUserId($userId);
 
-        if( $user->roleUserExists() === true ) {
+        if ($user->roleUserExists() === true) {
             return false;
         } else {
             $user->add();
@@ -342,6 +334,11 @@ class Mage_Adminhtml_Permissions_RoleController extends Mage_Adminhtml_Controlle
                     ->setRoleId($role->getId())
                     ->setResources($selectedResourceIds)
                     ->saveRel();
+            }
+
+            $users = Mage::getResourceModel('admin/user_collection');
+            foreach ($users as $user) {
+                $user->getResource()->saveReloadAclFlag($user, 1);
             }
 
             Mage::getSingleton('adminhtml/session')->addSuccess($this->__('The roles have been refreshed.'));

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
@@ -162,17 +162,12 @@ class Mage_Adminhtml_Permissions_UserController extends Mage_Adminhtml_Controlle
                 if (Mage::getStoreConfigFlag('admin/security/crate_admin_user_notification') && $isNew) {
                     Mage::getModel('admin/user')->sendAdminNotification($model);
                 }
-                if ( $uRoles = $this->getRequest()->getParam('roles', false) ) {
-                    if (count($uRoles) === 1) {
-                        $model->setRoleIds($uRoles)
+                if ($uRoles = $this->getRequest()->getParam('roles', false)) {
+                    if (is_array($uRoles) && (count($uRoles) >= 1)) {
+                        // with fix for previous multi-roles logic
+                        $model->setRoleIds(array_slice($uRoles, 0, 1))
                             ->setRoleUserId($model->getUserId())
                             ->saveRelations();
-                    } else if (count($uRoles) > 1) {
-                        //@FIXME: stupid fix of previous multi-roles logic.
-                        //@TODO:  make proper DB upgrade in the future revisions.
-                        $rs = [];
-                        $rs[0] = $uRoles[0];
-                        $model->setRoleIds( $rs )->setRoleUserId( $model->getUserId() )->saveRelations();
                     }
                 }
                 Mage::getSingleton('adminhtml/session')->addSuccess($this->__('The user has been saved.'));
@@ -209,7 +204,7 @@ class Mage_Adminhtml_Permissions_UserController extends Mage_Adminhtml_Controlle
         $currentUser = Mage::getSingleton('admin/session')->getUser();
 
         if ($id = $this->getRequest()->getParam('user_id')) {
-            if ( $currentUser->getId() == $id ) {
+            if ($currentUser->getId() == $id) {
                 Mage::getSingleton('adminhtml/session')->addError($this->__('You cannot delete your own account.'));
                 $this->_redirect('*/*/edit', ['user_id' => $id]);
                 return;

--- a/app/code/core/Mage/Api/Model/Resource/Roles.php
+++ b/app/code/core/Mage/Api/Model/Resource/Roles.php
@@ -46,12 +46,12 @@ class Mage_Api_Model_Resource_Roles extends Mage_Core_Model_Resource_Db_Abstract
     {
         $this->_init('api/role', 'role_id');
 
-        $this->_usersTable  = $this->getTable('api/user');
-        $this->_ruleTable   = $this->getTable('api/rule');
+        $this->_usersTable = $this->getTable('api/user');
+        $this->_ruleTable  = $this->getTable('api/rule');
     }
 
     /**
-     * Action before save
+     * Process role before saving
      *
      * @param Mage_Core_Model_Abstract|Mage_Api_Model_Roles $role
      * @return $this
@@ -71,8 +71,10 @@ class Mage_Api_Model_Resource_Roles extends Mage_Core_Model_Resource_Db_Abstract
         } else {
             $row = ['tree_level' => 0];
         }
+
         $role->setTreeLevel($row['tree_level'] + 1);
         $role->setRoleName($role->getName());
+
         return $this;
     }
 
@@ -98,8 +100,8 @@ class Mage_Api_Model_Resource_Roles extends Mage_Core_Model_Resource_Db_Abstract
     protected function _afterDelete(Mage_Core_Model_Abstract $role)
     {
         $adapter = $this->_getWriteAdapter();
-        $adapter->delete($this->getMainTable(), ['parent_id=?'=>$role->getId()]);
-        $adapter->delete($this->_ruleTable, ['role_id=?'=>$role->getId()]);
+        $adapter->delete($this->getMainTable(), ['parent_id = ?' => (int) $role->getId()]);
+        $adapter->delete($this->_ruleTable, ['role_id = ?' => (int) $role->getId()]);
         return $this;
     }
 
@@ -111,8 +113,8 @@ class Mage_Api_Model_Resource_Roles extends Mage_Core_Model_Resource_Db_Abstract
      */
     public function getRoleUsers(Mage_Api_Model_Roles $role)
     {
-        $adapter   = $this->_getReadAdapter();
-        $select     = $adapter->select()
+        $adapter = $this->_getReadAdapter();
+        $select  = $adapter->select()
             ->from($this->getMainTable(), ['user_id'])
             ->where('parent_id = ?', $role->getId())
             ->where('role_type = ?', Mage_Api_Model_Acl::ROLE_TYPE_USER)
@@ -128,15 +130,17 @@ class Mage_Api_Model_Resource_Roles extends Mage_Core_Model_Resource_Db_Abstract
      */
     private function _updateRoleUsersAcl(Mage_Api_Model_Roles $role)
     {
-        $users  = $this->getRoleUsers($role);
+        $users = $this->getRoleUsers($role);
         $rowsCount = 0;
+
         if (count($users)) {
             $rowsCount = $this->_getWriteAdapter()->update(
                 $this->_usersTable,
                 ['reload_acl_flag' => 1],
-                ['user_id IN(?)' => $users]
+                ['user_id IN (?)' => $users]
             );
         }
+
         return $rowsCount > 0;
     }
 }

--- a/app/code/core/Mage/Api/Model/Resource/User.php
+++ b/app/code/core/Mage/Api/Model/Resource/User.php
@@ -64,7 +64,7 @@ class Mage_Api_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstract
         $data = [
             'lognum'  => $user->getLognum()+1,
         ];
-        $condition = $this->_getReadAdapter()->quoteInto('user_id=?', $user->getUserId());
+        $condition = $this->_getReadAdapter()->quoteInto('user_id = ?', $user->getUserId());
         $this->_getWriteAdapter()->update($this->getTable('api/user'), $data, $condition);
         return $this;
     }
@@ -262,7 +262,6 @@ class Mage_Api_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstract
         }
 
         $adapter = $this->_getWriteAdapter();
-
         $adapter->beginTransaction();
 
         try {
@@ -274,21 +273,22 @@ class Mage_Api_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstract
                 $rid = intval($rid);
                 if ($rid > 0) {
                     //$row = $this->load($user, $rid);
+                    $row = ['tree_level' => 0];
                 } else {
                     $row = ['tree_level' => 0];
                 }
-                $row = ['tree_level' => 0];
 
                 $data = [
-                    'parent_id'     => $rid,
-                    'tree_level'    => $row['tree_level'] + 1,
-                    'sort_order'    => 0,
-                    'role_type'     => Mage_Api_Model_Acl::ROLE_TYPE_USER,
-                    'user_id'       => $user->getId(),
-                    'role_name'     => $user->getFirstname()
+                    'parent_id'  => $rid,
+                    'tree_level' => $row['tree_level'] + 1,
+                    'sort_order' => 0,
+                    'role_type'  => Mage_Api_Model_Acl::ROLE_TYPE_USER,
+                    'user_id'    => $user->getId(),
+                    'role_name'  => $user->getFirstname()
                 ];
                 $adapter->insert($this->getTable('api/role'), $data);
             }
+
             $adapter->commit();
         } catch (Mage_Core_Exception $e) {
             $adapter->rollBack();
@@ -352,12 +352,12 @@ class Mage_Api_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstract
             $role = new Varien_Object(['tree_level' => 0]);
         }
         $adapter->insert($this->getTable('api/role'), [
-            'parent_id' => $user->getRoleId(),
-            'tree_level'=> ($role->getTreeLevel() + 1),
-            'sort_order'=> 0,
-            'role_type' => Mage_Api_Model_Acl::ROLE_TYPE_USER,
-            'user_id'   => $user->getUserId(),
-            'role_name' => $user->getFirstname()
+            'parent_id'  => $user->getRoleId(),
+            'tree_level' => $role->getTreeLevel() + 1,
+            'sort_order' => 0,
+            'role_type'  => Mage_Api_Model_Acl::ROLE_TYPE_USER,
+            'user_id'    => $user->getUserId(),
+            'role_name'  => $user->getFirstname()
         ]);
 
         return $this;
@@ -382,9 +382,10 @@ class Mage_Api_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstract
         $table     = $this->getTable('api/role');
 
         $condition = [
-            "{$table}.user_id = ?"  => $user->getUserId(),
-            "{$table}.parent_id = ?"=> $user->getRoleId()
+            $table.'.user_id = ?'   => (int) $user->getUserId(),
+            $table.'.parent_id = ?' => (int) $user->getRoleId()
         ];
+
         $adapter->delete($table, $condition);
         return $this;
     }
@@ -399,8 +400,8 @@ class Mage_Api_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstract
     {
         $result = [];
         if ($user->getUserId() > 0) {
-            $adapter    = $this->_getReadAdapter();
-            $select     = $adapter->select()->from($this->getTable('api/role'))
+            $adapter = $this->_getReadAdapter();
+            $select  = $adapter->select()->from($this->getTable('api/role'))
                 ->where('parent_id = ?', $user->getRoleId())
                 ->where('user_id = ?', $user->getUserId());
             $result = $adapter->fetchCol($select);


### PR DESCRIPTION
### Description

This PR allow to reload admin acl without logout/login:
- for associated users when a role is saved
- when admin user is saved

OpenMage 20.0.13 / PHP 7.4.6 + 8.0.18.

### Manual testing scenarios

* Create a new restricted role (for example, only with access to _Customers_).
* Create a new admin user, use the previous created role.
* **Open a private window** and login into backend with the previous created user.
* a/ Update the role of the new user: add access to _Sales_.
* Press F5 on the private window, and go to _Sales / Orders_.
* b/ Update the role of the new user: remove access to _Sales_.
* Press F5 on the private window.
* c/ Go to the Administrator role: associate the new user.
* Press F5 on the private window.
* d/ Go to the restricted role: associate the new user.
* Press F5 on the private window.
* e/ Update the new user: set role to Administrators.
* Press F5 on the private window.

You can add the following line in app/code/core/Mage/Admin/Model/Session.php on line 221 to add a success message when ACL is reloaded: `Mage::getSingleton('adminhtml/session')->addSuccess('ACL reloaded.');`

```php
    public function refreshAcl($user = null)
    {
        if (is_null($user)) {
            $user = $this->getUser();
        }
        if (!$user) {
            return $this;
        }
        if (!$this->getAcl() || $user->getReloadAclFlag()) {
            $this->setAcl(Mage::getResourceModel('admin/acl')->loadAcl());
            Mage::getSingleton('adminhtml/session')->addSuccess('ACL reloaded.');
        }
        if ($user->getReloadAclFlag()) {
            $user->getResource()->saveReloadAclFlag($user, 0);
        }
        return $this;
    }
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
