### PR TITLE
Fix undefined array key when an image depend on another field

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/File.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/File.php
@@ -48,7 +48,7 @@ class Mage_Adminhtml_Model_System_Config_Backend_File extends Mage_Core_Model_Co
     protected function _beforeSave()
     {
         $value = $this->getValue();
-        if ($_FILES['groups']['tmp_name'][$this->getGroupId()]['fields'][$this->getField()]['value']) {
+        if (!empty($_FILES['groups']['tmp_name'][$this->getGroupId()]['fields'][$this->getField()]['value'])) {
 
             $uploadDir = $this->_getUploadDir();
 


### PR DESCRIPTION
### Description

This PR fix a warning when an image field depend on another field in `system.xml`:
```
<image>
	<label>My image</label>
	<comment>Hello, this is me.</comment>
	<frontend_type>image</frontend_type>
	<backend_model>adminhtml/system_config_backend_image</backend_model>
	<upload_dir config="system/filesystem/media" scope_info="1">wysiwyg/banner</upload_dir>
	<base_url type="media" scope_info="1">wysiwyg/banner</base_url>
	<sort_order>3</sort_order>
	<show_in_default>1</show_in_default>
	<show_in_website>1</show_in_website>
	<show_in_store>1</show_in_store>
	<depends>
		<yes_no_field>2</yes_no_field>
	</depends>
</image>
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)