### PR TITLE
[PHP 8.1] Fix passing `null` to `trim()`

### DIFF
--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -1271,7 +1271,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
         $config = $this->_xml->global->{$groupType.'s'}->{$group};
 
         // First - check maybe the entity class was rewritten
-        $className = null;
+        $className = '';
         if (isset($config->rewrite->$class)) {
             $className = (string)$config->rewrite->$class;
         } else {


### PR DESCRIPTION
### Description (*)
Another PHP 8.1 compatibility PR, this time in `Mage_Core_Model_Config#getGroupedClassName` where `$className` variable is initialized with `null` and depending on the code path can lead to passing `null` to `trim` which accepts a non-nullable argument which is deprecated starting from PHP 8.1.

### Manual testing scenarios (*)
1. I discovered this deprecation error when running `Mage::getResourceModel('sales/order_collection')->load();` from the `n98-magerun` dev console. After this change, the error no longer shows.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 