### PR TITLE
Remove frontend_type tag for text

### DIFF
--- a/app/code/core/Mage/AdminNotification/etc/system.xml
+++ b/app/code/core/Mage/AdminNotification/etc/system.xml
@@ -31,7 +31,6 @@
             <groups>
                 <adminnotification translate="label" module="adminnotification">
                     <label>Notifications</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>250</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -57,7 +56,6 @@
                         </last_update>
                         <feed_url>
                             <label>Feed Url</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_protected</backend_model>
                             <sort_order>3</sort_order>
                             <show_in_default>0</show_in_default>

--- a/app/code/core/Mage/Api/etc/system.xml
+++ b/app/code/core/Mage/Api/etc/system.xml
@@ -30,7 +30,6 @@
         <api translate="label" module="api">
             <label>Magento Core API</label>
             <tab>service</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>101</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -38,7 +37,6 @@
             <groups>
                  <config translate="label">
                     <label>General Settings</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -46,7 +44,6 @@
                     <fields>
                         <charset translate="label">
                             <label>Default Response Charset</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -54,7 +51,6 @@
                         </charset>
                         <session_timeout translate="label">
                             <label>Client Session Timeout (sec.)</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Authorizenet/etc/system.xml
+++ b/app/code/core/Mage/Authorizenet/etc/system.xml
@@ -31,7 +31,6 @@
             <groups>
                 <authorizenet_directpost translate="label" module="authorizenet">
                     <label>Authorize.net Direct Post (Deprecated)</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>34</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -57,7 +56,6 @@
                         </payment_action>
                         <title translate="label">
                             <label>Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -119,7 +117,6 @@
                         </test>
                         <cgi_url translate="label">
                             <label>Gateway URL</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>90</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -154,7 +151,6 @@
                         </email_customer>
                         <merchant_email translate="label">
                             <label>Merchant's Email</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-email</validate>
                             <sort_order>130</sort_order>
                             <show_in_default>1</show_in_default>
@@ -199,7 +195,6 @@
                         </specificcountry>
                         <min_order_total translate="label">
                             <label>Minimum Order Total</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>180</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -207,7 +202,6 @@
                         </min_order_total>
                         <max_order_total translate="label">
                             <label>Maximum Order Total</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>190</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -215,7 +209,6 @@
                         </max_order_total>
                         <sort_order translate="label">
                             <label>Sort Order</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>200</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Backup/etc/system.xml
+++ b/app/code/core/Mage/Backup/etc/system.xml
@@ -31,7 +31,6 @@
             <groups>
                 <backup translate="label" module="backup">
                     <label>Scheduled Backup Settings</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>500</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>

--- a/app/code/core/Mage/Captcha/etc/system.xml
+++ b/app/code/core/Mage/Captcha/etc/system.xml
@@ -31,7 +31,6 @@
             <groups>
                 <captcha translate="label">
                     <label>CAPTCHA</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>50</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -78,7 +77,6 @@
                         </mode>
                         <failed_attempts_login translate="label comment">
                             <label>Number of Unsuccessful Attempts to Login</label>
-                            <frontend_type>text</frontend_type>
                             <comment>If 0 is specified, CAPTCHA on the Login form will be always available.</comment>
                             <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
@@ -92,7 +90,6 @@
                         </failed_attempts_login>
                         <timeout translate="label">
                             <label>CAPTCHA Timeout (minutes)</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>6</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
@@ -102,7 +99,6 @@
                         </timeout>
                         <length translate="label comment">
                             <label>Number of Symbols</label>
-                            <frontend_type>text</frontend_type>
                             <comment>Please specify 8 symbols at the most. Range allowed (e.g. 3-5)</comment>
                             <sort_order>7</sort_order>
                             <show_in_default>1</show_in_default>
@@ -113,7 +109,6 @@
                         </length>
                         <symbols translate="label comment">
                             <label>Symbols Used in CAPTCHA</label>
-                            <frontend_type>text</frontend_type>
                             <comment><![CDATA[Please use only letters (a-z or A-Z) or numbers (0-9) in this field. No spaces or other characters are allowed.<br />Similar looking characters (e.g. "i", "l", "1") decrease chance of correct recognition by customer.]]></comment>
                             <sort_order>8</sort_order>
                             <show_in_default>1</show_in_default>
@@ -140,7 +135,6 @@
             <groups>
                 <captcha translate="label">
                     <label>CAPTCHA</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>110</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -188,7 +182,6 @@
                         </mode>
                         <failed_attempts_login translate="label comment">
                             <label>Number of Unsuccessful Attempts to Login</label>
-                            <frontend_type>text</frontend_type>
                             <comment>If 0 is specified, CAPTCHA on the Login form will be always available.</comment>
                             <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
@@ -202,7 +195,6 @@
                         </failed_attempts_login>
                         <timeout translate="label">
                             <label>CAPTCHA Timeout (minutes)</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>6</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -212,7 +204,6 @@
                         </timeout>
                         <length translate="label comment">
                             <label>Number of Symbols</label>
-                            <frontend_type>text</frontend_type>
                             <comment>Please specify 8 symbols at the most. Range allowed (e.g. 3-5)</comment>
                             <sort_order>7</sort_order>
                             <show_in_default>1</show_in_default>
@@ -223,7 +214,6 @@
                         </length>
                         <symbols translate="label comment">
                             <label>Symbols Used in CAPTCHA</label>
-                            <frontend_type>text</frontend_type>
                             <comment><![CDATA[Please use only letters (a-z or A-Z) or numbers (0-9) in this field. No spaces or other characters are allowed.<br />Similar looking characters (e.g. "i", "l", "1") decrease chance of correct recognition by customer.]]></comment>
                             <sort_order>8</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/code/core/Mage/Catalog/etc/system.xml
+++ b/app/code/core/Mage/Catalog/etc/system.xml
@@ -37,7 +37,6 @@
             <class>separator-top</class>
             <label>Catalog</label>
             <tab>catalog</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>40</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -45,7 +44,6 @@
             <groups>
                 <frontend translate="label">
                     <label>Frontend</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>100</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -63,7 +61,6 @@
                         <grid_per_page_values translate="label comment">
                             <label>Products per Page on Grid Allowed Values</label>
                             <comment>Comma-separated.</comment>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-per-page-value-list</validate>
                             <!--<source_model>adminhtml/system_config_source_catalog_gridPerPage</source_model>-->
                             <sort_order>2</sort_order>
@@ -74,7 +71,6 @@
                         <grid_per_page translate="label comment">
                             <label>Products per Page on Grid Default Value</label>
                             <comment>Must be in the allowed values list.</comment>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-per-page-value</validate>
                             <!--<source_model>adminhtml/system_config_source_catalog_gridPerPage</source_model>-->
                             <sort_order>3</sort_order>
@@ -85,7 +81,6 @@
                         <list_per_page_values translate="label comment">
                             <label>Products per Page on List Allowed Values</label>
                             <comment>Comma-separated.</comment>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-per-page-value-list</validate>
                             <!--<source_model>adminhtml/system_config_source_catalog_gridPerPage</source_model>-->
                             <sort_order>4</sort_order>
@@ -96,7 +91,6 @@
                         <list_per_page translate="label comment">
                             <label>Products per Page on List Default Value</label>
                             <comment>Must be in the allowed values list.</comment>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-per-page-value</validate>
                             <!--<source_model>adminhtml/system_config_source_catalog_listPerPage</source_model>-->
                             <sort_order>5</sort_order>
@@ -161,7 +155,6 @@
                 </frontend>
                 <sitemap translate="label">
                     <label>Sitemap</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>100</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -178,7 +171,6 @@
                         </tree_mode>
                         <lines_perpage translate="label">
                             <label>Minimum Lines per Page</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -196,7 +188,6 @@
                         <base_width translate="label comment">
                             <label>Base Image Width</label>
                             <comment>Maximum width base product image will be scaled down to in pixels</comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -205,7 +196,6 @@
                         <small_width translate="label comment">
                             <label>Small Image Width</label>
                             <comment>Maximum width small product image will be scaled down to in pixels</comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -214,7 +204,6 @@
                         <max_dimension translate="label comment">
                             <label>Maximum resolution for upload image</label>
                             <comment>Maximum width and height resolutions for upload image</comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -223,7 +212,6 @@
                         <progressive_threshold translate="label comment">
                             <label>Enable Progressive Images Threshold</label>
                             <comment>Minimum size in megapixel for progressive JPEG resize</comment>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number</validate>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
@@ -255,7 +243,6 @@
 
                 <seo translate="label">
                     <label>Search Engine Optimizations</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>500</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -263,7 +250,6 @@
                     <fields>
                         <category_url_suffix translate="label comment">
                             <label>Category URL Suffix</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>catalog/system_config_backend_catalog_url_rewrite_suffix</backend_model>
                             <sort_order>3</sort_order>
                             <show_in_default>1</show_in_default>
@@ -273,7 +259,6 @@
                         </category_url_suffix>
                         <product_url_suffix translate="label comment">
                             <label>Product URL Suffix</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>catalog/system_config_backend_catalog_url_rewrite_suffix</backend_model>
                             <sort_order>2</sort_order>
                             <show_in_default>1</show_in_default>
@@ -302,7 +287,6 @@
                         </save_rewrites_history>
                         <title_separator translate="label">
                             <label>Page Title Separator</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>6</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -331,7 +315,6 @@
 
                 <price translate="label">
                     <label>Price</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>400</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -377,7 +360,6 @@
                         </price_range_calculation>
                         <price_range_step translate="label">
                             <label>Default Price Navigation Step</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-number-range number-range-0.01-1000000000</validate>
                             <sort_order>15</sort_order>
                             <show_in_default>1</show_in_default>
@@ -388,7 +370,6 @@
                         <price_range_max_intervals translate="label comment">
                             <label>Maximum Number of Price Intervals</label>
                             <comment>Maximum number of price intervals is 100</comment>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-digits validate-digits-range digits-range-2-100</validate>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
@@ -410,7 +391,6 @@
                         <interval_division_limit translate="label comment">
                             <label>Interval Division Limit</label>
                             <comment>Please specify the number of products, that will not be divided into subintervals.</comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -422,7 +402,6 @@
                 </layered_navigation>
                 <navigation translate="label">
                     <label>Category Top Navigation</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>500</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -430,7 +409,6 @@
                     <fields>
                         <max_depth translate="label">
                             <label>Maximal Depth</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                         </max_depth>
@@ -438,7 +416,6 @@
                 </navigation>
                 <custom_options translate="label">
                     <label>Date &amp; Time Custom Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>700</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -474,7 +451,6 @@
                         <year_range translate="label comment">
                             <label>Year Range</label>
                             <comment>Use four-digit year format.</comment>
-                            <frontend_type>text</frontend_type>
                             <frontend_model>adminhtml/catalog_form_renderer_config_yearRange</frontend_model>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
@@ -486,7 +462,6 @@
 <!--
                 <layer translate="label">
                     <label>Layered Navigation</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>450</sort_order>
                     <show_in_default>1</show_in_default>
                     <fields>
@@ -516,7 +491,6 @@
                     <fields>
                         <size translate="label">
                             <label>Watermark Default Size</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -525,7 +499,6 @@
                         </size>
                         <imageOpacity translate="label">
                             <label>Watermark Opacity, Percent</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>150</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -578,7 +551,6 @@
             <groups>
                 <msrp translate="label">
                     <label>Minimum Advertised Price</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>110</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/CatalogInventory/etc/system.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/system.xml
@@ -30,7 +30,6 @@
         <cataloginventory translate="label" module="cataloginventory">
             <label>Inventory</label>
             <tab>catalog</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>50</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -38,7 +37,6 @@
             <groups>
                 <options translate="label">
                     <label>Stock Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -74,7 +72,6 @@
                         </show_out_of_stock>
                         <stock_threshold_qty translate="label">
                             <label>Only X left Threshold</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number</validate>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
@@ -95,7 +92,6 @@
                 <item_options translate="label comment">
                     <comment><![CDATA[<strong>Note</strong> that these settings are applicable to cart line items, not the whole cart.]]></comment>
                     <label>Product Stock Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>10</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -122,7 +118,6 @@
                         </backorders>
                         <max_sale_qty translate="label">
                             <label>Maximum Qty Allowed in Shopping Cart</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number</validate>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
@@ -131,7 +126,6 @@
                         </max_sale_qty>
                         <min_qty translate="label">
                             <label>Qty for Item's Status to Become Out of Stock</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number</validate>
                             <backend_model>cataloginventory/system_config_backend_minqty</backend_model>
                             <sort_order>5</sort_order>
@@ -150,7 +144,6 @@
                        </min_sale_qty>
                        <notify_stock_qty translate="label">
                             <label>Notify for Quantity Below</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number</validate>
                             <sort_order>7</sort_order>
                             <show_in_default>1</show_in_default>
@@ -177,7 +170,6 @@
                        </enable_qty_increments>
                        <qty_increments translate="label">
                             <label>Qty Increments</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-greater-than-zero</validate>
                             <backend_model>cataloginventory/system_config_backend_qtyincrements</backend_model>
                             <sort_order>9</sort_order>

--- a/app/code/core/Mage/CatalogSearch/etc/system.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/system.xml
@@ -54,7 +54,6 @@
                 </seo>
                 <search translate="label" module="catalogsearch">
                     <label>Catalog Search</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>500</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -62,7 +61,6 @@
                     <fields>
                         <min_query_length translate="label">
                             <label>Minimal Query Length</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-digits</validate>
                             <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
@@ -71,7 +69,6 @@
                         </min_query_length>
                         <max_query_length translate="label">
                             <label>Maximum Query Length</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-digits</validate>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
@@ -80,7 +77,6 @@
                         </max_query_length>
                         <max_query_words translate="label comment">
                             <label>Maximum Query Words Count</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-digits</validate>
                             <sort_order>15</sort_order>
                             <show_in_default>1</show_in_default>
@@ -110,7 +106,6 @@
                         </search_separator>
                         <use_layered_navigation_count translate="label comment">
                             <label>Apply Layered Navigation if Search Results are Less Than</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-digits</validate>
                             <sort_order>25</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/code/core/Mage/Centinel/etc/system.xml
