### PR TITLE
Removed global polyfill function for PHP versions below 7.0

### DIFF
--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -404,19 +404,3 @@ if (!function_exists('hash_equals')) {
         return 0 === $result;
     }
 }
-
-if (version_compare(PHP_VERSION, '7.0.0', '<') && !function_exists('random_int')) {
-    /**
-     * Generates pseudo-random integers
-     *
-     * @param int $min
-     * @param int $max
-     * @return int Returns random integer in the range $min to $max, inclusive.
-     */
-    function random_int($min, $max)
-    {
-        mt_srand();
-
-        return mt_rand($min, $max);
-    }
-}


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

The `functions.php` in Core module introduces global functions useable in all of OpenMage. The minimal version of OpenMage currently is PHP 7.0 which is in fact enforced in `index.php`, `get.php` and `api.php` in the form of: 
```php
if (version_compare(phpversion(), '7.0.0', '<')===true) {
   echo ### SOME FLAVOR OF: 'INVALID PHP VERSION' ###
    exit;
}
```
(*the content of the displayed error message varies between the three files*)

Therefore I argue the conditional in the `functions.php` can never be true because `PHP_VERSION` is never below *7.0.0*. If the conditional would be true a polyfill function for `random_int` would be introduced. But because that's not the case the condition is evaluated unnecessarily for each request and subsequently can be deleted. 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)