### PR TITLE
fix wrong tier price percentage rounding

### DIFF
--- a/app/code/core/Mage/Catalog/Block/Product/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Abstract.php
@@ -426,7 +426,7 @@ abstract class Mage_Catalog_Block_Product_Abstract extends Mage_Core_Block_Templ
                 }
 
                 if ($price['price'] < $_productPrice) {
-                    $price['savePercent'] = ceil(100 - ((100 / $_productPrice) * $price['price']));
+                    $price['savePercent'] = ceil(100 - round((100 / $_productPrice) * $price['price']));
 
                     $tierPrice = Mage::app()->getStore()->convertPrice(
                         Mage::helper('tax')->getPrice($product, $price['website_price'])

--- a/app/code/core/Mage/Catalog/Block/Product/Price.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Price.php
@@ -135,7 +135,7 @@ class Mage_Catalog_Block_Product_Price extends Mage_Catalog_Block_Product_Abstra
 
                 if ($price['price'] < $productPrice) {
                     // use the original prices to determine the percent savings
-                    $price['savePercent'] = ceil(100 - ((100 / $productPrice) * $price['price']));
+                    $price['savePercent'] = ceil(100 - round((100 / $productPrice) * $price['price']));
 
                     // if applicable, adjust the tier prices
                     if (isset($bundlePriceModel)) {


### PR DESCRIPTION
### Description (*)
tier prices display wrong percentage saving due to rounding issues

### Manual testing scenarios (*)
create simple product 
with base price = $ 57
and tier prices:
qty = 3 and above price  = $ 55.29
qty = 5 and above price  = $ 54.15
qty = 10 and above price  = $ 51.30

frontend percentage saving is wrong
![immagine](https://user-images.githubusercontent.com/5071467/168781980-251dafaf-38d1-4473-871b-270a5424d313.png)


the issues is related to rounding in ceil function explained here:
https://www.php.net/manual/en/function.ceil.php#122724

correct values
![immagine](https://user-images.githubusercontent.com/5071467/168782183-f63c3ec7-501a-4d06-a142-0bed960602fc.png)

100 - ((100/57) * 55,29) = 3 %
**100 - ((100/57) * 54,15) = 5 %**
**100 - ((100/57) * 51,3) = 10 %**

tested on latest v20.0.13