### PR TITLE
API fix option labels for store view

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Api.php
@@ -111,6 +111,7 @@ class Mage_Catalog_Model_Product_Attribute_Api extends Mage_Catalog_Model_Api_Re
         }
         $options = array();
         if ($attribute->usesSource()) {
+            $attribute->setStoreId($storeId);
             foreach ($attribute->getSource()->getAllOptions() as $optionId => $optionValue) {
                 if (is_array($optionValue)) {
                     $options[] = $optionValue;


### PR DESCRIPTION


### Description (*)
When loading attribute options via the API, the labels should be loaded for the correct store (in the correct language)

### Fixed Issues (if relevant)

1. Fixes OpenMage/magento-lts#1822


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
