### PR TITLE
[PHP 8.0] Check if track `progressdetail` is an array before calling `count`

### DIFF
--- a/app/design/frontend/base/default/template/shipping/tracking/popup.phtml
+++ b/app/design/frontend/base/default/template/shipping/tracking/popup.phtml
@@ -128,7 +128,7 @@
                 </tbody>
             </table>
             <script type="text/javascript">decorateTable('tracking-table-popup-<?php echo $_id++ ?>');</script>
-            <?php if (is_object($track) && sizeof($track->getProgressdetail())>0): ?>
+            <?php if (is_object($track) && is_array($track->getProgressdetail()) && count($track->getProgressdetail()) > 0): ?>
                 <br />
                 <table class="data-table" id="track-history-table-<?php echo $track->getTracking(); ?>">
                     <col />


### PR DESCRIPTION

### Description (*)
In shipment tracking popup there is a use of `sizeof` on a nullable array which can end up throwing an error on PHP 8.0+, this PR fixes it by adding a simple `is_array` check before (and changing `sizeof` to `count` for clarity).

### Manual testing scenarios (*)
1. Create shipment for a Sales Order and select a built-in carrier like UPS for example.
2. Clicking "Track Order" will open the tracking popup which will display a warning on PHP 7.2+, and an error starting from PHP 8.0.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 