### PR TITLE
Use vanillaJS instead of prototype in Wishlist add to cart column

### DIFF
--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Cart.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Cart.php
@@ -64,8 +64,9 @@ class Mage_Wishlist_Block_Customer_Wishlist_Item_Column_Cart extends Mage_Wishli
                 } else {
                     url = '" . $this->getItemAddToCartUrlCustom('%item%', false) . "';
                 }
-                url = url.gsub('%item%', itemId);
-                var form = $('wishlist-view-form');
+                url = url.replace('%item%', itemId);
+
+                var form = document.getElementById('wishlist-view-form');
                 if (form) {
                     var input = form['qty[' + itemId + ']'];
                     if (input) {


### PR DESCRIPTION
Use vanillaJS instead of prototype in Wishlist add to cart column