### PR TITLE
Fix warnings on undefined user agent

### DIFF
--- a/app/code/core/Mage/Core/Model/Design/Package.php
+++ b/app/code/core/Mage/Core/Model/Design/Package.php
@@ -672,15 +672,16 @@ class Mage_Core_Model_Design_Package
     public static function getPackageByUserAgent(array $rules, $regexpsConfigPath = 'path_mock')
     {
         foreach ($rules as $rule) {
-            if (!empty(self::$_regexMatchCache[$rule['regexp']][$_SERVER['HTTP_USER_AGENT']])) {
+            $userAgent = $_SERVER['HTTP_USER_AGENT'] ?? '';
+            if (!empty(self::$_regexMatchCache[$rule['regexp']][$userAgent])) {
                 self::$_customThemeTypeCache[$regexpsConfigPath] = $rule['value'];
                 return $rule['value'];
             }
 
             $regexp = '/' . trim($rule['regexp'], '/') . '/';
 
-            if (@preg_match($regexp, $_SERVER['HTTP_USER_AGENT'])) {
-                self::$_regexMatchCache[$rule['regexp']][$_SERVER['HTTP_USER_AGENT']] = true;
+            if (@preg_match($regexp, $userAgent)) {
+                self::$_regexMatchCache[$rule['regexp']][$userAgent] = true;
                 self::$_customThemeTypeCache[$regexpsConfigPath] = $rule['value'];
                 return $rule['value'];
             }


### PR DESCRIPTION
### Description (*)
There can be HTTP requests without an user agent (not just empty, but not set at all). In my case they are coming from an internal system talking to Magento's SOAP API. Depending on PHP's error settings, this leads to warning in the system.log.

```
Warning: Undefined array key "HTTP_USER_AGENT"  in .../app/code/core/Mage/Core/Model/Design/Package.php on line 675
```

### Related Pull Requests
None

### Fixed Issues (if relevant)
None

### Manual testing scenarios (*)
Run `curl -H "User-Agent:" https:/example.com`. This sends a request without an user agent. Depending on your configuration you will see the warnings in system.log

### Questions or comments
None

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
