### PR TITLE
Small improvements in Manage Attributes grid

### DIFF
--- a/app/code/core/Mage/Api2/Model/Renderer/Xml.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Xml.php
@@ -105,7 +105,7 @@ class Mage_Api2_Model_Renderer_Xml implements Mage_Api2_Model_Renderer_Interface
             }
         }
         $data = $data instanceof Varien_Object ? $data->toArray() : (array)$data;
-        $isAssoc = !preg_match('/^\d+$/', implode(array_keys($data), ''));
+        $isAssoc = !preg_match('/^\d+$/', implode('', array_keys($data)));
 
         $preparedData = array();
         foreach ($data as $key => $value) {


### PR DESCRIPTION
This PR comes with small improvements in Manage Attributes grid page. 

Here is the grid before

![before](https://user-images.githubusercontent.com/8360474/147824579-56a54b1d-01c2-4186-91d7-9dde92130883.jpg)

And here is the grid after

![after](https://user-images.githubusercontent.com/8360474/147824587-aef505ee-ed95-4816-8c17-459abff937e8.jpg)

1. Column 2 (Attribute Label) and Column 1 (Attribute Code) are switched now.  In no other Magento grid the code is on the first column (see CMS sections).

2. The default sorting is no longer done by attribute_code but by the frontend_label.