### PR TITLE
Zend registry - removed method offset exists (using parental)

### DIFF
--- a/lib/Zend/Registry.php
+++ b/lib/Zend/Registry.php
@@ -195,15 +195,4 @@ class Zend_Registry extends ArrayObject
         parent::__construct($array, $flags);
     }
 
-    /**
-     * @param string $index
-     * @returns mixed
-     *
-     * Workaround for http://bugs.php.net/bug.php?id=40442 (ZF-960).
-     */
-    public function offsetExists($index)
-    {
-        return array_key_exists($index, $this);
-    }
-
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Using `PHP 7.4.21 (cli)` i getting this error:
```console
E_DEPRECATED: array_key_exists(): Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead

   in lib/Zend/Registry.php(207)
   in lib/Zend/Registry.php(183) Zend_Registry->offsetExists()

```

Method `offsetExists` was originally added for fixing some error in obsolete PHP version, which is not actual at these days.

### Manual testing scenarios (*)
```php
public function testAsserts() {
    Zend_Registry::getInstance();

    Assert::false(Zend_Registry::isRegistered('foo_bar'));
    Zend_Registry::set('foo_bar', 'barbar');
    Assert::true(Zend_Registry::isRegistered('foo_bar'));
    Assert::same(Zend_Registry::get('foo_bar'), 'barbar');
}
```


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->