### PR TITLE
Fix exception handling on Observer call when class not found

### DIFF
--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -1380,13 +1380,13 @@ class Mage_Core_Model_App
                         $method = $obs['method'];
                         $observer->addData($args);
                         $object = Mage::getModel($obs['model']);
-                        $this->_callObserverMethod($object, $method, $observer);
+                        $this->_callObserverMethod($object, $method, $observer, $obsName);
                         break;
                     default:
                         $method = $obs['method'];
                         $observer->addData($args);
                         $object = Mage::getSingleton($obs['model']);
-                        $this->_callObserverMethod($object, $method, $observer);
+                        $this->_callObserverMethod($object, $method, $observer, $obsName);
                         break;
                 }
                 Varien_Profiler::stop('OBSERVER: '.$obsName);
@@ -1401,15 +1401,22 @@ class Mage_Core_Model_App
      * @param object $object
      * @param string $method
      * @param Varien_Event_Observer $observer
+     * @param string $observerName
      * @return $this
      * @throws Mage_Core_Exception
      */
-    protected function _callObserverMethod($object, $method, $observer)
+    protected function _callObserverMethod($object, $method, $observer, $observerName = 'undefined')
     {
         if (is_object($object) && method_exists($object, $method)) {
             $object->$method($observer);
         } elseif (Mage::getIsDeveloperMode()) {
-            Mage::throwException('Method "'.$method.'" is not defined in "'.get_class($object).'"');
+            if (is_object($object)) {
+                $message = 'Method "' . $method . '" is not defined in "' . get_class($object) . '"';
+            } else {
+                $message = 'Class from observer "' . $observerName . '" is not initialized';
+            }
+
+            Mage::throwException($message);
         }
         return $this;
     }


### PR DESCRIPTION
### Description (*)
Is the instance running in developer mode and the registered observer class is not callable, the check returns a wrong error and we have no indication to find the wrong observer.
```
// currently (exception.log)
Warning: get_class() expects parameter 1 to be object, bool given

// should be (backend error message)
Method "execute" is not defined in "class_not_exists"
``` 
With this PR the exception have two different message: The correct original message and new a message with the observer name if the class is not initialized:
```
Class from observer "observer_name_example" is not initialized
``` 



### Manual testing scenarios (*)
1. Go into developer mode
2. Activate the exception log
3. Register an observer with a class path that doesn't exist
```xml
<catalog_product_save_after>
    <observers>
        <observer_name_example>
            <class>namespace/class_not_exists</class>
            <method>execute</method>
        </observer_name_example>
    </observers>
</catalog_product_save_after>
```
4. Trigger the observer

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list