### PR TITLE
Pass delimiter char to preg_quote

### DIFF
--- a/app/code/core/Mage/Api2/Model/Resource/Validator/Eav.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Validator/Eav.php
@@ -225,11 +225,11 @@ class Mage_Api2_Model_Resource_Validator_Eav extends Mage_Api2_Model_Resource_Va
         // business asked to avoid additional validation message, so we filter it here
         $errors        = array();
         $requiredAttrs = array();
-        $isRequiredRE  = '/^' . str_replace('%s', '(.+)', preg_quote(Mage::helper('eav')->__('"%s" is a required value.'))) . '$/';
+        $isRequiredRE  = '/^' . str_replace('%s', '(.+)', preg_quote(Mage::helper('eav')->__('"%s" is a required value.'), '/'), ) . '$/';
         $greaterThanRE = '/^' . str_replace(
             '%s',
             '(.+)',
-            preg_quote(Mage::helper('eav')->__('"%s" length must be equal or greater than %s characters.'))
+            preg_quote(Mage::helper('eav')->__('"%s" length must be equal or greater than %s characters.'), '/')
         ) . '$/';
 
         // find all required attributes labels

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -659,8 +659,8 @@ class Mage_Catalog_Model_Url
             }
             // match request_url abcdef1234(-12)(.html) pattern
             $match = array();
-            $regularExpression = '#(?P<prefix>(.*/)?' . preg_quote($urlKey) . ')(-(?P<increment>[0-9]+))?(?P<suffix>'
-                . preg_quote($suffix) . ')?$#i';
+            $regularExpression = '#(?P<prefix>(.*/)?' . preg_quote($urlKey, '#') . ')(-(?P<increment>[0-9]+))?(?P<suffix>'
+                . preg_quote($suffix, '#') . ')?$#i';
             if (!preg_match($regularExpression, $requestPath, $match)) {
                 return $this->getUnusedPathByUrlKey($storeId, '-', $idPath, $urlKey);
             }

--- a/app/code/core/Mage/Core/Model/Translate/Inline.php
+++ b/app/code/core/Mage/Core/Model/Translate/Inline.php
@@ -383,7 +383,7 @@ class Mage_Core_Model_Translate_Inline
             $attrRegExp = '#' . $this->_tokenRegex . '#S';
             $trArr = $this->_getTranslateData($attrRegExp, $tagHtml, array($this, '_getAttributeLocation'));
             if ($trArr) {
-                $transRegExp = '# data-translate=' . $quoteHtml . '\[([^'.preg_quote($quoteHtml).']*)]' . $quoteHtml . '#i';
+                $transRegExp = '# data-translate=' . $quoteHtml . '\[([^'.preg_quote($quoteHtml, '#').']*)]' . $quoteHtml . '#i';
                 if (preg_match($transRegExp, $tagHtml, $m)) {
                     $tagHtml = str_replace($m[0], '', $tagHtml); //remove tra
                     $trAttr = ' data-translate=' . $quoteHtml

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Xml/Excel.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Xml/Excel.php
@@ -126,7 +126,7 @@ class Mage_Dataflow_Model_Convert_Parser_Xml_Excel extends Mage_Dataflow_Model_C
                     continue;
                 }
                 else {
-                    if (preg_match('/ss:Name=\"'.preg_quote($worksheet).'\"/siU', substr($xmlTmpString, 0, $strposF))) {
+                    if (preg_match('/ss:Name=\"'.preg_quote($worksheet, '/').'\"/siU', substr($xmlTmpString, 0, $strposF))) {
                         $xmlString = substr($xmlTmpString, $strposF);
                         $isWorksheet = true;
                         continue;

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogCategory/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogCategory/Curl.php
@@ -137,7 +137,7 @@ class Curl extends AbstractCurl implements CatalogCategoryInterface
         $curl->write($url, [], CurlInterface::POST);
         $response = $curl->read();
         $curl->close();
-        preg_match('~<option.*value="(\d+)".*>' . preg_quote($landingName) . '</option>~', $response, $matches);
+        preg_match('~<option.*value="(\d+)".*>' . preg_quote($landingName, '~') . '</option>~', $response, $matches);
         $id = isset($matches[1]) ? (int)$matches[1] : null;
 
         return $id;

--- a/lib/Zend/Cloud/DocumentService/Adapter/WindowsAzure.php
+++ b/lib/Zend/Cloud/DocumentService/Adapter/WindowsAzure.php
@@ -525,7 +525,7 @@ class Zend_Cloud_DocumentService_Adapter_WindowsAzure
      */
     protected function _validateKey($key)
     {
-        if (preg_match('@[/#?' . preg_quote('\\') . ']@', $key)) {
+        if (preg_match('@[/#?' . preg_quote('\\', '@') . ']@', $key)) {
             throw new Zend_Cloud_DocumentService_Exception('Invalid partition or row key provided; must not contain /, \\,  #, or ? characters');
         }
     }

--- a/lib/Zend/Db/Statement.php
+++ b/lib/Zend/Db/Statement.php
@@ -180,20 +180,20 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
         // get the character for value quoting
         // this should be '
         $q = $this->_adapter->quote('a');
-        $q = $q[0];        
+        $q = $q[0];
         // get the value used as an escaped quote,
         // e.g. \' or ''
         $qe = $this->_adapter->quote($q);
         $qe = substr($qe, 1, 2);
-        $qe = preg_quote($qe);
+        $qe = preg_quote($qe, '/');
         $escapeChar = substr($qe,0,1);
         // remove 'foo\'bar'
         if (!empty($q)) {
-            $escapeChar = preg_quote($escapeChar);
+            $escapeChar = preg_quote($escapeChar, '/');
             // this segfaults only after 65,000 characters instead of 9,000
             $sql = preg_replace("/$q([^$q{$escapeChar}]*|($qe)*)*$q/s", '', $sql);
         }
-        
+
         // get a version of the SQL statement with all quoted
         // values and delimited identifiers stripped out
         // remove "foo\"bar"
@@ -207,7 +207,7 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
         // e.g. \" or "" or \`
         $de = $this->_adapter->quoteIdentifier($d);
         $de = substr($de, 1, 2);
-        $de = preg_quote($de);
+        $de = preg_quote($de, '/');
         // Note: $de and $d where never used..., now they are:
         $sql = preg_replace("/$d($de|\\\\{2}|[^$d])*$d/Us", '', $sql);
         return $sql;

--- a/lib/Zend/Http/Cookie.php
+++ b/lib/Zend/Http/Cookie.php
@@ -395,7 +395,7 @@ class Zend_Http_Cookie
 
         // Check for either exact match or suffix match
         return ($cookieDomain == $host ||
-                preg_match('/\.' . preg_quote($cookieDomain) . '$/', $host));
+                preg_match('/\.' . preg_quote($cookieDomain, '/') . '$/', $host));
     }
 
     /**


### PR DESCRIPTION
### Description (*)
The most common used delimiters in PHP are /@#~,
which are not escaped by default
(by default preg_quote escapes .\+*?[^]$(){}=!<>|:-).