### PR TITLE
Added ability to add target attribute for adminhtml menu items

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Page/Menu.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Menu.php
@@ -95,7 +95,9 @@ class Mage_Adminhtml_Block_Page_Menu extends Mage_Adminhtml_Block_Template
      */
     public function getMenuArray()
     {
-        return $this->_buildMenuArray();
+        $parent = Mage::getSingleton('admin/config')->getAdminhtmlConfig()->getNode('menu');
+
+        return $this->_buildMenuArray($parent);
     }
 
     /**
@@ -127,12 +129,8 @@ class Mage_Adminhtml_Block_Page_Menu extends Mage_Adminhtml_Block_Template
      * @param int $level
      * @return array
      */
-    protected function _buildMenuArray(Varien_Simplexml_Element $parent=null, $path='', $level=0)
+    protected function _buildMenuArray(Varien_Simplexml_Element $parent, $path='', $level=0)
     {
-        if (is_null($parent)) {
-            $parent = Mage::getSingleton('admin/config')->getAdminhtmlConfig()->getNode('menu');
-        }
-
         $parentArr = array();
         $sortOrder = 0;
         foreach ($parent->children() as $childName => $child) {
@@ -166,6 +164,10 @@ class Mage_Adminhtml_Block_Page_Menu extends Mage_Adminhtml_Block_Template
                 || (strpos($this->getActive(), $path.$childName.'/')===0);
 
             $menuArr['level'] = $level;
+
+            if (in_array($child->target, ["_blank", "_self", "_parent", "_top"])) {
+                $menuArr['target'] = $child->target;
+            }
 
             if ($child->children) {
                 $menuArr['children'] = $this->_buildMenuArray($child->children, $path.$childName.'/', $level+1);
@@ -294,6 +296,7 @@ class Mage_Adminhtml_Block_Page_Menu extends Mage_Adminhtml_Block_Template
                 . (!empty($level) && !empty($item['last']) ? ' last' : '')
                 . ' level' . $level . '"> <a href="' . $item['url'] . '" '
                 . (!empty($item['title']) ? 'title="' . $item['title'] . '"' : '') . ' '
+                . (!empty($item['target']) ? 'target="' . $item['target'] . '"' : '') . ' '
                 . (!empty($item['click']) ? 'onclick="' . $item['click'] . '"' : '') . ' class="'
                 . ($level === 0 && !empty($item['active']) ? 'active' : '') . '"><span>'
                 . $this->escapeHtml($item['label']) . '</span></a>' . PHP_EOL;

--- a/app/code/core/Mage/Adminhtml/Block/Page/Menu.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Menu.php
@@ -165,7 +165,7 @@ class Mage_Adminhtml_Block_Page_Menu extends Mage_Adminhtml_Block_Template
 
             $menuArr['level'] = $level;
 
-            if (in_array($child->target, ["_blank", "_self", "_parent", "_top"])) {
+            if ($child->target) {
                 $menuArr['target'] = $child->target;
             }
 

--- a/app/design/adminhtml/default/default/template/page/menu.phtml
+++ b/app/design/adminhtml/default/default/template/page/menu.phtml
@@ -23,6 +23,8 @@
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
  * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var $this Mage_Adminhtml_Block_Page_Menu */
 ?>
 
 <div class="nav-bar">


### PR DESCRIPTION
### Description (*)
In OM there is currently now way how to open hyperlinks to new tabs / windows.

#### Usage
```xml
<menu_item translate="title">
    <title>Menu item label</title>
    <action>adminhtml/hello_world/foo</action>
    <target>_blank</target>
</menu_item>
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->