### PR TITLE
Add `Mage_Index` helpers declaration to `config.xml`

### DIFF
--- a/app/code/core/Mage/Index/etc/config.xml
+++ b/app/code/core/Mage/Index/etc/config.xml
@@ -32,6 +32,11 @@
         </Mage_Index>
     </modules>
     <global>
+        <helpers>
+            <index>
+                <class>Mage_Index_Helper</class>
+            </index>
+        </helpers>
         <models>
             <index>
                 <class>Mage_Index_Model</class>


### PR DESCRIPTION
Add `Mage_Index` module's helpers declaration to its `config.xml`.

### Description (*)
If a module uses a helper but doesn't declare the helpers class path in `config.xml`, Magento infers it by following the convention. This PR adds the declaration for the `Mage_Index` module to avoid any confusion.

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#1877

### Manual testing scenarios (*)
None. Behavior should be same as before.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->