### PR TITLE
prevent customer review view from loading foreign reviews 

### DIFF
--- a/app/code/core/Mage/Review/Block/Customer/View.php
+++ b/app/code/core/Mage/Review/Block/Customer/View.php
@@ -51,7 +51,6 @@ class Mage_Review_Block_Customer_View extends Mage_Catalog_Block_Product_Abstrac
         parent::__construct();
         $this->setTemplate('review/customer/view.phtml');
 
-        $this->setReviewId($this->getRequest()->getParam('id', false));
     }
 
     /**
@@ -74,10 +73,7 @@ class Mage_Review_Block_Customer_View extends Mage_Catalog_Block_Product_Abstrac
      */
     public function getReviewData()
     {
-        if ($this->getReviewId() && !$this->getReviewCachedData()) {
-            $this->setReviewCachedData(Mage::getModel('review/review')->load($this->getReviewId()));
-        }
-        return $this->getReviewCachedData();
+        return Mage::registry('current_review');
     }
 
     /**

--- a/app/code/core/Mage/Review/Block/Customer/View.php
+++ b/app/code/core/Mage/Review/Block/Customer/View.php
@@ -51,6 +51,7 @@ class Mage_Review_Block_Customer_View extends Mage_Catalog_Block_Product_Abstrac
         parent::__construct();
         $this->setTemplate('review/customer/view.phtml');
 
+        $this->setReviewId($this->getRequest()->getParam('id', false));
     }
 
     /**
@@ -73,15 +74,10 @@ class Mage_Review_Block_Customer_View extends Mage_Catalog_Block_Product_Abstrac
      */
     public function getReviewData()
     {
-        return Mage::registry('current_review');
-    }
-
-    /**
-     * @return int
-     */
-    public function getReviewId()
-    {
-        return $this->getReviewData()->getId();
+        if ($this->getReviewId() && !$this->getReviewCachedData()) {
+            $this->setReviewCachedData(Mage::getModel('review/review')->load($this->getReviewId()));
+        }
+        return $this->getReviewCachedData();
     }
 
     /**

--- a/app/code/core/Mage/Review/Block/Customer/View.php
+++ b/app/code/core/Mage/Review/Block/Customer/View.php
@@ -77,6 +77,14 @@ class Mage_Review_Block_Customer_View extends Mage_Catalog_Block_Product_Abstrac
     }
 
     /**
+     * @return int
+     */
+    public function getReviewId()
+    {
+        return $this->getReviewData()->getId();
+    }
+
+    /**
      * @return string
      */
     public function getBackUrl()

--- a/app/code/core/Mage/Review/controllers/CustomerController.php
+++ b/app/code/core/Mage/Review/controllers/CustomerController.php
@@ -92,7 +92,7 @@ class Mage_Review_CustomerController extends Mage_Core_Controller_Front_Action
     {
         $review = $this->_loadReview((int) $this->getRequest()->getParam('id'));
         if (!$review) {
-            $this->_forward('index');
+            $this->_redirect('*/*');
             return;
         }
 

--- a/app/code/core/Mage/Review/controllers/CustomerController.php
+++ b/app/code/core/Mage/Review/controllers/CustomerController.php
@@ -60,13 +60,11 @@ class Mage_Review_CustomerController extends Mage_Core_Controller_Front_Action
             return false;
         }
 
-        $review = Mage::getModel('review/review')->load($reviewId);
         /* @var Mage_Review_Model_Review $review */
+        $review = Mage::getModel('review/review')->load($reviewId);
         if (!$review->getId() || $review->getCustomerId() != Mage::getSingleton('customer/session')->getCustomerId()){
             return false;
         }
-
-        Mage::register('current_review', $review);
 
         return $review;
     }

--- a/app/code/core/Mage/Review/controllers/CustomerController.php
+++ b/app/code/core/Mage/Review/controllers/CustomerController.php
@@ -62,7 +62,7 @@ class Mage_Review_CustomerController extends Mage_Core_Controller_Front_Action
 
         $review = Mage::getModel('review/review')->load($reviewId);
         /* @var Mage_Review_Model_Review $review */
-        if (!$review->getId() || !$review->getCustomerId() == Mage::getSingleton('customer/session')->getCustomerId()){
+        if (!$review->getId() || $review->getCustomerId() != Mage::getSingleton('customer/session')->getCustomerId()){
             return false;
         }
 
@@ -70,7 +70,6 @@ class Mage_Review_CustomerController extends Mage_Core_Controller_Front_Action
 
         return $review;
     }
-
 
     public function indexAction()
     {
@@ -93,7 +92,7 @@ class Mage_Review_CustomerController extends Mage_Core_Controller_Front_Action
     {
         $review = $this->_loadReview((int) $this->getRequest()->getParam('id'));
         if (!$review) {
-            $this->_forward('noroute');
+            $this->_forward('index');
             return;
         }
 

--- a/app/code/core/Mage/Review/controllers/CustomerController.php
+++ b/app/code/core/Mage/Review/controllers/CustomerController.php
@@ -47,6 +47,31 @@ class Mage_Review_CustomerController extends Mage_Core_Controller_Front_Action
         }
     }
 
+    /**
+     * Load review model with data by passed id.
+     * Return false if review was not loaded or was not created by customer
+     *
+     * @param int $reviewId
+     * @return bool|Mage_Review_Model_Review
+     */
+    protected function _loadReview($reviewId)
+    {
+        if (!$reviewId) {
+            return false;
+        }
+
+        $review = Mage::getModel('review/review')->load($reviewId);
+        /* @var Mage_Review_Model_Review $review */
+        if (!$review->getId() || !$review->getCustomerId() == Mage::getSingleton('customer/session')->getCustomerId()){
+            return false;
+        }
+
+        Mage::register('current_review', $review);
+
+        return $review;
+    }
+
+
     public function indexAction()
     {
         $this->loadLayout();
@@ -66,6 +91,12 @@ class Mage_Review_CustomerController extends Mage_Core_Controller_Front_Action
 
     public function viewAction()
     {
+        $review = $this->_loadReview((int) $this->getRequest()->getParam('id'));
+        if (!$review) {
+            $this->_forward('noroute');
+            return;
+        }
+
         $this->loadLayout();
         if ($navigationBlock = $this->getLayout()->getBlock('customer_account_navigation')) {
             $navigationBlock->setActive('review/customer');

--- a/app/code/core/Mage/Review/controllers/CustomerController.php
+++ b/app/code/core/Mage/Review/controllers/CustomerController.php
@@ -62,7 +62,7 @@ class Mage_Review_CustomerController extends Mage_Core_Controller_Front_Action
 
         /* @var Mage_Review_Model_Review $review */
         $review = Mage::getModel('review/review')->load($reviewId);
-        if (!$review->getId() || $review->getCustomerId() != Mage::getSingleton('customer/session')->getCustomerId()){
+        if (!$review->getId() || $review->getCustomerId() != Mage::getSingleton('customer/session')->getCustomerId()) {
             return false;
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Review View in the customers menu and load any review changing the id in the url. Even not approved reviews can be loaded. This PR moves the Review loading logic to the controller and prevents it from loading reviews not created by the customer loading it.

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#1965

### Manual testing scenarios (*)
Go to customer menu, select "My Product Reviews" and select an review. In the view, change the id to a review id not belonging to your customer. 

### Questions or comments
Some more changes were needed to move the loading logic to the controller. Could this be a breaking change?
This opens the ability to view not approved foreign reviews, this should be merged into the LTS branch.