+++ b/app/code/core/Mage/Centinel/etc/system.xml
@@ -30,7 +30,6 @@
         <payment_services translate="label" module="payment">
             <label>Payment Services</label>
             <tab>sales</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>450</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -38,7 +37,6 @@
             <groups>
                 <centinel translate="label">
                     <label>3D Secure Credit Card Validation</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -46,7 +44,6 @@
                     <fields>
                         <processor_id translate="label">
                             <label>Processor ID</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -54,7 +51,6 @@
                         </processor_id>
                         <merchant_id translate="label">
                             <label>Merchant ID</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Checkout/etc/system.xml
+++ b/app/code/core/Mage/Checkout/etc/system.xml
@@ -30,7 +30,6 @@
         <checkout translate="label" module="checkout">
             <label>Checkout</label>
             <tab>sales</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>305</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -38,7 +37,6 @@
             <groups>
                 <options translate="label">
                     <label>Checkout Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -93,7 +91,6 @@
                     <fields>
                         <delete_quote_after translate="label">
                             <label>Quote Lifetime (days)</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -166,7 +163,6 @@
                         </display>
                         <count translate="label">
                             <label>Maximum Display Recently Added Item(s)</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>2</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -177,7 +173,6 @@
 
                 <payment_failed translate="label">
                     <label>Payment Failed Emails</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>100</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -212,7 +207,6 @@
                         </template>
                         <copy_to translate="label comment">
                             <label>Send Payment Failed Email Copy To</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Cms/etc/system.xml
+++ b/app/code/core/Mage/Cms/etc/system.xml
@@ -74,7 +74,6 @@
         <cms translate="label" module="cms">
             <label>Content Management</label>
             <tab>general</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>1001</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -82,7 +81,6 @@
             <groups>
                 <wysiwyg translate="label">
                     <label>WYSIWYG Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>100</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/ConfigurableSwatches/etc/system.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/system.xml
@@ -92,7 +92,6 @@
                     <fields>
                         <width translate="label">
                             <label>Width</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -100,7 +99,6 @@
                         </width>
                         <height translate="label">
                             <label>Height</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -118,7 +116,6 @@
                     <fields>
                         <width translate="label">
                             <label>Width</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -126,7 +123,6 @@
                         </width>
                         <height translate="label">
                             <label>Height</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -144,7 +140,6 @@
                     <fields>
                         <width translate="label">
                             <label>Width</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -152,7 +147,6 @@
                         </width>
                         <height translate="label">
                             <label>Height</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Contacts/etc/system.xml
+++ b/app/code/core/Mage/Contacts/etc/system.xml
@@ -30,7 +30,6 @@
         <contacts translate="label" module="contacts">
             <label>Contacts</label>
             <tab>general</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>100</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -38,7 +37,6 @@
             <groups>
                 <contacts translate="label">
                     <label>Contact Us</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>10</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -58,7 +56,6 @@
                 </contacts>
                 <email translate="label">
                     <label>Email Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>50</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -66,7 +63,6 @@
                     <fields>
                         <recipient_email translate="label">
                             <label>Send Emails To</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-email required-entry</validate>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -45,7 +45,6 @@
             <groups>
                 <csrf translate="label" module="core">
                     <label>CSRF protection</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>0</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -64,7 +63,6 @@
                 </csrf>
                 <cache>
                     <label>Advanced Magento cache settings</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>10000</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -72,7 +70,6 @@
                     <fields>
                         <flush_cron_expr>
                             <label>Cron expression for regular cache flushing</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
@@ -85,7 +82,6 @@
         </system>
         <!--<web_track translate="label" module="core">
             <label>Web Tracking</label>
-            <frontend_type>text</frontend_type>
             <sort_order>180</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -94,7 +90,6 @@
         <advanced translate="label" module="core">
             <label>Advanced</label>
             <tab>advanced</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>910</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -102,7 +97,6 @@
             <groups>
                 <!--datashare translate="label">
                     <label>Datasharing</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -132,7 +126,6 @@
                 </datashare-->
                 <modules_disable_output translate="label">
                     <label>Disable Modules Output</label>
-                    <frontend_type>text</frontend_type>
                     <frontend_model>adminhtml/system_config_form_fieldset_modules_disableOutput</frontend_model>
                     <sort_order>2</sort_order>
                     <show_in_default>1</show_in_default>
@@ -146,7 +139,6 @@
             <class>separator-top</class>
             <label>Store Email Addresses</label>
             <tab>general</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>90</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -154,7 +146,6 @@
             <groups>
                 <ident_custom1 translate="label">
                     <label>Custom Email 1</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>4</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -162,7 +153,6 @@
                     <fields>
                         <email translate="label">
                             <label>Sender Email</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-email</validate>
                             <backend_model>adminhtml/system_config_backend_email_address</backend_model>
                             <sort_order>2</sort_order>
@@ -172,7 +162,6 @@
                         </email>
                         <name translate="label">
                             <label>Sender Name</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_email_sender</backend_model>
                             <validate>validate-emailSender</validate>
                             <sort_order>1</sort_order>
@@ -184,7 +173,6 @@
                 </ident_custom1>
                 <ident_custom2 translate="label">
                     <label>Custom Email 2</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>5</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -192,7 +180,6 @@
                     <fields>
                         <email translate="label">
                             <label>Sender Email</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-email</validate>
                             <backend_model>adminhtml/system_config_backend_email_address</backend_model>
                             <sort_order>2</sort_order>
@@ -202,7 +189,6 @@
                         </email>
                         <name translate="label">
                             <label>Sender Name</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_email_sender</backend_model>
                             <validate>validate-emailSender</validate>
                             <sort_order>1</sort_order>
@@ -214,7 +200,6 @@
                 </ident_custom2>
                 <ident_general translate="label">
                     <label>General Contact</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -222,7 +207,6 @@
                     <fields>
                         <email translate="label">
                             <label>Sender Email</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-email</validate>
                             <backend_model>adminhtml/system_config_backend_email_address</backend_model>
                             <sort_order>2</sort_order>
@@ -232,7 +216,6 @@
                         </email>
                         <name translate="label">
                             <label>Sender Name</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_email_sender</backend_model>
                             <validate>validate-emailSender</validate>
                             <sort_order>1</sort_order>
@@ -244,7 +227,6 @@
                 </ident_general>
                 <ident_sales translate="label">
                     <label>Sales Representative</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>2</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -252,7 +234,6 @@
                     <fields>
                         <email translate="label">
                             <label>Sender Email</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-email</validate>
                             <backend_model>adminhtml/system_config_backend_email_address</backend_model>
                             <sort_order>2</sort_order>
@@ -262,7 +243,6 @@
                         </email>
                         <name translate="label">
                             <label>Sender Name</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_email_sender</backend_model>
                             <validate>validate-emailSender</validate>
                             <sort_order>1</sort_order>
@@ -274,7 +254,6 @@
                 </ident_sales>
                 <ident_support translate="label">
                     <label>Customer Support</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>3</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -282,7 +261,6 @@
                     <fields>
                         <email translate="label">
                             <label>Sender Email</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-email</validate>
                             <backend_model>adminhtml/system_config_backend_email_address</backend_model>
                             <sort_order>2</sort_order>
@@ -292,7 +270,6 @@
                         </email>
                         <name translate="label">
                             <label>Sender Name</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_email_sender</backend_model>
                             <validate>validate-emailSender</validate>
                             <sort_order>1</sort_order>
@@ -308,7 +285,6 @@
         <design translate="label" module="core">
             <label>Design</label>
             <tab>general</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>30</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -316,7 +292,6 @@
             <groups>
                 <package translate="label">
                     <label>Package</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -324,7 +299,6 @@
                     <fields>
                         <name translate="label">
                             <label>Current Package Name</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_design_package</backend_model>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
@@ -345,7 +319,6 @@
                 </package>
                 <theme translate="label">
                     <label>Themes</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>2</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -353,7 +326,6 @@
                     <fields>
                         <locale translate="label">
                             <label>Translations</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -361,7 +333,6 @@
                         </locale>
                         <template translate="label">
                             <label>Templates</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -379,7 +350,6 @@
                         </template_ua_regexp>
                         <skin translate="label">
                             <label>Skin (Images / CSS)</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -396,7 +366,6 @@
                         </skin_ua_regexp>
                         <layout translate="label">
                             <label>Layout</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -413,7 +382,6 @@
                         </layout_ua_regexp>
                         <default translate="label">
                             <label>Default</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>60</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -432,7 +400,6 @@
                 </theme>
                 <pagination translate="label">
                     <label>Pagination</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>500</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -441,7 +408,6 @@
                         <pagination_frame translate="label comment">
                             <label>Pagination Frame</label>
                             <comment>How many links to display at once.</comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>7</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -450,7 +416,6 @@
                         <pagination_frame_skip translate="label comment">
                             <label>Pagination Frame Skip</label>
                             <comment>If the current frame position does not cover utmost pages, will render link to current position plus/minus this value.</comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>8</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -459,7 +424,6 @@
                         <anchor_text_for_previous translate="label comment">
                             <label>Anchor Text for Previous</label>
                             <comment>Alternative text for previous link in pagination menu. If empty, default arrow image will used.</comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>9</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -468,7 +432,6 @@
                         <anchor_text_for_next translate="label comment">
                             <label>Anchor Text for Next</label>
                             <comment>Alternative text for next link in pagination menu. If empty, default arrow image will used.</comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -478,7 +441,6 @@
                 </pagination>
                 <email translate="label">
                     <label>Transactional Emails</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>510</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -497,7 +459,6 @@
                         </logo>
                         <logo_alt translate="label">
                             <label>Logo Image Alt</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -506,7 +467,6 @@
                         <logo_width>
                             <label>Logo Width</label>
                             <comment>Only necessary if image has been uploaded above. Enter number of pixels, without appending "px".</comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>25</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -515,7 +475,6 @@
                         <logo_height>
                             <label>Logo Height</label>
                             <comment>Only necessary if image has been uploaded above. Enter number of pixels, without appending "px".</comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>27</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -542,7 +501,6 @@
                         <css_non_inline>
                             <label>Non-inline CSS File(s)</label>
                             <comment><![CDATA[Comma-delimited list of files that will be included inside &lt;style&gt; tag for all templates that include use the '{{var non_inline_styles}}' variable. File path is relative to skin/frontend/PACKAGE/THEME/css/]]></comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -555,7 +513,6 @@
         <dev translate="label" module="core">
             <label>Developer</label>
             <tab>advanced</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>920</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -563,7 +520,6 @@
             <groups>
                 <restrict translate="label">
                     <label>Developer Client Restrictions</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>10</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -571,7 +527,6 @@
                     <fields>
                         <allow_ips translate="label comment">
                             <label>Allowed IPs (comma separated)</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -582,7 +537,6 @@
                 </restrict>
                 <debug translate="label">
                     <label>Debug</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>20</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -653,7 +607,6 @@
                 </debug>
                 <template translate="label">
                     <label>Template Settings</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>25</sort_order>
                     <show_in_default>0</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -674,7 +627,6 @@
                 </template>
                 <translate_inline translate="label">
                     <label>Translate Inline</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>30</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -705,7 +657,6 @@
                 </translate_inline>
                 <log translate="label">
                     <label>Log Settings</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>40</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -732,7 +683,6 @@
                         </max_level>
                         <file translate="label comment">
                             <label>System Log File Name</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_filename</backend_model>
                             <sort_order>3</sort_order>
                             <show_in_default>1</show_in_default>
@@ -742,7 +692,6 @@
                         </file>
                         <exception_file translate="label comment">
                             <label>Exceptions Log File Name</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_filename</backend_model>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
@@ -754,7 +703,6 @@
                 </log>
                 <js translate="label">
                     <label>JavaScript Settings</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>100</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -773,7 +721,6 @@
                 </js>
                 <css translate="label">
                     <label>CSS Settings</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>110</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -795,7 +742,6 @@
         <general translate="label" module="core">
             <label>General</label>
             <tab>general</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>10</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -803,7 +749,6 @@
             <groups>
                 <country translate="label">
                     <label>Countries Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -841,7 +786,6 @@
                 </country>
                 <locale translate="label">
                     <label>Locale Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>8</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -889,7 +833,6 @@
                 </locale>
                 <file>
                     <label>File Settings</label>
-                    <frontend_type>text</frontend_type>
                     <show_in_default>0</show_in_default>
                     <show_in_website>0</show_in_website>
                     <show_in_store>0</show_in_store>
@@ -904,7 +847,6 @@
                 </file>
                 <store_information translate="label">
                     <label>Store Information</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>100</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -912,7 +854,6 @@
                     <fields>
                         <name translate="label">
                             <label>Store Name</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -921,7 +862,6 @@
                         <phone translate="label">
                             <label>Store Contact Telephone</label>
                             <comment>If present, this will be included in all Transactional Emails</comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -930,7 +870,6 @@
                         <hours translate="label">
                             <label>Store Hours of Operation</label>
                             <comment>If present, this will be included in all Transactional Emails</comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>22</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -948,7 +887,6 @@
                         </merchant_country>
                         <merchant_vat_number translate="label">
                             <label>VAT Number</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>27</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -971,7 +909,6 @@
             <class>separator-top</class>
             <label>System</label>
             <tab>advanced</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>900</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -979,7 +916,6 @@
             <groups>
                 <smtp translate="label">
                     <label>Mail Sending Settings</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>20</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -996,7 +932,6 @@
                         </disable>
                         <host translate="label">
                             <label>Host</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1005,7 +940,6 @@
                         </host>
                         <port translate="label">
                             <label>Port (25)</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1024,7 +958,6 @@
                         </auth>
                         <username translate="label">
                             <label>Username</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1032,7 +965,6 @@
                         </username>
                         <password translate="label">
                             <label>Password</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>60</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1050,7 +982,6 @@
                         </set_return_path>
                         <return_path_email translate="label">
                             <label>Return-Path Email</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-email</validate>
                             <backend_model>adminhtml/system_config_backend_email_address</backend_model>
                             <sort_order>80</sort_order>
