### PR TITLE
removed space after "To" in backend grids

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Price.php
@@ -41,9 +41,9 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Price
     {
         $html  = '<div class="range">';
         $html .= '<div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('From').':</span> <input type="text" name="'.$this->_getHtmlName().'[from]" id="'.$this->_getHtmlId().'_from" value="'.$this->getEscapedValue('from').'" class="input-text no-changes"/></div>';
-        $html .= '<div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('To').' : </span><input type="text" name="'.$this->_getHtmlName().'[to]" id="'.$this->_getHtmlId().'_to" value="'.$this->getEscapedValue('to').'" class="input-text no-changes"/></div>';
+        $html .= '<div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('To').': </span><input type="text" name="'.$this->_getHtmlName().'[to]" id="'.$this->_getHtmlId().'_to" value="'.$this->getEscapedValue('to').'" class="input-text no-changes"/></div>';
         if ($this->getDisplayCurrencySelect())
-            $html .= '<div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('In').' : </span>' . $this->_getCurrencySelectHtml() . '</div>';
+            $html .= '<div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('In').': </span>' . $this->_getCurrencySelectHtml() . '</div>';
         $html .= '</div>';
 
         return $html;

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
@@ -36,7 +36,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Range extends Mage_Adminhtm
     public function getHtml()
     {
         $html = '<div class="range"><div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('From').':</span> <input type="text" name="'.$this->_getHtmlName().'[from]" id="'.$this->_getHtmlId().'_from" value="'.$this->getEscapedValue('from').'" class="input-text no-changes"/></div>';
-        $html .= '<div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('To').' : </span><input type="text" name="'.$this->_getHtmlName().'[to]" id="'.$this->_getHtmlId().'_to" value="'.$this->getEscapedValue('to').'" class="input-text no-changes"/></div></div>';
+        $html .= '<div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('To').': </span><input type="text" name="'.$this->_getHtmlName().'[to]" id="'.$this->_getHtmlId().'_to" value="'.$this->getEscapedValue('to').'" class="input-text no-changes"/></div></div>';
         return $html;
     }
 


### PR DESCRIPTION
As stated in https://github.com/OpenMage/magento-lts/discussions/1742 is seems there's always been a small typo, there shouldn't be any space before the ":" symbol:

example:  
https://user-images.githubusercontent.com/8360474/126807333-439f8235-4095-4739-9a83-cb4538c45869.png

This PR removes the space