### PR TITLE
[PHP 8.0] Refactor legacy usage of implode in `Mage_Api2`

### DIFF
--- a/app/code/core/Mage/Api2/Model/Renderer/Xml.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Xml.php
@@ -105,7 +105,7 @@ class Mage_Api2_Model_Renderer_Xml implements Mage_Api2_Model_Renderer_Interface
             }
         }
         $data = $data instanceof Varien_Object ? $data->toArray() : (array)$data;
-        $isAssoc = !preg_match('/^\d+$/', implode(array_keys($data), ''));
+        $isAssoc = !preg_match('/^\d+$/', implode('', array_keys($data)));
 
         $preparedData = array();
         foreach ($data as $key => $value) {


### PR DESCRIPTION
### Description (*)
There's a legacy usage of [`implode`](https://www.php.net/manual/en/function.implode.php) in `Mage_Api2` Xml renderer with a signature that was removed in PHP 8.0, this PR swaps the arguments to match the new signature.

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#1937

### Manual testing scenarios (*)
1. Call a REST Api endpoint with `Accept` header set to `application/xml` or `text/xml`.
2. All should go well after the change.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list