### PR TITLE
Fix PHP 8 Fatal error: Uncaught ValueError: imagecolorsforindex() in Varien_Image_Adapter_Gd2

### DIFF
--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -268,7 +268,7 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
                 // fill image with indexed non-alpha transparency
                 elseif (false !== $transparentIndex) {
                     $transparentColor = false;
-                    if ($transparentIndex >=0 && $transparentIndex <= imagecolorstotal($this->_imageHandler)) {
+                    if ($transparentIndex >=0 && $transparentIndex < imagecolorstotal($this->_imageHandler)) {
                         list($r, $g, $b)  = array_values(imagecolorsforindex($this->_imageHandler, $transparentIndex));
                         $transparentColor = imagecolorallocate($imageResourceTo, $r, $g, $b);
                     }


### PR DESCRIPTION
### Description (*)
Fixes an issue which can occur using PHP >= 8.0.0 and certain images

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#2185

### Manual testing scenarios (*)
See issue