### PR TITLE
Fix typo in code comment

### DIFF
--- a/app/code/core/Mage/Catalog/Helper/Product/View.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/View.php
@@ -117,7 +117,7 @@ class Mage_Catalog_Helper_Product_View extends Mage_Core_Helper_Abstract
             $params = new Varien_Object();
         }
 
-        // Standard algorithm to prepare and rendern product view page
+        // Standard algorithm to prepare and render a product view page
         $product = $productHelper->initProduct($productId, $controller, $params);
         if (!$product) {
             throw new Mage_Core_Exception($this->__('Product is not loaded'), $this->ERR_NO_PRODUCT_LOADED);


### PR DESCRIPTION
### Description (*)

This pull request fixes the typo `rendern` to `render a`.

### Fixed Issues (if relevant)

No tickets were opened for this issue.

### Manual testing scenarios (*)

As this pull request changes only a comment, no changes to the testing suit are required.