### PR TITLE
Add phpstan configuration file

### DIFF
--- a/.github/phpstan.neon
+++ b/.github/phpstan.neon
@@ -1,0 +1,83 @@
+includes:
+    - ../vendor/macopedia/phpstan-magento1/extension.neon
+parameters:
+    magentoRootPath: %currentWorkingDirectory%
+    paths:
+        #lets start small with just few modules
+        - %currentWorkingDirectory%/app/code/core/Mage/Admin
+#        - %currentWorkingDirectory%/app/code/core/Mage/Adminhtml
+#        - %currentWorkingDirectory%/app/code/core/Mage/AdminNotification
+#        - %currentWorkingDirectory%/app/code/core/Mage/Api
+#        - %currentWorkingDirectory%/app/code/core/Mage/Api2
+#        - %currentWorkingDirectory%/app/code/core/Mage/Authorizenet
+#        - %currentWorkingDirectory%/app/code/core/Mage/Backup
+#        - %currentWorkingDirectory%/app/code/core/Mage/Bundle
+#        - %currentWorkingDirectory%/app/code/core/Mage/Captcha
+#        - %currentWorkingDirectory%/app/code/core/Mage/Catalog
+#        - %currentWorkingDirectory%/app/code/core/Mage/CatalogIndex
+#        - %currentWorkingDirectory%/app/code/core/Mage/CatalogInventory
+#        - %currentWorkingDirectory%/app/code/core/Mage/CatalogRule
+#        - %currentWorkingDirectory%/app/code/core/Mage/CatalogSearch
+#        - %currentWorkingDirectory%/app/code/core/Mage/Centinel
+#        - %currentWorkingDirectory%/app/code/core/Mage/Checkout
+        - %currentWorkingDirectory%/app/code/core/Mage/Cms
+#        - %currentWorkingDirectory%/app/code/core/Mage/ConfigurableSwatches
+#        - %currentWorkingDirectory%/app/code/core/Mage/Contacts
+#        - %currentWorkingDirectory%/app/code/core/Mage/Core
+#        - %currentWorkingDirectory%/app/code/core/Mage/Cron
+#        - %currentWorkingDirectory%/app/code/core/Mage/CurrencySymbol
+#        - %currentWorkingDirectory%/app/code/core/Mage/Customer
+#        - %currentWorkingDirectory%/app/code/core/Mage/Dataflow
+#        - %currentWorkingDirectory%/app/code/core/Mage/Directory
+#        - %currentWorkingDirectory%/app/code/core/Mage/Downloadable
+#        - %currentWorkingDirectory%/app/code/core/Mage/Eav
+#        - %currentWorkingDirectory%/app/code/core/Mage/GiftMessage
+#        - %currentWorkingDirectory%/app/code/core/Mage/GoogleAnalytics
+#        - %currentWorkingDirectory%/app/code/core/Mage/GoogleCheckout
+#        - %currentWorkingDirectory%/app/code/core/Mage/ImportExport
+#        - %currentWorkingDirectory%/app/code/core/Mage/Index
+#        - %currentWorkingDirectory%/app/code/core/Mage/Install
+        - %currentWorkingDirectory%/app/code/core/Mage/Log
+#        - %currentWorkingDirectory%/app/code/core/Mage/Media
+#        - %currentWorkingDirectory%/app/code/core/Mage/Newsletter
+#        - %currentWorkingDirectory%/app/code/core/Mage/Oauth
+#        - %currentWorkingDirectory%/app/code/core/Mage/Page
+#        - %currentWorkingDirectory%/app/code/core/Mage/PageCache
+#        - %currentWorkingDirectory%/app/code/core/Mage/Paygate
+#        - %currentWorkingDirectory%/app/code/core/Mage/Payment
+#        - %currentWorkingDirectory%/app/code/core/Mage/Paypal
+#        - %currentWorkingDirectory%/app/code/core/Mage/PaypalUk
+#        - %currentWorkingDirectory%/app/code/core/Mage/Persistent
+#        - %currentWorkingDirectory%/app/code/core/Mage/Poll
+#        - %currentWorkingDirectory%/app/code/core/Mage/ProductAlert
+#        - %currentWorkingDirectory%/app/code/core/Mage/Rating
+#        - %currentWorkingDirectory%/app/code/core/Mage/Reports
+#        - %currentWorkingDirectory%/app/code/core/Mage/Review
+#        - %currentWorkingDirectory%/app/code/core/Mage/Rss
+#        - %currentWorkingDirectory%/app/code/core/Mage/Rule
+#        - %currentWorkingDirectory%/app/code/core/Mage/Sales
+#        - %currentWorkingDirectory%/app/code/core/Mage/SalesRule
+#        - %currentWorkingDirectory%/app/code/core/Mage/Sendfriend
+#        - %currentWorkingDirectory%/app/code/core/Mage/Shipping
+#        - %currentWorkingDirectory%/app/code/core/Mage/Sitemap
+#        - %currentWorkingDirectory%/app/code/core/Mage/Tag
+#        - %currentWorkingDirectory%/app/code/core/Mage/Tax
+#        - %currentWorkingDirectory%/app/code/core/Mage/Uploader
+#        - %currentWorkingDirectory%/app/code/core/Mage/Usa
+#        - %currentWorkingDirectory%/app/code/core/Mage/Weee
+#        - %currentWorkingDirectory%/app/code/core/Mage/Widget
+#        - %currentWorkingDirectory%/app/code/core/Mage/Wishlist
+    excludePaths:
+        #incompatible interfaces
+        - */app/code/core/Mage/Admin/Model/Acl/Assert/Ip.php
+        - */app/code/core/Mage/Admin/Model/Acl/Assert/Time.php
+
+        - */app/code/core/Mage/Admin/Model/Config.php
+        - */app/code/core/Mage/Admin/Model/Roles.php
+        - */app/code/core/Mage/Admin/Model/User.php
+        # due to errors (variable passed to a factory):
+        - */app/code/core/Mage/Cms/Helper/Page.php
+        - */app/code/core/Mage/Cms/Helper/Data.php
+    level: 0
+#    universalObjectCratesClasses:
+#        - Varien_Object

