### PR TITLE
Remove suppression operator from translate method to support PHP 8

### DIFF
--- a/app/code/core/Mage/Core/Model/Translate.php
+++ b/app/code/core/Mage/Core/Model/Translate.php
@@ -422,9 +422,9 @@ class Mage_Core_Model_Translate
             $translated = $this->_getTranslatedString($text, $code);
         }
 
-        try{
+        try {
             $result = !empty($args) ? vsprintf($translated, $args) : false;
-        } catch (ValueError $e){
+        } catch (ValueError $e) {
             $result = false;
         }
 

--- a/app/code/core/Mage/Core/Model/Translate.php
+++ b/app/code/core/Mage/Core/Model/Translate.php
@@ -422,10 +422,12 @@ class Mage_Core_Model_Translate
             $translated = $this->_getTranslatedString($text, $code);
         }
 
-        //array_unshift($args, $translated);
-        //$result = @call_user_func_array('sprintf', $args);
+        try{
+            $result = !empty($args) ? vsprintf($translated, $args) : false;
+        } catch (ValueError $e){
+            $result = false;
+        }
 
-        $result = !empty($args) ? @vsprintf($translated, $args) : false;
         if ($result === false) {
             $result = $translated;
         }


### PR DESCRIPTION
To translate strings and replace placeholders with arguments, the `vsprintf` function is used by Magento. But if there is a mistake made in a translation string, an error occurs. Originally this error is suppressed with the suppresion operator `@`, but this is not working in PHP 8+ anymore. 

I chose to replace the suppression operator with a try catch block. An alternative would be to validate the string and arguments before passing them to `vsprintf`, but this is way too much effort and also prone to errors. With the current solution, the original behavior of the translate method is kept under PHP 8 and 7.

The error:

    PHP Fatal error:  Uncaught ValueError: The arguments array must contain 2 items, 1 given in /var/www/app/code/core/Mage/Core/Model/Translate.php:430