@@ -1063,7 +994,6 @@
                 </smtp>
                 <media_storage_configuration translate="label" module="core">
                     <label>Storage Configuration for Media</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>900</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -1102,7 +1032,6 @@
                         </synchronize>
                         <configuration_update_time translate="label">
                             <label>Environment Update Time</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>400</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
@@ -1115,7 +1044,6 @@
         <admin translate="label" module="core">
             <label>Admin</label>
             <tab>advanced</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>20</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>0</show_in_website>
@@ -1123,7 +1051,6 @@
             <groups>
                 <design translate="label">
                     <label>Admin Theme</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>5</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -1144,7 +1071,6 @@
 
                 <emails translate="label">
                     <label>Admin User Emails</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>10</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -1171,7 +1097,6 @@
                         <password_reset_link_expiration_period translate="label comment">
                             <label>Recovery Link Expiration Period (hours)</label>
                             <comment>Please enter a number 1 or greater in this field.</comment>
-                            <frontend_type>text</frontend_type>
                             <validate>required-entry validate-digits validate-digits-range digits-range-1-</validate>
                             <backend_model>adminhtml/system_config_backend_admin_password_link_expirationperiod</backend_model>
                             <sort_order>30</sort_order>
@@ -1192,7 +1117,6 @@
                 </emails>
                 <startup translate="label">
                     <label>Startup Page</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>20</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -1211,7 +1135,6 @@
                 </startup>
                 <url translate="label">
                     <label>Admin Base URL</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>30</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -1229,7 +1152,6 @@
                         </use_custom>
                         <custom translate="label comment">
                             <label>Custom Admin URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_admin_custom</backend_model>
                             <depends><use_custom>1</use_custom></depends>
                             <sort_order>2</sort_order>
@@ -1250,7 +1172,6 @@
                         </use_custom_path>
                         <custom_path translate="label comment">
                             <label>Custom Admin Path</label>
-                            <frontend_type>text</frontend_type>
                             <validate>required-entry validate-alphanum</validate>
                             <backend_model>adminhtml/system_config_backend_admin_custompath</backend_model>
                             <depends><use_custom_path>1</use_custom_path></depends>
@@ -1264,7 +1185,6 @@
                 </url>
                 <security translate="label">
                     <label>Security</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>35</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -1363,7 +1283,6 @@
         <web translate="label" module="core">
             <label>Web</label>
             <tab>general</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>20</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -1371,7 +1290,6 @@
             <groups>
                 <url translate="label">
                     <label>Url Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>3</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -1402,7 +1320,6 @@
                 </url>
                 <seo translate="label">
                     <label>Search Engines Optimization</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>5</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -1421,7 +1338,6 @@
                 </seo>
                 <unsecure translate="label">
                     <label>Unsecure</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>10</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -1429,7 +1345,6 @@
                     <fields>
                         <base_url translate="label">
                             <label>Base URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_baseurl</backend_model>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1438,7 +1353,6 @@
                         </base_url>
                         <base_link_url translate="label">
                             <label>Base Link URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_baseurl</backend_model>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1447,7 +1361,6 @@
                         </base_link_url>
                         <base_skin_url translate="label">
                             <label>Base Skin URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_baseurl</backend_model>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1456,7 +1369,6 @@
                         </base_skin_url>
                         <base_media_url translate="label">
                             <label>Base Media URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_baseurl</backend_model>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1465,7 +1377,6 @@
                         </base_media_url>
                         <base_js_url translate="label comment">
                             <label>Base JavaScript URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_baseurl</backend_model>
                             <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1477,7 +1388,6 @@
                 </unsecure>
                 <secure translate="label">
                     <label>Secure</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>20</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -1485,7 +1395,6 @@
                     <fields>
                         <base_url translate="label comment">
                             <label>Base URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_baseurl</backend_model>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1495,7 +1404,6 @@
                         </base_url>
                         <base_link_url translate="label comment">
                             <label>Base Link URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_baseurl</backend_model>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1505,7 +1413,6 @@
                         </base_link_url>
                         <base_skin_url translate="label">
                             <label>Base Skin URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_baseurl</backend_model>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1514,7 +1421,6 @@
                         </base_skin_url>
                         <base_media_url translate="label">
                             <label>Base Media URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_baseurl</backend_model>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1523,7 +1429,6 @@
                         </base_media_url>
                         <base_js_url translate="label comment">
                             <label>Base JavaScript URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_baseurl</backend_model>
                             <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1553,7 +1458,6 @@
                         </use_in_adminhtml>
                         <offloader_header translate="label">
                             <label>Offloader header</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_web_secure_offloaderheader</backend_model>
                             <sort_order>75</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1564,7 +1468,6 @@
                 </secure>
                 <default translate="label">
                     <label>Default Pages</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>30</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -1572,7 +1475,6 @@
                     <fields>
                         <front translate="label">
                             <label>Default Web URL</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1580,7 +1482,6 @@
                         </front>
                         <no_route translate="label">
                             <label>Default No-route URL</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>2</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1590,7 +1491,6 @@
                 </default>
                 <polls translate="label">
                     <label>Polls</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>40</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -1598,7 +1498,6 @@
                 </polls>
                 <cookie translate="label">
                     <label>Session Cookie Management</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>50</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -1606,7 +1505,6 @@
                     <fields>
                         <cookie_lifetime translate="label">
                             <label>Cookie Lifetime</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1614,7 +1512,6 @@
                         </cookie_lifetime>
                         <cookie_path translate="label">
                             <label>Cookie Path</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1622,7 +1519,6 @@
                         </cookie_path>
                         <cookie_domain translate="label">
                             <label>Cookie Domain</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1661,7 +1557,6 @@
                 </cookie>
                 <session translate="label">
                     <label>Session Validation Settings</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>60</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -1717,7 +1612,6 @@
                 </session>
                 <browser_capabilities translate="label">
                     <label>Browser Capabilities Detection</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>200</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Cron/etc/system.xml
+++ b/app/code/core/Mage/Cron/etc/system.xml
@@ -31,7 +31,6 @@
             <groups>
                 <cron translate="label comment" module="cron">
                     <label>Cron (Scheduled Tasks) - all the times are in minutes</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>15</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -40,7 +39,6 @@
                     <fields>
                         <schedule_generate_every translate="label">
                             <label>Generate Schedules Every</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -48,7 +46,6 @@
                         </schedule_generate_every>
                         <schedule_ahead_for translate="label">
                             <label>Schedule Ahead for</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -56,7 +53,6 @@
                         </schedule_ahead_for>
                         <schedule_lifetime translate="label">
                             <label>Missed if Not Run Within</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -64,7 +60,6 @@
                         </schedule_lifetime>
                         <history_cleanup_every translate="label">
                             <label>History Cleanup Every</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -72,7 +67,6 @@
                         </history_cleanup_every>
                         <history_success_lifetime translate="label">
                             <label>Success History Lifetime</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -80,7 +74,6 @@
                         </history_success_lifetime>
                         <history_failure_lifetime translate="label">
                             <label>Failure History Lifetime</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>60</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Customer/etc/system.xml
+++ b/app/code/core/Mage/Customer/etc/system.xml
@@ -44,7 +44,6 @@
             <groups>
                 <account_share translate="label">
                     <label>Account Sharing Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>10</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -64,7 +63,6 @@
                 </account_share>
                 <online_customers translate="label">
                     <label>Online Customers Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>10</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -72,7 +70,6 @@
                     <fields>
                         <online_minutes_interval translate="label comment">
                             <label>Online Minutes Interval</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
@@ -187,7 +184,6 @@
                         </vat_frontend_visibility>
                         <email_domain translate="label">
                             <label>Default Email Domain</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>60</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -252,7 +248,6 @@
                 </create_account>
                 <changed_account translate="label">
                     <label>Change Account Data</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>25</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -280,7 +275,6 @@
                 </changed_account>
                 <password translate="label">
                     <label>Password Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>30</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -316,7 +310,6 @@
                         <reset_link_expiration_period translate="label comment">
                             <label>Recovery Link Expiration Period (hours)</label>
                             <comment>Please enter a number 1 or greater in this field.</comment>
-                            <frontend_type>text</frontend_type>
                             <validate>required-entry validate-digits validate-digits-range digits-range-1-</validate>
                             <backend_model>adminhtml/system_config_backend_customer_password_link_expirationperiod</backend_model>
                             <sort_order>40</sort_order>
@@ -336,7 +329,6 @@
                         <min_password_length translate="label comment">
                             <label>Minimum password length</label>
                             <comment>Please enter a number 7 or greater in this field.</comment>
-                            <frontend_type>text</frontend_type>
                             <validate>required-entry validate-digits validate-digits-range digits-range-7-</validate>
                             <backend_model>adminhtml/system_config_backend_passwordlength</backend_model>
                             <sort_order>60</sort_order>
@@ -464,7 +456,6 @@
                 </startup>
                 <address_templates translate="label">
                     <label>Address Templates</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>100</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -546,7 +537,6 @@
                         </forgot_password_flow_secure>
                         <forgot_password_ip_times translate="label comment">
                             <label>Forgot password requests to times per hour from 1 IP</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>150</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -555,7 +545,6 @@
                         </forgot_password_ip_times>
                         <forgot_password_email_times translate="label">
                             <label>Forgot password requests to times per 24 hours from 1 e-mail</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>160</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -565,7 +554,6 @@
                         <min_admin_password_length translate="label comment">
                             <label>Minimum admin password length</label>
                             <comment>Please enter a number 7 or greater in this field.</comment>
-                            <frontend_type>text</frontend_type>
                             <validate>required-entry validate-digits validate-digits-range digits-range-7-</validate>
                             <backend_model>adminhtml/system_config_backend_passwordlength</backend_model>
                             <sort_order>170</sort_order>

--- a/app/code/core/Mage/Directory/etc/system.xml
+++ b/app/code/core/Mage/Directory/etc/system.xml
@@ -95,7 +95,6 @@
                         </active>
                         <timeout translate="label">
                             <label>Connection Timeout in Seconds</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
@@ -130,7 +129,6 @@
                         </active>
                         <timeout translate="label">
                             <label>Connection Timeout in Seconds</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
@@ -149,7 +147,6 @@
                 </fixerio>
                 <import translate="label">
                     <label>Scheduled Import Settings</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>50</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -166,7 +163,6 @@
                         </enabled>
                         <error_email translate="label">
                             <label>Error Email Recipient</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-email</validate>
                             <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
@@ -226,7 +222,6 @@
             <groups>
                 <currency translate="label">
                     <label>Currency</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>50</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -265,7 +260,6 @@
                 </country>
                 <region translate="label">
                     <label>States Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>4</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>

--- a/app/code/core/Mage/Downloadable/etc/system.xml
+++ b/app/code/core/Mage/Downloadable/etc/system.xml
@@ -31,7 +31,6 @@
             <groups>
                 <downloadable translate="label">
                     <label>Downloadable Product Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>600</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -48,7 +47,6 @@
                         </order_item_status>
                         <downloads_number translate="label">
                             <label>Default Maximum Number of Downloads</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>200</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -65,7 +63,6 @@
                         </shareable>
                         <samples_title translate="label">
                             <label>Default Sample Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>400</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -73,7 +70,6 @@
                         </samples_title>
                         <links_title translate="label">
                             <label>Default Link Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>500</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/GiftMessage/etc/system.xml
+++ b/app/code/core/Mage/GiftMessage/etc/system.xml
@@ -31,7 +31,6 @@
             <groups>
                 <gift_options translate="label" module="giftmessage">
                     <label>Gift Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>100</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/GoogleAnalytics/etc/system.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/system.xml
@@ -30,7 +30,6 @@
         <google translate="label" module="googleanalytics">
             <label>Google API</label>
             <tab>sales</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>340</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -38,7 +37,6 @@
             <groups>
                 <analytics translate="label">
                     <label>Google Analytics</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>10</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -65,7 +63,6 @@
                         </type>
                         <account translate="label">
                             <label>Account Number</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/ImportExport/etc/system.xml
+++ b/app/code/core/Mage/ImportExport/etc/system.xml
@@ -57,7 +57,6 @@
                     <fields>
                         <configurable_page_size translate="label,comment">
                             <label>Page size for import configurable products</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number</validate>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/code/core/Mage/Log/etc/system.xml
+++ b/app/code/core/Mage/Log/etc/system.xml
@@ -31,7 +31,6 @@
             <groups>
                 <log translate="label" module="log">
                     <label>Log</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>200</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -49,7 +48,6 @@
                         </enable_log>
                         <clean_after_day translate="label">
                             <label>Save Log, Days</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>2</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
@@ -84,7 +82,6 @@
                         </frequency>
                         <error_email translate="label">
                             <label>Error Email Recipient</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-email</validate>
                             <sort_order>6</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/code/core/Mage/Newsletter/etc/system.xml
+++ b/app/code/core/Mage/Newsletter/etc/system.xml
@@ -30,7 +30,6 @@
         <newsletter translate="label" module="newsletter">
             <label>Newsletter</label>
             <tab>customer</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>110</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -38,7 +37,6 @@
             <groups>
                 <subscription translate="label">
                     <label>Subscription Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -120,7 +118,6 @@
                 </subscription>
                 <security translate="label">
                     <label>Security</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Oauth/etc/system.xml
+++ b/app/code/core/Mage/Oauth/etc/system.xml
@@ -30,7 +30,6 @@
         <oauth translate="label" module="oauth">
             <label>OAuth</label>
             <tab>service</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>300</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -38,7 +37,6 @@
             <groups>
                  <cleanup translate="label">
                     <label>Cleanup Settings</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>300</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -46,7 +44,6 @@
                     <fields>
                         <cleanup_probability translate="label">
                             <label>Cleanup Probability</label>
-                            <frontend_type>text</frontend_type>
                             <comment>Integer. Launch cleanup in X OAuth requests. 0 (not recommended) - to disable cleanup</comment>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
@@ -56,7 +53,6 @@
                         <expiration_period translate="label">
                             <label>Expiration Period</label>
                             <comment>Cleanup entries older than X minutes.</comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
@@ -66,7 +62,6 @@
                 </cleanup>
                 <email translate="label">
                     <label>Email</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>300</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Page/etc/system.xml
