### PR TITLE
Introducing polyfill for is_countable()

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -33,7 +33,7 @@ if ((LIBXML_VERSION < 20900) && function_exists('libxml_disable_entity_loader'))
     libxml_disable_entity_loader(false);
 }
 
-// Polyfill for PHP<7.4
+// Polyfill for PHP<7.3
 if (!function_exists('is_countable')) {
     function is_countable($value) {
         return is_array($value) || $value instanceof Countable || $value instanceof ResourceBundle || $value instanceof SimpleXmlElement;

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -32,10 +32,3 @@
 if ((LIBXML_VERSION < 20900) && function_exists('libxml_disable_entity_loader')) {
     libxml_disable_entity_loader(false);
 }
-
-// Polyfill for PHP<7.3
-if (!function_exists('is_countable')) {
-    function is_countable($value) {
-        return is_array($value) || $value instanceof Countable || $value instanceof ResourceBundle || $value instanceof SimpleXmlElement;
-    }
-}

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -32,3 +32,10 @@
 if ((LIBXML_VERSION < 20900) && function_exists('libxml_disable_entity_loader')) {
     libxml_disable_entity_loader(false);
 }
+
+// Polyfill for PHP<7.4
+if (!function_exists('is_countable')) {
+    function is_countable($value) {
+        return is_array($value) || $value instanceof Countable || $value instanceof ResourceBundle || $value instanceof SimpleXmlElement;
+    }
+}

--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -467,3 +467,16 @@ if (!function_exists('str_ends_with')) {
         return '' === $needle || ('' !== $haystack && 0 === substr_compare($haystack, $needle, -\strlen($needle)));
     }
 }
+
+/**
+ * polyfill for PHP 7.3 function "is_countable"
+ */
+if (!function_exists('is_countable')) {
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    function is_countable($value) {
+        return is_array($value) || $value instanceof Countable || $value instanceof ResourceBundle || $value instanceof SimpleXmlElement;
+    }
+}

--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -477,6 +477,6 @@ if (!function_exists('is_countable')) {
      * @return bool
      */
     function is_countable($value) {
-        return is_array($value) || $value instanceof Countable || $value instanceof ResourceBundle || $value instanceof SimpleXmlElement;
+        return is_array($value) || $value instanceof Countable || $value instanceof ResourceBundle || $value instanceof SimpleXMLElement;
     }
 }


### PR DESCRIPTION
PR https://github.com/OpenMage/magento-lts/pull/2040 introduced an is_countable() call, which doesn't exist in PHP<7.3. Also PR https://github.com/OpenMage/magento-lts/pull/2162 is introducing the same problem.

So I thought about adding a polyfill