### PR TITLE
Fixed issue #2001, EAV datetime attribute can't save time.

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Datetime.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Datetime.php
@@ -83,7 +83,7 @@ class Mage_Eav_Model_Entity_Attribute_Backend_Datetime extends Mage_Eav_Model_En
         else {
             $date = Mage::app()->getLocale()->date(
                 $date,
-                Mage::app()->getLocale()->getDateFormat(Mage_Core_Model_Locale::FORMAT_TYPE_SHORT),
+                Mage::app()->getLocale()->getDateTimeFormat(Mage_Core_Model_Locale::FORMAT_TYPE_SHORT),
                 null,
                 false
             );


### PR DESCRIPTION

### Description (*)
See issue #2001.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#2001

### Manual testing scenarios (*)
1. Add a catalog attribute with property `frontend_input` set to `datetime`.
2. Add the attribute to a Attribute Set `default`.
3. In backend product page, try saving the attribute with date and time value.
4. Without this commit, the time is not saved.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->