### PR TITLE
Bugfix #1885 - Add to cart only accepts 1 item

### DIFF
--- a/lib/Zend/Locale/Data/es_419.xml
+++ b/lib/Zend/Locale/Data/es_419.xml
@@ -191,6 +191,11 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<group>,</group>
 		</symbols>
 		<decimalFormats numberSystem="latn">
+			<decimalFormatLength>
+				<decimalFormat>
+					<pattern>#,##0.###</pattern>
+				</decimalFormat>>
+			</decimalFormatLength>
 			<decimalFormatLength type="short">
 				<decimalFormat>
 					<pattern type="1000" count="one" draft="contributed">0</pattern>


### PR DESCRIPTION
### Fixed Issues

1. Fixes OpenMage/magento-lts#1885

