### PR TITLE
API: _getLocation - removed unused argument; fix phpdoc

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest.php
@@ -103,14 +103,13 @@ abstract class Mage_Catalog_Model_Api2_Product_Website_Rest extends Mage_Catalog
             $this->_critical(self::RESOURCE_INTERNAL_ERROR);
         }
 
-        return $this->_getLocation($website, $product);
+        return $this->_getLocation($website);
     }
 
     /**
      * Product website assign
      *
      * @param array $data
-     * @return string
      */
     protected function _multiCreate(array $data)
     {


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
- removed PHP doc (unexisting return statement)
- fixed call of method `_getLocation` with unexisting parameter. Method signature is: `protected function _getLocation($website) {`

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->