### PR TITLE
Prevent Zend_Date from checking locale for know date codes

### DIFF
--- a/app/code/core/Zend/Date.php
+++ b/app/code/core/Zend/Date.php
@@ -544,12 +544,12 @@ class Zend_Date extends Zend_Date_DateObject
         }
 
         if (($part !== null) && !defined($part)
-            && ($part != 'ee') && ($part != 'ss') && ($part != 'GG') && ($part != 'MM') && ($part != 'EE') && ($part != 'TT')
+            && ($part !== 'ee') && ($part !== 'ss') && ($part !== 'GG') && ($part !== 'MM') && ($part !== 'EE') && ($part !== 'TT')
+            && ($part !== 'U') && ($part !== 'X') && ($part !== 'c')
             && Zend_Locale::isLocale($part, null, false)) {
             $locale = $part;
             $part = null;
         }
-
         if ($part === null) {
             $part = self::TIMESTAMP;
         } else if (self::$_options['format_type'] == 'php') {


### PR DESCRIPTION
Add U, X and c, as we know the codes are not real locales.