### PR TITLE
fix download custom option backend

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
@@ -733,6 +733,11 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
      */
     protected function _getOptionDownloadUrl($route, $params)
     {
+        if(!$params['_store']){
+            $websites = Mage::app()->getWebsites();
+            $code = $websites[1]->getDefaultStore()->getCode();
+            $params['_store'] = $code;
+        }
         return Mage::getUrl($route, $params);
     }
 

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
@@ -738,7 +738,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
             if (is_object($order))
                 $params['_store'] = Mage::app()->getStore($order->getStoreId())->getCode();
             else
-                $params['_store'] = Mage::app()->getDefaultWebsite()->getDefaultStore()->getCode();
+                $params['_store'] = Mage::app()->getDefaultStoreView()->getCode();
         }
         return Mage::getUrl($route, $params);
     }

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
@@ -733,10 +733,12 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
      */
     protected function _getOptionDownloadUrl($route, $params)
     {
-        if(!$params['_store']){
-            $websites = Mage::app()->getWebsites();
-            $code = $websites[1]->getDefaultStore()->getCode();
-            $params['_store'] = $code;
+        if (empty($params['_store']) && Mage::app()->getStore()->isAdmin()) {
+            $order = Mage::registry('current_order');
+            if (is_object($order))
+                $params['_store'] = Mage::app()->getStore($order->getStoreId())->getCode();
+            else
+                $params['_store'] = Mage::app()->getDefaultWebsite()->getDefaultStore()->getCode();
         }
         return Mage::getUrl($route, $params);
     }


### PR DESCRIPTION


Merge this solution:
Reference: https://stackoverflow.com/questions/17830947/custom-option-file-download-from-sales-orders-page-in-admin-not-working-in-mage

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
When this config is enabled
System -> Configuration -> General -> Web -> Add Store Code to Urls = true
downloadCustomOption link in order view is broken like:
index.php/admin/sales/download/downloadCustomOption/id//key/ 

### Manual testing scenarios (*)
1. System -> Configuration -> General -> Web -> Add Store Code to Urls = true
2. add product with custom option type file
3. make an order 
4. view order in backend and click in preview custom option file
