### PR TITLE
Grid page size: replaced similar lines to foreach

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -1725,4 +1725,10 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
         $res = parent::getRowUrl($item);
         return ($res ? $res : '#');
     }
+
+    public function getLimitOptions(): array
+    {
+        return [20, 30, 50, 100, 200];
+    }
+
 }

--- a/app/design/adminhtml/default/default/template/widget/grid.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid.phtml
@@ -79,11 +79,10 @@ $numColumns = sizeof($this->getColumns());
             <span class="separator">|</span>
             <?php echo $this->__('View') ?>
             <select name="<?php echo $this->getVarNameLimit() ?>" onchange="<?php echo $this->getJsObjectName() ?>.loadByElement(this)">
-                <option value="20"<?php if($this->getCollection()->getPageSize()==20): ?> selected="selected"<?php endif ?>>20</option>
-                <option value="30"<?php if($this->getCollection()->getPageSize()==30): ?> selected="selected"<?php endif ?>>30</option>
-                <option value="50"<?php if($this->getCollection()->getPageSize()==50): ?> selected="selected"<?php endif ?>>50</option>
-                <option value="100"<?php if($this->getCollection()->getPageSize()==100): ?> selected="selected"<?php endif ?>>100</option>
-                <option value="200"<?php if($this->getCollection()->getPageSize()==200): ?> selected="selected"<?php endif ?>>200</option>
+                <?php $pageSizes = [20, 30, 50, 100, 200, 300, 500, 700, 1000]; ?>
+                <?php foreach ($pageSizes as $pageSize): ?>
+                    <option value="<?php echo $pageSize; ?>"<?php if($this->getCollection()->getPageSize() == $pageSize): ?> selected="selected"<?php endif; ?>><?php echo $pageSize; ?></option>
+                <?php endforeach; ?>
             </select>
             <?php echo $this->__('per page') ?><span class="separator">|</span>
             <?php echo $this->__('Total %d records found', $this->getCollection()->getSize()) ?>

--- a/app/design/adminhtml/default/default/template/widget/grid.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid.phtml
@@ -27,6 +27,7 @@
 <?php
 /**
  * Template for Mage_Adminhtml_Block_Widget_Grid
+ * @var Mage_Adminhtml_Block_Widget_Grid $this
  *
  *  getId()
  *  getCollection()
@@ -79,10 +80,9 @@ $numColumns = sizeof($this->getColumns());
             <span class="separator">|</span>
             <?php echo $this->__('View') ?>
             <select name="<?php echo $this->getVarNameLimit() ?>" onchange="<?php echo $this->getJsObjectName() ?>.loadByElement(this)">
-                <?php $pageSizes = [20, 30, 50, 100, 200, 300, 500, 700, 1000]; ?>
-                <?php foreach ($pageSizes as $pageSize): ?>
-                    <option value="<?php echo $pageSize; ?>"<?php if($this->getCollection()->getPageSize() == $pageSize): ?> selected="selected"<?php endif; ?>><?php echo $pageSize; ?></option>
-                <?php endforeach; ?>
+                <?php foreach ($this->getLimitOptions() as $pageSize): ?>
+                    <option value="<?php echo $pageSize; ?>"<?php if($this->getCollection()->getPageSize() == $pageSize): ?> selected="selected"<?php endif ?>><?php echo $pageSize; ?></option>
+                <?php endforeach ?>
             </select>
             <?php echo $this->__('per page') ?><span class="separator">|</span>
             <?php echo $this->__('Total %d records found', $this->getCollection()->getSize()) ?>


### PR DESCRIPTION
### Description (*)
Replaced "duplicate" lines with foreach + added more page size possibilities.

![image](https://user-images.githubusercontent.com/9967016/136654671-affe1aab-c5fe-4b91-a1da-36726aa4d15d.png)


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->