### PR TITLE
PHP 8: Fix cannot remove category on admin product edit categories tab

### DIFF
--- a/app/design/adminhtml/default/default/template/catalog/product/edit/categories.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/categories.phtml
@@ -139,8 +139,8 @@ function categoryAdd(id) {
 function categoryRemove(id) {
     var ids = $('product_categories').value.split(',');
     // bug #7654 fixed
-    while (-1 != ids.indexOf(id)) {
-        ids.splice(ids.indexOf(id), 1);
+    while (-1 != ids.indexOf(''+id)) {
+        ids.splice(ids.indexOf(''+id), 1);
     }
     $('product_categories').value = ids.join(',');
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
On PHP 8.0, ids in the category tree JSON are rendered as integers instead of as strings on previous PHP versions. Whether this has something to do with `Mage_Adminhtml_Block_Catalog_Category_Tree::_getNodeJson`, with `Zend_Json::encode` or with `json_encode` is unknown to me and not relevant for this PR and worth another discussion.

The issue fixed in this PR is that with PHP 8.0+ a product cannot be removed from categories in the categories tab of the product edit view. This is because the ids in the JSON provided by Magento to populate the categories tree (with `bildCategoryTree`) are integers instead of strings previously. The JS function `categoryRemove()` in categories.phtml can only handle ids as strings.

The best solution imho is to make `categoryRemove()` a bit more robust and support both integers and strings.


### Manual testing scenario of solved issue
1. Go to categories tree in product edit view and deselect a checkbox. 
2. Save product
3. Category checkbox is selected again.