+++ b/app/code/core/Mage/Page/etc/system.xml
@@ -31,7 +31,6 @@
             <groups>
                 <head translate="label">
                     <label>HTML Head</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>20</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -50,7 +49,6 @@
                         </shortcut_icon>
                         <default_title translate="label">
                             <label>Default Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -58,7 +56,6 @@
                         </default_title>
                         <title_prefix translate="label">
                             <label>Title Prefix</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>12</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -66,7 +63,6 @@
                         </title_prefix>
                         <title_suffix translate="label">
                             <label>Title Suffix</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>14</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -100,7 +96,6 @@
 <!--
                         <default_media_type translate="label">
                             <label>Default Media Type</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -108,7 +103,6 @@
                         </default_media_type>
                         <default_charset translate="label">
                             <label>Default Charset</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>60</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -137,7 +131,6 @@
                 </head>
                 <header translate="label">
                     <label>Header</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>30</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -145,7 +138,6 @@
                     <fields>
                         <logo_src translate="label">
                             <label>Logo Image Src</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -153,7 +145,6 @@
                         </logo_src>
                         <logo_alt translate="label">
                             <label>Logo Image Alt</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -161,7 +152,6 @@
                         </logo_alt>
                         <logo_src_small translate="label">
                             <label>Small Logo Image Src</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>25</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -169,7 +159,6 @@
                         </logo_src_small>
                         <welcome translate="label">
                             <label>Welcome Text</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -179,7 +168,6 @@
                 </header>
                 <footer translate="label">
                     <label>Footer</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>40</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/PageCache/etc/system.xml
+++ b/app/code/core/Mage/PageCache/etc/system.xml
@@ -47,7 +47,6 @@
                         </enabled>
                         <cookie_lifetime translate="label comment">
                             <label>Cookie Lifetime (seconds)</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>

--- a/app/code/core/Mage/Paygate/etc/system.xml
+++ b/app/code/core/Mage/Paygate/etc/system.xml
@@ -31,7 +31,6 @@
             <groups>
                 <authorizenet translate="label" module="paygate">
                     <label>Authorize.net (Deprecated)</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>34</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -85,7 +84,6 @@
                         </login>
                         <merchant_email translate="label">
                             <label>Merchant's Email</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-email</validate>
                             <sort_order>15</sort_order>
                             <show_in_default>1</show_in_default>
@@ -103,7 +101,6 @@
                         </order_status>
                         <sort_order translate="label">
                             <label>Sort Order</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>95</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -129,7 +126,6 @@
                         </debug>
                         <title translate="label">
                             <label>Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -155,7 +151,6 @@
                         </payment_action>
                         <cgi_url>
                             <label>Gateway URL</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -163,7 +158,6 @@
                         </cgi_url>
                         <cgi_url_td>
                             <label>Payment Update URL</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>35</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -198,7 +192,6 @@
                         </specificcountry>
                         <min_order_total translate="label">
                             <label>Minimum Order Total</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>85</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -206,7 +199,6 @@
                         </min_order_total>
                         <max_order_total translate="label">
                             <label>Maximum Order Total</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>90</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -249,7 +241,6 @@
                         <centinel_api_url translate="label comment">
                             <label>Centinel API URL</label>
                             <comment>If empty, a default value will be used. Custom URL may be provided by CardinalCommerce agreement.</comment>
-                            <frontend_type>text</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>135</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/code/core/Mage/Payment/etc/system.xml
+++ b/app/code/core/Mage/Payment/etc/system.xml
@@ -30,7 +30,6 @@
         <payment translate="label" module="payment">
             <label>Payment Methods</label>
             <tab>sales</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>400</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -38,7 +37,6 @@
             <groups>
                 <checkmo translate="label">
                     <label>Check / Money Order</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>30</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -64,7 +62,6 @@
                         </order_status>
                         <sort_order translate="label">
                             <label>Sort Order</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -73,7 +70,6 @@
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -115,7 +111,6 @@
                         </mailing_address>
                         <min_order_total translate="label">
                             <label>Minimum Order Total</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>98</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -123,7 +118,6 @@
                         </min_order_total>
                         <max_order_total translate="label">
                             <label>Maximum Order Total</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>99</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -135,7 +129,6 @@
                 </checkmo>
                 <free translate="label">
                     <label>Zero Subtotal Checkout</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>30</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -173,7 +166,6 @@
                         </payment_action>
                         <sort_order translate="label">
                             <label>Sort Order</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -182,7 +174,6 @@
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -210,7 +201,6 @@
 <!--
                         <min_order_total translate="label">
                             <label>Minimum Order Total</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>98</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -218,7 +208,6 @@
                         </min_order_total>
                         <max_order_total translate="label">
                             <label>Maximum Order Total</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>99</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -231,7 +220,6 @@
                 </free>
                 <purchaseorder translate="label">
                     <label>Purchase Order</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>32</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -257,7 +245,6 @@
                         </order_status>
                         <sort_order translate="label">
                             <label>Sort Order</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -266,7 +253,6 @@
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -293,7 +279,6 @@
                         </specificcountry>
                         <min_order_total translate="label">
                             <label>Minimum Order Total</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>98</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -301,7 +286,6 @@
                         </min_order_total>
                         <max_order_total translate="label">
                             <label>Maximum Order Total</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>99</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -313,7 +297,6 @@
                 </purchaseorder>
                 <banktransfer translate="label">
                     <label>Bank Transfer Payment</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>30</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -330,7 +313,6 @@
                         </active>
                         <title translate="label">
                             <label>Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -374,7 +356,6 @@
                         </instructions>
                         <min_order_total translate="label">
                             <label>Minimum Order Total</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>98</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -382,7 +363,6 @@
                         </min_order_total>
                         <max_order_total translate="label">
                             <label>Maximum Order Total</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>99</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -390,7 +370,6 @@
                         </max_order_total>
                         <sort_order translate="label">
                             <label>Sort Order</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -400,7 +379,6 @@
                 </banktransfer>
                 <cashondelivery translate="label">
                     <label>Cash On Delivery Payment</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>30</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -417,7 +395,6 @@
                         </active>
                         <title translate="label">
                             <label>Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -461,7 +438,6 @@
                         </instructions>
                         <min_order_total translate="label">
                             <label>Minimum Order Total</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>98</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -469,7 +445,6 @@
                         </min_order_total>
                         <max_order_total translate="label">
                             <label>Maximum Order Total</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>99</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -477,7 +452,6 @@
                         </max_order_total>
                         <sort_order translate="label">
                             <label>Sort Order</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Paypal/etc/system.xml
+++ b/app/code/core/Mage/Paypal/etc/system.xml
@@ -41,7 +41,6 @@
                     <label>Merchant Location</label>
                     <fieldset_css>paypal-config</fieldset_css>
                     <expanded>1</expanded>
-                    <frontend_type>text</frontend_type>
                     <sort_order>5</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -119,7 +118,6 @@
                 <paypal_payments>
                     <payflow_advanced type="group" translate="label comment">
                         <label>Payments Advanced (Includes Express Checkout)</label>
-                        <frontend_type>text</frontend_type>
                         <show_in_default>1</show_in_default>
                         <show_in_website>1</show_in_website>
                         <show_in_store>1</show_in_store>
@@ -138,7 +136,6 @@
                         <fields>
                             <required_settings type="group" translate="label">
                                 <label>Required PayPal Settings</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <frontend_model>paypal/adminhtml_system_config_fieldset_expanded</frontend_model>
@@ -146,7 +143,6 @@
                                 <fields>
                                     <payments_advanced type="group" translate="label">
                                         <label>Payments Advanced</label>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <frontend_model>paypal/adminhtml_system_config_fieldset_expanded</frontend_model>
@@ -155,7 +151,6 @@
                                             <partner translate="label">
                                                 <label>Partner</label>
                                                 <config_path>payment/payflow_advanced/partner</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>10</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -163,7 +158,6 @@
                                             <vendor translate="label">
                                                 <label>Vendor</label>
                                                 <config_path>payment/payflow_advanced/vendor</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>20</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -172,7 +166,6 @@
                                                 <label>User</label>
                                                 <comment>PayPal recommends that you set up an additional User on your account at manager.paypal.com</comment>
                                                 <tooltip>PayPal recommends you set up an additional User on your account at manager.paypal.com, instead of entering your admin username and password here. This will enhance your security and prevent service interruptions if you later change your password. If you do not want to set up an additional User, you can re-enter your Merchant Login here.</tooltip>
-                                                <frontend_type>text</frontend_type>
                                                 <config_path>payment/payflow_advanced/user</config_path>
                                                 <sort_order>30</sort_order>
                                                 <show_in_default>1</show_in_default>
@@ -209,7 +202,6 @@
                                             <proxy_host translate="label">
                                                 <label>Proxy Host</label>
                                                 <config_path>payment/payflow_advanced/proxy_host</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>70</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -218,7 +210,6 @@
                                             <proxy_port translate="label">
                                                 <label>Proxy Port</label>
                                                 <config_path>payment/payflow_advanced/proxy_port</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>80</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -235,7 +226,6 @@
                                     </payments_advanced>
                                     <express type="group" translate="label">
                                         <label>Express Checkout</label>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <frontend_model>paypal/adminhtml_system_config_fieldset_expanded</frontend_model>
@@ -337,7 +327,6 @@
                                             <proxy_host translate="label">
                                                 <label>Proxy Host</label>
                                                 <config_path>paypal/wpp/proxy_host</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>100</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -347,7 +336,6 @@
                                             <proxy_port translate="label">
                                                 <label>Proxy Port</label>
                                                 <config_path>paypal/wpp/proxy_port</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>110</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -386,7 +374,6 @@
                                             The PayPal Advertising Program has been shown to generate additional purchases as well as increase consumer's average purchase sizes by 15%
                                             or more. <a href="https://financing.paypal.com/ppfinportal/content/forrester" target="_blank">See Details</a>.]]>
                                         </comment>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <sort_order>32</sort_order>
@@ -395,7 +382,6 @@
                                             <bml_wizard extends="//paypal_payments/express_checkout//advertise_bml//bml_wizard" />
                                             <advanced_settings_bml_homepage type="group" translate="label">
                                                 <label>Home Page</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -422,7 +408,6 @@
                                             </advanced_settings_bml_homepage>
                                             <advanced_settings_bml_categorypage type="group" translate="label">
                                                 <label>Catalog Category Page</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -450,7 +435,6 @@
                                             </advanced_settings_bml_categorypage>
                                             <advanced_settings_bml_productpage type="group" translate="label">
                                                 <label>Catalog Product Page</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -478,7 +462,6 @@
                                             </advanced_settings_bml_productpage>
                                             <advanced_settings_bml_checkout type="group" translate="label">
                                                 <label>Checkout Cart Page</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -512,7 +495,6 @@
 
                             <settings_payments_advanced type="group" translate="label">
                                 <label>Basic Settings - PayPal Payments Advanced</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <show_in_store>1</show_in_store>
@@ -523,7 +505,6 @@
                                         <label>Title</label>
                                         <comment>It is recommended to set this value to "Debit or Credit Card" per store views.</comment>
                                         <config_path>payment/payflow_advanced/title</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>10</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -532,7 +513,6 @@
                                     <sort_order translate="label">
                                         <label>Sort Order</label>
                                         <config_path>payment/payflow_advanced/sort_order</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>20</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -551,7 +531,6 @@
                                     <settings_payments_advanced_advanced type="group" translate="label">
                                         <label>Advanced Settings</label>
                                         <frontend_class>config-advanced</frontend_class>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <show_in_store>1</show_in_store>
@@ -642,7 +621,6 @@
                                             </mobile_optimized>
                                             <billing_agreement type="group" translate="label">
                                                 <label>PayPal Billing Agreement Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -662,7 +640,6 @@
                                                     <title translate="label">
                                                         <label>Title</label>
                                                         <config_path>payment/paypal_billing_agreement/title</config_path>
-                                                        <frontend_type>text</frontend_type>
                                                         <sort_order>20</sort_order>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
@@ -672,7 +649,6 @@
                                                     <sort_order translate="label">
                                                         <label>Sort Order</label>
                                                         <config_path>payment/paypal_billing_agreement/sort_order</config_path>
-                                                        <frontend_type>text</frontend_type>
                                                         <sort_order>30</sort_order>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
@@ -755,7 +731,6 @@
                                             </billing_agreement>
                                             <settlement_report type="group" translate="label">
                                                 <label>Settlement Report Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <sort_order>90</sort_order>
@@ -802,7 +777,6 @@
                                                         <comment>By default it is "reports.paypal.com".</comment>
                                                         <tooltip>Use colon to specify port. For example: "test.example.com:5224".</tooltip>
                                                         <config_path>paypal/fetch_reports/ftp_ip</config_path>
-                                                        <frontend_type>text</frontend_type>
                                                         <sort_order>50</sort_order>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
@@ -813,7 +787,6 @@
                                                         <label>Custom Path</label>
                                                         <comment>By default it is "/ppreports/outgoing".</comment>
                                                         <config_path>paypal/fetch_reports/ftp_path</config_path>
-                                                        <frontend_type>text</frontend_type>
                                                         <sort_order>60</sort_order>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
@@ -860,7 +833,6 @@
                                             </settlement_report>
                                             <frontend type="group" translate="label">
                                                 <label>Frontend Experience Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -891,7 +863,6 @@
                                                         <label>Page Style</label>
                                                         <config_path>paypal/style/page_style</config_path>
                                                         <tooltip><![CDATA[Allowable values: "paypal", "primary" (default), your_custom_value (a custom payment page style from your merchant account profile).]]></tooltip>
-                                                        <frontend_type>text</frontend_type>
                                                         <sort_order>30</sort_order>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
@@ -946,7 +917,6 @@
                             </settings_payments_advanced>
                             <settings_express_checkout type="group" translate="label">
                                 <label>Basic Settings - PayPal Express Checkout</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <show_in_store>1</show_in_store>
