### PR TITLE
Stop hiding errors inside broken PHP files when loaded through the autoloader

### DIFF
--- a/lib/Varien/Autoload.php
+++ b/lib/Varien/Autoload.php
@@ -62,6 +62,6 @@ class Varien_Autoload
      */
     public function autoload($class)
     {
-        return @include str_replace(' ', DIRECTORY_SEPARATOR, ucwords(str_replace('_', ' ', $class))) . '.php';
+        return include str_replace(' ', DIRECTORY_SEPARATOR, ucwords(str_replace('_', ' ', $class))) . '.php';
     }
 }


### PR DESCRIPTION
### Description (*)
A PHP class of mine had by mistake a method return type of `: true` instead of `:bool` making the PHP file unparsable.
The Magento autoloader suppresses all errors, so I could not see this error at all.
Because of this, I lost many hours trying to find the error.

I believe Magento should not suppress any errors when loading files. We definately want to know about these.

### Manual testing scenarios (*)
1. Purposefully break a PHP file that would be loaded through the autoloader. In my case I added a method return type `: true` instead of `: bool`.
2. Refresh the page. The output will be cut off and you will NOT see any errors.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
