### PR TITLE
Sourcemap link removed since this file is not minified

### DIFF
--- a/skin/adminhtml/default/openmage/calendar-blue2.css
+++ b/skin/adminhtml/default/openmage/calendar-blue2.css
@@ -188,5 +188,3 @@
 div.calendar {
   position: relative;
 }
-
-/*# sourceMappingURL=calendar-blue2.css.map */


### PR DESCRIPTION
skin/adminhtml/default/openmage/calendar-blue2.css file has a link to a sourcemap which doesn't exist, also, this sourcemap is not necessary anyway since the original file is not minified.

This PR removed the link to the sourcemap so that chrome dev console will not throw errors anymore.

### Fixed Issues

https://github.com/OpenMage/magento-lts/issues/1375

### Manual testing scenarios (*)

- use openmage admin theme
- open backend
- open chrome dev console and see the sourcemap error
- once updated with this PR the error doesn't show anymore