### PR TITLE
Fix infinite loop caused by #1467

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -969,7 +969,6 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
     public function _exportIterateCollection($callback, array $args)
     {
         $originalCollection = $this->getCollection();
-        $count = null;
         $page  = 1;
 
         do {
@@ -978,7 +977,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
             $collection->setCurPage($page);
             $collection->load();
 
-            $count = $collection->count();
+            $lastPageNumber = $collection->getLastPageNumber();
 
             $page++;
 
@@ -987,7 +986,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
             }
             $collection->clear();
             unset($collection);
-        } while($count == $this->_exportPageSize);
+        } while ($page <= $lastPageNumber);
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The infinite loop happens when you try to export collection that has number of items divisible by 1000(`$this->_exportPageSize`).

In this case the Varien collection will reset the page number to `lastPageNumber` when `$page` is higher.
`$page` is higher than `lastPageNumber` because the current logic assume that there is always one more page if the current page count is the same as page export size which is not true in case when count is divisible by page size.

### Related Pull Requests
<!-- related pull request placeholder -->
https://github.com/OpenMage/magento-lts/pull/1467

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create sales rule without coupon code
2. Generate 1000 coupons
3. Export them as CSV

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->