@@ -957,7 +927,6 @@
                                         <label>Title</label>
                                         <comment>It is recommended to set this value to "PayPal" per store views.</comment>
                                         <config_path>payment/paypal_express/title</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>10</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -967,7 +936,6 @@
                                     <sort_order translate="label">
                                         <label>Sort Order</label>
                                         <config_path>payment/paypal_express/sort_order</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>20</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -1000,7 +968,6 @@
                                         <label>Authorization Honor Period (days)</label>
                                         <comment>Specifies what the Authorization Honor Period is on the merchant’s PayPal account. It must mirror the setting in PayPal.</comment>
                                         <config_path>payment/paypal_express/authorization_honor_period</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>50</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -1011,7 +978,6 @@
                                         <label>Order Valid Period (days)</label>
                                         <comment>Specifies what the Order Valid Period is on the merchant’s PayPal account. It must mirror the setting in PayPal.</comment>
                                         <config_path>payment/paypal_express/order_valid_period</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>60</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -1022,7 +988,6 @@
                                         <label>Number of Child Authorizations</label>
                                         <comment>The default number of child authorizations in your PayPal account is 1. To do multiple authorizations please contact PayPal to request an increase.</comment>
                                         <config_path>payment/paypal_express/child_authorization_number</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>70</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -1032,7 +997,6 @@
                                     <settings_express_checkout_advanced type="group" translate="label">
                                         <label>Advanced Settings</label>
                                         <frontend_class>config-advanced</frontend_class>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <show_in_store>1</show_in_store>
@@ -1178,7 +1142,6 @@
                     </payflow_advanced>
                     <wpp type="group" translate="label comment">
                         <label>Website Payments Pro (Includes Express Checkout)</label>
-                        <frontend_type>text</frontend_type>
                         <show_in_default>1</show_in_default>
                         <show_in_website>1</show_in_website>
                         <show_in_store>1</show_in_store>
@@ -1231,7 +1194,6 @@
                                             The PayPal Advertising Program has been shown to generate additional purchases as well as increase consumer's average purchase sizes by 15%
                                             or more. <a href="https://financing.paypal.com/ppfinportal/content/forrester" target="_blank">See Details</a>.]]>
                                                     </comment>
-                                                    <frontend_type>text</frontend_type>
                                                     <show_in_default>1</show_in_default>
                                                     <show_in_website>1</show_in_website>
                                                     <sort_order>22</sort_order>
@@ -1240,7 +1202,6 @@
                                                         <bml_wizard extends="//paypal_payments/express_checkout//advertise_bml//bml_wizard" />
                                                         <wpp_settings_bml_homepage type="group" translate="label">
                                                             <label>Home Page</label>
-                                                            <frontend_type>text</frontend_type>
                                                             <show_in_default>1</show_in_default>
                                                             <show_in_website>1</show_in_website>
                                                             <show_in_store>1</show_in_store>
@@ -1267,7 +1228,6 @@
                                                         </wpp_settings_bml_homepage>
                                                         <wpp_settings_bml_categorypage type="group" translate="label">
                                                             <label>Catalog Category Page</label>
-                                                            <frontend_type>text</frontend_type>
                                                             <show_in_default>1</show_in_default>
                                                             <show_in_website>1</show_in_website>
                                                             <show_in_store>1</show_in_store>
@@ -1295,7 +1255,6 @@
                                                         </wpp_settings_bml_categorypage>
                                                         <wpp_settings_bml_productpage type="group" translate="label">
                                                             <label>Catalog Product Page</label>
-                                                            <frontend_type>text</frontend_type>
                                                             <show_in_default>1</show_in_default>
                                                             <show_in_website>1</show_in_website>
                                                             <show_in_store>1</show_in_store>
@@ -1323,7 +1282,6 @@
                                                         </wpp_settings_bml_productpage>
                                                         <wpp_settings_bml_checkout type="group" translate="label">
                                                             <label>Checkout Cart Page</label>
-                                                            <frontend_type>text</frontend_type>
                                                             <show_in_default>1</show_in_default>
                                                             <show_in_website>1</show_in_website>
                                                             <show_in_store>1</show_in_store>
@@ -1363,7 +1321,6 @@
                         <fields>
                             <wpp_required_settings type="group" translate="label">
                                 <label>Required PayPal Settings</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <frontend_model>paypal/adminhtml_system_config_fieldset_expanded</frontend_model>
@@ -1371,7 +1328,6 @@
                                 <fields>
                                     <wpp_and_express_checkout type="group" translate="label">
                                         <label>Website Payments Pro and Express Checkout</label>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <frontend_model>paypal/adminhtml_system_config_fieldset_expanded</frontend_model>
@@ -1408,7 +1364,6 @@
 
                             <wpp_settings type="group" translate="label">
                                 <label>Basic Settings - PayPal Website Payments Pro</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <show_in_store>1</show_in_store>
@@ -1419,7 +1374,6 @@
                                         <label>Title</label>
                                         <comment>It is recommended to set this value to "Debit or Credit Card" per store views.</comment>
                                         <config_path>payment/paypal_direct/title</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>10</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -1428,7 +1382,6 @@
                                     <sort_order translate="label">
                                         <label>Sort Order</label>
                                         <config_path>payment/paypal_direct/sort_order</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>20</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -1464,7 +1417,6 @@
                                     <wpp_settings_advanced type="group" translate="label">
                                         <label>Advanced Settings</label>
                                         <frontend_class>config-advanced</frontend_class>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <show_in_store>1</show_in_store>
@@ -1556,7 +1508,6 @@
                                                 <label>Centinel Custom API URL</label>
                                                 <config_path>payment/paypal_direct/centinel_api_url</config_path>
                                                 <comment>If empty, a default value will be used. Custom URL may be provided by CardinalCommerce agreement.</comment>
-                                                <frontend_type>text</frontend_type>
                                                 <source_model>adminhtml/system_config_source_yesno</source_model>
                                                 <sort_order>70</sort_order>
                                                 <show_in_default>1</show_in_default>
@@ -1565,7 +1516,6 @@
                                             </centinel_api_url>
                                             <wpp_billing_agreement type="group" translate="label">
                                                 <label>PayPal Billing Agreement Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -1585,7 +1535,6 @@
                                             </wpp_billing_agreement>
                                             <wpp_settlement_report type="group" translate="label">
                                                 <label>Settlement Report Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <sort_order>90</sort_order>
@@ -1604,7 +1553,6 @@
                                             </wpp_settlement_report>
                                             <wpp_frontend type="group" translate="label">
                                                 <label>Frontend Experience Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -1626,7 +1574,6 @@
 
                             <wpp_settings_express_checkout type="group" translate="label">
                                 <label>Basic Settings - PayPal Express Checkout</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <show_in_store>1</show_in_store>
@@ -1644,7 +1591,6 @@
                                     <wpp_settings_express_checkout_advanced type="group" translate="label">
                                         <label>Advanced Settings</label>
                                         <frontend_class>config-advanced</frontend_class>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <show_in_store>1</show_in_store>
@@ -1670,7 +1616,6 @@
                     </wpp>
                     <wps type="group" translate="label comment">
                         <label>Website Payments Standard</label>
-                        <frontend_type>text</frontend_type>
                         <show_in_default>1</show_in_default>
                         <show_in_website>1</show_in_website>
                         <show_in_store>1</show_in_store>
@@ -1711,7 +1656,6 @@
                         <fields>
                             <wps_required_settings type="group" translate="label">
                                 <label>Required PayPal Settings</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <frontend_model>paypal/adminhtml_system_config_fieldset_expanded</frontend_model>
@@ -1733,7 +1677,6 @@
                             </wps_required_settings>
                             <settings_payments_standart type="group" translate="label">
                                 <label>Basic Settings - PayPal Website Payments Standard</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <show_in_store>1</show_in_store>
@@ -1744,7 +1687,6 @@
                                         <label>Title</label>
                                         <comment>It is recommended to set this value to "PayPal" per store views.</comment>
                                         <config_path>payment/paypal_standard/title</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>10</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -1753,7 +1695,6 @@
                                     <sort_order translate="label">
                                         <label>Sort Order</label>
                                         <config_path>payment/paypal_standard/sort_order</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>20</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -1772,7 +1713,6 @@
                                     <settings_payments_standart_advanced type="group" translate="label">
                                         <label>Advanced Settings</label>
                                         <frontend_class>config-advanced</frontend_class>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <sort_order>40</sort_order>
@@ -1818,7 +1758,6 @@
                                                 <label>Summary Text for Aggregated Cart</label>
                                                 <config_path>payment/paypal_standard/line_items_summary</config_path>
                                                 <comment>Uses store frontend name by default.</comment>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>50</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -1851,7 +1790,6 @@
                     </wps>
                     <wps_express type="group" translate="label comment">
                         <label>Website Payments Standard (Includes Express Checkout)</label>
-                        <frontend_type>text</frontend_type>
                         <show_in_default>1</show_in_default>
                         <show_in_website>1</show_in_website>
                         <show_in_store>1</show_in_store>
@@ -1893,7 +1831,6 @@
                                             The PayPal Advertising Program has been shown to generate additional purchases as well as increase consumer's average purchase sizes by 15%
                                             or more. <a href="https://financing.paypal.com/ppfinportal/content/forrester" target="_blank">See Details</a>.]]>
                                                 </comment>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <sort_order>32</sort_order>
@@ -1902,7 +1839,6 @@
                                                     <bml_wizard extends="//paypal_payments/express_checkout//advertise_bml//bml_wizard" />
                                                     <wps_express_settings_bml_homepage type="group" translate="label">
                                                         <label>Home Page</label>
-                                                        <frontend_type>text</frontend_type>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
                                                         <show_in_store>1</show_in_store>
@@ -1928,7 +1864,6 @@
                                                     </wps_express_settings_bml_homepage>
                                                     <wps_express_settings_bml_categorypage type="group" translate="label">
                                                         <label>Catalog Category Page</label>
-                                                        <frontend_type>text</frontend_type>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
                                                         <show_in_store>1</show_in_store>
@@ -1956,7 +1891,6 @@
                                                     </wps_express_settings_bml_categorypage>
                                                     <wps_express_settings_bml_productpage type="group" translate="label">
                                                         <label>Catalog Product Page</label>
-                                                        <frontend_type>text</frontend_type>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
                                                         <show_in_store>1</show_in_store>
@@ -1984,7 +1918,6 @@
                                                     </wps_express_settings_bml_productpage>
                                                     <wps_express_settings_bml_checkout type="group" translate="label">
                                                         <label>Checkout Cart Page</label>
-                                                        <frontend_type>text</frontend_type>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
                                                         <show_in_store>1</show_in_store>
@@ -2028,7 +1961,6 @@
                         <fields>
                             <wps_express_checkout_required type="group" translate="label">
                                 <label>Required PayPal Settings</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <sort_order>10</sort_order>
@@ -2036,7 +1968,6 @@
                                 <fields>
                                     <wps_express_checkout_required_express_checkout type="group" translate="label">
                                         <label>PayPal Website Payments Standard</label>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <frontend_model>paypal/adminhtml_system_config_fieldset_expanded</frontend_model>
@@ -2071,7 +2002,6 @@
                             </wps_express_checkout_required>
                             <settings_wps_express type="group" translate="label">
                                 <label>Basic Settings - PayPal Website Payments Standard</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <show_in_store>1</show_in_store>
@@ -2089,7 +2019,6 @@
                                     <settings_wps_express_advanced type="group" translate="label">
                                         <label>Advanced Settings</label>
                                         <frontend_class>config-advanced</frontend_class>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <show_in_store>1</show_in_store>
@@ -2110,7 +2039,6 @@
 
                                             <wps_express_billing_agreement type="group" translate="label">
                                                 <label>PayPal Billing Agreement Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -2130,7 +2058,6 @@
                                             </wps_express_billing_agreement>
                                             <wps_express_settlement_report type="group" translate="label">
                                                 <label>Settlement Report Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <sort_order>110</sort_order>
@@ -2149,7 +2076,6 @@
                                             </wps_express_settlement_report>
                                             <wps_express_frontend type="group" translate="label">
                                                 <label>Frontend Experience Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -2172,7 +2098,6 @@
                     </wps_express>
                     <paypal_verisign type="group" translate="label comment">
                         <label>Payflow Pro</label>
-                        <frontend_type>text</frontend_type>
                         <frontend_model>paypal/adminhtml_system_config_fieldset_payment</frontend_model>
                         <frontend_class>pp-method-payflow</frontend_class>
                         <show_in_default>1</show_in_default>
@@ -2201,7 +2126,6 @@
                         <fields>
                             <paypal_payflow_required type="group" translate="label">
                                 <label>Required PayPal Settings</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <frontend_model>paypal/adminhtml_system_config_fieldset_expanded</frontend_model>
@@ -2209,7 +2133,6 @@
                                 <fields>
                                     <paypal_payflow_api_settings type="group" translate="label">
                                         <label>Payflow Pro</label>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <frontend_model>paypal/adminhtml_system_config_fieldset_expanded</frontend_model>
@@ -2218,7 +2141,6 @@
                                             <partner translate="label">
                                                 <label>Partner</label>
                                                 <config_path>payment/verisign/partner</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>20</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -2235,7 +2157,6 @@
                                             <vendor translate="label">
                                                 <label>Vendor</label>
                                                 <config_path>payment/verisign/vendor</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>40</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -2270,7 +2191,6 @@
                                             <proxy_host translate="label">
                                                 <label>Proxy Host</label>
                                                 <config_path>payment/verisign/proxy_host</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>80</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -2279,7 +2199,6 @@
                                             <proxy_port translate="label">
                                                 <label>Proxy Port</label>
                                                 <config_path>payment/verisign/proxy_port</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>90</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -2302,7 +2221,6 @@
                             </paypal_payflow_required>
                             <settings_paypal_payflow type="group" translate="label">
                                 <label>Basic Settings - PayPal Payflow Pro</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <show_in_store>1</show_in_store>
@@ -2313,7 +2231,6 @@
                                         <label>Title</label>
                                         <comment>It is recommended to set this value to "Debit or Credit Card" per store views.</comment>
                                         <config_path>payment/verisign/title</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>10</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -2322,7 +2239,6 @@
                                     <sort_order translate="label">
                                         <label>Sort Order</label>
                                         <config_path>payment/verisign/sort_order</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>20</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -2358,7 +2274,6 @@
                                     <settings_paypal_payflow_advanced type="group" translate="label">
                                         <label>Advanced Settings</label>
                                         <frontend_class>config-advanced</frontend_class>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <show_in_store>1</show_in_store>
