### PR TITLE
Missing middlename for salesOrderAddressEntity in SOAP APIs

### DIFF
--- a/app/code/core/Mage/Sales/etc/wsdl.xml
+++ b/app/code/core/Mage/Sales/etc/wsdl.xml
@@ -272,6 +272,7 @@
                     <element name="is_active" type="xsd:string" minOccurs="0" />
                     <element name="address_type" type="xsd:string" minOccurs="0" />
                     <element name="firstname" type="xsd:string" minOccurs="0" />
+                    <element name="middlename" type="xsd:string" minOccurs="0" />
                     <element name="lastname" type="xsd:string" minOccurs="0" />
                     <element name="company" type="xsd:string" minOccurs="0" />
                     <element name="street" type="xsd:string" minOccurs="0" />

--- a/app/code/core/Mage/Sales/etc/wsi.xml
+++ b/app/code/core/Mage/Sales/etc/wsi.xml
@@ -273,6 +273,7 @@
                     <xsd:element name="is_active" type="xsd:string" minOccurs="0" />
                     <xsd:element name="address_type" type="xsd:string" minOccurs="0" />
                     <xsd:element name="firstname" type="xsd:string" minOccurs="0" />
+                    <xsd:element name="middlename" type="xsd:string" minOccurs="0" />
                     <xsd:element name="lastname" type="xsd:string" minOccurs="0" />
                     <xsd:element name="company" type="xsd:string" minOccurs="0" />
                     <xsd:element name="street" type="xsd:string" minOccurs="0" />


### PR DESCRIPTION
The PR subject should be self explanatory :-)

The sales_flat_order_address table has a middlename field which is not returned buy the SOAP APIs, this PR adds it.