### PR TITLE
Array to string conversion when adding reviews from backend

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Review/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Product/Grid.php
@@ -37,6 +37,7 @@ class Mage_Adminhtml_Block_Review_Product_Grid extends Mage_Adminhtml_Block_Cata
     public function __construct()
     {
         parent::__construct();
+        $this->setId('reviewProductGrid');
         $this->setRowClickCallback('review.gridRowClick');
         $this->setUseAjax(true);
     }


### PR DESCRIPTION
This PR fixes issue https://github.com/OpenMage/magento-lts/issues/741 simply forcing a unique ID for the review_products_grid in order to avoid conflicts with the main products grid

### Fixed Issues (if relevant)
1. https://github.com/OpenMage/magento-lts/issues/741

### Manual testing scenarios (*)
All is explained in the issue