### PR TITLE
Revert "creditmemo bundle inventory calculation error"

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -793,7 +793,7 @@ class Mage_CatalogInventory_Model_Observer
                 $parentOrderId = $item->getOrderItem()->getParentItemId();
                 /* @var $parentItem Mage_Sales_Model_Order_Creditmemo_Item */
                 $parentItem = $parentOrderId ? $creditmemo->getItemByOrderId($parentOrderId) : false;
-                $qty = $item->getQty();
+                $qty = $parentItem ? ($parentItem->getQty() * $item->getQty()) : $item->getQty();
                 if (isset($items[$item->getProductId()])) {
                     $items[$item->getProductId()]['qty'] += $qty;
                 } else {


### PR DESCRIPTION
Reverts OpenMage/magento-lts#275 since, as you can see from the PR, people said it was causing problems and should be reverted