### PR TITLE
Fix Tax Rule name update

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
@@ -110,7 +110,8 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
             return $this->getResponse()->setRedirect($this->getUrl('*/tax_rule'));
         }
 
-        $ruleModel = $this->_getSingletonModel('tax/calculation_rule');
+        $ruleId = (int)$this->getRequest()->getParam('tax_calculation_rule_id');
+        $ruleModel = $this->_getSingletonModel('tax/calculation_rule')->load($ruleId);
         $ruleModel->setData($postData);
         $ruleModel->setCalculateSubtotal($this->getRequest()->getParam('calculate_subtotal', 0));
 
@@ -153,17 +154,21 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
      */
     protected function _isValidRuleRequest($ruleModel)
     {
-        $existingRules = $ruleModel->fetchRuleCodes($ruleModel->getTaxRate(),
-            $ruleModel->getTaxCustomerClass(), $ruleModel->getTaxProductClass());
+        $existingRules = $ruleModel->fetchRuleCodes(
+            $ruleModel->getTaxRate(),
+            $ruleModel->getTaxCustomerClass(),
+            $ruleModel->getTaxProductClass()
+        );
 
         //Remove the current one from the list
-        $existingRules = array_diff($existingRules, array($ruleModel->getCode()));
+        $existingRules = array_diff($existingRules, array($ruleModel->getOrigData('code')));
 
         //Verify if a Rule already exists. If not throw an error
         if (count($existingRules) > 0) {
             $ruleCodes = implode(",", $existingRules);
             $this->_getSingletonModel('adminhtml/session')->addError(
-                $this->_getHelperModel('tax')->__('Rules (%s) already exist for the specified Tax Rate, Customer Tax Class and Product Tax Class combinations', $ruleCodes));
+                $this->_getHelperModel('tax')->__('Rules (%s) already exist for the specified Tax Rate, Customer Tax Class and Product Tax Class combinations', $ruleCodes)
+            );
             return false;
         }
         return true;


### PR DESCRIPTION
Fix Tax Rule name update from Admin

### Description (*)
This PR will fix a bug where changing the name of a Tax Rule will trigger an error. This was caused by a check that is supposed to prevent creating multiple rules with the same Tax Rate/Customer Tax Class/Product Tax Class combination, but the issue was that it was checking the original name of the rule against the newly submitted one from the`POST` request, which is not gonna match if you submit a new name. All I did here is `load` the existing rule and use the original rule name instead of the submitted one to perform the check.

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#1056

### Manual testing scenarios (*)
Go to `Sales > Tax > Manage Tax Rules` and choose or create a rule:
1. You should be able to set a new name for any rule and save it.
2. If you try to create a new rule with the same Tax Rate/Customer Tax Class/Product Tax Class combination, it should show an error.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
