### PR TITLE
Fix (Adminhtml-Customer-Edit): allowed countries of selected website aren't considered when editing existing addresses

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Addresses.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Addresses.php
@@ -131,6 +131,9 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_Addresses extends Mage_Adminhtml_Bl
             /* @var $attribute Mage_Eav_Model_Entity_Attribute */
             $attribute->setFrontendLabel(Mage::helper('customer')->__($attribute->getFrontend()->getLabel()));
             $attribute->unsIsVisible();
+            
+            // sets store id to attribute, is evaluated in customer country input fields to provide correct allowed countries
+            $attribute->setStoreId($customer->getStore()->getId());
         }
         $this->_setFieldset($attributes, $fieldset);
 


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR enables the editing of customers with addresses using countries that aren't allowed in the default config (`General > Countries Options > Allow Countries [general/country/allow]`) but are in `Website` scope, without the need to change the country first.

This is achieved by taking the customer's store id into account when determining the allowed countries to fill the select options. Previously the input was always filled with the allowed country of the default store (admin, store id 0). Setting the customer's store id in select and multiselect attributes is necessary because the way in which values are set in `Mage_Adminhtml_Block_Widget_Form::_setFieldset()` line 208 and 210 respectively.

### Related Pull Requests
<!-- related pull request placeholder -->
* None

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
* #1762 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set system config `General > Countries Options > Allow Countries [general/country/allow]` so that at least one country is allowed in `Website` scope that is not allowed in default config scope. 
2. Have a customer for this website, log into it and create an address that uses a country that is only allowed in `Website` scope.
3. Navigate to Adminhtml Customer/Edit, edit the customer and select addresses.
4. See the created address with the country selected in the country input select.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
This PR can't fix cases in which one decides to set the allowed countries in `Store View` scope because a customer is assigned to a website (and within the database to a store id it was created in). This is true in some circumstances and additionally depends on the configured store scenario (how many websites/stores/store views and in what distribution).

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
