### PR TITLE
enable programmatic creation of reviews for specific users

### DIFF
--- a/app/code/core/Mage/Rating/Model/Rating.php
+++ b/app/code/core/Mage/Rating/Model/Rating.php
@@ -83,14 +83,16 @@ class Mage_Rating_Model_Rating extends Mage_Core_Model_Abstract
     /**
      * @param int $optionId
      * @param string $entityPkValue
+     * @param int $customerId
      * @return $this
      */
-    public function addOptionVote($optionId, $entityPkValue)
+    public function addOptionVote($optionId, $entityPkValue, $customerId = null)
     {
         Mage::getModel('rating/rating_option')->setOptionId($optionId)
             ->setRatingId($this->getId())
             ->setReviewId($this->getReviewId())
             ->setEntityPkValue($entityPkValue)
+            ->setCustomerId($customerId)
             ->addVote();
         return $this;
     }

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Option.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Option.php
@@ -125,7 +125,7 @@ class Mage_Rating_Model_Resource_Rating_Option extends Mage_Core_Model_Resource_
         if (!$option->getDoUpdate()) {
             $data['remote_ip']       = Mage::helper('core/http')->getRemoteAddr();
             $data['remote_ip_long']  = Mage::helper('core/http')->getRemoteAddr(true);
-            $data['customer_id']     = Mage::getSingleton('customer/session')->getCustomerId();
+            $data['customer_id']     = $option->getCustomerId() ?? Mage::getSingleton('customer/session')->getCustomerId();
             $data['entity_pk_value'] = $option->getEntityPkValue();
             $data['rating_id']       = $option->getRatingId();
         }


### PR DESCRIPTION
### Description

This commit allow user to create reviews from script.

### Manual testing scenarios

Update an run;
```php
$productId = 5;

$review = Mage::getModel('review/review');
$review->setEntityPkValue($productId);
$review->setStatusId(1); // 1 = approved
$review->setNickname("Guest");
$review->setTitle("Hello");
$review->setDetail("This is me!");
$review->setEntityId(1);
$review->setStoreId(Mage::app()->getDefaultStoreView()->getId());
$review->setStores([Mage::app()->getDefaultStoreView()->getId()]);
$review->save();

$rating = Mage::getModel('rating/rating')
	->setRatingId(1)
	->setReviewId($review->getId())
	->addOptionVote(3, $productId, $customer->getId());

$review->save();
$review->aggregate();
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list