### PR TITLE
Change default sort in CMS Pages/Blocks/Widgets grids

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
@@ -38,7 +38,7 @@ class Mage_Adminhtml_Block_Cms_Block_Grid extends Mage_Adminhtml_Block_Widget_Gr
     {
         parent::__construct();
         $this->setId('cmsBlockGrid');
-        $this->setDefaultSort('block_identifier');
+        $this->setDefaultSort('title');
         $this->setDefaultDir('ASC');
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
@@ -38,7 +38,7 @@ class Mage_Adminhtml_Block_Cms_Page_Grid extends Mage_Adminhtml_Block_Widget_Gri
     {
         parent::__construct();
         $this->setId('cmsPageGrid');
-        $this->setDefaultSort('identifier');
+        $this->setDefaultSort('title');
         $this->setDefaultDir('ASC');
     }
 

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Grid.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Grid.php
@@ -41,7 +41,7 @@ class Mage_Widget_Block_Adminhtml_Widget_Instance_Grid extends Mage_Adminhtml_Bl
     {
         parent::_construct();
         $this->setId('widgetInstanceGrid');
-        $this->setDefaultSort('instance_id');
+        $this->setDefaultSort('title');
         $this->setDefaultDir('ASC');
     }
 


### PR DESCRIPTION
**CMS Pages** grid is sorted ascending by column 2 (URL Key).

**CMS Static Blocks** is not sorted by any columns. The issues comes from this file

/app/code/core/Mage/Adminthml/Block/Cms/Block/Grid.php.

```
class Mage_Adminhtml_Block_Cms_Block_Grid extends Mage_Adminhtml_Block_Widget_Grid
{

    public function __construct()
    {
        parent::__construct();
        $this->setId('cmsBlockGrid');
        $this->setDefaultSort('block_identifier');
        $this->setDefaultDir('ASC');
    }

```
The **block_identifier** value doesn't exist. It should be **identifier**.

**CMS Widgets** is sorted ascending by column 1 (Widget ID).

This PR fixes the block_identifier issue. Also it will change the default sorting as follows

**CMS Pages** default sorting will be Title column. I always watch this column and not the URL key.

**CMS Static Blocks** default sorting will be Title column too. And here I never set out to find a block by its identifier.

**CMS Widgets** default sorting will be Widget Instance Title. I always clicked on this column to quick find a widget.