### PR TITLE
Changed timestamp definition to fix issue #1166

### DIFF
--- a/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
+++ b/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
@@ -115,6 +115,9 @@ class Mage_CatalogRule_Model_Action_Index_Refresh
     public function execute()
     {
         $this->_app->dispatchEvent('catalogrule_before_apply', array('resource' => $this->_resource));
+        
+        /** @var Mage_Core_Model_Date $coreDate */
+        $coreDate  = $this->_factory->getModel('core/date');
         $timestamp = $coreDate->gmtTimestamp();
 
         foreach ($this->_app->getWebsites(false) as $website) {

--- a/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
+++ b/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
@@ -115,10 +115,7 @@ class Mage_CatalogRule_Model_Action_Index_Refresh
     public function execute()
     {
         $this->_app->dispatchEvent('catalogrule_before_apply', array('resource' => $this->_resource));
-
-        /** @var Mage_Core_Model_Date $coreDate */
-        $coreDate  = $this->_factory->getModel('core/date');
-        $timestamp = $coreDate->gmtTimestamp('Today');
+        $timestamp = Mage::app()->getLocale()->date(null, null, null,true)->get(Zend_Date::TIMESTAMP);
 
         foreach ($this->_app->getWebsites(false) as $website) {
             /** @var Mage_Core_Model_Website $website */

--- a/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
+++ b/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
@@ -115,7 +115,7 @@ class Mage_CatalogRule_Model_Action_Index_Refresh
     public function execute()
     {
         $this->_app->dispatchEvent('catalogrule_before_apply', array('resource' => $this->_resource));
-        $timestamp = Mage::app()->getLocale()->date(null, null, null,true)->get(Zend_Date::TIMESTAMP);
+        $timestamp = $coreDate->gmtTimestamp();
 
         foreach ($this->_app->getWebsites(false) as $website) {
             /** @var Mage_Core_Model_Website $website */

--- a/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
+++ b/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
@@ -115,7 +115,7 @@ class Mage_CatalogRule_Model_Action_Index_Refresh
     public function execute()
     {
         $this->_app->dispatchEvent('catalogrule_before_apply', array('resource' => $this->_resource));
-        
+
         /** @var Mage_Core_Model_Date $coreDate */
         $coreDate  = $this->_factory->getModel('core/date');
         $timestamp = $coreDate->gmtTimestamp();


### PR DESCRIPTION
The scope of this PR is perfectly explained in issue https://github.com/OpenMage/magento-lts/issues/1166

Solution is taken from multiple sources, provided by @matteotestoni:
https://magento.stackexchange.com/questions/68042/catalog-price-rule-disappear-after-mid-night
https://magento.stackexchange.com/questions/188432/magento-1-9-catalog-price-rules-disappear-in-view-page-overnight
https://ogeek.cn/qa/?qa=952942/
https://wisedesignlab.com/magento-catalog-price-rule-dissapears-at-midnight/

### Manual testing scenarios (*)

Explained in https://github.com/OpenMage/magento-lts/issues/1166