### PR TITLE
Revert "creditmemo bundle inventory calculation error"

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -806,7 +806,7 @@ class Mage_CatalogInventory_Model_Observer
                 $parentOrderId = $item->getOrderItem()->getParentItemId();
                 /* @var Mage_Sales_Model_Order_Creditmemo_Item $parentItem */
                 $parentItem = $parentOrderId ? $creditmemo->getItemByOrderId($parentOrderId) : false;
-                $qty = $item->getQty();
+                $qty = $parentItem ? ($parentItem->getQty() * $item->getQty()) : $item->getQty();
                 if (isset($items[$item->getProductId()])) {
                     $items[$item->getProductId()]['qty'] += $qty;
                 } else {


### PR DESCRIPTION
Since PR https://github.com/OpenMage/magento-lts/pull/2180/ was merged on branch 1.9.3.x by mistake, this PR is just a forward port (done by cherry-picking the single commit) to the 1.9.4.x branch.

PR https://github.com/OpenMage/magento-lts/pull/2180/ was necessary because we needed to revert PR https://github.com/OpenMage/magento-lts/pull/275 (check the comments, maintainers said we needed to revert) so... here we are.