### PR TITLE
Change default sort in Manage Attributes grid

### DIFF
--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Grid/Abstract.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Grid/Abstract.php
@@ -38,7 +38,7 @@ abstract class Mage_Eav_Block_Adminhtml_Attribute_Grid_Abstract extends Mage_Adm
     {
         parent::__construct();
         $this->setId('attributeGrid');
-        $this->setDefaultSort('attribute_code');
+        $this->setDefaultSort('frontend_label');
         $this->setDefaultDir('ASC');
     }
 


### PR DESCRIPTION
This changes the default sort order in Manage Attributes grid from column 1 (Attribute Code) to column 2 (Attribute Label)