### PR TITLE
Fix getting default `min_sale_qty` when trying to mass-update product attributes

### DIFF
--- a/app/design/adminhtml/default/default/template/catalog/product/edit/action/inventory.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/action/inventory.phtml
@@ -85,7 +85,7 @@ function toggleValueElementsWithCheckbox(checkbox) {
             </tr>
             <tr>
                 <td class="label"><label for="inventory_min_sale_qty"><?php echo Mage::helper('catalog')->__('Minimum Qty Allowed in Shopping Cart') ?></label></td>
-                <td class="value"><input type="text" class="input-text validate-number" id="inventory_min_sale_qty" name="<?php echo $this->getFieldSuffix() ?>[min_sale_qty]" value="<?php echo $this->getDefaultConfigValue('min_sale_qty')*1 ?>" disabled="disabled" />
+                <td class="value"><input type="text" class="input-text validate-number" id="inventory_min_sale_qty" name="<?php echo $this->getFieldSuffix() ?>[min_sale_qty]" value="<?php echo Mage::helper('catalog/product')->getDefaultProductValue('min_sale_qty', null) ?>" disabled="disabled" />
                     <input type="checkbox" id="inventory_use_config_min_sale_qty" name="<?php echo $this->getFieldSuffix() ?>[use_config_min_sale_qty]" value="1" onclick="toggleValueElements(this, this.parentNode, $('inventory_min_sale_qty_checkbox'));" checked="checked" disabled="disabled" />
                     <label for="inventory_use_config_min_sale_qty" class="normal"><?php echo Mage::helper('catalog')->__('Use Config Settings') ?></label>
                     <input type="checkbox" id="inventory_min_sale_qty_checkbox" onclick="toggleValueElementsWithCheckbox(this)" />

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/action/inventory.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/action/inventory.phtml
@@ -85,7 +85,7 @@ function toggleValueElementsWithCheckbox(checkbox) {
             </tr>
             <tr>
                 <td class="label"><label for="inventory_min_sale_qty"><?php echo Mage::helper('catalog')->__('Minimum Qty Allowed in Shopping Cart') ?></label></td>
-                <td class="value"><input type="text" class="input-text validate-number" id="inventory_min_sale_qty" name="<?php echo $this->getFieldSuffix() ?>[min_sale_qty]" value="<?php echo Mage::helper('catalog/product')->getDefaultProductValue('min_sale_qty', null) ?>" disabled="disabled" />
+                <td class="value"><input type="text" class="input-text validate-number" id="inventory_min_sale_qty" name="<?php echo $this->getFieldSuffix() ?>[min_sale_qty]" value="<?php echo Mage_Catalog_Helper_Product::DEFAULT_QTY ?>" disabled="disabled" />
                     <input type="checkbox" id="inventory_use_config_min_sale_qty" name="<?php echo $this->getFieldSuffix() ?>[use_config_min_sale_qty]" value="1" onclick="toggleValueElements(this, this.parentNode, $('inventory_min_sale_qty_checkbox'));" checked="checked" disabled="disabled" />
                     <label for="inventory_use_config_min_sale_qty" class="normal"><?php echo Mage::helper('catalog')->__('Use Config Settings') ?></label>
                     <input type="checkbox" id="inventory_min_sale_qty_checkbox" onclick="toggleValueElementsWithCheckbox(this)" />


### PR DESCRIPTION
When trying to mass-update multiple products' attributes from the grid, the inventory `min_sale_qty` was getting retrieved from the config and converted to a number. Because the config setting allows setting a qty per customer group, the `min_sale_qty` value is stored as a serialized object and the conversion throws a warning which was [introduced in PHP 7.1](https://www.php.net/manual/en/migration71.other-changes.php)

### Description (*)
Instead of getting the `min_sale_qty` from the inventory config, get it from `global/fieldsets` to match [what's happening in the product edit page](https://github.com/openmage/magento-lts/blob/1.9.4.x/app/design/adminhtml/default/default/template/catalog/product/tab/inventory.phtml#L80). In this case since we don't have a specific product type, passing `null` ends up returning the `DEFAULT_QTY` constant which is 1.

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#1849

### Manual testing scenarios (*)
See linked issue.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list