### PR TITLE
Default sortby should be read from core_config_data

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Default.php
@@ -58,6 +58,7 @@ class Mage_Adminhtml_Block_Catalog_Category_Helper_Sortby_Default
         $disabled = false;
 
         if (!$this->getValue() || $elementDisabled) {
+            $this->setValue(Mage::getStoreConfig(Mage_Catalog_Model_Config::XML_PATH_LIST_DEFAULT_SORT_BY));
             $this->setData('disabled', 'disabled');
             $disabled = true;
         }


### PR DESCRIPTION
The problem is explained in https://github.com/OpenMage/magento-lts/issues/278

Technical explanation: 
Setting the default value with the setValue() method allows the select to be rendered with the default selected value (from the core_config_data). The select is still disabled so nothing will be saved, it's just a cosmetic improvement.