### PR TITLE
Reduce needless saves by avoiding setting _hasDataChanges flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Do not use 20.x.x if you need IE support.
 - fixed incorrect datetime in customer block (`$useTimezone` parameter) #1525
 - add redis as a valid option for `global/session_save` #1513
 - possibility to disable global search in backend #1532
+- reduce needless saves by avoiding setting `_hasDataChanges` flag #2066
 
 For full list of changes, you can [compare tags](https://github.com/OpenMage/magento-lts/compare/1.9.4.x...20.0).
 

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -223,9 +223,6 @@
  * @method $this setStoreId(int $store)
  * @method bool hasStoreIds()
  * @method $this setStoreIds(array $storeIds)
- * @method Mage_CatalogInventory_Model_Stock_Item getStockItem()
- * @method bool hasStockItem()
- * @method $this setStockItem(Mage_CatalogInventory_Model_Stock_Item $value)
  * @method array getSwatchPrices()
  *
  * @method int getTaxClassId()
@@ -343,6 +340,11 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
      * @var boolean
      */
     protected $_calculatePrice = true;
+
+    /**
+     * @var Mage_CatalogInventory_Model_Stock_Item
+     */
+    protected $_stockItem;
 
     /**
      * Initialize resources
@@ -692,6 +694,32 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
         }
 
         return $attributes;
+    }
+
+    /**
+     * @return Mage_CatalogInventory_Model_Stock_Item
+     */
+    public function getStockItem()
+    {
+        return $this->_stockItem;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasStockItem()
+    {
+        return !!$this->_stockItem;
+    }
+
+    /**
+     * @param Mage_CatalogInventory_Model_Stock_Item $stockItem
+     * @return $this
+     */
+    public function setStockItem(Mage_CatalogInventory_Model_Stock_Item $stockItem)
+    {
+        $this->_stockItem = $stockItem;
+        return $this;
     }
 
     /**

--- a/app/code/core/Mage/Customer/Model/Address.php
+++ b/app/code/core/Mage/Customer/Model/Address.php
@@ -97,7 +97,9 @@ class Mage_Customer_Model_Address extends Mage_Customer_Model_Address_Abstract
     public function setCustomer(Mage_Customer_Model_Customer $customer)
     {
         $this->_customer = $customer;
-        $this->setCustomerId($customer->getId());
+        if ($this->getCustomerId() != $customer->getId()) {
+            $this->setCustomerId($customer->getId());
+        }
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Item.php
@@ -176,7 +176,9 @@ class Mage_Sales_Model_Order_Creditmemo_Item extends Mage_Core_Model_Abstract
     public function setOrderItem(Mage_Sales_Model_Order_Item $item)
     {
         $this->_orderItem = $item;
-        $this->setOrderItemId($item->getId());
+        if ($this->getOrderItemId() != $item->getId()) {
+            $this->setOrderItemId($item->getId());
+        }
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Item.php
@@ -159,7 +159,9 @@ class Mage_Sales_Model_Order_Invoice_Item extends Mage_Core_Model_Abstract
     public function setOrderItem(Mage_Sales_Model_Order_Item $item)
     {
         $this->_orderItem = $item;
-        $this->setOrderItemId($item->getId());
+        if ($this->getOrderItemId() != $item->getId()) {
+            $this->setOrderItemId($item->getId());
+        }
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Item.php
@@ -440,7 +440,9 @@ class Mage_Sales_Model_Order_Item extends Mage_Core_Model_Abstract
     public function setOrder(Mage_Sales_Model_Order $order)
     {
         $this->_order = $order;
-        $this->setOrderId($order->getId());
+        if ($this->getOrderId() != $order->getId()) {
+            $this->setOrderId($order->getId());
+        }
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Item.php
@@ -104,7 +104,9 @@ class Mage_Sales_Model_Order_Shipment_Item extends Mage_Core_Model_Abstract
     public function setOrderItem(Mage_Sales_Model_Order_Item $item)
     {
         $this->_orderItem = $item;
-        $this->setOrderItemId($item->getId());
+        if ($this->getOrderItemId() != $item->getId()) {
+            $this->setOrderItemId($item->getId());
+        }
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -297,7 +297,9 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
      */
     public function setStore(Mage_Core_Model_Store $store)
     {
-        $this->setStoreId($store->getId());
+        if ($this->getStoreId() != $store->getId()) {
+            $this->setStoreId($store->getId());
+        }
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -427,7 +427,9 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
     public function setQuote(Mage_Sales_Model_Quote $quote)
     {
         $this->_quote = $quote;
-        $this->setQuoteId($quote->getId());
+        if ($this->getQuoteId() != $quote->getId()) {
+            $this->setQuoteId($quote->getId());
+        }
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item.php
@@ -275,7 +275,9 @@ class Mage_Sales_Model_Quote_Item extends Mage_Sales_Model_Quote_Item_Abstract
     public function setQuote(Mage_Sales_Model_Quote $quote)
     {
         $this->_quote = $quote;
-        $this->setQuoteId($quote->getId());
+        if ($this->getQuoteId() != $quote->getId()) {
+            $this->setQuoteId($quote->getId());
+        }
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Quote/Item/Option.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item/Option.php
@@ -83,8 +83,10 @@ class Mage_Sales_Model_Quote_Item_Option extends Mage_Core_Model_Abstract implem
      */
     public function setItem($item)
     {
-        $this->setItemId($item->getId());
         $this->_item = $item;
+        if ($this->getItemId() != $item->getId()) {
+            $this->setItemId($item->getId());
+        }
         return $this;
     }
 
@@ -106,8 +108,10 @@ class Mage_Sales_Model_Quote_Item_Option extends Mage_Core_Model_Abstract implem
      */
     public function setProduct($product)
     {
-        $this->setProductId($product->getId());
         $this->_product = $product;
+        if ($this->getProductId() != $product->getId()) {
+            $this->setProductId($product->getId());
+        }
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Quote/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Payment.php
@@ -119,7 +119,9 @@ class Mage_Sales_Model_Quote_Payment extends Mage_Payment_Model_Info
     public function setQuote(Mage_Sales_Model_Quote $quote)
     {
         $this->_quote = $quote;
-        $this->setQuoteId($quote->getId());
+        if ($this->getQuoteId() != $quote->getId()) {
+            $this->setQuoteId($quote->getId());
+        }
         return $this;
     }
 

--- a/app/code/core/Mage/Wishlist/Model/Item/Option.php
+++ b/app/code/core/Mage/Wishlist/Model/Item/Option.php
@@ -36,6 +36,7 @@
  * @method int getProductId()
  * @method $this setProductId(int $value)
  * @method $this setWishlistItemId(int $value)
+ * @method int getWishlistItemId()
  * @method $this setValue(string $sBuyRequest)
  */
 class Mage_Wishlist_Model_Item_Option extends Mage_Core_Model_Abstract implements Mage_Catalog_Model_Product_Configuration_Item_Option_Interface
@@ -73,8 +74,10 @@ class Mage_Wishlist_Model_Item_Option extends Mage_Core_Model_Abstract implement
      */
     public function setItem($item)
     {
-        $this->setWishlistItemId($item->getId());
         $this->_item = $item;
+        if ($this->getWishlistItemId() != $item->getId()) {
+            $this->setWishlistItemId($item->getId());
+        }
         return $this;
     }
 
@@ -96,8 +99,10 @@ class Mage_Wishlist_Model_Item_Option extends Mage_Core_Model_Abstract implement
      */
     public function setProduct($product)
     {
-        $this->setProductId($product->getId());
         $this->_product = $product;
+        if ($this->getProductId() != $product->getId()) {
+            $this->setProductId($product->getId());
+        }
         return $this;
     }
 


### PR DESCRIPTION
In some cases a setter is called just to store a reference to an object and not actually update the model data but it causes the model to be considered dirty thereby causing needles model saves. This tackles specific instances of this occurring but there is also a more holistic approach proposed in #1306.

This implements alternative changes proposed in https://github.com/OpenMage/magento-lts/issues/1306#issuecomment-728287043 and also an alternative solution to #1307 