@@ -2441,7 +2356,6 @@
                                                 <label>Centinel API URL</label>
                                                 <config_path>payment/verisign/centinel_api_url</config_path>
                                                 <comment>A value is required for live mode. Refer to your CardinalCommerce agreement.</comment>
-                                                <frontend_type>text</frontend_type>
                                                 <source_model>adminhtml/system_config_source_yesno</source_model>
                                                 <sort_order>80</sort_order>
                                                 <show_in_default>1</show_in_default>
@@ -2450,7 +2364,6 @@
                                             </centinel_api_url>
                                             <paypal_payflow_settlement_report type="group" translate="label">
                                                 <label>Settlement Report Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <sort_order>90</sort_order>
@@ -2527,7 +2440,6 @@
                                                     The PayPal Advertising Program has been shown to generate additional purchases as well as increase consumer's average purchase sizes by 15%
                                                     or more. <a href="https://financing.paypal.com/ppfinportal/content/forrester" target="_blank">See Details</a>.]]>
                                                 </comment>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <sort_order>22</sort_order>
@@ -2536,7 +2448,6 @@
                                                     <bml_wizard extends="//paypal_payments/express_checkout//advertise_bml//bml_wizard" />
                                                     <paypal_payflow_settings_bml_homepage type="group" translate="label">
                                                         <label>Home Page</label>
-                                                        <frontend_type>text</frontend_type>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
                                                         <show_in_store>1</show_in_store>
@@ -2563,7 +2474,6 @@
                                                     </paypal_payflow_settings_bml_homepage>
                                                     <paypal_payflow_settings_bml_categorypage type="group" translate="label">
                                                         <label>Catalog Category Page</label>
-                                                        <frontend_type>text</frontend_type>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
                                                         <show_in_store>1</show_in_store>
@@ -2591,7 +2501,6 @@
                                                     </paypal_payflow_settings_bml_categorypage>
                                                     <paypal_payflow_settings_bml_productpage type="group" translate="label">
                                                         <label>Catalog Product Page</label>
-                                                        <frontend_type>text</frontend_type>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
                                                         <show_in_store>1</show_in_store>
@@ -2619,7 +2528,6 @@
                                                     </paypal_payflow_settings_bml_productpage>
                                                     <paypal_payflow_settings_bml_checkout type="group" translate="label">
                                                         <label>Checkout Cart Page</label>
-                                                        <frontend_type>text</frontend_type>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
                                                         <show_in_store>1</show_in_store>
@@ -2660,7 +2568,6 @@
                         <fields>
                             <paypal_payflow_required type="group" translate="label">
                                 <label>Required PayPal Settings</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <sort_order>10</sort_order>
@@ -2676,7 +2583,6 @@
                                         <fields>
                                             <paypal_payflow_frontend type="group" translate="label">
                                                 <label>Frontend Experience Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -2697,7 +2603,6 @@
                             </settings_paypal_payflow>
                             <paypal_payflow_express_checkout type="group" translate="label">
                                 <label>Basic Settings - PayPal Express Checkout</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <show_in_store>1</show_in_store>
@@ -2716,7 +2621,6 @@
                                     <title translate="label">
                                         <label>Title</label>
                                         <config_path>payment/paypaluk_express/title</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>10</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -2725,7 +2629,6 @@
                                     <sort_order translate="label">
                                         <label>Sort Order</label>
                                         <config_path>payment/paypaluk_express/sort_order</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>20</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -2754,7 +2657,6 @@
                                     <paypal_payflow_express_checkout_advanced type="group" translate="label">
                                         <label>Advanced Settings</label>
                                         <frontend_class>config-advanced</frontend_class>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <sort_order>60</sort_order>
@@ -2824,7 +2726,6 @@
                     </paypal_verisign_with_express_checkout>
                     <payflow_link type="group" translate="label comment">
                         <label>Payflow Link (Includes Express Checkout)</label>
-                        <frontend_type>text</frontend_type>
                         <show_in_default>1</show_in_default>
                         <show_in_website>1</show_in_website>
                         <show_in_store>1</show_in_store>
@@ -2864,7 +2765,6 @@
                                             The PayPal Advertising Program has been shown to generate additional purchases as well as increase consumer's average purchase sizes by 15%
                                             or more. <a href="https://financing.paypal.com/ppfinportal/content/forrester" target="_blank">See Details</a>.]]>
                                                     </comment>
-                                                    <frontend_type>text</frontend_type>
                                                     <show_in_default>1</show_in_default>
                                                     <show_in_website>1</show_in_website>
                                                     <sort_order>42</sort_order>
@@ -2873,7 +2773,6 @@
                                                         <bml_wizard extends="//paypal_payments/express_checkout//advertise_bml//bml_wizard" />
                                                         <payflow_link_settings_bml_homepage type="group" translate="label">
                                                             <label>Home Page</label>
-                                                            <frontend_type>text</frontend_type>
                                                             <show_in_default>1</show_in_default>
                                                             <show_in_website>1</show_in_website>
                                                             <show_in_store>1</show_in_store>
@@ -2900,7 +2799,6 @@
                                                         </payflow_link_settings_bml_homepage>
                                                         <payflow_link_settings_bml_categorypage type="group" translate="label">
                                                             <label>Catalog Category Page</label>
-                                                            <frontend_type>text</frontend_type>
                                                             <show_in_default>1</show_in_default>
                                                             <show_in_website>1</show_in_website>
                                                             <show_in_store>1</show_in_store>
@@ -2928,7 +2826,6 @@
                                                         </payflow_link_settings_bml_categorypage>
                                                         <payflow_link_settings_bml_productpage type="group" translate="label">
                                                             <label>Catalog Product Page</label>
-                                                            <frontend_type>text</frontend_type>
                                                             <show_in_default>1</show_in_default>
                                                             <show_in_website>1</show_in_website>
                                                             <show_in_store>1</show_in_store>
@@ -2956,7 +2853,6 @@
                                                         </payflow_link_settings_bml_productpage>
                                                         <payflow_link_settings_bml_checkout type="group" translate="label">
                                                             <label>Checkout Cart Page</label>
-                                                            <frontend_type>text</frontend_type>
                                                             <show_in_default>1</show_in_default>
                                                             <show_in_website>1</show_in_website>
                                                             <show_in_store>1</show_in_store>
@@ -2993,7 +2889,6 @@
                         <fields>
                             <payflow_link_required type="group" translate="label">
                                 <label>Required PayPal Settings</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <frontend_model>paypal/adminhtml_system_config_fieldset_expanded</frontend_model>
@@ -3001,7 +2896,6 @@
                                 <fields>
                                     <payflow_link_payflow_link type="group" translate="label">
                                         <label>Payflow Link</label>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <frontend_model>paypal/adminhtml_system_config_fieldset_expanded</frontend_model>
@@ -3010,7 +2904,6 @@
                                             <partner translate="label">
                                                 <label>Partner</label>
                                                 <config_path>payment/payflow_link/partner</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>10</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -3018,7 +2911,6 @@
                                             <vendor translate="label">
                                                 <label>Vendor</label>
                                                 <config_path>payment/payflow_link/vendor</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>20</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -3026,7 +2918,6 @@
                                             <user translate="label comment">
                                                 <label>User</label>
                                                 <comment>If you do not have multiple users set up on your account, please re-enter your Vendor/Merchant Login here.</comment>
-                                                <frontend_type>text</frontend_type>
                                                 <config_path>payment/payflow_link/user</config_path>
                                                 <sort_order>30</sort_order>
                                                 <show_in_default>1</show_in_default>
@@ -3062,7 +2953,6 @@
                                             <proxy_host translate="label">
                                                 <label>Proxy Host</label>
                                                 <config_path>payment/payflow_link/proxy_host</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>70</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -3071,7 +2961,6 @@
                                             <proxy_port translate="label">
                                                 <label>Proxy Port</label>
                                                 <config_path>payment/payflow_link/proxy_port</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>80</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -3099,7 +2988,6 @@
                                     </enable_payflow_link>
                                     <payflow_link_express_checkout type="group" translate="label">
                                         <label>Express Checkout</label>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <frontend_model>paypal/adminhtml_system_config_fieldset_expanded</frontend_model>
@@ -3135,7 +3023,6 @@
                             </payflow_link_required>
                             <settings_payflow_link type="group" translate="label">
                                 <label>Basic Settings - PayPal Payflow Link</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <show_in_store>1</show_in_store>
@@ -3146,7 +3033,6 @@
                                         <label>Title</label>
                                         <comment>It is recommended to set this value to "Debit or Credit Card" per store views.</comment>
                                         <config_path>payment/payflow_link/title</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>10</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -3155,7 +3041,6 @@
                                     <sort_order translate="label">
                                         <label>Sort Order</label>
                                         <config_path>payment/payflow_link/sort_order</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>20</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -3174,7 +3059,6 @@
                                     <settings_payflow_link_advanced type="group" translate="label">
                                         <label>Advanced Settings</label>
                                         <frontend_class>config-advanced</frontend_class>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <show_in_store>1</show_in_store>
@@ -3265,7 +3149,6 @@
                                             </mobile_optimized>
                                             <payflow_link_settlement_report type="group" translate="label">
                                                 <label>Settlement Report Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <sort_order>80</sort_order>
@@ -3284,7 +3167,6 @@
                                             </payflow_link_settlement_report>
                                             <payflow_link_frontend type="group" translate="label">
                                                 <label>Frontend Experience Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -3305,7 +3187,6 @@
                             </settings_payflow_link>
                             <settings_payflow_link_express_checkout type="group" translate="label">
                                 <label>Basic Settings - PayPal Express Checkout</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <show_in_store>1</show_in_store>
@@ -3323,7 +3204,6 @@
                                     <settings_payflow_link_express_checkout_advanced type="group" translate="label">
                                         <label>Advanced Settings</label>
                                         <frontend_class>config-advanced</frontend_class>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <show_in_store>1</show_in_store>
@@ -3344,7 +3224,6 @@
 
                                             <payflow_link_billing_agreement type="group" translate="label">
                                                 <label>PayPal Billing Agreement Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -3408,7 +3287,6 @@
                                             <partner translate="label">
                                                 <label>Partner</label>
                                                 <config_path>paypal/wpuk/partner</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>20</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -3425,7 +3303,6 @@
                                             <vendor translate="label">
                                                 <label>Vendor</label>
                                                 <config_path>paypal/wpuk/vendor</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>40</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -3460,7 +3337,6 @@
                                             <proxy_host translate="label">
                                                 <label>Proxy Host</label>
                                                 <config_path>paypal/wpuk/proxy_host</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>80</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -3469,7 +3345,6 @@
                                             <proxy_port translate="label">
                                                 <label>Proxy Port</label>
                                                 <config_path>paypal/wpuk/proxy_port</config_path>
-                                                <frontend_type>text</frontend_type>
                                                 <sort_order>90</sort_order>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
@@ -3503,7 +3378,6 @@
                                         <label>Title</label>
                                         <comment>It is recommended to set this value to "Debit or Credit Card" per store views.</comment>
                                         <config_path>payment/paypaluk_direct/title</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>10</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -3512,7 +3386,6 @@
                                     <sort_order translate="label">
                                         <label>Sort Order</label>
                                         <config_path>payment/paypaluk_direct/sort_order</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>20</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -3639,7 +3512,6 @@
                                                 <label>Centinel API URL</label>
                                                 <config_path>payment/paypaluk_direct/centinel_api_url</config_path>
                                                 <comment>If empty, a default value will be used. Custom URL may be provided by CardinalCommerce agreement.</comment>
-                                                <frontend_type>text</frontend_type>
                                                 <source_model>adminhtml/system_config_source_yesno</source_model>
                                                 <sort_order>80</sort_order>
                                                 <show_in_default>1</show_in_default>
@@ -3648,7 +3520,6 @@
                                             </centinel_api_url>
                                             <pp_pe_settlement_report type="group" translate="label">
                                                 <label>Settlement Report Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <sort_order>90</sort_order>
@@ -3667,7 +3538,6 @@
                                             </pp_pe_settlement_report>
                                             <pp_pe_frontend type="group" translate="label">
                                                 <label>Frontend Experience Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -3688,7 +3558,6 @@
                             </settings_pp_pe>
                             <settings_pp_pe_express_checkout type="group" translate="label">
                                 <label>Basic Settings - PayPal Express Checkout</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <show_in_store>1</show_in_store>
@@ -3843,7 +3712,6 @@
                                         <label>Title</label>
                                         <comment>It is recommended to set this value to "PayPal" per store views.</comment>
                                         <config_path>payment/hosted_pro/title</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>10</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -3852,7 +3720,6 @@
                                     <sort_order translate="label">
                                         <label>Sort Order</label>
                                         <config_path>payment/hosted_pro/sort_order</config_path>
-                                        <frontend_type>text</frontend_type>
                                         <sort_order>20</sort_order>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
@@ -3933,7 +3800,6 @@
                                             </mobile_optimized>
                                             <pphs_settlement_report type="group" translate="label">
                                                 <label>Settlement Report Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <sort_order>45</sort_order>
@@ -4010,7 +3876,6 @@
                                         <fields>
                                             <pphs_billing_agreement type="group" translate="label">
                                                 <label>PayPal Billing Agreement Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -4030,7 +3895,6 @@
                                             </pphs_billing_agreement>
                                             <pphs_frontend type="group" translate="label">
                                                 <label>Frontend Experience Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -4051,7 +3915,6 @@
                             </pphs_settings>
                             <pphs_settings_express_checkout type="group" translate="label">
                                 <label>Basic Settings - PayPal Express Checkout</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <show_in_store>1</show_in_store>
@@ -4069,7 +3932,6 @@
                                     <pphs_settings_express_checkout_advanced type="group" translate="label">
                                         <label>Advanced Settings</label>
                                         <frontend_class>config-advanced</frontend_class>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <show_in_store>1</show_in_store>
