### PR TITLE
Upgrade GitHub action/checkout to v3

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: php version
       run: php --version

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -17,7 +17,7 @@ jobs:
         operating-system: [ubuntu-latest]
         php-versions: ['7.4', '8.1']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/static-code-analyses.yml
+++ b/.github/workflows/static-code-analyses.yml
@@ -14,7 +14,7 @@ jobs:
         operating-system: [ubuntu-latest]
         php-versions: ['7.0', '7.4']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@master
         with:
@@ -44,7 +44,7 @@ jobs:
             '.github/phpstan.neon',
         ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest --ignore-platform-reqs
       - name: ensure existance of ./app/code/local
@@ -63,7 +63,7 @@ jobs:
         operating-system: [ubuntu-latest]
         php-versions: ['8.0','8.1']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@master
         with:
@@ -100,7 +100,7 @@ jobs:
           - directories: 'lib/'
             config_files: '.github/phpstan.neon'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest --ignore-platform-reqs
       - name: ensure existance of ./app/code/local

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OpenMage/Testfield
           path: ./
@@ -22,7 +22,7 @@ jobs:
         run: composer install --prefer-dist --no-progress --ignore-platform-reqs
 
       - name: Checkout OpenMage repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: openmage
 


### PR DESCRIPTION
Since issue https://github.com/OpenMage/magento-lts/issues/1906 highlighted that old actions/checkout were used in our worklflows and those version have vulnerabilities, I've upgraded all workflows to actions/checkout@v3.

All workflows seem to run fine on my repository

### Fixed Issues (if relevant)

1. https://github.com/OpenMage/magento-lts/issues/1906