### PR TITLE
Aggregate most viewed products report daily via a Cron job

### DIFF
--- a/app/code/core/Mage/Reports/Model/Observer.php
+++ b/app/code/core/Mage/Reports/Model/Observer.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Reports Observer
+ */
+class Mage_Reports_Model_Observer
+{
+    /**
+     * Refresh viewed report statistics for last day
+     *
+     * @param Mage_Cron_Model_Schedule $schedule
+     * @return $this
+     */
+    public function aggregateReportsReportProductViewedData($schedule)
+    {
+        Mage::app()->getLocale()->emulate(0);
+        $currentDate = Mage::app()->getLocale()->date();
+        $date = $currentDate->subHour(25);
+        Mage::getResourceModel('reports/report_product_viewed')->aggregate($date);
+        Mage::app()->getLocale()->revert();
+        return $this;
+    }
+}

--- a/app/code/core/Mage/Reports/etc/config.xml
+++ b/app/code/core/Mage/Reports/etc/config.xml
@@ -212,4 +212,16 @@
             </dashboard>
         </reports>
     </default>
+    <crontab>
+        <jobs>
+            <aggregate_reports_report_product_viewed_data>
+                <schedule>
+                    <cron_expr>0 0 * * *</cron_expr>
+                </schedule>
+                <run>
+                    <model>reports/observer::aggregateReportsReportProductViewedData</model>
+                </run>
+            </aggregate_reports_report_product_viewed_data>
+        </jobs>
+    </crontab>
 </config>


### PR DESCRIPTION
### Description (*)
This PR will add a Cron job to aggregate most viewed products report daily at midnight. I added this Cron job in the `Mage_Reports` module instead of `Mage_Catalog` because that's where the aggregator model resides, I just wanted to keep them in the same place.

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#1823

### Manual testing scenarios (*)
1. You can either wait for the Cron job to run at midnight or, you can invoke it manually with `n98-magerun`:
```sh
$ n98-magerun sys:cron:run aggregate_reports_report_product_viewed_data
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list