### PR TITLE
Added database ID to EAV options table

### DIFF
--- a/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
+++ b/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
@@ -75,7 +75,6 @@
         <div class="hor-scroll">
             <table class="dynamic-grid" cellspacing="0"  cellpadding="0">
                 <tr id="attribute-options-table">
-                    <th style="width:1px" class="a-right">ID&nbsp;&nbsp;</th>
                     <?php foreach ($this->getStores() as $_store): ?>
                         <th><?php echo $this->escapeHtml($_store->getName()); ?></th>
                     <?php endforeach ?>
@@ -88,7 +87,6 @@
                         </th>
                     </tr>
                     <tr class="no-display template" id="row-template">
-                        <td class="a-right">{{_id}}&nbsp;&nbsp;</td>
                         <?php foreach ($this->getStores() as $_store): ?>
                         <td><input name="option[value][{{id}}][<?php echo $_store->getId() ?>]" value="{{store<?php echo $_store->getId() ?>}}" class="input-text<?php if($_store->getId()==0): ?> required-option<?php endif ?>" type="text" <?php if ($this->getReadOnly()):?> disabled="disabled"<?php endif ?>/></td>
                         <?php endforeach ?>
@@ -112,8 +110,7 @@ var optionDefaultInputType = 'radio';
 
 // IE removes quotes from element.innerHTML whenever it thinks they're not needed, which breaks html.
 var templateText =
-        '<tr class="option-row">'+
-            '<td class="a-right">{{_id}}&nbsp;&nbsp;</td>'+
+        '<tr class="option-row" title="ID: {{id}}">'+
 <?php foreach ($this->getStores() as $_store): ?>
             '<td><input name="option[value][{{id}}][<?php echo $_store->getId() ?>]" value="{{store<?php echo $_store->getId() ?>}}" class="input-text<?php if($_store->getId()==0): ?> required-option<?php endif ?>" type="text" <?php if ($this->getReadOnly()):?> disabled="disabled"<?php endif ?>/><\/td>'+
 <?php endforeach ?>
@@ -137,7 +134,6 @@ var attributeOption = {
     add : function(data) {
         this.template = new Template(this.templateText, this.templateSyntax);
         var isNewOption = false;
-        data._id = data.id;
         if(!data.id){
             data = {};
             data.id  = 'option_'+this.itemCount;

--- a/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
+++ b/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
@@ -75,7 +75,7 @@
         <div class="hor-scroll">
             <table class="dynamic-grid" cellspacing="0"  cellpadding="0">
                 <tr id="attribute-options-table">
-                    <th style="width:1px">ID</th>
+                    <th style="width:1px" class="a-right">ID&nbsp;&nbsp;</th>
                     <?php foreach ($this->getStores() as $_store): ?>
                         <th><?php echo $this->escapeHtml($_store->getName()); ?></th>
                     <?php endforeach ?>
@@ -88,7 +88,7 @@
                         </th>
                     </tr>
                     <tr class="no-display template" id="row-template">
-                        <td>{{_id}}</td>
+                        <td class="a-right">{{_id}}&nbsp;&nbsp;</td>
                         <?php foreach ($this->getStores() as $_store): ?>
                         <td><input name="option[value][{{id}}][<?php echo $_store->getId() ?>]" value="{{store<?php echo $_store->getId() ?>}}" class="input-text<?php if($_store->getId()==0): ?> required-option<?php endif ?>" type="text" <?php if ($this->getReadOnly()):?> disabled="disabled"<?php endif ?>/></td>
                         <?php endforeach ?>
@@ -113,7 +113,7 @@ var optionDefaultInputType = 'radio';
 // IE removes quotes from element.innerHTML whenever it thinks they're not needed, which breaks html.
 var templateText =
         '<tr class="option-row">'+
-            '<td>{{_id}}</td>'+
+            '<td class="a-right">{{_id}}&nbsp;&nbsp;</td>'+
 <?php foreach ($this->getStores() as $_store): ?>
             '<td><input name="option[value][{{id}}][<?php echo $_store->getId() ?>]" value="{{store<?php echo $_store->getId() ?>}}" class="input-text<?php if($_store->getId()==0): ?> required-option<?php endif ?>" type="text" <?php if ($this->getReadOnly()):?> disabled="disabled"<?php endif ?>/><\/td>'+
 <?php endforeach ?>

--- a/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
+++ b/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
@@ -75,6 +75,7 @@
         <div class="hor-scroll">
             <table class="dynamic-grid" cellspacing="0"  cellpadding="0">
                 <tr id="attribute-options-table">
+                    <th style="width:1px">ID</th>
                     <?php foreach ($this->getStores() as $_store): ?>
                         <th><?php echo $this->escapeHtml($_store->getName()); ?></th>
                     <?php endforeach ?>
@@ -87,6 +88,7 @@
                         </th>
                     </tr>
                     <tr class="no-display template" id="row-template">
+                        <td>{{_id}}</td>
                         <?php foreach ($this->getStores() as $_store): ?>
                         <td><input name="option[value][{{id}}][<?php echo $_store->getId() ?>]" value="{{store<?php echo $_store->getId() ?>}}" class="input-text<?php if($_store->getId()==0): ?> required-option<?php endif ?>" type="text" <?php if ($this->getReadOnly()):?> disabled="disabled"<?php endif ?>/></td>
                         <?php endforeach ?>
@@ -111,6 +113,7 @@ var optionDefaultInputType = 'radio';
 // IE removes quotes from element.innerHTML whenever it thinks they're not needed, which breaks html.
 var templateText =
         '<tr class="option-row">'+
+            '<td>{{_id}}</td>'+
 <?php foreach ($this->getStores() as $_store): ?>
             '<td><input name="option[value][{{id}}][<?php echo $_store->getId() ?>]" value="{{store<?php echo $_store->getId() ?>}}" class="input-text<?php if($_store->getId()==0): ?> required-option<?php endif ?>" type="text" <?php if ($this->getReadOnly()):?> disabled="disabled"<?php endif ?>/><\/td>'+
 <?php endforeach ?>
@@ -134,6 +137,7 @@ var attributeOption = {
     add : function(data) {
         this.template = new Template(this.templateText, this.templateSyntax);
         var isNewOption = false;
+        data._id = data.id;
         if(!data.id){
             data = {};
             data.id  = 'option_'+this.itemCount;


### PR DESCRIPTION
Everything is exaplained in https://github.com/OpenMage/magento-lts/issues/828

### Tech info

I've added a "new" prototype variable called "_id" because, when adding a new attribute option, the template would have printed "option_1", "option_2" etc for the not-yet-saved options, which seemed wrong. This way only the IDs that are already saved in the database are actually shown.

### Fixed Issues (if relevant)

https://github.com/OpenMage/magento-lts/issues/828

### Manual testing scenarios (*)

From the backend, go to "catalog -> attributes -> manage attributes", open an attribute with multiple options.