### PR TITLE
Fixed origData is empty in a quote

### DIFF
--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -416,6 +416,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
         }
         $this->_getResource()->loadByCustomerId($this, $customerId);
         $this->_afterLoad();
+        $this->setOrigData();
         return $this;
     }
 
@@ -429,6 +430,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
     {
         $this->_getResource()->loadActive($this, $quoteId);
         $this->_afterLoad();
+        $this->setOrigData();
         return $this;
     }
 
@@ -442,6 +444,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
     {
         $this->_getResource()->loadByIdWithoutStore($this, $quoteId);
         $this->_afterLoad();
+        $this->setOrigData();
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -417,6 +417,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
         $this->_getResource()->loadByCustomerId($this, $customerId);
         $this->_afterLoad();
         $this->setOrigData();
+        $this->setDataChanges(false);
         return $this;
     }
 
@@ -431,6 +432,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
         $this->_getResource()->loadActive($this, $quoteId);
         $this->_afterLoad();
         $this->setOrigData();
+        $this->setDataChanges(false);
         return $this;
     }
 
@@ -445,6 +447,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
         $this->_getResource()->loadByIdWithoutStore($this, $quoteId);
         $this->_afterLoad();
         $this->setOrigData();
+        $this->setDataChanges(false);
         return $this;
     }
 


### PR DESCRIPTION
### Description (*)

`_origData` is empty when quotes are loaded though 
- loadByIdWithoutStore()
- loadActive()
- loadByCustomer()

When loading a quote with load(), then `_origData` is filled, but only in that case.

### Fixed Issues (if relevant)
This fixed change detection and is important for my module because origData is always NULL on the cart page and several other locations.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
