### PR TITLE
Dashboard - Top 5 Search Terms link issue

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Review/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Product/Grid.php
@@ -37,6 +37,7 @@ class Mage_Adminhtml_Block_Review_Product_Grid extends Mage_Adminhtml_Block_Cata
     public function __construct()
     {
         parent::__construct();
+        $this->setId('reviewProductGrid');
         $this->setRowClickCallback('review.gridRowClick');
         $this->setUseAjax(true);
     }

--- a/lib/Varien/Data/Collection.php
+++ b/lib/Varien/Data/Collection.php
@@ -449,7 +449,7 @@ class Varien_Data_Collection implements IteratorAggregate, Countable
      *
      * Returns array with results of callback for each item
      *
-     * @param string $callback
+     * @param callable $callback
      * @param array $args
      * @return array
      */
@@ -470,7 +470,7 @@ class Varien_Data_Collection implements IteratorAggregate, Countable
     }
 
     /**
-     * @param string $obj_method
+     * @param callable $obj_method
      * @param array $args
      */
     public function each($obj_method, $args = array())


### PR DESCRIPTION
Go to Dashboard page in Backend and take a look to the following blocks **Last 5 Search Terms** and **Top 5 Search Terms**. 

Now place your mouse pointer over a search term in **Last 5 Search Terms** list and take a look to the URL. Here is the link in my case https://www.mydomain.tld/index.php/admin/catalog_search/edit/id/41/key/5874688c27ec9781d42bacfd92420f0e/

Now place your mouse pointer over a search term in **Top 5 Search Terms** list and take a look to the URL. Here is the link in my case https://www.mydomain.tld/index.php/admin/catalog_search/edit/key/5874688c27ec9781d42bacfd92420f0e/

The last link has an issue. Comparing with the first one which redirects correctly to edit the search term this one is opening the page to create a new search query not editing the search term. This is happening because the link has missing two parameters id and id_number between /edit/ ... /key/

This PR fixes this issues and closes issue #1310 .