@@ -4095,7 +3957,6 @@
                     </payments_pro_hosted_solution_with_express_checkout>
                     <express_checkout type="group" translate="label comment">
                         <label>Express Checkout</label>
-                        <frontend_type>text</frontend_type>
                         <show_in_default>1</show_in_default>
                         <show_in_website>1</show_in_website>
                         <show_in_store>1</show_in_store>
@@ -4139,7 +4000,6 @@
                                             The PayPal Advertising Program has been shown to generate additional purchases as well as increase consumer's average purchase sizes by 15%
                                             or more. <a href="https://financing.paypal.com/ppfinportal/content/forrester" target="_blank">See Details</a>.]]>
                                                 </comment>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <sort_order>30</sort_order>
@@ -4164,7 +4024,6 @@
                                                     </bml_wizard>
                                                     <settings_bml_homepage type="group" translate="label">
                                                         <label>Home Page</label>
-                                                        <frontend_type>text</frontend_type>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
                                                         <show_in_store>1</show_in_store>
@@ -4209,7 +4068,6 @@
                                                     </settings_bml_homepage>
                                                     <settings_bml_categorypage type="group" translate="label">
                                                         <label>Catalog Category Page</label>
-                                                        <frontend_type>text</frontend_type>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
                                                         <show_in_store>1</show_in_store>
@@ -4254,7 +4112,6 @@
                                                     </settings_bml_categorypage>
                                                     <settings_bml_productpage type="group" translate="label">
                                                         <label>Catalog Product Page</label>
-                                                        <frontend_type>text</frontend_type>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
                                                         <show_in_store>1</show_in_store>
@@ -4299,7 +4156,6 @@
                                                     </settings_bml_productpage>
                                                     <settings_bml_checkout type="group" translate="label">
                                                         <label>Checkout Cart Page</label>
-                                                        <frontend_type>text</frontend_type>
                                                         <show_in_default>1</show_in_default>
                                                         <show_in_website>1</show_in_website>
                                                         <show_in_store>1</show_in_store>
@@ -4359,7 +4215,6 @@
                         <fields>
                             <express_checkout_required type="group" translate="label">
                                 <label>Required PayPal Settings</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <sort_order>10</sort_order>
@@ -4367,7 +4222,6 @@
                                 <fields>
                                     <express_checkout_required_express_checkout type="group" translate="label">
                                         <label>Express Checkout</label>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <frontend_model>paypal/adminhtml_system_config_fieldset_expanded</frontend_model>
@@ -4403,7 +4257,6 @@
                             </express_checkout_required>
                             <settings_ec type="group" translate="label">
                                 <label>Basic Settings - PayPal Express Checkout</label>
-                                <frontend_type>text</frontend_type>
                                 <show_in_default>1</show_in_default>
                                 <show_in_website>1</show_in_website>
                                 <show_in_store>1</show_in_store>
@@ -4421,7 +4274,6 @@
                                     <settings_ec_advanced type="group" translate="label">
                                         <label>Advanced Settings</label>
                                         <frontend_class>config-advanced</frontend_class>
-                                        <frontend_type>text</frontend_type>
                                         <show_in_default>1</show_in_default>
                                         <show_in_website>1</show_in_website>
                                         <show_in_store>1</show_in_store>
@@ -4442,7 +4294,6 @@
 
                                             <express_checkout_billing_agreement type="group" translate="label">
                                                 <label>PayPal Billing Agreement Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>
@@ -4462,7 +4313,6 @@
                                             </express_checkout_billing_agreement>
                                             <express_checkout_settlement_report type="group" translate="label">
                                                 <label>Settlement Report Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <sort_order>110</sort_order>
@@ -4481,7 +4331,6 @@
                                             </express_checkout_settlement_report>
                                             <express_checkout_frontend type="group" translate="label">
                                                 <label>Frontend Experience Settings</label>
-                                                <frontend_type>text</frontend_type>
                                                 <show_in_default>1</show_in_default>
                                                 <show_in_website>1</show_in_website>
                                                 <show_in_store>1</show_in_store>

--- a/app/code/core/Mage/Persistent/etc/system.xml
+++ b/app/code/core/Mage/Persistent/etc/system.xml
@@ -31,7 +31,6 @@
             <class>separator-top</class>
             <label>Persistent Shopping Cart</label>
             <tab>customer</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>500</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -40,7 +39,6 @@
             <groups>
                 <options translate="label" module="persistent">
                     <label>General Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>10</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -60,7 +58,6 @@
                         <lifetime translate="label" module="persistent">
                             <label>Persistence Lifetime (seconds)</label>
                             <validate>validate-digits validate-digits-range digits-range-0-3153600000</validate>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <depends><enabled>1</enabled></depends>
                             <show_in_default>1</show_in_default>

--- a/app/code/core/Mage/ProductAlert/etc/system.xml
+++ b/app/code/core/Mage/ProductAlert/etc/system.xml
@@ -31,7 +31,6 @@
             <groups>
                 <productalert translate="label" module="productalert">
                     <label>Product Alerts</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>250</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -87,7 +86,6 @@
                 </productalert>
                 <productalert_cron translate="label" module="productalert">
                     <label>Product Alerts Run Settings</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>260</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -113,7 +111,6 @@
                         </time>
                         <error_email translate="label">
                             <label>Error Email Recipient</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-email</validate>
                             <sort_order>3</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/code/core/Mage/Reports/etc/system.xml
+++ b/app/code/core/Mage/Reports/etc/system.xml
@@ -31,7 +31,6 @@
             <groups>
                 <recently_products translate="label" module="reports">
                     <label>Recently Viewed/Compared Products</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>350</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -48,7 +47,6 @@
                         </scope>
                         <viewed_count translate="label">
                             <label>Default Recently Viewed Products Count</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -56,7 +54,6 @@
                         </viewed_count>
                         <compared_count translate="label">
                             <label>Default Recently Compared Products Count</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -69,7 +66,6 @@
         <reports translate="label" module="reports">
             <label>Reports</label>
             <tab>general</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>1000</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>0</show_in_website>
@@ -77,7 +73,6 @@
             <groups>
                 <general translate="label">
                     <label>General</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -96,7 +91,6 @@
                 </general>
                 <dashboard translate="label">
                     <label>Dashboard</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>2</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>

--- a/app/code/core/Mage/Review/etc/system.xml
+++ b/app/code/core/Mage/Review/etc/system.xml
@@ -31,7 +31,6 @@
             <groups>
                 <review translate="label" module="review">
                     <label>Product Reviews</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>100</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Rss/etc/system.xml
+++ b/app/code/core/Mage/Rss/etc/system.xml
@@ -30,7 +30,6 @@
         <rss translate="label" module="rss">
             <label>RSS Feeds</label>
             <tab>catalog</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>80</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -38,7 +37,6 @@
             <groups>
                 <config translate="label">
                     <label>Rss Config</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -58,7 +56,6 @@
                 </config>
                 <wishlist translate="label">
                     <label>Wishlist</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>2</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -77,7 +74,6 @@
                 </wishlist>
                 <catalog translate="label">
                     <label>Catalog</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>3</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -150,7 +146,6 @@
                 </catalog>
                 <order translate="label">
                     <label>Order</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>4</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -188,7 +183,6 @@
                 </order>
                 <admin_catalog translate="label">
                     <label>Admin Catalog</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>5</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -216,7 +210,6 @@
                 </admin_catalog>
                 <admin_order translate="label">
                     <label>Admin Order</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>6</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Sales/etc/system.xml
+++ b/app/code/core/Mage/Sales/etc/system.xml
@@ -37,7 +37,6 @@
             <class>separator-top</class>
             <label>Sales</label>
             <tab>sales</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>300</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -45,7 +44,6 @@
             <groups>
                 <general translate="label">
                     <label>General</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>5</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -64,7 +62,6 @@
                 </general>
                 <totals_sort translate="label">
                     <label>Checkout Totals Sort Order</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>10</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -72,7 +69,6 @@
                     <fields>
                         <discount translate="label">
                             <label>Discount</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>2</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -80,7 +76,6 @@
                         </discount>
                         <grand_total translate="label">
                             <label>Grand Total</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -88,7 +83,6 @@
                         </grand_total>
                         <shipping translate="label">
                             <label>Shipping</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>3</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -96,7 +90,6 @@
                         </shipping>
                         <subtotal translate="label">
                             <label>Subtotal</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -104,7 +97,6 @@
                         </subtotal>
                         <tax translate="label">
                             <label>Tax</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -114,7 +106,6 @@
                 </totals_sort>
                 <reorder translate="label">
                     <label>Reorder</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>20</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -267,7 +258,6 @@
         <sales_email translate="label" module="sales">
             <label>Sales Emails</label>
             <tab>sales</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>301</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -275,7 +265,6 @@
             <groups>
                 <order translate="label">
                     <label>Order</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -319,7 +308,6 @@
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Order Email Copy To</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -340,7 +328,6 @@
 
                 <order_comment translate="label">
                     <label>Order Comments</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>2</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -384,7 +371,6 @@
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Order Comment Email Copy To</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -405,7 +391,6 @@
 
                 <invoice translate="label">
                     <label>Invoice</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>3</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -449,7 +434,6 @@
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Invoice Email Copy To</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -469,7 +453,6 @@
                 </invoice>
                 <invoice_comment translate="label">
                     <label>Invoice Comments</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>4</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -513,7 +496,6 @@
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Invoice Comment Email Copy To</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -534,7 +516,6 @@
 
                 <shipment translate="label">
                     <label>Shipment</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>5</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -578,7 +559,6 @@
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Shipment Email Copy To</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -598,7 +578,6 @@
                 </shipment>
                 <shipment_comment translate="label">
                     <label>Shipment Comments</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>6</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -642,7 +621,6 @@
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Shipment Comment Email Copy To</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -663,7 +641,6 @@
 
                 <creditmemo translate="label">
                     <label>Credit Memo</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>7</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -707,7 +684,6 @@
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Credit Memo Email Copy To</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -727,7 +703,6 @@
                 </creditmemo>
                 <creditmemo_comment translate="label">
                     <label>Credit Memo Comments</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>8</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -771,7 +746,6 @@
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Credit Memo Comment Email Copy To</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -794,7 +768,6 @@
         <sales_pdf translate="label" module="sales">
             <label>PDF Print-outs</label>
             <tab>sales</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>302</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -802,7 +775,6 @@
             <groups>
                 <invoice translate="label">
                     <label>Invoice</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>10</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -821,7 +793,6 @@
                 </invoice>
                 <shipment translate="label">
                     <label>Shipment</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>20</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -840,7 +811,6 @@
                 </shipment>
                 <creditmemo translate="label">
                     <label>Credit Memo</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>30</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/SalesRule/etc/system.xml
+++ b/app/code/core/Mage/SalesRule/etc/system.xml
@@ -31,7 +31,6 @@
             <class>separator-top</class>
             <label>Promotions</label>
             <tab>customer</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>400</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>0</show_in_website>
@@ -44,7 +43,6 @@
                     <fields>
                         <length translate="label comment" module="salesrule">
                             <label>Code Length</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
@@ -63,7 +61,6 @@
                         </format>
                         <prefix translate="label" module="salesrule">
                             <label>Code Prefix</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
@@ -71,7 +68,6 @@
                         </prefix>
                         <suffix translate="label" module="salesrule">
                             <label>Code Suffix</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
@@ -79,7 +75,6 @@
                         </suffix>
                         <dash translate="label comment" module="salesrule">
                             <label>Dash Every X Characters</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>

--- a/app/code/core/Mage/Sendfriend/etc/system.xml
+++ b/app/code/core/Mage/Sendfriend/etc/system.xml
@@ -30,7 +30,6 @@
         <sendfriend translate="label" module="sendfriend">
             <label>Email to a Friend</label>
             <tab>catalog</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>120</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -38,7 +37,6 @@
             <groups>
                 <email translate="label">
                     <label>Email Templates</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -74,7 +72,6 @@
                         </allow_guest>
                         <max_recipients translate="label">
                             <label>Max Recipients</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -83,7 +80,6 @@
                         </max_recipients>
                         <max_per_hour translate="label">
                             <label>Max Products Sent in 1 Hour</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Shipping/etc/system.xml
+++ b/app/code/core/Mage/Shipping/etc/system.xml
@@ -30,7 +30,6 @@
         <shipping translate="label" module="shipping">
             <label>Shipping Settings</label>
             <tab>sales</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>310</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -38,7 +37,6 @@
             <groups>
                 <option translate="label">
                     <label>Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>2</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -55,7 +53,6 @@
                         </checkout_multiple>
                         <checkout_multiple_maximum_qty translate="label">
                             <label>Maximum Qty Allowed for Shipping to Multiple Addresses</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number</validate>
                             <sort_order>2</sort_order>
                             <show_in_default>1</show_in_default>
@@ -66,7 +63,6 @@
                 </option>
                 <origin translate="label">
                     <label>Origin</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -84,7 +80,6 @@
                         </country_id>
                         <region_id translate="label">
                             <label>Region/State</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -92,7 +87,6 @@
                         </region_id>
                         <postcode translate="label">
                             <label>ZIP/Postal Code</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -100,7 +94,6 @@
                         </postcode>
                         <city translate="label">
                             <label>City</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -108,7 +101,6 @@
                         </city>
                         <street_line1 translate="label">
                             <label>Street Address</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -116,7 +108,6 @@
                         </street_line1>
                         <street_line2 translate="label">
                             <label>Street Address Line 2</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>60</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -129,7 +120,6 @@
         <carriers translate="label" module="shipping">
             <label>Shipping Methods</label>
             <tab>sales</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>320</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -137,7 +127,6 @@
             <groups>
                 <flatrate translate="label">
                     <label>Flat Rate</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>2</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -154,7 +143,6 @@
                         </active>
                         <name translate="label">
                             <label>Method Name</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>3</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -162,7 +150,6 @@
                         </name>
                         <price translate="label">
                             <label>Price</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
@@ -180,7 +167,6 @@
                         </handling_type>
                         <handling_fee translate="label">
                             <label>Handling Fee</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>8</sort_order>
                             <show_in_default>1</show_in_default>
