### PR TITLE
rewrite isTableExists for performance reasons

### DIFF
--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -2630,7 +2630,22 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
      */
     public function isTableExists($tableName, $schemaName = null)
     {
-        return $this->showTableStatus($tableName, $schemaName) !== false;
+        $fromDbName = 'DATABASE()';
+        if ($schemaName !== null) {
+            $fromDbName = $this->quote($schemaName);
+        }
+
+        $sql = sprintf(
+            'SELECT COUNT(1) AS tbl_exists FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = %s AND TABLE_SCHEMA = %s',
+            $this->quote($tableName),
+            $fromDbName
+        );
+        $ddl = $this->rawFetchRow($sql, 'tbl_exists');
+        if ($ddl) {
+            return true;
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
### Description (*)
implementation of isTableExists without the use of "show table status" to gain more performance.

See https://github.com/magento/magento2/pull/28516 for details

This versions comes without the DDL cache, as magento1 is not using this function as much as magento 2.

### Related Pull Requests
#1712

### Fixed Issues (if relevant)
/

### Manual testing scenarios (*)
/

### Questions or comments
/

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
