### PR TITLE
Some changes for compatibility with PHP 8.1

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -421,7 +421,8 @@ final class Mage
      */
     public static function getStoreConfigFlag($path, $store = null)
     {
-        $flag = strtolower(self::getStoreConfig($path, $store));
+        $flag = self::getStoreConfig($path, $store);
+        $flag = is_string($flag) ? strtolower($flag) : $flag;
         if (!empty($flag) && 'false' !== $flag) {
             return true;
         } else {

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
@@ -140,8 +140,8 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_View
     public function getCurrentStatus()
     {
         $log = $this->getCustomerLog();
-        if ($log->getLogoutAt() ||
-            strtotime(now())-strtotime($log->getLastVisitAt())>Mage_Log_Model_Visitor::getOnlineMinutesInterval()*60) {
+        if ($log->getLogoutAt() || (!empty($log->getLastVisitAt()) &&
+            (strtotime(now()) - strtotime($log->getLastVisitAt()) > Mage_Log_Model_Visitor::getOnlineMinutesInterval() * 60))) {
             return Mage::helper('customer')->__('Offline');
         }
         return Mage::helper('customer')->__('Online');

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
@@ -206,7 +206,8 @@ class Mage_Adminhtml_Block_Widget_Grid_Column extends Mage_Adminhtml_Block_Widge
 
     protected function _getRendererByType()
     {
-        $type = strtolower($this->getType());
+        $type = $this->getType();
+        $type = is_string($type) ? strtolower($type) : $type;
         $renderers = $this->getGrid()->getColumnRenderers();
 
         if (is_array($renderers) && isset($renderers[$type])) {

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
@@ -301,7 +301,8 @@ class Mage_Adminhtml_Block_Widget_Grid_Column extends Mage_Adminhtml_Block_Widge
 
     protected function _getFilterByType()
     {
-        $type = strtolower($this->getType());
+        $type = $this->getType();
+        $type = is_string($type) ? strtolower($type) : $type;
         $filters = $this->getGrid()->getColumnFilters();
         if (is_array($filters) && isset($filters[$type])) {
             return $filters[$type];

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Abstract.php
@@ -94,7 +94,8 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Abstract extends Mage_Admin
      */
     public function getEscapedValue($index = null)
     {
-        return htmlspecialchars($this->getValue($index));
+        $value = $this->getValue($index);
+        return is_string($value) ? htmlspecialchars($value) : $value;
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
@@ -107,8 +107,9 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract
     {
         if (false !== $this->getColumn()->getGrid()->getSortable() && false !== $this->getColumn()->getSortable()) {
             $className = 'not-sort';
-            $dir = strtolower($this->getColumn()->getDir());
-            $nDir= ($dir=='asc') ? 'desc' : 'asc';
+            $dir  = $this->getColumn()->getDir();
+            $dir  = is_string($dir) ? strtolower($dir) : $dir;
+            $nDir = ($dir == 'asc') ? 'desc' : 'asc';
             if ($this->getColumn()->getDir()) {
                 $className = 'sort-arrow-' . $dir;
             }

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -215,7 +215,7 @@ abstract class Mage_Core_Helper_Abstract
             }
         } else {
             // process single item
-            if (strlen($data)) {
+            if (is_string($data) && (strlen($data) > 0)) {
                 if (is_array($allowedTags) && !empty($allowedTags)) {
                     $allowed = implode('|', $allowedTags);
                     $result = preg_replace('/<([\/\s\r\n]*)(' . $allowed . ')([\/\s\r\n]*)>/si', '##$1$2$3##', $data);

--- a/app/code/core/Mage/Core/Helper/String.php
+++ b/app/code/core/Mage/Core/Helper/String.php
@@ -187,7 +187,7 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
             }
         } // split smartly, keeping words
         else {
-            $split = preg_split('/(' . $wordSeparatorRegex . '+)/siu', $str, null, PREG_SPLIT_DELIM_CAPTURE);
+            $split    = preg_split('/(' . $wordSeparatorRegex . '+)/siu', $str, -1, PREG_SPLIT_DELIM_CAPTURE);
             $i        = 0;
             $space    = '';
             $spaceLen = 0;

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -1273,7 +1273,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
         // First - check maybe the entity class was rewritten
         $className = null;
         if (isset($config->rewrite->$class)) {
-            $className = (string)$config->rewrite->$class;
+            $className = trim((string) $config->rewrite->$class);
         } else {
             /**
              * Backwards compatibility for pre-MMDB extensions.
@@ -1284,12 +1284,10 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
                 $deprecatedNode = $config->deprecatedNode;
                 $configOld = $this->_xml->global->{$groupType.'s'}->$deprecatedNode;
                 if (isset($configOld->rewrite->$class)) {
-                    $className = (string) $configOld->rewrite->$class;
+                    $className = trim((string) $configOld->rewrite->$class);
                 }
             }
         }
-
-        $className = trim($className);
 
         // Second - if entity is not rewritten then use class prefix to form class name
         if (empty($className)) {

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -1315,7 +1315,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      */
     public function getBlockClassName($blockType)
     {
-        if (strpos($blockType, '/')===false) {
+        if (strpos($blockType, '/') === false) {
             return $blockType;
         }
         return $this->getGroupedClassName('block', $blockType);
@@ -1365,11 +1365,13 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      */
     public function getModelClassName($modelClass)
     {
-        $modelClass = trim($modelClass);
-        if (strpos($modelClass, '/')===false) {
-            return $modelClass;
+        if (empty($modelClass)) {
+            return '';
         }
-        return $this->getGroupedClassName('model', $modelClass);
+        if (strpos($modelClass, '/') === false) {
+            return trim($modelClass);
+        }
+        return $this->getGroupedClassName('model', trim($modelClass));
     }
 
     /**

--- a/app/code/core/Mage/Core/Model/Design/Package.php
+++ b/app/code/core/Mage/Core/Model/Design/Package.php
@@ -537,7 +537,7 @@ class Mage_Core_Model_Design_Package
         Varien_Profiler::start(__METHOD__);
 
         // Prevent reading files outside of the proper directory while still allowing symlinked files
-        if (strpos($file, '..') !== false) {
+        if (is_string($file) && (strpos($file, '..') !== false)) {
             Mage::log(sprintf('Invalid path requested: %s (params: %s)', $file, json_encode($params)), Zend_Log::ERR);
             throw new Exception('Invalid path requested.');
         }

--- a/app/code/core/Mage/Core/Model/Resource/Config.php
+++ b/app/code/core/Mage/Core/Model/Resource/Config.php
@@ -101,7 +101,7 @@ class Mage_Core_Model_Resource_Config extends Mage_Core_Model_Resource_Db_Abstra
             if ($r['scope'] !== 'default') {
                 continue;
             }
-            $value = str_replace($substFrom, $substTo, $r['value']);
+            $value = empty($r['value']) ? $r['value'] : str_replace($substFrom, $substTo, $r['value']);
             $xmlConfig->setNode('default/' . $r['path'], $value);
         }
 

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Multiline.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Multiline.php
@@ -135,7 +135,7 @@ class Mage_Eav_Model_Attribute_Data_Multiline extends Mage_Eav_Model_Attribute_D
     {
         $values = $this->getEntity()->getData($this->getAttribute()->getAttributeCode());
         if (!is_array($values)) {
-            $values = explode("\n", $values);
+            $values = is_string($values) ? explode("\n", $values) : [];
         }
         $values = array_map(array($this, '_applyOutputFilter'), $values);
         switch ($format) {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
@@ -638,7 +638,8 @@ abstract class Mage_Eav_Model_Entity_Attribute_Abstract extends Mage_Core_Model_
             if ($this->isStatic()) {
                 $this->_dataTable = $this->getEntityType()->getValueTablePrefix();
             } else {
-                $backendTable = trim($this->_getData('backend_table'));
+                $backendTable = $this->_getData('backend_table');
+                $backendTable = is_string($backendTable) ? trim($backendTable) : $backendTable;
                 if (empty($backendTable)) {
                     $entityTable  = array($this->getEntity()->getEntityTablePrefix(), $this->getBackendType());
                     $backendTable = $this->getResource()->getTable($entityTable);

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Created.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Created.php
@@ -41,8 +41,8 @@ class Mage_Eav_Model_Entity_Attribute_Backend_Time_Created extends Mage_Eav_Mode
      */
     protected function _getFormat($date)
     {
-        if (is_string($date) && preg_match('#^\d{4,4}-\d{2,2}-\d{2,2}\s\d{2,2}:\d{2,2}:\d{2,2}$#', $date)
-            || preg_match('#^\d{4,4}-\d{2,2}-\d{2,2}\w{1,1}\d{2,2}:\d{2,2}:\d{2,2}[+-]\d{2,2}:\d{2,2}$#', $date)) {
+        if (is_string($date) && (preg_match('#^\d{4,4}-\d{2,2}-\d{2,2}\s\d{2,2}:\d{2,2}:\d{2,2}$#', $date)
+            || preg_match('#^\d{4,4}-\d{2,2}-\d{2,2}\w{1,1}\d{2,2}:\d{2,2}:\d{2,2}[+-]\d{2,2}:\d{2,2}$#', $date))) {
             return 'yyyy-MM-dd HH:mm:ss';
         }
         return null;

--- a/app/code/core/Mage/Eav/Model/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Type.php
@@ -264,7 +264,8 @@ class Mage_Eav_Model_Entity_Type extends Mage_Core_Model_Abstract
      */
     public function getEntityTablePrefix()
     {
-        $tablePrefix = trim($this->_data['value_table_prefix']);
+        $tablePrefix = $this->_data['value_table_prefix'];
+        $tablePrefix = is_string($tablePrefix) ? trim($tablePrefix) : $tablePrefix;
 
         if (empty($tablePrefix)) {
             $tablePrefix = $this->getEntityTable();

--- a/app/design/adminhtml/default/default/template/widget/tabs.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabs.phtml
@@ -24,15 +24,15 @@
  * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<?php if($this->getTitle()): ?>
+<?php if ($this->getTitle()): ?>
     <h3><?php echo $this->getTitle() ?></h3>
 <?php endif ?>
-<?php if(!empty($tabs)): ?>
+<?php if (!empty($tabs)): ?>
 <ul id="<?php echo $this->getId() ?>" class="tabs">
 <?php foreach ($tabs as $_tab): ?>
 <?php if (!$this->canShowTab($_tab)): continue;  endif; ?>
-    <li <?php if($this->getTabIsHidden($_tab)): ?> style="display:none"<?php endif ?>>
-        <a href="<?php echo $this->getTabUrl($_tab) ?>" id="<?php echo $this->getTabId($_tab) ?>" name="<?php echo $this->getTabId($_tab, false) ?>" title="<?php echo Mage::helper('core')->quoteEscape($this->getTabTitle($_tab)) ?>" class="tab-item-link <?php echo $this->getTabClass($_tab) ?><?php if (preg_match('/\s?ajax\s?/', $_tab->getClass())) {?> notloaded<?php }?>">
+    <li <?php if ($this->getTabIsHidden($_tab)): ?> style="display:none"<?php endif ?>>
+        <a href="<?php echo $this->getTabUrl($_tab) ?>" id="<?php echo $this->getTabId($_tab) ?>" name="<?php echo $this->getTabId($_tab, false) ?>" title="<?php echo Mage::helper('core')->quoteEscape($this->getTabTitle($_tab)) ?>" class="tab-item-link <?php echo $this->getTabClass($_tab) ?><?php if (!empty($_tab->getClass()) && preg_match('/\s?ajax\s?/', $_tab->getClass())) {?> notloaded<?php }?>">
             <span><span class="changed" title="<?php echo Mage::helper('core')->quoteEscape($this->__('The information in this tab has been changed.')) ?>"></span><span class="error" title="<?php echo Mage::helper('core')->quoteEscape($this->__('This tab contains invalid data. Please solve the problem before saving.')) ?>"></span><?php echo $this->getTabLabel($_tab); ?></span>
         </a>
         <div id="<?php echo $this->getTabId($_tab) ?>_content" style="display:none;"><?php echo $this->getTabContent($_tab) ?></div>

--- a/app/design/adminhtml/default/default/template/widget/tabshoriz.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabshoriz.phtml
@@ -24,22 +24,19 @@
  * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<!-- <?php if($this->getTitle()): ?>
-    <h3><?php echo $this->getTitle() ?></h3>
-<?php endif ?> -->
-<?php if(!empty($tabs)): ?>
-<ul id="<?php echo $this->getId() ?>" class="tabs-horiz">
-<?php foreach ($tabs as $_tab): ?>
-    <li>
-        <a href="<?php echo $this->getTabUrl($_tab)?>" id="<?php echo $this->getTabId($_tab) ?>" title="<?php echo $this->getTabTitle($_tab) ?>" class="tab-item-link <?php echo $this->getTabClass($_tab) ?><?php if (preg_match('/\s?ajax\s?/', $this->getTabClass($_tab))) {?> notloaded<?php }?>">
-            <span><span class="changed" title="<?php echo Mage::helper('core')->quoteEscape($this->__('The information in this tab has been changed.')) ?>"></span><span class="error" title="<?php echo Mage::helper('core')->quoteEscape($this->__('This tab contains invalid data. Please solve the problem before saving.')) ?>"></span><?php echo $this->getTabLabel($_tab) ?></span>
-        </a>
-        <div id="<?php echo $this->getTabId($_tab) ?>_content" style="display:none"><?php echo $this->getTabContent($_tab) ?></div>
-    </li>
-<?php endforeach ?>
-</ul>
-<script type="text/javascript">
 
-    <?php echo $this->getId() ?>JsTabs = new varienTabs('<?php echo $this->getId() ?>', '<?php echo $this->getDestElementId() ?>', '<?php echo $this->getActiveTabId() ?>', <?php echo $this->getAllShadowTabs()?>);
-</script>
+<?php if (!empty($tabs)): ?>
+    <ul id="<?php echo $this->getId() ?>" class="tabs-horiz">
+        <?php foreach ($tabs as $tab): ?>
+            <li>
+                <a href="<?php echo $this->getTabUrl($tab) ?>" id="<?php echo $this->getTabId($tab) ?>" title="<?php echo $this->getTabTitle($tab) ?>" class="tab-item-link <?php echo $class = $this->getTabClass($tab),((!empty($class) && preg_match('/\s?ajax\s?/', $class)) ? ' notloaded' : '') ?>">
+                    <span><span class="changed" title="<?php echo Mage::helper('core')->quoteEscape($this->__('The information in this tab has been changed.')) ?>"></span><span class="error" title="<?php echo Mage::helper('core')->quoteEscape($this->__('This tab contains invalid data. Please solve the problem before saving.')) ?>"></span><?php echo $this->getTabLabel($tab) ?></span>
+                </a>
+                <div id="<?php echo $this->getTabId($tab) ?>_content" style="display:none"><?php echo $this->getTabContent($tab) ?></div>
+            </li>
+        <?php endforeach ?>
+    </ul>
+    <script type="text/javascript">
+    <?php echo $this->getId() ?>JsTabs = new varienTabs('<?php echo $this->getId() ?>', '<?php echo $this->getDestElementId() ?>', '<?php echo $this->getActiveTabId() ?>', <?php echo $this->getAllShadowTabs() ?>);
+    </script>
 <?php endif ?>

--- a/lib/Varien/Data/Form/Element/Abstract.php
+++ b/lib/Varien/Data/Form/Element/Abstract.php
@@ -214,7 +214,7 @@ abstract class Varien_Data_Form_Element_Abstract extends Varien_Data_Form_Abstra
      */
     protected function _escape($string)
     {
-        return htmlspecialchars($string, ENT_COMPAT);
+        return is_string($string) ? htmlspecialchars($string, ENT_COMPAT) : $string;
     }
 
     /**

--- a/lib/Varien/Data/Form/Element/Multiselect.php
+++ b/lib/Varien/Data/Form/Element/Multiselect.php
@@ -77,7 +77,7 @@ class Varien_Data_Form_Element_Multiselect extends Varien_Data_Form_Element_Abst
 
         $value = $this->getValue();
         if (!is_array($value)) {
-            $value = explode(',', $value);
+            $value = is_string($value) ? explode(',', $value) : [];
         }
 
         if ($values = $this->getValues()) {

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -130,7 +130,7 @@ class Varien_Io_File extends Varien_Io_Abstract
             throw new Exception('Permission denied for write to ' . $this->getFilteredPath($this->_cwd));
         }
 
-        if (!ini_get('auto_detect_line_endings')) {
+        if ((PHP_VERSION_ID < 80100) && !ini_get('auto_detect_line_endings')) {
             ini_set('auto_detect_line_endings', 1);
         }
 

--- a/lib/Varien/Object.php
+++ b/lib/Varien/Object.php
@@ -340,7 +340,7 @@ class Varien_Object implements ArrayAccess
         $default = null;
 
         // accept a/b/c as ['a']['b']['c']
-        if (strpos($key,'/')) {
+        if (is_string($key) && strpos($key, '/')) {
             $keyArr = explode('/', $key);
             $data = $this->_data;
             foreach ($keyArr as $i=>$k) {

--- a/lib/Varien/Object.php
+++ b/lib/Varien/Object.php
@@ -609,7 +609,7 @@ class Varien_Object implements ArrayAccess
         } else {
             preg_match_all('/\{\{([a-z0-9_]+)\}\}/is', $format, $matches);
             foreach ($matches[1] as $var) {
-                $format = str_replace('{{'.$var.'}}', $this->getData($var), $format);
+                $format = str_replace('{{'.$var.'}}', (string) $this->getData($var), $format);
             }
             $str = $format;
         }

--- a/lib/Zend/Db/Adapter/Pdo/Abstract.php
+++ b/lib/Zend/Db/Adapter/Pdo/Abstract.php
@@ -289,6 +289,9 @@ abstract class Zend_Db_Adapter_Pdo_Abstract extends Zend_Db_Adapter_Abstract
      */
     protected function _quote($value)
     {
+        if (is_null($value)) {
+            return "''";
+        }
         if (is_int($value) || is_float($value)) {
             return $value;
         }

--- a/lib/Zend/Db/Statement/Pdo.php
+++ b/lib/Zend/Db/Statement/Pdo.php
@@ -245,7 +245,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
      * @return mixed Array, object, or scalar depending on fetch mode.
      * @throws Zend_Db_Statement_Exception
      */
-    public function fetch($style = null, $cursor = null, $offset = null)
+    public function fetch($style = null, $cursor = PDO::FETCH_ORI_NEXT, $offset = 0)
     {
         if ($style === null) {
             $style = $this->_fetchMode;

--- a/lib/Zend/Locale/Data.php
+++ b/lib/Zend/Locale/Data.php
@@ -340,7 +340,7 @@ class Zend_Locale_Data
             $val = implode('_' , $value);
         }
 
-        $val = urlencode($val);
+        $val = is_string($val) ? urlencode($val) : $val;
         $id  = self::_filterCacheId('Zend_LocaleL_' . $locale . '_' . $path . '_' . $val);
 
         // add runtime cache to avoid calling cache backend multiple times during one request
@@ -998,7 +998,8 @@ class Zend_Locale_Data
         if (is_array($value)) {
             $val = implode('_' , $value);
         }
-        $val = urlencode($val);
+
+        $val = is_string($val) ? urlencode($val) : $val;
         $id  = self::_filterCacheId('Zend_LocaleC_' . $locale . '_' . $path . '_' . $val);
 
         // add runtime cache to avoid calling cache backend multiple times during one request


### PR DESCRIPTION
### Description

Not sure if all changes are the best or not.
PHP 8.0.11 and 8.1.0-rc2 (from [deb.sury.org](https://deb.sury.org/)).

### Manual testing scenario

First, disable _Suppress deprecation warnings_ in app/code/core/Mage/Core/functions.php:
```
diff --git a/app/code/core/Mage/Core/functions.php b/app/code/core/Mage/Core/functions.php
index 29e308d1b6..88b17f9c83 100644
--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -136,9 +136,9 @@ function mageCoreErrorHandler($errno, $errstr, $errfile, $errline)
     }

     // Suppress deprecation warnings on PHP 7.x
-    if ($errno == E_DEPRECATED && version_compare(PHP_VERSION, '7.0.0', '>=')) {
-        return true;
-    }
+    //if ($errno == E_DEPRECATED && version_compare(PHP_VERSION, '7.0.0', '>=')) {
+    //    return true;
+    //}

     // PEAR specific message handling
     if (stripos($errfile.$errstr, 'pear') !== false) {
```

Go to your backend login page, login, go to dashboard, then enable PHP 8.1, clear your cache, and press F5.

**Commit 1 fix:**
```
Deprecated functionality: trim(): Passing null to parameter #1 ($string) of type string is deprecated
  in app/code/core/Mage/Core/Model/Config.php on line 1292
```

Apply commit 1, then press F5.

**Commit 2 fix:**
```
Deprecated functionality: PDOStatement::fetch(): Passing null to parameter #2 ($cursorOrientation)
  of type int is deprecated in lib/Zend/Db/Statement/Pdo.php on line 254
```

Solution found here: https://github.com/matomo-org/matomo/pull/17689
Apply commit 2, then press F5.

**Commit 3 fix:**
```
Deprecated functionality: str_replace(): Passing null to parameter #3 ($subject) of type array|string
  is deprecated in app/code/core/Mage/Core/Model/Resource/Config.php on line 104
```

Apply commit 3, then press F5.

Dashboard is displayed.
Clear your cache and your log directory, then press F5.

**Commit 4 fix (exception.log):**
```
Exception: Deprecated functionality: strlen(): Passing null to parameter #1 ($string) of type string
  is deprecated  in app/code/core/Mage/Core/Helper/Abstract.php on line 218
```

Apply commit 4, then press F5.

Clear your cache and your log directory, then press F5.
Go to Sales / Order.

**Commit 5 fix:**
```
Deprecated functionality: strpos(): Passing null to parameter #1 ($haystack) of type string is
  deprecated in app/code/core/Mage/Core/Model/Design/Package.php on line 540
```

Apply commit 5, then press F5.

**Commit 6 fix:**
```
Deprecated functionality: strtolower(): Passing null to parameter #1 ($string) of type string
  is deprecated in app/Mage.php on line 424
```

Apply commit 6, then press F5.

**Commit 7 fix:**
```
Deprecated functionality: addcslashes(): Passing null to parameter #1 ($string) of type string
  is deprecated  in lib/Zend/Db/Adapter/Pdo/Abstract.php on line 296
```

TODO Make a PR for zf1-future.
Apply commit 7, then press F5.

**Commit 8 fix:**
```
Deprecated functionality: strtolower(): Passing null to parameter #1 ($string) of type string
  is deprecated in app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php on line 304
```

Apply commit 8, then press F5.

**Commit 9 fix:**
```
Deprecated functionality: strtolower(): Passing null to parameter #1 ($string) of type string
  is deprecated in app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php on line 209
```

Apply commit 9, then press F5.

**Commit 10 fix:**
```
Deprecated functionality: strtolower(): Passing null to parameter #1 ($string) of type string
  is deprecated in app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
  on line 110
```

Apply commit 10, then press F5.

**Commit 11 fix:**
```
Deprecated functionality: htmlspecialchars(): Passing null to parameter #1 ($string) of type string
  is deprecated in app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Abstract.php
  on line 97
```

Apply commit 11, then press F5.

Orders grid is displayed.
Click on Export to CSV button.

**Commit 12 fix:**
```
Deprecated functionality: auto_detect_line_endings is deprecated in lib/Varien/Io/File.php on line 134
```

Apply commit 12, then press F5.

Back to Sales / Order.
Filter grid and reset filter.
Sort grid.
Go to any pending order.

**Commit 13 fix:**
```
Deprecated functionality: trim(): Passing null to parameter #1 ($string) of type string is deprecated
  in app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php on line 641
```

Apply commit 13, then press F5.

**Commit 14 fix:**
```
Deprecated functionality: trim(): Passing null to parameter #1 ($string) of type string is deprecated
  in app/code/core/Mage/Eav/Model/Entity/Type.php on line 267
```

Apply commit 14, then press F5.

Order is displayed.
Click on Invoice button.

**Commit 15 fix:**
```
Deprecated functionality: urlencode(): Passing null to parameter #1 ($string) of type string is
  deprecated in lib/Zend/Locale/Data.php on line 1001
```

TODO Make a PR for zf1-future.
Apply commit 15, then press F5.

**Commit 16 fix:**
```
Deprecated functionality: preg_split(): Passing null to parameter #3 ($limit) of type int is
  deprecated in app/code/core/Mage/Core/Helper/String.php on line 190
```

Apply commit 16, then press F5.

New Invoice for Order is displayed.
Set quantity to invoice to 0 and press Update Qty button.
TODO There is an hidden error.

Click on Submit invoice button.
Click on Ship button.
Click on Submit shipment button.
Click on Credit memo button.
Set quantity to refund to 0 and press Update Qty button.
Click on Refund offline button.
Click on Credit memo button.
Click on Refund offline button.

Go to Sales / Invoice.
Click on export to CSV button.
Filter grid and reset filter.
Sort grid.
Go to any invoice.

Go to Sales / Shipment.
Click on export to CSV button.
Filter grid and reset filter.
Sort grid.
Go to any shipment.

Go to Sales / Credit memos.
Click on export to CSV button.
Filter grid and reset filter.
Sort grid.
Go to any credit memo.

Go to Sales / Order, click on Create New Order.

**Commit 17 fix:**
```
Deprecated functionality: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is
  deprecated in lib/Varien/Data/Form/Element/Abstract.php on line 217
```

Apply commit 17, then press F5.

**Commit 18 fix:**
```
Deprecated functionality: preg_match(): Passing null to parameter #2 ($subject) of type string is
  deprecated in app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Created.php on line 45
```

Apply commit 18, then press F5.

**Commit 19 fix:**
```
Deprecated functionality: explode(): Passing null to parameter #2 ($string) of type string is
  deprecated in app/code/core/Mage/Eav/Model/Attribute/Data/Multiline.php on line 138
```

Apply commit 19, then press F5.

Create new order is displayed.
Filter grid and reset filter.
Sort grid.
Select a customer and select a store view.
Add a product and select a shipping method.
Click on Submit order button.
Order is displayed.
Click on Cancel button.
Click on Reorder button.
Click on Submit order button.

Go to Sales / Terms and Conditions.
Filter grid and reset filter.
Sort grid.
Click on Add new button.

**Commit 20 fix:**
```
Deprecated functionality: explode(): Passing null to parameter #2 ($string) of type string is
  deprecated in lib/Varien/Data/Form/Element/Multiselect.php on line 80
```

Apply commit 20, then press F5.

New Terms and Conditions is displayed.
Fill the form and click on Save condition button.
Reboot your computer.

Go to Sales / Order.

**Commit 21 fix:**
```
Deprecated functionality: strpos(): Passing null to parameter #1 ($haystack) of type string is
  deprecated in lib/Varien/Object.php on line 343
```

Apply commit 21, then press F5.
Open a complete order.

**Commit 22 fix:**
```
Deprecated functionality: preg_match(): Passing null to parameter #2 ($subject) of type string
  is deprecated in app/design/adminhtml/default/default/template/widget/tabs.phtml on line 35
```

Apply commit 22, then press F5.

Go to Sales / Tax / Import Export.
Click on Export.

**Commit 23 fix:**
```
Deprecated functionality: str_replace(): Passing null to parameter #2 ($replace) of type
  array|string is deprecated in lib/Varien/Object.php on line 612
```

Apply commit 23, then press F5.
Go to Customers / Customers.
Go to any customer.

**Commit 24 fix:**
```
Deprecated functionality: strtotime(): Passing null to parameter #1 ($datetime) of type string
  is deprecated  in app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php on line 144
```

Apply commit 24, then press F5.

**Commit 25 fix:**
```
Deprecated functionality: trim(): Passing null to parameter #1 ($string) of type string
  is deprecated in app/code/core/Mage/Core/Model/Config.php on line 1368
```

Apply commit 25, then press F5.

Customer edit is displayed.
Go to dashboard.

**Commit 26 fix:**
```
Deprecated functionality: preg_match(): Passing null to parameter #2 ($subject) of type
  string is deprecated in app/design/adminhtml/default/default/template/widget/tabshoriz.phtml on line 34
```

Apply commit 26, then press F5.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list