### PR TITLE
Deprecated global function "now" because it's equivalent to Varien_Date::now()

### DIFF
--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -70,10 +70,12 @@ function uc_words($str, $destSep = '_', $srcSep = '_')
  *
  * @param bool $dayOnly
  * @return string
+ * @deprecated use equivalent Varien method directly
+ * @see Varien_Date::now()
  */
 function now($dayOnly = false)
 {
-    return date($dayOnly ? 'Y-m-d' : 'Y-m-d H:i:s');
+    return Varien_Date::now($dayOnly);
 }
 
 /**


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
There are currently two `now` methods that are doing the exact same thing, returning the formatted version of the current timestamp either with or without the time part (*Besides those there is a third one within Zend that does a similar thing but is not part of this PR*).

global `now` (_app/code/core/Mage/Core/functions.php_): 
```php
/**
 * Simple sql format date
 *
 * @param bool $dayOnly
 * @return string
 */
function now($dayOnly = false)
{
    return date($dayOnly ? 'Y-m-d' : 'Y-m-d H:i:s');
}
```

Varien_Date (_lib/Varien/Date.php_): 
```php
/**
 * Retrieve current date in internal format
 *
 * @param boolean $withoutTime day only flag
 * @return string
 */
public static function now($withoutTime = false)
{
    $format = $withoutTime ? self::DATE_PHP_FORMAT : self::DATETIME_PHP_FORMAT;
    return date($format);
}
```

the used constants: 
```php
const DATETIME_PHP_FORMAT       = 'Y-m-d H:i:s';
const DATE_PHP_FORMAT           = 'Y-m-d';
```

It's clear to see that both functions are equivalent. I propose: 
1. To deprecate global function `now`
2. To reference the replacement `Varien_Date::now()`
3. To use the replacement call instead of the redundant code

In subsequent PRs the following changes can be implemented: 
1. For v19 occurrences of deprecated global function shall be replaced one-to-one
2. For v20 deprecated global function shall be removed 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)