### PR TITLE
Fix admin menu z-index when debug template paths is enabled

### DIFF
--- a/skin/adminhtml/default/default/menu.css
+++ b/skin/adminhtml/default/default/menu.css
@@ -29,8 +29,8 @@
 
 /************** ALL LEVELS  *************/ /* Style consistent throughout all nav levels */
 #nav li { position:relative; text-align:left; }
-#nav li.over { z-index:99; }
-#nav li.active { z-index:100; } /* to prevent the li separator from showing through on mouseover on li */
+#nav li.over { z-index:999; }
+#nav li.active { z-index:1000; } /* to prevent the li separator from showing through on mouseover on li */
 #nav a,
 #nav a:hover { display:block; text-decoration:none; }
 #nav span { display:block; /*cursor:pointer;*/ }

--- a/skin/adminhtml/default/openmage/menu.css
+++ b/skin/adminhtml/default/openmage/menu.css
@@ -39,7 +39,7 @@
   float: left;
 }
 #nav li.over {
-  z-index: 99;
+  z-index: 999;
 }
 #nav li.over a {
   color: #d6e2e5;
@@ -64,7 +64,7 @@
   left: 100px;
 }
 #nav li.active {
-  z-index: 100;
+  z-index: 1000;
   margin-left: -1px;
   color: #fff;
   font-weight: bold;

--- a/skin/adminhtml/default/openmage/scss/menu.scss
+++ b/skin/adminhtml/default/openmage/scss/menu.scss
@@ -28,7 +28,7 @@
     float: left;
 
     &.over {
-      z-index: 99;
+      z-index: 999;
 
       a {
         color: $color_geyser_approx;
@@ -61,7 +61,7 @@
     }
 
     &.active {
-      z-index: 100;
+      z-index: 1000;
       margin-left: -1px;
       color: $white;
       font-weight: bold;


### PR DESCRIPTION
Fixes an issue where the admin menu overlaps with template paths and block names when enabled.

### Description (*)
When "Template Path Hints" or "Add Block Names to Hints" is enabled, they overlap the menu on the top which makes it annoying and tedious to navigate. This PR will fix it by simply increasing the `z-index` for the menu to always be the top-most element. This is done for both the legacy and openmage theme.
| Before | After |
| --- | --- |
| ![Before](https://user-images.githubusercontent.com/67818913/132986065-8390e5e0-a9f6-442f-a2f0-453df1fcf402.png) | ![After](https://user-images.githubusercontent.com/67818913/132986077-f30a6030-6e1f-4ecb-b98d-b171e2b6e8b5.png) |

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#1744

### Manual testing scenarios (*)
1. Go to `System` -> `Configuration` -> `Developer` and enable ` Template Path Hints` or `Add Block Names to Hints`
2. Now try to hover over some menu items.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list