### PR TITLE
Fix instructions update for bank transfer orders

### DIFF
--- a/app/code/core/Mage/Payment/Model/Observer.php
+++ b/app/code/core/Mage/Payment/Model/Observer.php
@@ -124,7 +124,7 @@ class Mage_Payment_Model_Observer
         if ($payment->getMethod() === Mage_Payment_Model_Method_Banktransfer::PAYMENT_METHOD_BANKTRANSFER_CODE) {
             $payment->setAdditionalInformation(
                 'instructions',
-                $payment->getMethodInstance()->getInstructions()
+                $payment->getMethodInstance()->setStore($payment->getOrder()->getStoreId())->getInstructions()
             );
         }
     }


### PR DESCRIPTION
### Description

When you have multiple store views (at least 2) with bank transfer enabled, when the order is saved, bank transfer instructions are updated, but data are fetched from default configuration instead of order store configuration.

### Manual testing scenarios

From memory:
- set bank transfer instructions from default configuration
- set bank transfer instructions from store configuration
- create an order from the previous store used
- update bank transfer instructions from store configuration
- check bank transfer instructions on order page
- invoice the order
- check bank transfer instructions on order page

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list