### PR TITLE
Wrap max log level retrieval from config in a try catch

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -865,7 +865,7 @@ final class Mage
 
         try {
             $maxLogLevel = (int) self::getStoreConfig('dev/log/max_level');
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $maxLogLevel = Zend_Log::DEBUG;
         }
 

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -863,7 +863,11 @@ final class Mage
 
         static $loggers = array();
 
-        $maxLogLevel = (int) self::getStoreConfig('dev/log/max_level');
+        try {
+            $maxLogLevel = (int) self::getStoreConfig('dev/log/max_level');
+        } catch (Exception $e) {
+            $maxLogLevel = Zend_Log::DEBUG;
+        }
 
         $level  = is_null($level) ? Zend_Log::DEBUG : $level;
 


### PR DESCRIPTION
As reviewed by @tmotyl in my previous PR, `getStoreConfig` may throw an Exception in certain cases and so it's safer to wrap inside a `try...catch` and default to DEBUG level in case of an exception.

### Related Pull Requests
https://github.com/OpenMage/magento-lts/pull/1727

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list