### PR TITLE
add unit Tests and send coverage results to SonarCloud

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,53 @@
+name: OpenMage LTS - Sonar - Full Analyses
+
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+
+
+jobs:
+  unit:
+    name: Unit Tests on ${{ matrix.php-versions }}
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      max-parallel: 5
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['7.4', '8.1']
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring
+          tools: composer, pecl, phpcs, phpstan, phpunit:9.5
+          ini-values-csv: pcov.directory=api, post_max_size=256M, short_open_tag=On #optional, setup php.ini configuration
+          coverage: pcov #optional, setup coverage driver
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare
+        run: |
+          php -v
+          composer --version
+          composer install --dev -n --prefer-source
+      - name: Run Unit Tests
+        run: ./vendor/bin/phpunit --configuration ./dev/phpunit.xml.dist --testsuite=Unit;
+      - name: prepare SonarCloud Scan Data
+        if: ${{ matrix.php-versions == '8.1' }}
+        run: |
+          ls -la
+          sed -i 's@'$GITHUB_WORKSPACE'/@/github/workspace/@g' ./dev/tests/junit.xml
+          sed -i 's@'$GITHUB_WORKSPACE'/@/github/workspace/@g' ./dev/tests/coverage.clover
+          ls -la
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        if: ${{ matrix.php-versions == '8.1' }}
+        with:
+          args: >
+            -Dproject.settings=dev/sonar-project.properties
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -47,7 +47,7 @@ jobs:
           ls -la
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
-        if: ${{ matrix.php-versions == '8.1' }}
+        if: ${{ matrix.php-versions == '8.1' }} && SONAR_TOKEN
         with:
           args: >
             -Dproject.settings=dev/sonar-project.properties

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -38,9 +38,12 @@ jobs:
       - name: prepare SonarCloud Scan Data
         if: ${{ matrix.php-versions == '8.1' }}
         run: |
+          echo $PWD
           ls -la
+          head ./dev/tests/clover.xml
           sed -i 's@'$GITHUB_WORKSPACE'/@/github/workspace/@g' ./dev/tests/junit.xml
           sed -i 's@'$GITHUB_WORKSPACE'/@/github/workspace/@g' ./dev/tests/clover.xml
+          head ./dev/tests/clover.xml
           ls -la
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           ls -la
           sed -i 's@'$GITHUB_WORKSPACE'/@/github/workspace/@g' ./dev/tests/junit.xml
-          sed -i 's@'$GITHUB_WORKSPACE'/@/github/workspace/@g' ./dev/tests/coverage.clover
+          sed -i 's@'$GITHUB_WORKSPACE'/@/github/workspace/@g' ./dev/tests/clover.xml
           ls -la
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -34,7 +34,7 @@ jobs:
           composer --version
           composer install --dev -n --prefer-source
       - name: Run Unit Tests
-        run: ./vendor/bin/phpunit --configuration ./dev/phpunit.xml.dist --testsuite=Unit;
+        run: phpunit --configuration ./dev/phpunit.xml.dist --testsuite=Unit;
       - name: prepare SonarCloud Scan Data
         if: ${{ matrix.php-versions == '8.1' }}
         run: |

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           php -v
           composer --version
-          composer install --dev -n --prefer-source
+          composer install --dev -n --prefer-source --ignore-platform-req=php
       - name: Run Unit Tests
         run: phpunit --configuration ./dev/phpunit.xml.dist --testsuite=Unit;
       - name: prepare SonarCloud Scan Data

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,9 @@
       "role": "Maintainer"
     }
   ],
