### PR TITLE
Cast params receiving int to string

### DIFF
--- a/app/code/core/Mage/Oauth/Model/Server.php
+++ b/app/code/core/Mage/Oauth/Model/Server.php
@@ -331,7 +331,7 @@ class Mage_Oauth_Model_Server
                 if (!hash_equals($this->_token->getVerifier(), $this->_protocolParams['oauth_verifier'])) {
                     $this->_throwException('', self::ERR_VERIFIER_INVALID);
                 }
-                if (!hash_equals($this->_token->getConsumerId(), $this->_consumer->getId())) {
+                if (!hash_equals((string)$this->_token->getConsumerId(), (string)$this->_consumer->getId())) {
                     $this->_throwException('', self::ERR_TOKEN_REJECTED);
                 }
                 if (Mage_Oauth_Model_Token::TYPE_REQUEST != $this->_token->getType()) {


### PR DESCRIPTION
Mage_Oauth_Model_Server uses php's hash_equals(string1, string2) to check the matching of tokens.

Php's hash_equals(string1, string2) expects strings as params and throws a warning if it receives numbers. In concreto, we compare the identity of the consumerId, which is an integer. We should cast the params to string here to avoid breaking the oauth authorization.

While it would (in principle) be possible to change Mage_Oauth_Model_Token and Mage_Oauth_Model_Consumer to return a string as the id/consumerId we should not do this IMHO because while we understand that a token usually is represented by a string value this is not the case for an id in models based on Mage_Core_Model_Abstract.