### PR TITLE
Fix incompatible declaration error

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Option/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Api/V2.php
@@ -69,7 +69,7 @@ class Mage_Catalog_Model_Product_Option_Api_V2 extends Mage_Catalog_Model_Produc
      * @param int|string|null $store
      * @return array
      */
-    public function items($productId, $store)
+    public function items($productId, $store = null)
     {
         $result = parent::items($productId, $store);
         foreach ($result as $key => $option) {


### PR DESCRIPTION
Fix incompatible declaration in method items of Mage_Catalog_Model_Product_Option_Api_V2. 

### Comments
Declaration of this method in parent class Mage_Catalog_Model_Product_Option_Api allows the parameter $store to be null. Php 8.1 throws a PHP Fatal error "Declaration of Mage_Catalog_Model_Product_Option_Api_V2::items($productId, $store) must be compatible with Mage_Catalog_Model_Product_Option_Api::items($productId, $store = null)."

This fix has no side effects because the child method passes the $store parameter directly on to the parent method which explicitly allowes null as the $store parameter value.