### PR TITLE
Fix count(): Parameter must be an array or an object that implements Countable

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
@@ -634,7 +634,7 @@ abstract class Mage_Catalog_Model_Resource_Abstract extends Mage_Eav_Model_Entit
         if ($staticAttributes) {
             $select = $adapter->select()->from($staticTable, $staticAttributes)
                 ->where($this->getEntityIdField() . ' = :entity_id');
-            $attributesData = $adapter->fetchRow($select, array('entity_id' => $entityId));
+            $attributesData = $adapter->fetchRow($select, array('entity_id' => $entityId)) ?: [];
         }
 
         /**


### PR DESCRIPTION
### Description (*)
Unfortunatelly I found new bug in my favourite obscure method `getAttributeRawValue`. 

When `fetchRow` called there `$attributesData = $adapter->fetchRow($select, array('entity_id' => $entityId))` returned `false` method ends with `E_WARNING`: `count(): Parameter must be an array or an object that implements Countable` on line 694
![image](https://user-images.githubusercontent.com/9967016/148298151-b30d6ecc-1f4f-4fe9-a302-68c50f9fe103.png)


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->