### PR TITLE
Allow to cancel orders like registerCancellation

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -1248,15 +1248,14 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
 
     /**
      * Cancel order
-     *
+     * @param string $comment
      * @return $this
      */
-    public function cancel()
+    public function cancel($comment = '')
     {
         if ($this->canCancel()) {
             $this->getPayment()->cancel();
-            $this->registerCancellation();
-
+            $this->registerCancellation($comment);
             Mage::dispatchEvent('order_cancel_after', array('order' => $this));
         }
 


### PR DESCRIPTION
### Description

This little change allow user to cancel order with a comment.

### Manual testing scenarios

For example:
```php
$order->registerCancellation('Message')->save();
$order->cancel('Message')->save();
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list