### PR TITLE
Improve getScheme on Zend_Controller_Request_Http

### DIFF
--- a/app/code/core/Zend/Controller/Request/Http.php
+++ b/app/code/core/Zend/Controller/Request/Http.php
@@ -1034,7 +1034,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      */
     public function getScheme()
     {
-        return (strtolower($this->getServer('HTTPS')) == 'on') || $this->getServer('HTTP_X_FORWARDED_PROTO') == 'https' ?
+        return (strtolower((string)$this->getServer('HTTPS')) == 'on') || $this->getServer('HTTP_X_FORWARDED_PROTO') == 'https' ?
             self::SCHEME_HTTPS :
             self::SCHEME_HTTP;
     }

--- a/app/code/core/Zend/Controller/Request/Http.php
+++ b/app/code/core/Zend/Controller/Request/Http.php
@@ -1034,7 +1034,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      */
     public function getScheme()
     {
-        return ($this->getServer('HTTPS') == 'on') || $this->getServer('HTTP_X_FORWARDED_PROTO') == 'https' ?
+        return (strtolower($this->getServer('HTTPS')) == 'on') || $this->getServer('HTTP_X_FORWARDED_PROTO') == 'https' ?
             self::SCHEME_HTTPS :
             self::SCHEME_HTTP;
     }


### PR DESCRIPTION
### Description (*)
Some web servers (for example the [local web server of the Symfony CLI](https://symfony.com/doc/current/setup/symfony_server.html#getting-started)) puts the value `On` (and not `on`)  in the `$_SERVER['HTTPS']` super global.

With this PR the `Zend_Controller_Request_Http::getScheme` properly returns the HTTPS scheme in such situations.

### Manual testing scenarios (*)
1. Install a clean copy of OpenMage as usual
2. Install Symfony CLI and its [SSL certificates](https://symfony.com/doc/current/setup/symfony_server.html#enabling-tls)
3. Start the Symfony CLI local web server with `symfony server:start`
4. Configure OpenMage to use the `https://127.0.0.1:8000/` base URL for both secure and unsecure
5. Try to open the home page at https://127.0.0.1:8000/
6. Without this PR you'll get "Too many redirects" error, with this PR you'll properly get the home page

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->