### PR TITLE
PHPDoc fix for Mage_Core_Model_Config

### DIFF
--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -1558,7 +1558,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     /**
      * Get DB table names prefix
      *
-     * @return string
+     * @return Mage_Core_Model_Config_Element
      */
     public function getTablePrefix()
     {


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

The PHPDoc return type of method `getTablePrefix()` was wrong (_string_ vs. _Mage_Core_Model_Config_). The method is used one time in core but could be and - in my case is - used more frequently by 3rd party modules. The using line casts the value correctly to string. An IDE that parses PHPDoc and considers the return types assumed the cast as redundant though: 

old
![image](https://user-images.githubusercontent.com/2728018/131136069-72841e29-a36a-4739-8df7-0ace32fed72f.png)

fixed
![image](https://user-images.githubusercontent.com/2728018/131136090-53a7f6e2-67cb-4a0c-b03b-441f54ddf987.png)
 
### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
* Check your IDE (with active PHPDoc support)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 