### PR TITLE
Add "Times used" indicator field to promo rule quote grid

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Grid.php
@@ -115,8 +115,8 @@ class Mage_Adminhtml_Block_Promo_Quote_Grid extends Mage_Adminhtml_Block_Widget_
             'index'     => 'is_active',
             'type'      => 'options',
             'options'   => array(
-                1 => 'Active',
-                0 => 'Inactive',
+                1 => Mage::helper('salesrule')->__('Active'),
+                0 => Mage::helper('salesrule')->__('Inactive'),
             ),
         ));
 

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Grid.php
@@ -58,6 +58,7 @@ class Mage_Adminhtml_Block_Promo_Quote_Grid extends Mage_Adminhtml_Block_Widget_
         $collection = Mage::getModel('salesrule/rule')
             ->getResourceCollection();
         $collection->addWebsitesToResult();
+        $collection->addFilterToMap('times_used', 'main_table.times_used');
         $this->setCollection($collection);
 
         parent::_prepareCollection();

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Grid.php
@@ -120,6 +120,13 @@ class Mage_Adminhtml_Block_Promo_Quote_Grid extends Mage_Adminhtml_Block_Widget_
             ),
         ));
 
+        $this->addColumn('times_used', array(
+            'header'    => Mage::helper('salesrule')->__('Times used'),
+            'align'     => 'left',
+            'index'     => 'times_used',
+            'type'      => 'number',
+        ));
+
         if (!Mage::app()->isSingleStoreMode()) {
             $this->addColumn('rule_website', array(
                 'header'    => Mage::helper('salesrule')->__('Website'),
@@ -154,5 +161,4 @@ class Mage_Adminhtml_Block_Promo_Quote_Grid extends Mage_Adminhtml_Block_Widget_
     {
         return $this->getUrl('*/*/edit', array('id' => $row->getRuleId()));
     }
-
 }

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser.php
@@ -161,8 +161,8 @@ class Mage_Adminhtml_Block_Promo_Widget_Chooser extends Mage_Adminhtml_Block_Wid
             'index'     => 'is_active',
             'type'      => 'options',
             'options'   => array(
-                1 => 'Active',
-                0 => 'Inactive',
+                1 => Mage::helper('salesrule')->__('Active'),
+                0 => Mage::helper('salesrule')->__('Inactive'),
             ),
         ));
 

--- a/app/code/core/Mage/SalesRule/Model/Observer.php
+++ b/app/code/core/Mage/SalesRule/Model/Observer.php
@@ -153,6 +153,14 @@ class Mage_SalesRule_Model_Observer
                     $coupon->setTimesUsed($coupon->getTimesUsed() - 1);
                     $coupon->save();
 
+                    // Decrement times_used on rule
+                    $rule = Mage::getModel('salesrule/rule');
+                    $rule->load($coupon->getRuleId());
+                    if ($rule->getId()) {
+                        $rule->setTimesUsed($rule->getTimesUsed() - 1);
+                        $rule->save();
+                    }
+                    
                     if ($customerId = $order->getCustomerId()) {
                         // Decrement coupon_usage times_used
                         Mage::getResourceModel('salesrule/coupon_usage')->updateCustomerCouponTimesUsed($customerId, $coupon->getId(), true);


### PR DESCRIPTION
### Description (*)
When I use a single coupon code without the generator, there is no indicator to check how many times the coupon has been used. 
And when i cancel an order the "times_used" field from the "salesrule" table was not decremented. 
This PR will show the "times_used" field in the promo rule quote grid and fixes the decrementing while cancel an order.

### Manual testing scenarios (*)
1. Goto Backend > Promotions > Shopping Cart Price Rules > Add New Rule
2. Create the new Rule with the "Specific Coupon"-Option and set the Coupon Code manually (without the generator)
3. Trigger the Rule
4. Goto Backend > Promotions > Shopping Cart Price Rules and check the "Times used" field.

### Contribution checklist 
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list