### PR TITLE
Fix attribute model has data changes was true right after loading

### DIFF
--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute.php
@@ -521,7 +521,7 @@ class Mage_Eav_Model_Resource_Entity_Attribute extends Mage_Core_Model_Resource_
                 $object->addData($result);
             }
         }
-
+        $object->setDataChanges(false);
         return $this;
     }
 


### PR DESCRIPTION
### Description (*)
Immediately after loading an attribute, it already has the "has data changes" flag set to true, even though it was just loaded and could not possibly have been changed yet.

### Fixed Issues (if relevant)
1. Saving attributes does faster if they are not really changed.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
