### PR TITLE
Price Alerts unsubscribe - Wrong messages

### DIFF
--- a/app/code/core/Mage/ProductAlert/controllers/UnsubscribeController.php
+++ b/app/code/core/Mage/ProductAlert/controllers/UnsubscribeController.php
@@ -60,7 +60,7 @@ class Mage_ProductAlert_UnsubscribeController extends Mage_Core_Controller_Front
         $product = Mage::getModel('catalog/product')->load($productId);
         if (!$product->getId() || !$product->isVisibleInCatalog()) {
             /* @var Mage_Catalog_Model_Product $product */
-            Mage::getSingleton('customer/session')->addError($this->__('The product is not found.'));
+            Mage::getSingleton('customer/session')->addError($this->__('The product was not found.'));
             $this->_redirect('customer/account/');
             return ;
         }
@@ -75,7 +75,7 @@ class Mage_ProductAlert_UnsubscribeController extends Mage_Core_Controller_Front
                 $model->delete();
             }
 
-            $session->addSuccess($this->__('The alert subscription has been deleted.'));
+            $session->addSuccess($this->__('You will no longer receive price alerts for this product.'));
         } catch (Exception $e) {
             $session->addException($e, $this->__('Unable to update the alert subscription.'));
         }
@@ -92,7 +92,7 @@ class Mage_ProductAlert_UnsubscribeController extends Mage_Core_Controller_Front
                 $session->getCustomerId(),
                 Mage::app()->getStore()->getWebsiteId()
             );
-            $session->addSuccess($this->__('You will no longer receive price alerts for this product.'));
+            $session->addSuccess($this->__('You will no longer receive price alerts.'));
         } catch (Exception $e) {
             $session->addException($e, $this->__('Unable to update the alert subscription.'));
         }

--- a/app/locale/en_US/Mage_ProductAlert.csv
+++ b/app/locale/en_US/Mage_ProductAlert.csv
@@ -32,4 +32,5 @@
 "You are receiving this notification because you subscribed to receive alerts when the prices for the following products changed:","You are receiving this notification because you subscribed to receive alerts when the prices for the following products changed:"
 "You will no longer receive price alerts for this product.","You will no longer receive price alerts for this product."
 "You will no longer receive stock alerts for this product.","You will no longer receive stock alerts for this product."
+"You will no longer receive price alerts.","You will no longer receive price alerts."
 "You will no longer receive stock alerts.","You will no longer receive stock alerts."


### PR DESCRIPTION
Wrong messages when you click to unsubscribe from receiving price alerts for that product/all products. It adds also a missing one line in translation too.

The issue was discussed here #1584.