### PR TITLE
make fulltext search separator (OR/AND) configurable from backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Most important changes will be listed here, all other changes since `19.4.0` can
 - `admin/design/use_legacy_theme`
 - `admin/emails/admin_notification_email_template`
 - `catalog/product_image/progressive_threshold`
+- `catalog/search/search_separator`
 
 ### New Events
 - `adminhtml_block_widget_form_init_form_values_after`

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Search/Separator.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Search/Separator.php
@@ -1,0 +1,24 @@
+<?php
+
+class Mage_Adminhtml_Model_System_Config_Backend_Catalog_Search_Separator extends Mage_Core_Model_Config_Data
+{
+    /**
+     * After change Catalog Search Type process
+     *
+     * @return $this
+     */
+    protected function _afterSave()
+    {
+        $newValue = $this->getValue();
+        $oldValue = Mage::getConfig()->getNode(
+            Mage_CatalogSearch_Model_Fulltext::XML_PATH_CATALOG_SEARCH_SEPARATOR,
+            $this->getScope(),
+            $this->getScopeId()
+        );
+        if ($newValue != $oldValue) {
+            Mage::getSingleton('catalogsearch/fulltext')->resetSearchResults();
+        }
+
+        return $this;
+    }
+}

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Separator.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Separator.php
@@ -2,6 +2,9 @@
 
 class Mage_Adminhtml_Model_System_Config_Source_Catalog_Search_Separator
 {
+    /**
+     * @return array
+     */
     public function toOptionArray()
     {
         $types = [

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Separator.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Separator.php
@@ -1,0 +1,20 @@
+<?php
+
+class Mage_Adminhtml_Model_System_Config_Source_Catalog_Search_Separator
+{
+    public function toOptionArray()
+    {
+        $types = [
+            ' OR ' => 'OR (default)',
+            ' AND ' => 'AND'
+        ];
+        $options = [];
+        foreach ($types as $k => $v) {
+            $options[] = [
+                'value' => $k,
+                'label' => $v
+            ];
+        }
+        return $options;
+    }
+}

--- a/app/code/core/Mage/Catalog/Block/Product/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Abstract.php
@@ -383,15 +383,12 @@ abstract class Mage_Catalog_Block_Product_Abstract extends Mage_Core_Block_Templ
             ->callParentToHtml();
     }
 
-    /*
+    /**
      * Calls the object's to Html method.
      * This method exists to make the code more testable.
      * By having a protected wrapper for the final method toHtml, we can 'mock' out this method
      * when unit testing
      *
-     *  @return string
-     */
-    /**
      * @return string
      */
     protected function callParentToHtml()

--- a/app/code/core/Mage/CatalogSearch/Model/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Fulltext.php
@@ -48,6 +48,7 @@ class Mage_CatalogSearch_Model_Fulltext extends Mage_Core_Model_Abstract
     const SEARCH_TYPE_FULLTEXT          = 2;
     const SEARCH_TYPE_COMBINE           = 3;
     const XML_PATH_CATALOG_SEARCH_TYPE  = 'catalog/search/search_type';
+    const XML_PATH_CATALOG_SEARCH_SEPARATOR  = 'catalog/search/search_separator';
 
     /**
      * Whether table changes are allowed

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
@@ -355,7 +355,8 @@ class Mage_CatalogSearch_Model_Resource_Fulltext extends Mage_Core_Model_Resourc
             }
 
             if ($like) {
-                $likeCond = '(' . implode(' OR ', $like) . ')';
+                $separator = Mage::getStoreConfig(Mage_CatalogSearch_Model_Fulltext::XML_PATH_CATALOG_SEARCH_SEPARATOR);
+                $likeCond = '(' . implode($separator, $like) . ')';
             }
         }
 

--- a/app/code/core/Mage/CatalogSearch/etc/config.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/config.xml
@@ -137,6 +137,7 @@
                 <max_query_length>128</max_query_length>
                 <max_query_words>10</max_query_words>
                 <search_type>1</search_type>
+                <search_separator> OR </search_separator>
                 <use_layered_navigation_count>2000</use_layered_navigation_count>
                 <show_autocomplete_results_count>1</show_autocomplete_results_count>
             </search>

--- a/app/code/core/Mage/CatalogSearch/etc/system.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/system.xml
@@ -98,6 +98,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </search_type>
+                        <search_separator translate="label">
+                            <label>Fulltext Separator</label>
+                            <frontend_type>select</frontend_type>
+                            <backend_model>adminhtml/system_config_backend_catalog_search_separator</backend_model>
+                            <source_model>adminhtml/system_config_source_catalog_search_separator</source_model>
+                            <sort_order>22</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </search_separator>
                         <use_layered_navigation_count translate="label comment">
                             <label>Apply Layered Navigation if Search Results are Less Than</label>
                             <frontend_type>text</frontend_type>


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

https://magento.stackexchange.com/a/84312/46249

> The biggest inexplicably nonsensical move by Magento is to use "OR" search instead of "AND". If you search "red cars" you will get everything red (including cars, dogs, forks, mountainsides, etc), and every kind of car (including red, blue, green, yellow, etc). With "AND", you get only items that contain "red" AND "car", which is how search should work!

Just added a config option to change from OR to AND.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->