### PR TITLE
Added option not to use timezone in rendering datetime in backend grid.

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Datetime.php
@@ -74,9 +74,12 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Datetime
     {
         if ($data = $this->_getValue($row)) {
             $format = $this->_getFormat();
+            $useTimezone = $this->getColumn()->getUseTimezone() ?? true;
+            $locale = $this->getColumn()->getLocale() ?? null;
             try {
                 $data = Mage::app()->getLocale()
-                    ->date($data, Varien_Date::DATETIME_INTERNAL_FORMAT)->toString($format);
+                    ->date($data, Varien_Date::DATETIME_INTERNAL_FORMAT, $locale, $useTimezone)
+                    ->toString($format);
             }
             catch (Exception $e)
             {


### PR DESCRIPTION
### Description (*)
I needed to render a datetime field in local timezone. The field is flight estimated time of arrival, input in local timezone (as opposed to GMT) to the table in DB.

An example: `eta` is **2022-01-28 20:05:00** stored in local time in the table.

Before this commit:
![image](https://user-images.githubusercontent.com/1106470/151649805-034e3d71-e806-4df0-8f4a-571176bb5a98.png)

After this commit:
![image](https://user-images.githubusercontent.com/1106470/151649828-76efdde2-2a9d-465a-abe0-00e4b5053112.png)

Sample code:
```php
        $this->addColumn('eta', [
            'header'    => $helper->__('ETA'),
            'index'     => 'eta',
            'width'     => '120px',
            'type'      => 'datetime',
            'use_timezone' => false, // <--- disable timezone conversion
        ]);
```

### Related Pull Requests

### Fixed Issues (if relevant)

### Manual testing scenarios (*)
See description.

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->