### PR TITLE
Fixed error in Varien_Io_File if $this->_iwd is null

### DIFF
--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -557,7 +557,7 @@ class Varien_Io_File extends Varien_Io_Abstract
     {
         @chdir($this->_cwd);
         $result = @file_put_contents($filename, $src);
-        chdir($this->_iwd);
+        @chdir($this->_iwd);
 
         return $result;
     }


### PR DESCRIPTION
### Description (*)

The following code breaks because `$this->_iwd` is `NULL` and the line `chdir($this->_iwd)` cannot work.

```
$io = new Varien_Io_File();
$io->write('/tmp/test.txt', 'body');
```

This happens because `$io->open()` was never called, and it shouldn't really. The use case is valid as `Varien_Io_File` is the class to use for all disk IO. Problem is: sometimes Magento uses it to present a single file, somethimes Magento uses it in a generic way.

I want to use it in a generic way too, but my 2 lines break, so I propose this simple fix.


<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->


### Questions or comments
I am using `Varien_Io_File` for all disk IO stuff, but I cannot because it breaks.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
