### PR TITLE
Change the default sort column - Export page

### DIFF
--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Filter.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Filter.php
@@ -55,7 +55,7 @@ class Mage_ImportExport_Block_Adminhtml_Export_Filter extends Mage_Adminhtml_Blo
 
         $this->setRowClickCallback(null);
         $this->setId('export_filter_grid');
-        $this->setDefaultSort('attribute_code');
+        $this->setDefaultSort('frontend_label');
         $this->setDefaultDir('ASC');
         $this->setPagerVisibility(false);
         $this->setDefaultLimit(null);


### PR DESCRIPTION
This PR changes the default sort column on the Export page in backend from **Attribute Code** to **Attribute Label**.

Based on this change it is so easy to check those rows you want to skip from export.

![sort_export](https://user-images.githubusercontent.com/8360474/147394121-d44a01bd-c23e-40cf-b754-b23551229b59.jpg)

