### PR TITLE
Replaced remaining deprecated urlEscape calls.

### DIFF
--- a/app/code/core/Mage/Widget/Model/Widget.php
+++ b/app/code/core/Mage/Widget/Model/Widget.php
@@ -256,7 +256,7 @@ class Mage_Widget_Model_Widget extends Varien_Object
             '<img id="%s" src="%s" title="%s">',
             $this->_idEncode($directive),
             $image,
-            Mage::helper('core')->urlEscape($directive)
+            Mage::helper('core')->escapeUrl($directive)
         );
         return $html;
     }

--- a/app/design/frontend/base/default/template/catalog/layer/filter.phtml
+++ b/app/design/frontend/base/default/template/catalog/layer/filter.phtml
@@ -36,7 +36,7 @@
 <?php foreach ($this->getItems() as $_item): ?>
     <li>
         <?php if ($_item->getCount() > 0): ?>
-        <a href="<?php echo $this->urlEscape($_item->getUrl()) ?>"><?php echo $_item->getLabel() ?></a>
+        <a href="<?php echo $this->escapeUrl($_item->getUrl()) ?>"><?php echo $_item->getLabel() ?></a>
         <?php else: echo $_item->getLabel() ?>
         <?php endif ?>
         <?php if ($this->shouldDisplayProductCount()): ?>

--- a/app/design/frontend/rwd/default/template/catalog/layer/filter.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/layer/filter.phtml
@@ -36,7 +36,7 @@
 <?php foreach ($this->getItems() as $_item): ?>
     <li>
         <?php if ($_item->getCount() > 0): ?>
-            <a href="<?php echo $this->urlEscape($_item->getUrl()) ?>">
+            <a href="<?php echo $this->escapeUrl($_item->getUrl()) ?>">
                 <?php echo $_item->getLabel() ?>
                 <?php if ($this->shouldDisplayProductCount()): ?>
                 <span class="count">(<?php echo $_item->getCount() ?>)</span>

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/layer/filter/swatches.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/layer/filter/swatches.phtml
@@ -51,7 +51,7 @@ $_swatchOuterHeight = $_dimHelper->getOuterHeight(Mage_ConfigurableSwatches_Help
         ?>
         <li<?php if ($_hasImage){ echo ' style="line-height: ' . $_lineHeight . 'px;"'; } ?>>
             <?php if ($_hasItems): ?>
-                <a href="<?php echo $this->urlEscape($_item->getUrl()) ?>" class="<?php echo $_linkClass ?>">
+                <a href="<?php echo $this->escapeUrl($_item->getUrl()) ?>" class="<?php echo $_linkClass ?>">
             <?php else: ?>
                 <span class="<?php echo $_linkClass ?>">
             <?php endif ?>


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The method `urlEscape` in `Mage_Core_Block_Abstract` is deprecated in Magento versions newer than 1.4.0.0-rc1 (for a long time). A few calls to the deprecated method still remained in the codebase, different from the similar and also deprecated `htmlEscape`.  This PR replaces the occurrences so that both legacy methods are no longer used in Core. 

This gives the opportunity to remove both legacy methods altogether in v20. 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)