### PR TITLE
Fix syntax in lib/Zend/Locale/Data/es_419.xml

### DIFF
--- a/lib/Zend/Locale/Data/es_419.xml
+++ b/lib/Zend/Locale/Data/es_419.xml
@@ -194,7 +194,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<decimalFormatLength>
 				<decimalFormat>
 					<pattern>#,##0.###</pattern>
-				</decimalFormat>>
+				</decimalFormat>
 			</decimalFormatLength>
 			<decimalFormatLength type="short">
 				<decimalFormat>


### PR DESCRIPTION
Fixes a syntax error introduced in OpenMage/magento-lts#1896 as spotted by @luigifab 


### Related Pull Requests
OpenMage/magento-lts#1896


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