--- a/app/code/core/Mage/Admin/Model/Observer.php
+++ b/app/code/core/Mage/Admin/Model/Observer.php
@@ -39,7 +39,7 @@ class Mage_Admin_Model_Observer
      * Handler for controller_action_predispatch event
      *
      * @param Varien_Event_Observer $observer
-     * @return boolean
+     * @return void
      */
     public function actionPreDispatchAdmin($observer)
     {
@@ -106,7 +106,7 @@ class Mage_Admin_Model_Observer
                             ->setActionName('login')
                             ->setDispatched(false);
                     }
-                    return false;
+                    return;
                 }
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,11 @@
       "email": "github-sr@hotmail.com",
       "role": "Maintainer"
     }
-  ]
+  ],
+  "require-dev": {
+    "macopedia/phpstan-magento1": "^1.0"
+  },
+  "extra": {
+    "magento-root-dir": "."
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,5 @@
   ],
   "require-dev": {
     "macopedia/phpstan-magento1": "^1.0"
-  },
-  "extra": {
-    "magento-root-dir": "."
   }
 }


### PR DESCRIPTION
This PR provides basic configuration file to run phpstan on openMage code base.
Right now it just whitelists few core modules to show that it's working.
allowing more modules requires validation and probably some fixes, so should be tackled in separate PR's.

TODO:
Help is needed in providing a github action which will run phpstan on every PR.


<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Provides basic configuration for running phpstan


### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

Fixes: 
1. Fixes https://github.com/OpenMage/magento-lts/issues/365

### Manual testing scenarios (*)

1. pull
2. composer install
3. run  `vendor/bin/phpstan analyze -c .github/phpstan.neon`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->