### PR TITLE
Handle empty Order increment prefix

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
@@ -46,7 +46,7 @@ class Mage_Eav_Model_Entity_Increment_Numeric extends Mage_Eav_Model_Entity_Incr
         if (empty($last)) {
             $last = 0;
         } else if (!empty($prefix = (string)$this->getPrefix()) && strpos($last, $prefix) === 0) {
-            $last = (int)substr($last, strlen($this->getPrefix()));
+            $last = (int)substr($last, strlen($prefix);
         } else {
             $last = (int)$last;
         }

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
@@ -46,7 +46,7 @@ class Mage_Eav_Model_Entity_Increment_Numeric extends Mage_Eav_Model_Entity_Incr
         if (empty($last)) {
             $last = 0;
         } else if (!empty($prefix = (string)$this->getPrefix()) && strpos($last, $prefix) === 0) {
-            $last = (int)substr($last, strlen($prefix);
+            $last = (int)substr($last, strlen($prefix));
         } else {
             $last = (int)$last;
         }

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
@@ -45,7 +45,7 @@ class Mage_Eav_Model_Entity_Increment_Numeric extends Mage_Eav_Model_Entity_Incr
 
         if (empty($last)) {
             $last = 0;
-        } else if (strpos($last, (string)$this->getPrefix()) === 0) {
+        } else if (!empty($prefix = (string)$this->getPrefix()) && strpos($last, $prefix) === 0) {
             $last = (int)substr($last, strlen($this->getPrefix()));
         } else {
             $last = (int)$last;


### PR DESCRIPTION
### Description (*)
A call to `strpos` with an empty needle would throw a warning pre PHP 8.0. This change will check if the prefix is not empty first before performing the call to `strpos`.

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#1645

### Manual testing scenarios (*)
1. Make sure you're on PHP 7.x as this warning is not thrown in PHP 8.0
2. Execute the following query to set an empty prefix for order increment ids:
```sql
update eav_entity_store set increment_prefix = '' where entity_type_id = '5';
```
3. Try to create an order from the Admin and a similar error should show up:
```txt
Order saving error: Warning: strpos(): Empty needle in /var/www/openmage/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php on line 48
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
