### PR TITLE
Remove white space for config values for #1852

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Separator.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Separator.php
@@ -7,17 +7,14 @@ class Mage_Adminhtml_Model_System_Config_Source_Catalog_Search_Separator
      */
     public function toOptionArray()
     {
-        $types = [
-            ' OR ' => 'OR (default)',
-            ' AND ' => 'AND'
+        return [
+            [
+                'value' => 'OR',
+                'label' => 'OR (default)'
+            ], [
+                'value' => 'AND',
+                'label' => 'AND'
+            ]
         ];
-        $options = [];
-        foreach ($types as $k => $v) {
-            $options[] = [
-                'value' => $k,
-                'label' => $v
-            ];
-        }
-        return $options;
     }
 }

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
@@ -356,7 +356,7 @@ class Mage_CatalogSearch_Model_Resource_Fulltext extends Mage_Core_Model_Resourc
 
             if ($like) {
                 $separator = Mage::getStoreConfig(Mage_CatalogSearch_Model_Fulltext::XML_PATH_CATALOG_SEARCH_SEPARATOR);
-                $likeCond = '(' . implode($separator, $like) . ')';
+                $likeCond = '(' . implode(' '.$separator.' ', $like) . ')';
             }
         }
 

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
@@ -356,7 +356,7 @@ class Mage_CatalogSearch_Model_Resource_Fulltext extends Mage_Core_Model_Resourc
 
             if ($like) {
                 $separator = Mage::getStoreConfig(Mage_CatalogSearch_Model_Fulltext::XML_PATH_CATALOG_SEARCH_SEPARATOR);
-                $likeCond = '(' . implode(' '.$separator.' ', $like) . ')';
+                $likeCond = '(' . implode(' ' . $separator . ' ', $like) . ')';
             }
         }
 

--- a/app/code/core/Mage/CatalogSearch/etc/config.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/config.xml
@@ -137,7 +137,7 @@
                 <max_query_length>128</max_query_length>
                 <max_query_words>10</max_query_words>
                 <search_type>1</search_type>
-                <search_separator> OR </search_separator>
+                <search_separator>OR</search_separator>
                 <use_layered_navigation_count>2000</use_layered_navigation_count>
                 <show_autocomplete_results_count>1</show_autocomplete_results_count>
             </search>


### PR DESCRIPTION
### Description
I removed white space from config values for `OR` and `AND` (introduced with #1852).

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
