### PR TITLE
Add/Remove mark when region/zip is required

### DIFF
--- a/app/design/adminhtml/default/default/layout/sales.xml
+++ b/app/design/adminhtml/default/default/layout/sales.xml
@@ -491,9 +491,11 @@
             <block type="adminhtml/sales_transactions" name="sales_transactions.grid.container"></block>
         </reference>
     </adminhtml_sales_transactions_index>
+
     <adminhtml_sales_transactions_grid>
         <block type="adminhtml/sales_transactions_grid" name="sales_transactions.grid" output="toHtml"></block>
     </adminhtml_sales_transactions_grid>
+
     <adminhtml_sales_transactions_view>
         <reference name="content">
             <block type="adminhtml/sales_transactions_detail" name="sales_transactions.detail" template="sales/transactions/detail.phtml">
@@ -637,7 +639,6 @@
             <block type="adminhtml/sales_order_create_header" name="header" />
         </reference>
     </adminhtml_sales_order_create_load_block_header>
-
 
     <adminhtml_sales_order_create_load_block_sidebar>
         <reference name="content">
@@ -1057,22 +1058,29 @@
             <block type="adminhtml/sales_order_status" name="sales_order_status.grid.container"></block>
         </reference>
     </adminhtml_sales_order_status_index>
+
     <adminhtml_sales_order_status_new>
         <reference name="content">
             <block type="adminhtml/sales_order_status_new" name="sales_order_status.new.container"></block>
         </reference>
     </adminhtml_sales_order_status_new>
+
     <adminhtml_sales_order_status_edit>
         <reference name="content">
             <block type="adminhtml/sales_order_status_edit" name="sales_order_status.edit.container"></block>
         </reference>
     </adminhtml_sales_order_status_edit>
+
     <adminhtml_sales_order_status_assign>
         <reference name="content">
             <block type="adminhtml/sales_order_status_assign" name="sales_order_status.assign.container"></block>
         </reference>
     </adminhtml_sales_order_status_assign>
+
     <adminhtml_sales_order_address>
+        <reference name="head">
+            <block type="adminhtml/template" name="optional_zip_countries" as="optional_zip_countries" template="directory/js/optional_zip_countries.phtml" />
+        </reference>
         <reference name="content">
             <block type="adminhtml/sales_order_address" name="sales_order_address.form.container"></block>
         </reference>