@@ -189,7 +175,6 @@
                         </handling_fee>
                         <sort_order translate="label">
                             <label>Sort Order</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -197,7 +182,6 @@
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>2</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -253,7 +237,6 @@
                 </flatrate>
                 <freeshipping translate="label">
                     <label>Free Shipping</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>2</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -270,7 +253,6 @@
                         </active>
                         <free_shipping_subtotal translate="label">
                             <label>Minimum Order Amount</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
@@ -279,7 +261,6 @@
                         </free_shipping_subtotal>
                         <name translate="label">
                             <label>Method Name</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>3</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -287,7 +268,6 @@
                         </name>
                         <sort_order translate="label">
                             <label>Sort Order</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -295,7 +275,6 @@
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>2</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -342,7 +321,6 @@
                 </freeshipping>
                 <tablerate translate="label">
                     <label>Table Rates</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>2</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -359,7 +337,6 @@
                         </handling_type>
                         <handling_fee translate="label">
                             <label>Handling Fee</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>8</sort_order>
                             <show_in_default>1</show_in_default>
@@ -412,7 +389,6 @@
                         </import>
                         <name translate="label">
                             <label>Method Name</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>3</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -420,7 +396,6 @@
                         </name>
                         <sort_order translate="label">
                             <label>Sort Order</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -428,7 +403,6 @@
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>2</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Sitemap/etc/system.xml
+++ b/app/code/core/Mage/Sitemap/etc/system.xml
@@ -30,7 +30,6 @@
         <sitemap translate="label" module="sitemap">
             <label>Google Sitemap</label>
             <tab>catalog</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>70</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -38,7 +37,6 @@
             <groups>
                 <category translate="label">
                     <label>Categories Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -55,7 +53,6 @@
                         </changefreq>
                         <priority translate="label comment">
                             <label>Priority</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_sitemap</backend_model>
                             <sort_order>2</sort_order>
                             <show_in_default>1</show_in_default>
@@ -67,7 +64,6 @@
                 </category>
                 <product translate="label">
                     <label>Products Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>2</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -84,7 +80,6 @@
                         </changefreq>
                         <priority translate="label comment">
                             <label>Priority</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_sitemap</backend_model>
                             <sort_order>2</sort_order>
                             <show_in_default>1</show_in_default>
@@ -96,7 +91,6 @@
                 </product>
                 <page translate="label">
                     <label>CMS Pages Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>3</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -113,7 +107,6 @@
                         </changefreq>
                         <priority translate="label comment">
                             <label>Priority</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_sitemap</backend_model>
                             <sort_order>2</sort_order>
                             <show_in_default>1</show_in_default>
@@ -125,7 +118,6 @@
                 </page>
                 <generate translate="label">
                     <label>Generation Settings</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>50</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
@@ -142,7 +134,6 @@
                         </enabled>
                         <error_email translate="label">
                             <label>Error Email Recipient</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-email</validate>
                             <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/code/core/Mage/Tax/etc/system.xml
+++ b/app/code/core/Mage/Tax/etc/system.xml
@@ -172,7 +172,6 @@
                         </region>
                         <postcode translate="label">
                             <label>Default Post Code</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Usa/etc/system.xml
+++ b/app/code/core/Mage/Usa/etc/system.xml
@@ -31,7 +31,6 @@
             <groups>
                 <dhl translate="label" module="usa">
                     <label>DHL (Deprecated)</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>130</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -39,7 +38,6 @@
                     <fields>
                         <account translate="label">
                             <label>Account Number</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>70</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -66,7 +64,6 @@
                         </allowed_methods>
                         <contentdesc translate="label">
                             <label>Package Description</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>120</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -87,7 +84,6 @@
                         </free_shipping_enable>
                         <free_shipping_subtotal translate="label">
                             <label>Minimum Order Amount for Free Shipping</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>1220</sort_order>
                             <show_in_default>1</show_in_default>
@@ -124,7 +120,6 @@
                         </free_method>
                         <gateway_url translate="label">
                             <label>Gateway URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_gatewayurl</backend_model>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
@@ -160,7 +155,6 @@
                         </handling_action>
                         <handling_fee translate="label">
                             <label>Handling Fee</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>120</sort_order>
                             <show_in_default>1</show_in_default>
@@ -169,7 +163,6 @@
                         </handling_fee>
                         <max_package_weight translate="label">
                             <label>Maximum Package Weight (Please consult your shipping carrier for maximum supported shipping weight)</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>130</sort_order>
                             <show_in_default>1</show_in_default>
@@ -232,7 +225,6 @@
                         </shipping_key>
                         <sort_order translate="label">
                             <label>Sort Order</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>2000</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -240,7 +232,6 @@
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -296,7 +287,6 @@
                         </additional_protection_enabled>
                         <additional_protection_min_value translate="label">
                             <label>Additional Protection Min Subtotal</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>1310</sort_order>
                             <show_in_default>1</show_in_default>
@@ -315,7 +305,6 @@
                         <additional_protection_value translate="label comment">
                             <label>Additional Protection Configuration Value</label>
                             <comment>Used only when "Additional Protection Value" is set to "Configuration". Can contain only numeric amount.</comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>1330</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -344,7 +333,6 @@
 
                         <default_length translate="label">
                             <label>Default Package Length</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>1360</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -352,7 +340,6 @@
                         </default_length>
                         <default_width translate="label">
                             <label>Default Package Width</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>1370</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -360,7 +347,6 @@
                         </default_width>
                         <default_height translate="label">
                             <label>Default Package Height</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>1380</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -401,7 +387,6 @@
                 </dhl>
                 <fedex translate="label" module="usa">
                     <label>FedEx</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>120</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -418,7 +403,6 @@
                         </active>
                         <title translate="label">
                             <label>Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -508,7 +492,6 @@
                         </unit_of_measure>
                         <max_package_weight translate="label">
                             <label>Maximum Package Weight (Please consult your shipping carrier for maximum supported shipping weight)</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
@@ -535,7 +518,6 @@
                         </handling_action>
                         <handling_fee translate="label">
                             <label>Handling Fee</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>130</sort_order>
                             <show_in_default>1</show_in_default>
@@ -563,7 +545,6 @@
                         </allowed_methods>
                         <smartpost_hubid translate="label comment">
                             <label>Hub ID</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>155</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -591,7 +572,6 @@
                         </free_shipping_enable>
                         <free_shipping_subtotal translate="label">
                             <label>Minimum Order Amount for Free Shipping</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>180</sort_order>
                             <show_in_default>1</show_in_default>
@@ -647,7 +627,6 @@
                         </showmethod>
                         <sort_order translate="label">
                             <label>Sort Order</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>240</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -657,7 +636,6 @@
                 </fedex>
                 <ups translate="label" module="usa">
                     <label>UPS</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>100</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -720,7 +698,6 @@
                         </free_shipping_enable>
                         <free_shipping_subtotal translate="label">
                             <label>Minimum Order Amount for Free Shipping</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>220</sort_order>
                             <show_in_default>1</show_in_default>
@@ -749,7 +726,6 @@
                         </free_method>
                         <gateway_url translate="label">
                             <label>Gateway URL</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -766,7 +742,6 @@
                         </verify_peer>
                         <gateway_xml_url translate="label">
                             <label>Gateway XML URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_gatewayurl</backend_model>
                             <sort_order>22</sort_order>
                             <show_in_default>1</show_in_default>
@@ -775,7 +750,6 @@
                         </gateway_xml_url>
                         <tracking_xml_url translate="label">
                             <label>Tracking XML URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_gatewayurl</backend_model>
                             <sort_order>24</sort_order>
                             <show_in_default>1</show_in_default>
@@ -784,7 +758,6 @@
                         </tracking_xml_url>
                         <shipconfirm_xml_url translate="label">
                             <label>Shipping Confirm XML URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_gatewayurl</backend_model>
                             <sort_order>26</sort_order>
                             <show_in_default>1</show_in_default>
@@ -793,7 +766,6 @@
                         </shipconfirm_xml_url>
                         <shipaccept_xml_url translate="label">
                             <label>Shipping Accept XML URL</label>
-                            <frontend_type>text</frontend_type>
                             <backend_model>adminhtml/system_config_backend_gatewayurl</backend_model>
                             <sort_order>28</sort_order>
                             <show_in_default>1</show_in_default>
@@ -820,7 +792,6 @@
                         </handling_action>
                         <handling_fee translate="label">
                             <label>Handling Fee</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>130</sort_order>
                             <show_in_default>1</show_in_default>
@@ -829,7 +800,6 @@
                         </handling_fee>
                         <max_package_weight translate="label">
                             <label>Maximum Package Weight (Please consult your shipping carrier for maximum supported shipping weight)</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>80</sort_order>
                             <show_in_default>1</show_in_default>
@@ -838,7 +808,6 @@
                         </max_package_weight>
                         <min_package_weight translate="label">
                             <label>Minimum Package Weight (Please consult your shipping carrier for minimum supported shipping weight)</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>90</sort_order>
                             <show_in_default>1</show_in_default>
@@ -875,7 +844,6 @@
                         </pickup>
                         <sort_order translate="label">
                             <label>Sort Order</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>1000</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -883,7 +851,6 @@
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -928,7 +895,6 @@
                         </negotiated_active>
                         <shipper_number translate="label comment">
                             <label>Shipper Number</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -996,7 +962,6 @@
                 </ups>
                 <usps translate="label" module="usa">
                     <label>USPS</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>110</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -1013,7 +978,6 @@
                         </active>
                         <gateway_url translate="label">
                             <label>Gateway URL</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1021,7 +985,6 @@
                         </gateway_url>
                         <gateway_secure_url translate="label">
                             <label>Secure Gateway URL</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1029,7 +992,6 @@
                         </gateway_secure_url>
                         <title translate="label">
                             <label>Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1091,7 +1053,6 @@
                         </size>
                         <width translate="label">
                             <label>Width</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>73</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1100,7 +1061,6 @@
                         </width>
                         <length translate="label">
                             <label>Length</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>72</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1109,7 +1069,6 @@
                         </length>
                         <height translate="label">
                             <label>Height</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>74</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1118,7 +1077,6 @@
                         </height>
                         <girth translate="label">
                             <label>Girth</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>76</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1136,7 +1094,6 @@
                         </machinable>
                         <max_package_weight translate="label">
                             <label>Maximum Package Weight (Please consult your shipping carrier for maximum supported shipping weight)</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>90</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1163,7 +1120,6 @@
                         </handling_action>
                         <handling_fee translate="label">
                             <label>Handling Fee</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>120</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1201,7 +1157,6 @@
                         </free_shipping_enable>
                         <free_shipping_subtotal translate="label">
                             <label>Minimum Order Amount for Free Shipping</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>160</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1257,7 +1212,6 @@
                         </showmethod>
                         <sort_order translate="label">
                             <label>Sort Order</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>220</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1267,7 +1221,6 @@
                 </usps>
                 <dhlint translate="label" module="usa">
                     <label>DHL</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>140</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -1284,7 +1237,6 @@
                         </active>
                         <gateway_url translate="label">
                             <label>Gateway URL</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1301,7 +1253,6 @@
                         </verify_peer>
                         <title translate="label">
                             <label>Title</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1327,7 +1278,6 @@
                         </password>
                         <account translate="label">
                             <label>Account Number</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>70</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1363,7 +1313,6 @@
                         </handling_action>
                         <handling_fee translate="label">
                             <label>Handling Fee</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>120</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1401,7 +1350,6 @@
                         </size>
                         <height translate="label">
                             <label>Height</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>151</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1410,7 +1358,6 @@
                         </height>
                         <depth translate="label">
                             <label>Depth</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>152</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1419,7 +1366,6 @@
                         </depth>
                         <width translate="label">
                             <label>Width</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>153</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1449,7 +1395,6 @@
                         <ready_time>
                             <label>Ready time</label>
                             <comment>Package ready time after order submission (in hours)</comment>
-                            <frontend_type>text</frontend_type>
                             <sort_order>180</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1500,7 +1445,6 @@
                         </free_shipping_enable>
                         <free_shipping_subtotal translate="label">
                             <label>Minimum Order Amount for Free Shipping</label>
-                            <frontend_type>text</frontend_type>
                             <validate>validate-number validate-zero-or-greater</validate>
                             <sort_order>1220</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1539,7 +1483,6 @@
                         </showmethod>
                         <sort_order translate="label">
                             <label>Sort Order</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>2000</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Weee/etc/system.xml
+++ b/app/code/core/Mage/Weee/etc/system.xml
@@ -118,7 +118,6 @@
                     <fields>
                         <weee translate="label">
                             <label>Fixed Product Tax</label>
-                            <frontend_type>text</frontend_type>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/core/Mage/Wishlist/etc/system.xml
+++ b/app/code/core/Mage/Wishlist/etc/system.xml
@@ -30,7 +30,6 @@
         <wishlist translate="label" module="wishlist">
             <label>Wishlist</label>
             <tab>customer</tab>
-            <frontend_type>text</frontend_type>
             <sort_order>140</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
@@ -38,7 +37,6 @@
             <groups>
                 <email translate="label">
                     <label>Share Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>2</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
@@ -66,7 +64,6 @@
                 </email>
                 <general translate="label">
                     <label>General Options</label>
-                    <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>


### PR DESCRIPTION
### Description

For each system.xml file in module directory, we have:
```xml
<config>
  <sections>
    <example1>
      <label>Example</label>
      <frontend_type>text</frontend_type><!-- useless -->
      <groups>
        <example2>
          <label>Example</label>
          <frontend_type>text</frontend_type><!-- useless -->
          <fields>
            <example3>
              <label>Example</label>
              <frontend_type>text</frontend_type><!-- this is the default value -->
              <sort_order>1</sort_order>
              <show_in_default>1</show_in_default>
              <show_in_website>1</show_in_website>
              <show_in_store>1</show_in_store>
```

For `example1` and `example2` tags, `<frontend_type>text</frontend_type>` are not needed.
For `example3` tag, `<frontend_type>text</frontend_type>` is the default value, so not really required.

So, because it's more easy to remove all, I removed all tags.
Moreover, this will reduce the size of the merged XML in memory.
After #1916, this will also reduce the size of the cache.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list