### PR TITLE
Allow for easier adding of general order information on the order view page

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Most important changes will be listed here, all other changes since `19.4.0` can
 - `checkout_cart_product_add_before`
 - `sitemap_cms_pages_generating_before`
 - `sitemap_urlset_generating_before`
+- `adminhtml_block_order_view_collect_additional_info`
 
 ### New Translations
 

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Info.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Info.php
@@ -170,4 +170,11 @@ class Mage_Adminhtml_Block_Sales_Order_View_Info extends Mage_Adminhtml_Block_Sa
     {
         return !Mage::getStoreConfigFlag('sales/general/hide_customer_ip', $this->getOrder()->getStoreId());
     }
+    
+    public function getAdditionalInfo()
+    {
+        $orderAdditionalInfo = new ArrayObject();
+        Mage::dispatchEvent('adminhtml_block_order_view_collect_additional_info', ['order'=> $this->getOrder(), 'info' => $orderAdditionalInfo]);
+        return $orderAdditionalInfo;
+    }
 }

--- a/app/design/adminhtml/default/default/template/sales/order/view/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/info.phtml
@@ -98,7 +98,7 @@ $orderStoreDate = $this->formatDate($_order->getCreatedAtStoreDate(), 'medium', 
                 <td class="label"><label><?php echo Mage::helper('sales')->__('%s / %s rate:', $_order->getOrderCurrencyCode(), $_order->getBaseCurrencyCode()) ?></label></td>
                 <td class="value"><strong><?php echo $_order->getBaseToOrderRate() ?></strong></td>
             </tr>
-            <?php endif 
+            <?php endif;
             
             foreach($this->getAdditionalInfo() as $label => $htmlFragment){
                 ?>

--- a/app/design/adminhtml/default/default/template/sales/order/view/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/info.phtml
@@ -98,7 +98,17 @@ $orderStoreDate = $this->formatDate($_order->getCreatedAtStoreDate(), 'medium', 
                 <td class="label"><label><?php echo Mage::helper('sales')->__('%s / %s rate:', $_order->getOrderCurrencyCode(), $_order->getBaseCurrencyCode()) ?></label></td>
                 <td class="value"><strong><?php echo $_order->getBaseToOrderRate() ?></strong></td>
             </tr>
-            <?php endif ?>
+            <?php endif 
+            
+            foreach($this->getAdditionalInfo() as $label => $htmlFragment){
+                ?>
+                <tr>
+                    <td class="label"><label><?=$this->escapeHtml($label) ?></label></td>
+                    <td class="value"><?=$htmlFragment ?></td>
+                </tr>
+                <?php
+            }
+            ?>
             </table>
         </div>
     </div>


### PR DESCRIPTION
### Description (*)
Allow for easier adding of general order information on the order view page.

In this screenshot I added "Some Item, Some Value" at the top of the order page using an event observer.

The data is collected as a key-value array using a new event: `adminhtml_block_order_view_collect_additional_info`
The value can be HTML.

I mentioned the new event in the README as well.

![Screenshot from 2021-07-30 10-24-25](https://user-images.githubusercontent.com/71019/127625203-e4efee14-faa2-41c3-84eb-cb6b714bfcd5.png)


### Fixed Issues (if relevant)
1. Fixes how hard it is to add generic order information without overriding the block or template or adding yet another block to the page.

###

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