--- a/app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
@@ -592,6 +592,10 @@ addressesModel.prototype = {
             label = $$('label[for="' + currentElement.id + '"]')[0];
             if (label) {
                 wildCard = label.down('em') || label.down('span.required');
+                if (!wildCard) {
+                    label.insert(' <span class="required">*</span>');
+                    wildCard = label.down('span.required');
+                }
                 if (!that.showAllRegions) {
                     if (regionRequired) {
                         label.up('tr').show();

--- a/app/design/adminhtml/default/default/template/directory/js/optional_zip_countries.phtml
+++ b/app/design/adminhtml/default/default/template/directory/js/optional_zip_countries.phtml
@@ -35,32 +35,5 @@
 <script type="text/javascript">
 //<![CDATA[
 optionalZipCountries = <?php echo $this->helper('directory')->getCountriesWithOptionalZip(true) ?>;
-
-function onAddressCountryChanged (countryElement) {
-    var zipElementId = countryElement.id.replace(/country_id/, 'postcode');
-
-    // Ajax-request and normal content load compatibility
-    if ($(zipElementId) != undefined) {
-        setPostcodeOptional($(zipElementId), countryElement.value);
-    } else {
-        Event.observe(window, "load", function () {
-            setPostcodeOptional($(zipElementId), countryElement.value);
-        });
-    }
-}
-
-function setPostcodeOptional(zipElement, country) {
-    if (optionalZipCountries.indexOf(country) != -1) {
-        while (zipElement.hasClassName('required-entry')) {
-            zipElement.removeClassName('required-entry');
-        }
-        zipElement.up(1).down('label > span.required').hide();
-    } else {
-        zipElement.addClassName('required-entry');
-        zipElement.up(1).down('label > span.required').show();
-    }
-}
-
-varienGlobalEvents.attachEventHandler("address_country_changed", onAddressCountryChanged);
 //]]>
 </script>

--- a/js/mage/adminhtml/form.js
+++ b/js/mage/adminhtml/form.js
@@ -228,6 +228,10 @@ RegionUpdater.prototype = {
             label = $$('label[for="' + currentElement.id + '"]')[0];
             if (label) {
                 wildCard = label.down('em') || label.down('span.required');
+                if (!wildCard) {
+                    label.insert(' <span class="required">*</span>');
+                    wildCard = label.down('span.required');
+                }
                 var topElement = label.up('tr') || label.up('li');
                 if (!that.config.show_all_regions && topElement) {
                     if (regionRequired) {
@@ -582,3 +586,32 @@ FormElementDependenceController.prototype = {
         }
     }
 };
+
+// optional_zip_countries.phtml
+function onAddressCountryChanged(countryElement) {
+    var zipElementId = countryElement.id.replace(/country_id/, 'postcode');
+
+    // Ajax-request and normal content load compatibility
+    if ($(zipElementId) != undefined) {
+        setPostcodeOptional($(zipElementId), countryElement.value);
+    } else {
+        Event.observe(window, "load", function () {
+            setPostcodeOptional($(zipElementId), countryElement.value);
+        });
+    }
+}
+
+function setPostcodeOptional(zipElement, country) {
+    if (optionalZipCountries.indexOf(country) != -1) {
+        Validation.reset(zipElement);
+        while (zipElement.hasClassName('required-entry')) {
+            zipElement.removeClassName('required-entry');
+        }
+        zipElement.up(1).down('label > span.required').hide();
+    } else {
+        zipElement.addClassName('required-entry');
+        zipElement.up(1).down('label > span.required').show();
+    }
+}
+
+varienGlobalEvents.attachEventHandler("address_country_changed", onAddressCountryChanged);

--- a/js/mage/adminhtml/form.js
+++ b/js/mage/adminhtml/form.js
@@ -590,7 +590,6 @@ FormElementDependenceController.prototype = {
 // optional_zip_countries.phtml
 function onAddressCountryChanged(countryElement) {
     var zipElementId = countryElement.id.replace(/country_id/, 'postcode');
-
     // Ajax-request and normal content load compatibility
     if ($(zipElementId) != undefined) {
         setPostcodeOptional($(zipElementId), countryElement.value);
@@ -602,15 +601,19 @@ function onAddressCountryChanged(countryElement) {
 }
 
 function setPostcodeOptional(zipElement, country) {
+    var spanElement = zipElement.up(1).down('label > span.required');
+    if (!spanElement || (typeof optionalZipCountries == 'undefined')) {
+        return; // nothing to do (for example in system config)
+    }
     if (optionalZipCountries.indexOf(country) != -1) {
         Validation.reset(zipElement);
         while (zipElement.hasClassName('required-entry')) {
             zipElement.removeClassName('required-entry');
         }
-        zipElement.up(1).down('label > span.required').hide();
+        spanElement.hide();
     } else {
         zipElement.addClassName('required-entry');
-        zipElement.up(1).down('label > span.required').show();
+        spanElement.show();
     }
 }
 

--- a/js/varien/form.js
+++ b/js/varien/form.js
@@ -22,6 +22,7 @@
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
  * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
 VarienForm = Class.create();
 VarienForm.prototype = {
     initialize: function(formId, firstFieldFocus){
@@ -162,8 +163,7 @@ VarienForm.prototype = {
 
 RegionUpdater = Class.create();
 RegionUpdater.prototype = {
-    initialize: function (countryEl, regionTextEl, regionSelectEl, regions, disableAction, zipEl)
-    {
+    initialize: function (countryEl, regionTextEl, regionSelectEl, regions, disableAction, zipEl){
         this.countryEl = $(countryEl);
         this.regionTextEl = $(regionTextEl);
         this.regionSelectEl = $(regionSelectEl);
@@ -182,8 +182,7 @@ RegionUpdater.prototype = {
         Event.observe(this.countryEl, 'change', this.update.bind(this));
     },
 
-    _checkRegionRequired: function()
-    {
+    _checkRegionRequired: function(){
         var label, wildCard;
         var elements = [this.regionTextEl, this.regionSelectEl];
         var that = this;
@@ -197,6 +196,10 @@ RegionUpdater.prototype = {
             label = $$('label[for="' + currentElement.id + '"]')[0];
             if (label) {
                 wildCard = label.down('em') || label.down('span.required');
+                if (!wildCard) {
+                    label.insert(' <span class="required">*</span>');
+                    wildCard = label.down('span.required');
+                }
                 if (!that.config.show_all_regions) {
                     if (regionRequired) {
                         label.up().show();
@@ -240,8 +243,7 @@ RegionUpdater.prototype = {
         });
     },
 
-    update: function()
-    {
+    update: function(){
         if (this.regions[this.countryEl.value]) {
             var i, option, region, def;
 
@@ -338,7 +340,8 @@ RegionUpdater.prototype = {
             }
         }
     },
-    sortSelect : function () {
+
+    sortSelect: function () {
         var elem = this.regionSelectEl;
         var tmpArray = new Array();
         var currentVal = $(elem).value;
@@ -362,14 +365,12 @@ RegionUpdater.prototype = {
 
 ZipUpdater = Class.create();
 ZipUpdater.prototype = {
-    initialize: function(country, zipElement)
-    {
+    initialize: function(country, zipElement){
         this.country = country;
         this.zipElement = $(zipElement);
     },
 
-    update: function()
-    {
+    update: function(){
         // Country ISO 2-letter codes must be pre-defined
         if (typeof optionalZipCountries == 'undefined') {
             return false;
@@ -384,8 +385,7 @@ ZipUpdater.prototype = {
         }
     },
 
-    _setPostcodeOptional: function()
-    {
+    _setPostcodeOptional: function(){
         this.zipElement = $(this.zipElement);
         if (this.zipElement == undefined) {
             return false;
@@ -395,10 +395,17 @@ ZipUpdater.prototype = {
         var label = $$('label[for="' + this.zipElement.id + '"]')[0];
         if (label != undefined) {
             var wildCard = label.down('em') || label.down('span.required');
+            if (!wildCard) {
+                label.insert(' <span class="required">*</span>');
+                wildCard = label.down('span.required');
+            }
         }
 
         // Make Zip and its label required/optional
         if (optionalZipCountries.indexOf(this.country) != -1) {
+            if (label.hasClassName('required')) {
+                label.removeClassName('required');
+            }
             while (this.zipElement.hasClassName('required-entry')) {
                 this.zipElement.removeClassName('required-entry');
             }
@@ -406,6 +413,9 @@ ZipUpdater.prototype = {
                 wildCard.hide();
             }
         } else {
+            if (!label.hasClassName('required')) {
+                label.addClassName('required');
+            }
             this.zipElement.addClassName('required-entry');
             if (wildCard != undefined) {
                 wildCard.show();


### PR DESCRIPTION
### Description

This PR fix display and validation when region/zip are required, for Customers addresses in backend.

### Manual testing scenarios

In _System / Configuration / General_, set _Allow Countries_ to USA, France, Ireland ; and remove France for _State is required for_.
Go to _Customers_, open any customer or add a new customer, then go to _Addresses_ tab and add a new address.
Go to _Sales_, open any order, and try to edit Shipping or Billing address.

If you set country to **usa**, if you try to save the customer:

![image](https://user-images.githubusercontent.com/31816829/170367676-1a503d25-8ef4-4f00-b78b-eadbc546e9c8.png)

That's the truth.
Now if you set country to **Ireland**, if you try to save the customer:

![image](https://user-images.githubusercontent.com/31816829/170367943-106db649-9eab-472a-bd99-aad32e457521.png)

That's wrong.
Now if you set country to **France**, if you try to save the customer:

![image](https://user-images.githubusercontent.com/31816829/170368153-a784707d-78bd-45f1-82bc-5c13d36be9a1.png)

That's the truth.
Apply the PR and try again.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list