### PR TITLE
PHP 8.1 Fix deprecation notice in mcryptcompat lib

### DIFF
--- a/lib/mcryptcompat/mcrypt.php
+++ b/lib/mcryptcompat/mcrypt.php
@@ -1087,7 +1087,8 @@ if (!function_exists('phpseclib_mcrypt_list_algorithms')) {
          * @return int
          * @access public
          */
-        public function filter($in, $out, &$consumed, $closing): int
+        #[\ReturnTypeWillChange]
+        public function filter($in, $out, &$consumed, $closing)
         {
             $newlen = 0;
             $block_mode = phpseclib_mcrypt_module_is_block_mode($this->cipher->mcrypt_mode);
@@ -1124,7 +1125,8 @@ if (!function_exists('phpseclib_mcrypt_list_algorithms')) {
          * @return bool
          * @access public
          */
-        public function onCreate(): bool
+        #[\ReturnTypeWillChange]
+        public function onCreate()
         {
             if (!isset($this->params) || !is_array($this->params)) {
                 trigger_error('stream_filter_append(): Filter parameters for ' . $this->filtername . ' must be an array');

--- a/lib/mcryptcompat/mcrypt.php
+++ b/lib/mcryptcompat/mcrypt.php
@@ -1087,7 +1087,7 @@ if (!function_exists('phpseclib_mcrypt_list_algorithms')) {
          * @return int
          * @access public
          */
-        public function filter($in, $out, &$consumed, $closing)
+        public function filter($in, $out, &$consumed, $closing): int
         {
             $newlen = 0;
             $block_mode = phpseclib_mcrypt_module_is_block_mode($this->cipher->mcrypt_mode);
@@ -1124,7 +1124,7 @@ if (!function_exists('phpseclib_mcrypt_list_algorithms')) {
          * @return bool
          * @access public
          */
-        public function onCreate()
+        public function onCreate(): bool
         {
             if (!isset($this->params) || !is_array($this->params)) {
                 trigger_error('stream_filter_append(): Filter parameters for ' . $this->filtername . ' must be an array');


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Open Mage contains a mcrypt polyfill to provide extension functionality after PHP 7.1 removed the extension. 
This polyfill contains a class extending [php_user_filter](https://www.php.net/manual/en/class.php-user-filter.php), an internal class. 

PHP 8.1 introduced *tentative return types* for internal classes that will throw a deprecation notice instead of fail in case an extending child class omits a return type set in the internal parent class (In PHP 9.0 those notices will become errors). 
As a consequence executing an arbitrary request in OpenMage results in two deprecation notices: 
```
Deprecated: Return type of phpseclib_mcrypt_filter::filter($in, $out, &$consumed, $closing) should either be compatible with php_user_filter::filter($in, $out, &$consumed, bool $closing): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
Deprecated: Return type of phpseclib_mcrypt_filter::onCreate() should either be compatible with php_user_filter::onCreate(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice 
```

This PR sets the return type of those two methods as they are defined internally. Because OpenMage requires at least PHP 7.0 those return types have no implications regarding backwards compatibility and it's unnecessary to use the mentioned workaround via attribute.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)

 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->