### PR TITLE
Removed getQty() from Mage_Wishlist_IndexController

### DIFF
--- a/app/code/core/Mage/Wishlist/controllers/IndexController.php
+++ b/app/code/core/Mage/Wishlist/controllers/IndexController.php
@@ -769,12 +769,4 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
         }
         exit(0);
     }
-
-    /**
-     * @return float
-     */
-    public function getQty()
-    {
-        return (float) $this->_getData('qty');
-    }
 }


### PR DESCRIPTION
PR https://github.com/OpenMage/magento-lts/pull/1915 introduced a getQty() method in Mage_Wishlist_IndexController which triggers a PHPStan error https://github.com/OpenMage/magento-lts/actions/runs/2299769470 and shouldn't be in the controller anyway.

I've removed it.