+  "autoload-dev": {
+    "psr-4": { "OpenMage\\Tests\\Unit\\": "dev/tests/unit" }
+  },
   "extra": {
     "branch-alias": {
       "dev-main": "1.9.4.x-dev"

--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -1,0 +1,4 @@
+/testfield
+/tests/clover.xml
+/tests/crap4j.xml
+/tests/junit.xml

--- a/dev/phpunit.xml.dist
+++ b/dev/phpunit.xml.dist
@@ -31,18 +31,18 @@
             processUncoveredFiles="true"
     >
         <include>
-            <directory suffix=".php">app/code</directory>
-            <directory suffix=".php">lib</directory>
+            <directory suffix=".php">../app/code</directory>
+            <directory suffix=".php">../lib</directory>
         </include>
         <exclude>
-            <file>app/bootstrap.php</file>
+            <file>../app/bootstrap.php</file>
         </exclude>
         <report>
-            <clover outputFile="./dev/tests/clover.xml"/>
-            <crap4j outputFile="./dev/tests/crap4j.xml"/>
+            <clover outputFile="./tests/clover.xml"/>
+            <crap4j outputFile="./tests/crap4j.xml"/>
         </report>
     </coverage>
     <logging>
-        <junit outputFile="./dev/tests/junit.xml"/>
+        <junit outputFile="./tests/junit.xml"/>
     </logging>
 </phpunit>

--- a/dev/phpunit.xml.dist
+++ b/dev/phpunit.xml.dist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit
+
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+        backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/bootstrap.php"
+>
+    <testsuites>
+        <testsuite name="TestfieldUnit">
+            <directory>./dev/testfield/tests/Unit</directory>
+        </testsuite>
+        <testsuite name="TestfieldFullstack">
+            <directory>./dev/testfield/tests/MagentoHackathon/Composer/FullStack</directory>
+        </testsuite>
+        <testsuite name="Unit">
+            <directory>./dev/tests/unit</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage
+            includeUncoveredFiles="true"
+            processUncoveredFiles="true"
+    >
+        <include>
+            <directory suffix=".php">app/code</directory>
+            <directory suffix=".php">lib</directory>
+        </include>
+        <exclude>
+            <file>app/bootstrap.php</file>
+        </exclude>
+        <report>
+            <clover outputFile="./dev/tests/clover.xml"/>
+            <crap4j outputFile="./dev/tests/crap4j.xml"/>
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile="./dev/tests/junit.xml"/>
+    </logging>
+</phpunit>

--- a/dev/phpunit.xml.dist
+++ b/dev/phpunit.xml.dist
@@ -28,7 +28,7 @@
 
     <coverage
             includeUncoveredFiles="true"
-            processUncoveredFiles="true"
+            processUncoveredFiles="false"
     >
         <include>
             <directory suffix=".php">../app/code</directory>

--- a/dev/phpunit.xml.dist
+++ b/dev/phpunit.xml.dist
@@ -16,13 +16,13 @@
 >
     <testsuites>
         <testsuite name="TestfieldUnit">
-            <directory>./dev/testfield/tests/Unit</directory>
+            <directory>./testfield/tests/Unit</directory>
         </testsuite>
         <testsuite name="TestfieldFullstack">
-            <directory>./dev/testfield/tests/MagentoHackathon/Composer/FullStack</directory>
+            <directory>./testfield/tests/MagentoHackathon/Composer/FullStack</directory>
         </testsuite>
         <testsuite name="Unit">
-            <directory>./dev/tests/unit</directory>
+            <directory>./tests/unit</directory>
         </testsuite>
     </testsuites>
 

--- a/dev/phpunit.xml.dist
+++ b/dev/phpunit.xml.dist
@@ -36,6 +36,8 @@
         </include>
         <exclude>
             <file>../app/bootstrap.php</file>
+            <file>../app/code/core/Mage/Admin/Model/Acl/Assert/Ip.php</file>
+            <file>../app/code/core/Mage/Admin/Model/Acl/Assert/Time.php</file>
         </exclude>
         <report>
             <clover outputFile="./tests/clover.xml"/>

--- a/dev/sonar-project.properties
+++ b/dev/sonar-project.properties
@@ -1,0 +1,17 @@
+sonar.projectKey=openmage-lts
+sonar.organization=openmage
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=openmage-lts
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=./app/code,./lib/
+sonar.tests=./dev/tests/
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8
+
+sonar.language=php
+sonar.php.tests.reportPath=./dev/tests/junit.xml
+sonar.php.coverage.reportPaths=./dev/tests/clover.xml

--- a/dev/sonar-project.properties
+++ b/dev/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.organization=openmage
 #sonar.projectVersion=1.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources=./app/code,./lib/
+sonar.sources=./app/code
 sonar.tests=./dev/tests/
 
 # Encoding of the source code. Default is default system encoding

--- a/dev/tests/bootstrap.php
+++ b/dev/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+// Set up autoloading
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+ini_set('error_reporting', -1);

--- a/dev/tests/bootstrap.php
+++ b/dev/tests/bootstrap.php
@@ -2,4 +2,5 @@
 // Set up autoloading
 require_once __DIR__ . '/../../vendor/autoload.php';
 
+require_once __DIR__ . '/../../app/Mage.php';
 ini_set('error_reporting', -1);

--- a/dev/tests/unit/Base/ClassLoadingTest.php
+++ b/dev/tests/unit/Base/ClassLoadingTest.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace OpenMage\Tests\Unit\Base;
+
+use PHPUnit\Framework\TestCase;
+
+class ClassLoadingTest extends TestCase
+{
+
+    public function testClassExists()
+    {
+        $this->assertTrue(class_exists('Mage'));
+        $this->assertTrue(class_exists('Mage_Eav_Model_Entity_Increment_Numeric'));
+    }
+
+    public function testClassDoesNotExists()
+    {
+        $this->assertFalse(class_exists('Mage_Non_Existent'));
+    }
+}

--- a/dev/tests/unit/Mage/Core/Helper/StringTest.php
+++ b/dev/tests/unit/Mage/Core/Helper/StringTest.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Core\Helper;
+
+use Mage_Core_Helper_String;
+use PHPUnit\Framework\TestCase;
+
+class StringTest extends TestCase
+{
+    const TEST_STRING_1 = 'Test 12345 a lot more Text';
+
+    public function testSubstr()
+    {
+        $subject = new Mage_Core_Helper_String();
+        $resultString = $subject->substr(
+            self::TEST_STRING_1,
+            5,
+            5
+        );
+        $this->assertEquals(
+            '12345',
+            $resultString
+        );
+    }
+
+    public function testTruncate()
+    {
+        $subject = new Mage_Core_Helper_String();
+        $resultString = $subject->truncate(
+            self::TEST_STRING_1,
+            13,
+            '###'
+        );
+        $this->assertEquals(
+            'Test 12345###',
+            $resultString
+        );
+
+    }
+
+    public function testStrlen()
+    {
+        $subject = new Mage_Core_Helper_String();
+        $this->assertEquals(
+            26,
+            $subject->strlen(self::TEST_STRING_1)
+        );
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
adds a base setup for running unit Tests with code coverage and sends them to sonarCloud
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->


### Questions or comments
the code coverage should have been created correctly, not sure why its not imported
example how it currently looks: https://sonarcloud.io/summary/new_code?id=openmage-lts&branch=sonarcube

example from another project how it can look:
https://sonarcloud.io/summary/overall?id=Cotya_magento-composer-installer


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->