### PR TITLE
PHP 8 fix null provided to count() in tax calculation class

### DIFF
--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Tax.php
@@ -209,7 +209,7 @@ class Mage_Sales_Model_Quote_Address_Total_Tax extends Mage_Sales_Model_Quote_Ad
     protected function _saveAppliedTaxes(Mage_Sales_Model_Quote_Address $address, $applied, $amount, $baseAmount, $rate)
     {
         $previouslyAppliedTaxes = $address->getAppliedTaxes();
-        $process = count($previouslyAppliedTaxes);
+        $process = is_countable($previouslyAppliedTaxes) ? count($previouslyAppliedTaxes) : 0;
 
         foreach ($applied as $row) {
             if (!isset($previouslyAppliedTaxes[$row['id']])) {


### PR DESCRIPTION
This is a fix for a type error which occurs when PHP 8 is used.

    Fix Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in Mage/Sales/Model/Quote/Address/Total/Tax.php:212

This error is very hard to reproduce. I saw it in my production logs and this PR fixes it.

The fix uses `is_countable`, so is working from PHP 7.3. The Magento-LTS readme states that it is compatible with PHP 7.0. Is this actually the case? In that case `is_countable` can be replaced with `!== null` for PHP 7.0 compatibility.

