### PR TITLE
Revert "Fix wrong payment info template paths"

### DIFF
--- a/app/code/core/Mage/Payment/Block/Info.php
+++ b/app/code/core/Mage/Payment/Block/Info.php
@@ -74,7 +74,7 @@ class Mage_Payment_Block_Info extends Mage_Core_Block_Template
      */
     public function toPdf()
     {
-        $this->setTemplate('payment/info/default.phtml');
+        $this->setTemplate('payment/info/pdf/default.phtml');
         return $this->toHtml();
     }
 

--- a/app/code/core/Mage/Payment/Block/Info/Checkmo.php
+++ b/app/code/core/Mage/Payment/Block/Info/Checkmo.php
@@ -92,7 +92,7 @@ class Mage_Payment_Block_Info_Checkmo extends Mage_Payment_Block_Info
      */
     public function toPdf()
     {
-        $this->setTemplate('payment/info/checkmo.phtml');
+        $this->setTemplate('payment/info/pdf/checkmo.phtml');
         return $this->toHtml();
     }
 }

--- a/app/code/core/Mage/Payment/Block/Info/Purchaseorder.php
+++ b/app/code/core/Mage/Payment/Block/Info/Purchaseorder.php
@@ -38,7 +38,7 @@ class Mage_Payment_Block_Info_Purchaseorder extends Mage_Payment_Block_Info
      */
     public function toPdf()
     {
-        $this->setTemplate('payment/info/purchaseorder.phtml');
+        $this->setTemplate('payment/info/pdf/purchaseorder.phtml');
         return $this->toHtml();
     }
 }


### PR DESCRIPTION
Reverts OpenMage/magento-lts#1201 since in issue https://github.com/OpenMage/magento-lts/issues/1548 maintainers said it had to be reverted