### PR TITLE
Added optgroup feature for massaction items (grids)

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
@@ -289,4 +289,26 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract extends Mage
         $this->setData('use_select_all', (bool) $flag);
         return $this;
     }
+
+    /**
+     * Group items for optgroups
+     *
+     * @return array
+     */
+    public function getGroupedItems(): array
+    {
+        $groupedItems = [];
+
+        foreach ($this->getItems() as $item) {
+            if ($item->getData('group')) {
+                $groupedItems['grouped'][$item->getData('group')][$item->getId()] = $item;
+            }
+            else {
+                $groupedItems['default'][$item->getId()] = $item;
+            }
+        }
+
+        return $groupedItems;
+    }
+
 }

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
@@ -297,7 +297,9 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract extends Mage
      */
     public function getGroupedItems(): array
     {
-        $groupedItems = [];
+        $groupedItems = [
+            'default' => [],
+        ];
 
         foreach ($this->getItems() as $item) {
             if ($item->getData('group')) {

--- a/app/design/adminhtml/default/default/template/widget/grid/massaction.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/massaction.phtml
@@ -48,12 +48,24 @@
                     <?php echo $this->getBlockHtml('formkey')?>
                     <fieldset>
                         <span class="field-row">
-                            <label><?php echo $this->__('Actions') ?></label>
+                            <label for="<?php echo $this->getHtmlId() ?>-select"><?php echo $this->__('Actions') ?></label>
                             <select id="<?php echo $this->getHtmlId() ?>-select" class="required-entry select absolute-advice local-validation">
                                 <option value=""></option>
-                                <?php foreach($this->getItems() as $_item): ?>
-                                    <option value="<?php echo $_item->getId() ?>"<?php echo ($_item->getSelected() ? ' selected="selected"' : '')?>><?php echo $_item->getLabel() ?></option>
-                                <?php endforeach ?>
+                                <?php foreach($this->getGroupedItems() as $key => $group): ?>
+                                    <?php if ($key === 'default'): ?>
+                                        <?php foreach($group as $_item): ?>
+                                            <option value="<?php echo $_item->getId() ?>"<?php echo ($_item->getSelected() ? ' selected="selected"' : '')?>><?php echo $_item->getLabel() ?></option>
+                                        <?php endforeach; ?>
+                                    <?php elseif ($key === 'grouped'): ?>
+                                        <?php foreach($group as $label => $_massGroup): ?>
+                                            <optgroup label="<?php echo $this->quoteEscape($label); ?>">
+                                                <?php foreach($_massGroup as $_item): ?>
+                                                    <option value="<?php echo $_item->getId() ?>"<?php echo ($_item->getSelected() ? ' selected="selected"' : '')?>><?php echo $_item->getLabel() ?></option>
+                                                <?php endforeach; ?>
+                                            </optgroup>
+                                        <?php endforeach; ?>
+                                    <?php endif; ?>
+                                <?php endforeach; ?>
                             </select>
                         </span>
                         <span class="outer-span" id="<?php echo $this->getHtmlId() ?>-form-hiddens"></span>

--- a/app/design/adminhtml/default/default/template/widget/grid/massaction.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/massaction.phtml
@@ -55,17 +55,17 @@
                                     <?php if ($key === 'default'): ?>
                                         <?php foreach($group as $_item): ?>
                                             <option value="<?php echo $_item->getId() ?>"<?php echo ($_item->getSelected() ? ' selected="selected"' : '')?>><?php echo $_item->getLabel() ?></option>
-                                        <?php endforeach; ?>
+                                        <?php endforeach ?>
                                     <?php elseif ($key === 'grouped'): ?>
                                         <?php foreach($group as $label => $_massGroup): ?>
                                             <optgroup label="<?php echo $this->quoteEscape($label); ?>">
                                                 <?php foreach($_massGroup as $_item): ?>
                                                     <option value="<?php echo $_item->getId() ?>"<?php echo ($_item->getSelected() ? ' selected="selected"' : '')?>><?php echo $_item->getLabel() ?></option>
-                                                <?php endforeach; ?>
+                                                <?php endforeach ?>
                                             </optgroup>
-                                        <?php endforeach; ?>
-                                    <?php endif; ?>
-                                <?php endforeach; ?>
+                                        <?php endforeach ?>
+                                    <?php endif ?>
+                                <?php endforeach ?>
                             </select>
                         </span>
                         <span class="outer-span" id="<?php echo $this->getHtmlId() ?>-form-hiddens"></span>


### PR DESCRIPTION
### Description (*)
![image](https://user-images.githubusercontent.com/9967016/146915536-05f0f39d-cb46-4b7d-ad7f-1a229751d2bb.png)

I'm glad to present new feature for grid massactions. This feature allows you to group related massactions to groups for better clarity.
This feature request is completely backward compatible. I added a new method, which is called in `massaction.phtml`, so if someone is using custom template nothing should be broken.

### Usage
Use keyword `group` and as a value put translated key label. If you do not use `group` keyword, item is not in group.

```php
$this->getMassactionBlock()->addItem('stop_tracking_now', [
    'label' => Mage::helper('adminhtml')->__('Stop tracking now'),
    'url' => $this->getUrl('*/*/stopTracking'),
    'confirm' => Mage::helper('adminhtml')->__('Are you sure?'),
    'group' => Mage::helper('adminhtml')->__('Tracking management'),
]);
```


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
