### PR TITLE
Allows to make creditmemo on payment type "free"

### DIFF
--- a/app/code/core/Mage/Payment/Model/Method/Free.php
+++ b/app/code/core/Mage/Payment/Model/Method/Free.php
@@ -46,6 +46,8 @@ class Mage_Payment_Model_Method_Free extends Mage_Payment_Model_Method_Abstract
      * @var bool
      */
     protected $_canAuthorize = true;
+    protected $_canRefund = true;
+    protected $_canRefundInvoicePartial = true;
 
     /**
      * Payment code name

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -751,7 +751,8 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
          * for this we have additional diapason for 0
          * TotalPaid - contains amount, that were not rounded.
          */
-        if (abs($this->getStore()->roundPrice($this->getTotalPaid()) - $this->getTotalRefunded()) < .0001) {
+        if (abs($this->getStore()->roundPrice($this->getTotalPaid()) - $this->getTotalRefunded()) < .0001
+            && $this->getPayment()->getMethod() !== 'free') {
             return false;
         }
 

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Grand.php
@@ -48,7 +48,7 @@ class Mage_Sales_Model_Order_Creditmemo_Total_Grand extends Mage_Sales_Model_Ord
         $creditmemo->setAdjustment($creditmemo->getAdjustmentPositive()-$creditmemo->getAdjustmentNegative());
         $creditmemo->setBaseAdjustment($creditmemo->getBaseAdjustmentPositive()-$creditmemo->getBaseAdjustmentNegative());
 
-        if ($creditmemo->getOrder()->getPayment()->getMethod() == 'free') {
+        if ($creditmemo->getOrder()->hasForcedCanCreditmemo()) {
             $creditmemo->setAllowZeroGrandTotal(true);
         }
         

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Grand.php
@@ -48,6 +48,10 @@ class Mage_Sales_Model_Order_Creditmemo_Total_Grand extends Mage_Sales_Model_Ord
         $creditmemo->setAdjustment($creditmemo->getAdjustmentPositive()-$creditmemo->getAdjustmentNegative());
         $creditmemo->setBaseAdjustment($creditmemo->getBaseAdjustmentPositive()-$creditmemo->getBaseAdjustmentNegative());
 
+        if ($creditmemo->getOrder()->getPayment()->getMethod() == 'free') {
+            $creditmemo->setAllowZeroGrandTotal(true);
+        }
+        
         return $this;
     }
 }

--- a/app/code/core/Mage/Sales/etc/config.xml
+++ b/app/code/core/Mage/Sales/etc/config.xml
@@ -28,7 +28,7 @@
 <config>
     <modules>
         <Mage_Sales>
-            <version>1.6.0.10</version>
+            <version>1.6.0.11</version>
         </Mage_Sales>
     </modules>
     <global>

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magento.com for more information.
+ *
+ * @category    Mage
+ * @package     Mage_Sales
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/* @var Mage_Sales_Model_Entity_Setup $installer */
+$installer = $this;
+
+$installer->startSetup();
+
+$installer->getConnection()
+    ->addColumn(
+        $installer->getTable('sales/order'),
+        'forced_can_creditmemo',
+        array(
+            'type' => Varien_Db_Ddl_Table::TYPE_SMALLINT,
+            'length' => 5,
+            'unsigned' => true,
+            'nullable' => true,
+            'default' => null,
+            'after' => 'forced_shipment_with_invoice',
+            'comment' => 'Forced Can Creditmemo'
+        )
+    );
+
+$installer->endSetup();


### PR DESCRIPTION
# Description

With this PR allows the merchant to create a creditmemo on orders with payment method "free". 

We ourselves require this option when an order is completely covered by a voucher code and the payment method "Free" is used. It is mainly so that we can cancel items and release them for another customer in the inventory as well as for the administrative overview.

# Manual testing scenarios

a) Activate "Free" Payment Method

1. Goto Backend > System > Configuration > [SALES] Payment Methods > Zero Subtotal Checkout
2. Set Enabled => Yes
3. Set Automatically Invoice All Items => Yes
4. Save

b) Create a Coupon Code

1. Goto Promotions > Shopping Cart Price Rules > Add New Rule
2. Fill all the form to use with your own code
3. Set under Actions Apply => Fixed amount discount for whole cart
4. Set Discount Amount => [amount to trigger the "free" payment method]

c) Make an order as customer with single item

1. Add a product to the cart
2. Use your coupon code
3. Check if payment method "free" is using
4. Complete the order

d) Make an order as customer with multiple item

1. Add a product to the cart
2. Add another product to the cart and set amount to 2
2. Use your coupon code
3. Check if payment method "free" is using
4. Complete the order

e) Make creditmemo with the single item order

f) Make creditmemo with the multiple item order

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list