### PR TITLE
Initialize Api2 Fields validator's required fields array

### DIFF
--- a/app/code/core/Mage/Api2/Model/Resource/Validator/Fields.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Validator/Fields.php
@@ -58,7 +58,7 @@ class Mage_Api2_Model_Resource_Validator_Fields extends Mage_Api2_Model_Resource
      *
      * @var array
      */
-    protected $_requiredFields;
+    protected $_requiredFields = array();
 
     /**
      * Construct. Set all depends.


### PR DESCRIPTION
Initializes the `$_requiredFields` array in `Mage_Api2_Model_Resource_Validator_Fields`.

### Description (*)
I'm implementing a new REST endpoint for adding comments to sales orders, I started by using the built-in `Fields` validator to validate the request. I kept all of the request data optional because I wanted to be able to only supply the status if I wanna change it but don't want to add a comment, or only supply a comment if I want to keep the current status, but I stumbled across this warning:
```
{
  "messages": {
    "error": [
      {
        "code": 0,
        "message": "Warning: count(): Parameter must be an array or an object that implements Countable  in \/srv\/http\/openmage\/public_html\/app\/code\/core\/Mage\/Api2\/Model\/Resource\/Validator\/Fields.php on line 160"
      }
    ]
  }
}
```
The issue is that the validator only initializes the `$_requiredFields` variable when it finds a required field in config, and there is another method that calls `count` on the array during the validation:
https://github.com/OpenMage/magento-lts/blob/c14982deaca0ce6d7d24e4c392fd082d319d4ac6/app/code/core/Mage/Api2/Model/Resource/Validator/Fields.php#L103-L106
https://github.com/OpenMage/magento-lts/blob/c14982deaca0ce6d7d24e4c392fd082d319d4ac6/app/code/core/Mage/Api2/Model/Resource/Validator/Fields.php#L160

### Manual testing scenarios (*)
1. Create, or go to an existing REST endpoint that uses the Fields validator, make all the request data optional by removing `<required>1</required>`.
2. Call the endpoint and you should see the warning before the fix, but not after.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
