### PR TITLE
Backend - Change the default sort column in Export page

### DIFF
--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Filter.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Filter.php
@@ -55,7 +55,7 @@ class Mage_ImportExport_Block_Adminhtml_Export_Filter extends Mage_Adminhtml_Blo
 
         $this->setRowClickCallback(null);
         $this->setId('export_filter_grid');
-        $this->setDefaultSort('attribute_code');
+        $this->setDefaultSort('frontend_label');
         $this->setDefaultDir('ASC');
         $this->setPagerVisibility(false);
         $this->setDefaultLimit(null);
@@ -358,8 +358,7 @@ class Mage_ImportExport_Block_Adminhtml_Export_Filter extends Mage_Adminhtml_Blo
         ));
         $this->addColumn('frontend_label', array(
             'header'   => Mage::helper('importexport')->__('Attribute Label'),
-            'index'    => 'frontend_label',
-            'sortable' => false,
+            'index'    => 'frontend_label'
         ));
         $this->addColumn('attribute_code', array(
             'header' => Mage::helper('importexport')->__('Attribute Code'),


### PR DESCRIPTION
Go to OpenMage Backend then **System -> Import/Export**. Select Products or Customers from "Entity Type" list and look at the "Entity Attributes" grid bellow.

![export](https://user-images.githubusercontent.com/8360474/171203196-a7a0cbd9-fb40-4e84-95d0-ddc573ab9c15.jpg)

By default this grid is sorted by "Attribute Code" column ASC/DESC. All the other columns are not sortable (for "Skip" and "Filter" columns it is correct). This PR makes the following changes:

- the default sorted column is changed from "Attribute Code" to "Attribute Label". As benefit it becomes easier to choose what rows to skip from export. Most of the users know the attribute label not the code. In some cases these users don't have rights to edit Attributes.

- initially only "Attribute Code" column was sortable ASC/DESC. now we are able to sort ASC/DESC the "Attribute Label" column too.

**TODO IN OTHER PR**: One or two orange buttons inline with [Reset Filter] and [Search] buttons for [Select All] / [Unselect All] rows. This was discussed here https://github.com/OpenMage/magento-lts/discussions/1657
