### PR TITLE
Fix argument must contain at least one element

### DIFF
--- a/app/code/core/Mage/Bundle/Model/Product/Price.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Price.php
@@ -317,8 +317,8 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
         }
         // condition is TRUE when all product options are NOT required
         if (!$hasRequiredOptions) {
-            $minimalPrice = min($selectionMinimalPrices);
-            $minimalPriceWithTax = min($selectionMinimalPricesWithTax);
+            $minimalPrice = empty($selectionMinimalPrices) ? 0 : min($selectionMinimalPrices);
+            $minimalPriceWithTax = empty($selectionMinimalPricesWithTax) ? max(0, $minimalPrice) : min($selectionMinimalPricesWithTax);
         }
 
         $taxConfig = $this->_getHelperData('tax')->getConfig();


### PR DESCRIPTION
### Description

This fix `ValueError: min(): Argument #1 ($value) must contain at least one element`.
This is for bundle products, not sure how this case can happen.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)