### PR TITLE
[PHP 8] Fix TypeError when calling round() with a string argument

### DIFF
--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
@@ -768,9 +768,9 @@ class Mage_Usa_Model_Shipping_Carrier_Dhl_International
     {
         $sizeChecker = (string)$this->getConfigData('size');
 
-        $height = $this->_getDimension((string)$this->getConfigData('height'));
-        $depth = $this->_getDimension((string)$this->getConfigData('depth'));
-        $width = $this->_getDimension((string)$this->getConfigData('width'));
+        $height = $this->_getDimension((float)$this->getConfigData('height'));
+        $depth = $this->_getDimension((float)$this->getConfigData('depth'));
+        $width = $this->_getDimension((float)$this->getConfigData('width'));
 
         if ($sizeChecker && $height && $depth && $width) {
             $nodePiece->addChild('Height', $height);


### PR DESCRIPTION
Fix a `TypeError` in PHP 8 and above when calling `round` with a mismatching argument type. 

### Related Pull Requests
https://github.com/OpenMage/magento-lts/pull/1403 fixed this error in the past but missed three usages.

### Manual testing scenarios (*)
1. Make sure DHL shipping method is enabled from System -> Configuration -> Shipping Methods -> DHL -> Enabled for Checkout
2. Try creating an Order from Admin, when clicking "Get shipping methods and rates" the request returns 500 error and no shipping methods are shown.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list