### PR TITLE
Add title for old googlecheckout payment method

### DIFF
--- a/app/code/core/Mage/GoogleCheckout/etc/config.xml
+++ b/app/code/core/Mage/GoogleCheckout/etc/config.xml
@@ -42,6 +42,7 @@
         <payment>
             <googlecheckout>
                 <active>1</active>
+                <title>Google Checkout</title>
                 <model>googlecheckout/payment</model>
             </googlecheckout>
         </payment>


### PR DESCRIPTION
### Description

When you go to any order, transaction tab, there is an empty option for "Payment Method Name". This is googlecheckout, and this PR is the solution.

![aa](https://user-images.githubusercontent.com/31816829/167712842-158419c0-3fc8-4b92-b5c7-37073aac28c2.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list