### PR TITLE
Fix Core Bug: To make "01/01/1970" a valid birthday

### DIFF
--- a/app/code/core/Mage/Customer/Block/Widget/Dob.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Dob.php
@@ -77,7 +77,7 @@ class Mage_Customer_Block_Widget_Dob extends Mage_Customer_Block_Widget_Abstract
      */
     public function getDay()
     {
-        return $this->getTime() ? date('d', $this->getTime()) : '';
+        return ($this->getTime() !== null) ? date('d', $this->getTime()) : '';
     }
 
     /**
@@ -85,7 +85,7 @@ class Mage_Customer_Block_Widget_Dob extends Mage_Customer_Block_Widget_Abstract
      */
     public function getMonth()
     {
-        return $this->getTime() ? date('m', $this->getTime()) : '';
+        return ($this->getTime() !== null) ? date('m', $this->getTime()) : '';
     }
 
     /**
@@ -93,7 +93,7 @@ class Mage_Customer_Block_Widget_Dob extends Mage_Customer_Block_Widget_Abstract
      */
     public function getYear()
     {
-        return $this->getTime() ? date('Y', $this->getTime()) : '';
+        return ($this->getTime() !== null) ? date('Y', $this->getTime()) : '';
     }
 
     /**

--- a/app/code/core/Mage/Customer/Block/Widget/Dob.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Dob.php
@@ -62,38 +62,54 @@ class Mage_Customer_Block_Widget_Dob extends Mage_Customer_Block_Widget_Abstract
     }
 
     /**
-     * @param string $date
+     * @param $date
      * @return $this
      */
     public function setDate($date)
     {
-        $this->setTime($date ? strtotime($date) : false);
+        if ($date) {
+            try {
+                $dateTime = new DateTime($date);
+                $this->setTime($dateTime);
+            } catch (Exception $e) {
+            }
+        }
+
         $this->setData('date', $date);
+
         return $this;
     }
 
     /**
-     * @return false|string
+     * @return bool
+     */
+    public function hasTime()
+    {
+        return ($this->getTime() instanceof DateTime);
+    }
+
+    /**
+     * @return string
      */
     public function getDay()
     {
-        return ($this->getTime() !== null) ? date('d', $this->getTime()) : '';
+        return ($this->hasTime()) ? $this->getTime()->format('d') : '';
     }
 
     /**
-     * @return false|string
+     * @return string
      */
     public function getMonth()
     {
-        return ($this->getTime() !== null) ? date('m', $this->getTime()) : '';
+        return ($this->hasTime()) ? $this->getTime()->format('m') : '';
     }
 
     /**
-     * @return false|string
+     * @return string
      */
     public function getYear()
     {
-        return ($this->getTime() !== null) ? date('Y', $this->getTime()) : '';
+        return ($this->hasTime()) ? $this->getTime()->format('o') : '';
     }
 
     /**

--- a/app/code/core/Mage/Customer/Block/Widget/Dob.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Dob.php
@@ -62,7 +62,7 @@ class Mage_Customer_Block_Widget_Dob extends Mage_Customer_Block_Widget_Abstract
     }
 
     /**
-     * @param $date
+     * @param string $date
      * @return $this
      */
     public function setDate($date)

--- a/app/code/core/Mage/Customer/Block/Widget/Dob.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Dob.php
@@ -25,7 +25,7 @@
  */
 
 /**
- * @method string getTime()
+ * @method DateTime getTime()
  * @method $this setTime(string $value)
  */
 class Mage_Customer_Block_Widget_Dob extends Mage_Customer_Block_Widget_Abstract


### PR DESCRIPTION
When parsing "01/01/1970" as date to setDate() the output is '0'.
Because default value of strtoftime() is "01/01/1970".
```
    public function setDate($date)
    {
        $this->setTime($date ? strtotime($date) : false);
        $this->setData('date', $date);
        return $this;
    }
```

### Description (*)
According to this bug means that Magento 1.X.X never allowed a birthday of "01/01/1970".
A simple null check in the getter will prevent it.

### Manual testing scenarios (*)

1. https://www.tehplayground.com/auf4jhP1T5thJDtK
2. Text form:
```
<?php
// example code

//setDate() simulation
$customerBirthday = '01/01/1970';
$isDate             = $customerBirthday ? strtotime($customerBirthday) : false;

//getDate() simulation
$isDate ? print('Yeaj 01/01/1970 is valid') : print('but it´s not...');

//fix
($isDate !== null) ? print('Yeaj 01/01/1970 is valid') : print('but it´s not...');

?>
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [Having Issues] Add yourself to contributors list
