### PR TITLE
PHP 8.1 Fix cookie deletion behavior

### DIFF
--- a/app/code/core/Mage/Core/Model/Cookie.php
+++ b/app/code/core/Mage/Core/Model/Cookie.php
@@ -264,7 +264,7 @@ class Mage_Core_Model_Cookie
         if (PHP_VERSION_ID >= 70300) {
             setcookie(
                 $name,
-                $value,
+                (string)$value,
                 [
                     'expires'  => $expire,
                     'path'     => $path,
@@ -278,7 +278,7 @@ class Mage_Core_Model_Cookie
             if (!empty($sameSite)) {
                 $path.= "; samesite=${sameSite}";
             }
-            setcookie($name, $value, $expire, $path, $domain, $secure, $httponly);
+            setcookie($name, (string)$value, $expire, $path, $domain, $secure, $httponly);
         }
 
         return $this;

--- a/app/code/core/Mage/Core/Model/Cookie.php
+++ b/app/code/core/Mage/Core/Model/Cookie.php
@@ -339,6 +339,6 @@ class Mage_Core_Model_Cookie
             return $this;
         }
 
-        return $this->set($name, null, null, $path, $domain, $secure, $httponly, $sameSite);
+        return $this->set($name, '', null, $path, $domain, $secure, $httponly, $sameSite);
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
As described in the corresponding issue internal function `setcookie` only excepts string as value parameter and PHP 8.1 emits decription error (if not ignored by OpenMage) in case _null_ is passed. 
While the prior way of using _null_ still works (but with deprecation error) the_ correct way to delete the cookie is using an empty string as value. PHP internally changes the value to `deleted` which is sent in the response header. It's not necessary to pass anything else like a period that lies in the past (using negative value when calling set method of cookie model). 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#1958

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Log into Admin area
2. Immediately log out and observe the response header
3. Find a Set-Cookie field with `adminhtml=deleted`


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)

 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->