### PR TITLE
Made sitemap more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Most important changes will be listed here, all other changes since `19.4.0` can
 
 - bug fixes and PHP 7.x and 8.0 compatibility
 - added config cache for system.xml #1916
-- more flexible sitemap generation #1854
 
 ### Between OpenMage 19.x and 20.x
 
@@ -104,6 +103,9 @@ For full list of changes, you can [compare tags](https://github.com/OpenMage/mag
 - `catalog/search/search_separator`
 - `dev/log/max_level`
 - `newsletter/security/enable_form_key`
+- `sitemap/category/lastmod`
+- `sitemap/page/lastmod`
+- `sitemap/product/lastmod`
 
 ### New Events
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Most important changes will be listed here, all other changes since `19.4.0` can
 
 - bug fixes and PHP 7.x and 8.0 compatibility
 - added config cache for system.xml #1916
+- more flexible sitemap generation #1854
 
 ### Between OpenMage 19.x and 20.x
 

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Frequency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Frequency.php
@@ -27,16 +27,20 @@
 
 class Mage_Adminhtml_Model_System_Config_Source_Frequency
 {
+    /**
+     * @return array[]
+     */
     public function toOptionArray()
     {
-        return array(
-            array('value'=>'always', 'label'=>Mage::helper('sitemap')->__('Always')),
-            array('value'=>'hourly', 'label'=>Mage::helper('sitemap')->__('Hourly')),
-            array('value'=>'daily', 'label'=>Mage::helper('sitemap')->__('Daily')),
-            array('value'=>'weekly', 'label'=>Mage::helper('sitemap')->__('Weekly')),
-            array('value'=>'monthly', 'label'=>Mage::helper('sitemap')->__('Monthly')),
-            array('value'=>'yearly', 'label'=>Mage::helper('sitemap')->__('Yearly')),
-            array('value'=>'never', 'label'=>Mage::helper('sitemap')->__('Never')),
-        );
+        return [
+            ['value' => '', 'label' => Mage::helper('sitemap')->__('Do not show in sitemap')],
+            ['value' => 'always', 'label' => Mage::helper('sitemap')->__('Always')],
+            ['value' => 'hourly', 'label' => Mage::helper('sitemap')->__('Hourly')],
+            ['value' => 'daily', 'label' => Mage::helper('sitemap')->__('Daily')],
+            ['value' => 'weekly', 'label' => Mage::helper('sitemap')->__('Weekly')],
+            ['value' => 'monthly', 'label' => Mage::helper('sitemap')->__('Monthly')],
+            ['value' => 'yearly', 'label' => Mage::helper('sitemap')->__('Yearly')],
+            ['value' => 'never', 'label' => Mage::helper('sitemap')->__('Never')],
+        ];
     }
 }

--- a/app/code/core/Mage/Sitemap/Model/Sitemap.php
+++ b/app/code/core/Mage/Sitemap/Model/Sitemap.php
@@ -66,6 +66,7 @@ class Mage_Sitemap_Model_Sitemap extends Mage_Core_Model_Abstract
 
     /**
      * @inheritDoc
+     * @throws Mage_Core_Exception
      */
     protected function _beforeSave()
     {
@@ -131,12 +132,13 @@ class Mage_Sitemap_Model_Sitemap extends Mage_Core_Model_Abstract
      * Generate XML file
      *
      * @return $this
+     * @throws Throwable
      */
     public function generateXml()
     {
         $io = new Varien_Io_File();
         $io->setAllowCreateFolders(true);
-        $io->open(array('path' => $this->getPath()));
+        $io->open(['path' => $this->getPath()]);
 
         if ($io->fileExists($this->getSitemapFilename()) && !$io->isWriteable($this->getSitemapFilename())) {
             Mage::throwException(Mage::helper('sitemap')->__('File "%s" cannot be saved. Please, make sure the directory "%s" is writeable by web server.', $this->getSitemapFilename(), $this->getPath()));
@@ -156,21 +158,16 @@ class Mage_Sitemap_Model_Sitemap extends Mage_Core_Model_Abstract
          */
         $changefreq = (string)Mage::getStoreConfig('sitemap/category/changefreq', $storeId);
         $priority   = (string)Mage::getStoreConfig('sitemap/category/priority', $storeId);
+        $lastmod    = Mage::getStoreConfigFlag('sitemap/category/lastmod', $storeId) ? $date : '';
         $collection = Mage::getResourceModel('sitemap/catalog_category')->getCollection($storeId);
         $categories = new Varien_Object();
         $categories->setItems($collection);
-        Mage::dispatchEvent('sitemap_categories_generating_before', array(
+        Mage::dispatchEvent('sitemap_categories_generating_before', [
             'collection' => $categories,
             'store_id' => $storeId
-        ));
+        ]);
         foreach ($categories->getItems() as $item) {
-            $xml = sprintf(
-                '<url><loc>%s</loc><lastmod>%s</lastmod><changefreq>%s</changefreq><priority>%.1f</priority></url>',
-                htmlspecialchars($baseUrl . $item->getUrl()),
-                $date,
-                $changefreq,
-                $priority
-            );
+            $xml = $this->getSitemapRow($baseUrl . $item->getUrl(), $lastmod, $changefreq, $priority);
             $io->streamWrite($xml);
         }
         unset($collection);
@@ -180,21 +177,16 @@ class Mage_Sitemap_Model_Sitemap extends Mage_Core_Model_Abstract
          */
         $changefreq = (string)Mage::getStoreConfig('sitemap/product/changefreq', $storeId);
         $priority   = (string)Mage::getStoreConfig('sitemap/product/priority', $storeId);
+        $lastmod    = Mage::getStoreConfigFlag('sitemap/product/lastmod', $storeId) ? $date : '';
         $collection = Mage::getResourceModel('sitemap/catalog_product')->getCollection($storeId);
         $products = new Varien_Object();
         $products->setItems($collection);
-        Mage::dispatchEvent('sitemap_products_generating_before', array(
+        Mage::dispatchEvent('sitemap_products_generating_before', [
             'collection' => $products,
             'store_id' => $storeId
-        ));
+        ]);
         foreach ($products->getItems() as $item) {
-            $xml = sprintf(
-                '<url><loc>%s</loc><lastmod>%s</lastmod><changefreq>%s</changefreq><priority>%.1f</priority></url>',
-                htmlspecialchars($baseUrl . $item->getUrl()),
-                $date,
-                $changefreq,
-                $priority
-            );
+            $xml = $this->getSitemapRow($baseUrl . $item->getUrl(), $lastmod, $changefreq, $priority);
             $io->streamWrite($xml);
         }
         unset($collection);
@@ -205,35 +197,31 @@ class Mage_Sitemap_Model_Sitemap extends Mage_Core_Model_Abstract
         $homepage = (string)Mage::getStoreConfig('web/default/cms_home_page', $storeId);
         $changefreq = (string)Mage::getStoreConfig('sitemap/page/changefreq', $storeId);
         $priority   = (string)Mage::getStoreConfig('sitemap/page/priority', $storeId);
+        $lastmod    = Mage::getStoreConfigFlag('sitemap/page/lastmod', $storeId) ? $date : '';
         $collection = Mage::getResourceModel('sitemap/cms_page')->getCollection($storeId);
         $pages = new Varien_Object();
         $pages->setItems($collection);
-        Mage::dispatchEvent('sitemap_cms_pages_generating_before', array(
+        Mage::dispatchEvent('sitemap_cms_pages_generating_before', [
             'collection' => $pages,
             'store_id' => $storeId
-        ));
+        ]);
         foreach ($pages->getItems() as $item) {
             $url = $item->getUrl();
             if ($url == $homepage) {
                 $url = '';
             }
-            $xml = sprintf(
-                '<url><loc>%s</loc><lastmod>%s</lastmod><changefreq>%s</changefreq><priority>%.1f</priority></url>',
-                htmlspecialchars($baseUrl . $url),
-                $date,
-                $changefreq,
-                $priority
-            );
+
+            $xml = $this->getSitemapRow($baseUrl . $url, $lastmod, $changefreq, $priority);
             $io->streamWrite($xml);
         }
         unset($collection);
 
-        Mage::dispatchEvent('sitemap_urlset_generating_before', array(
+        Mage::dispatchEvent('sitemap_urlset_generating_before', [
             'file'      => $io ,
             'base_url'  => $baseUrl ,
             'date'      => $date,
             'store_id'  => $storeId
-        ));
+        ]);
 
         $io->streamWrite('</urlset>');
         $io->streamClose();
@@ -242,5 +230,30 @@ class Mage_Sitemap_Model_Sitemap extends Mage_Core_Model_Abstract
         $this->save();
 
         return $this;
+    }
+
+    /**
+     * Get sitemap row
+     *
+     * @param string $url
+     * @param null|string $lastmod
+     * @param null|string $changefreq
+     * @param null|string $priority
+     * @return string
+     */
+    protected function getSitemapRow(string $url, $lastmod = null, $changefreq = null, $priority = null): string
+    {
+        $row = '<loc>' . htmlspecialchars($url) . '</loc>';
+        if ($lastmod) {
+            $row .= '<lastmod>' . $lastmod . '</lastmod>';
+        }
+        if ($changefreq) {
+            $row .= '<changefreq>' . $changefreq . '</changefreq>';
+        }
+        if ($priority) {
+            $row .= sprintf('<priority>%.1f</priority>', $priority);
+        }
+
+        return '<url>' . $row . '</url>';
     }
 }

--- a/app/code/core/Mage/Sitemap/etc/config.xml
+++ b/app/code/core/Mage/Sitemap/etc/config.xml
@@ -80,14 +80,17 @@
             <page>
                 <priority>0.25</priority>
                 <changefreq>daily</changefreq>
+                <lastmod>1</lastmod>
             </page>
             <category>
                 <priority>0.5</priority>
                 <changefreq>daily</changefreq>
+                <lastmod>1</lastmod>
             </category>
             <product>
                 <priority>1</priority>
                 <changefreq>daily</changefreq>
+                <lastmod>1</lastmod>
             </product>
             <generate>
                 <enabled>0</enabled>

--- a/app/code/core/Mage/Sitemap/etc/system.xml
+++ b/app/code/core/Mage/Sitemap/etc/system.xml
@@ -60,6 +60,15 @@
                             <show_in_store>1</show_in_store>
                             <comment>Valid values range: from 0.0 to 1.0.</comment>
                         </priority>
+                        <lastmod translate="label">
+                            <label>Show lastmod</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>3</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </lastmod>
                     </fields>
                 </category>
                 <product translate="label">
@@ -87,6 +96,15 @@
                             <show_in_store>1</show_in_store>
                             <comment>Valid values range: from 0.0 to 1.0.</comment>
                         </priority>
+                        <lastmod translate="label">
+                            <label>Show lastmod</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>3</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </lastmod>
                     </fields>
                 </product>
                 <page translate="label">
@@ -114,6 +132,15 @@
                             <show_in_store>1</show_in_store>
                             <comment>Valid values range: from 0.0 to 1.0.</comment>
                         </priority>
+                        <lastmod translate="label">
+                            <label>Show lastmod</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>3</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </lastmod>
                     </fields>
                 </page>
                 <generate translate="label">

--- a/app/locale/en_US/Mage_Sitemap.csv
+++ b/app/locale/en_US/Mage_Sitemap.csv
@@ -4,6 +4,7 @@
 "CMS Pages Options","CMS Pages Options"
 "Categories Options","Categories Options"
 "Daily","Daily"
+"Do not show in sitemap","Do not show in sitemap"
 "Edit Sitemap","Edit Sitemap"
 "Enabled","Enabled"
 "Error Email Recipient","Error Email Recipient"

--- a/app/locale/en_US/Mage_Sitemap.csv
+++ b/app/locale/en_US/Mage_Sitemap.csv
@@ -31,6 +31,7 @@
 "Please use only letters (a-z or A-Z), numbers (0-9) or underscore (_) in the filename. No spaces or other characters are allowed.","Please use only letters (a-z or A-Z), numbers (0-9) or underscore (_) in the filename. No spaces or other characters are allowed."
 "Priority","Priority"
 "Products Options","Products Options"
+"Show lastmod","Show lastmod"
 "Sitemap","Sitemap"
 "Sitemap generate Warnings","Sitemap generate Warnings"
 "Start Time","Start Time"


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

https://www.sitemaps.org/protocol.html

For sitemaps `lastmod`, `changefreq` and `priority` are optional,  but actually its not possible to remove these nodes from generated xml.

Code for `getSitemapRow()` is a simplified M2 backport.

changed behavior: if you set changefreq or priority to zero, the xml node is removed.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->