### PR TITLE
Add event sales_order_creditmemo_refund_before

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -276,6 +276,7 @@
 | sales_model_service_quote_submit_failure | 1.9.4.5 |
 | sales_model_service_quote_submit_success | 1.9.4.5 |
 | sales_order_creditmemo_cancel | 1.9.4.5 |
+| sales_order_creditmemo_refund_before | 19.4.15 / 20.0.13 |
 | sales_order_creditmemo_refund | 1.9.4.5 |
 | sales_order_invoice_cancel | 1.9.4.5 |
 | sales_order_invoice_pay | 1.9.4.5 |

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
@@ -464,6 +464,8 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
      */
     public function refund()
     {
+        Mage::dispatchEvent('sales_order_creditmemo_refund_before', array($this->_eventObject=>$this));
+
         $this->setState(self::STATE_REFUNDED);
         $orderRefund = Mage::app()->getStore()->roundPrice(
             $this->getOrder()->getTotalRefunded()+$this->getGrandTotal()


### PR DESCRIPTION
### Description (*)
Add a event for `sales_order_creditmemo_refund_before`. I am sort of surprised there is no event that could be used to prevent a credit memo from being able to be placed, unless I missed it. While you can use `sales_order_creditmemo_refund` and throw an exception there, it is too late to prevent an online refund from hitting your credit card processor. I will use this event for two main cases: Preventing a creditmemo if a custom giftcard product type has been used, and preventing a creditmemo if a downloadable product type has already been accessed.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
Hook into the event with:
```
      <sales_order_creditmemo_refund_before>
        <observers>
          <my_module>
            <class>my_module/observer</class>
            <method>beforeRefund</method>
          </my_module>
        </observers>
      </sales_order_creditmemo_refund_before>
```
```
    public function beforeRefund(Varien_Event_Observer $observer)
    {
        $creditmemo = $observer->getCreditmemo();
        Mage::throwException('Test prevent creditmemo');
    }
```

Then try and refund online a transaction. The refund should not be processed.

### Questions or comments
I modified the EVENTS.md file to use the next anticipated 19.4.x and 20.0.x release, but if this is not merged before then I will have to update there.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
