### PR TITLE
Replace Magento word with OpenMage in root files

### DIFF
--- a/api.php
+++ b/api.php
@@ -25,7 +25,7 @@
  */
 
 if (version_compare(phpversion(), '7.0.0', '<')===true) {
-    echo 'It looks like you have an invalid PHP version. Magento supports PHP 7.0.0 or newer';
+    echo 'It looks like you have an invalid PHP version. OpenMage supports PHP 7.0.0 or newer';
     exit;
 }
 

--- a/get.php
+++ b/get.php
@@ -28,7 +28,7 @@ if (version_compare(phpversion(), '7.0.0', '<')===true) {
         . 'border-bottom:1px solid #ccc;"><h3 style="margin:0; font-size:1.7em; font-weight:normal; '
         . 'text-transform:none; text-align:left; color:#2f2f2f;">Whoops, it looks like you have an invalid PHP version.'
 
-        . '</h3></div><p>Magento supports PHP 7.0.0 or newer. <a href="https://www.openmage.org/magento-lts/install.html" '
+        . '</h3></div><p>OpenMage supports PHP 7.0.0 or newer. <a href="https://www.openmage.org/magento-lts/install.html" '
         . 'target="">Find out</a> how to install</a> Magento using PHP-CGI as a work-around.</p></div>';
     exit;
 }

--- a/get.php
+++ b/get.php
@@ -29,7 +29,7 @@ if (version_compare(phpversion(), '7.0.0', '<')===true) {
         . 'text-transform:none; text-align:left; color:#2f2f2f;">Whoops, it looks like you have an invalid PHP version.'
 
         . '</h3></div><p>OpenMage supports PHP 7.0.0 or newer. <a href="https://www.openmage.org/magento-lts/install.html" '
-        . 'target="">Find out</a> how to install</a> Magento using PHP-CGI as a work-around.</p></div>';
+        . 'target="">Find out</a> how to install</a> OpenMage using PHP-CGI as a work-around.</p></div>';
     exit;
 }
 $start = microtime(true);

--- a/index.php
+++ b/index.php
@@ -28,7 +28,7 @@ if (version_compare(phpversion(), '7.0.0', '<')===true) {
     echo  '<div style="font:12px/1.35em arial, helvetica, sans-serif;">
 <div style="margin:0 0 25px 0; border-bottom:1px solid #ccc;">
 <h3 style="margin:0; font-size:1.7em; font-weight:normal; text-transform:none; text-align:left; color:#2f2f2f;">
-Whoops, it looks like you have an invalid PHP version.</h3></div><p>Magento supports PHP 7.0.0 or newer.
+Whoops, it looks like you have an invalid PHP version.</h3></div><p>OpenMage supports PHP 7.0.0 or newer.
 <a href="https://www.openmage.org/magento-lts/install.html" target="">Find out</a> how to install</a>
  Magento using PHP-CGI as a work-around.</p></div>';
     exit;

--- a/index.php
+++ b/index.php
@@ -30,7 +30,7 @@ if (version_compare(phpversion(), '7.0.0', '<')===true) {
 <h3 style="margin:0; font-size:1.7em; font-weight:normal; text-transform:none; text-align:left; color:#2f2f2f;">
 Whoops, it looks like you have an invalid PHP version.</h3></div><p>OpenMage supports PHP 7.0.0 or newer.
 <a href="https://www.openmage.org/magento-lts/install.html" target="">Find out</a> how to install</a>
- Magento using PHP-CGI as a work-around.</p></div>';
+ OpenMage using PHP-CGI as a work-around.</p></div>';
     exit;
 }
 

--- a/index.php.sample
+++ b/index.php.sample
@@ -25,7 +25,7 @@
  */
 
 if (version_compare(phpversion(), '7.0.0', '<')===true) {
-    echo  '<div style="font:12px/1.35em arial, helvetica, sans-serif;"><div style="margin:0 0 25px 0; border-bottom:1px solid #ccc;"><h3 style="margin:0; font-size:1.7em; font-weight:normal; text-transform:none; text-align:left; color:#2f2f2f;">Whoops, it looks like you have an invalid PHP version.</h3></div><p>Magento supports PHP 7.0.0 or newer. <a href="https://www.openmage.org/magento-lts/install.html" target="">Find out</a> how to install</a> Magento using PHP-CGI as a work-around.</p></div>';
+    echo  '<div style="font:12px/1.35em arial, helvetica, sans-serif;"><div style="margin:0 0 25px 0; border-bottom:1px solid #ccc;"><h3 style="margin:0; font-size:1.7em; font-weight:normal; text-transform:none; text-align:left; color:#2f2f2f;">Whoops, it looks like you have an invalid PHP version.</h3></div><p>OpenMage supports PHP 7.0.0 or newer. <a href="https://www.openmage.org/magento-lts/install.html" target="">Find out</a> how to install</a> OpenMage using PHP-CGI as a work-around.</p></div>';
     exit;
 }
 

--- a/install.php
+++ b/install.php
@@ -65,10 +65,10 @@
  *
  *  php -f install.php -- --license_agreement_accepted yes \
  *  --locale en_US --timezone "America/Los_Angeles" --default_currency USD \
- *  --db_host localhost --db_name magento_database --db_user magento_user --db_pass 123123 \
- *  --db_prefix magento_ \
- *  --url "http://magento.example.com/" --use_rewrites yes \
- *  --use_secure yes --secure_base_url "https://magento.example.com/" --use_secure_admin yes \
+ *  --db_host localhost --db_name openmage_database --db_user openmage_user --db_pass 123123 \
+ *  --db_prefix openmage_ \
+ *  --url "http://openmage.example.com/" --use_rewrites yes \
+ *  --use_secure yes --secure_base_url "https://openmage.example.com/" --use_secure_admin yes \
  *  --admin_lastname Owner --admin_firstname Store --admin_email "admin@example.com" \
  *  --admin_username admin --admin_password 123123 \
  *  --encryption_key "Encryption Key"
@@ -102,7 +102,7 @@
  *                              // Enable this option only if you have SSL available.
  * --secure_base_url            // optional, Secure Base URL
  *                              // Provide a complete base URL for SSL connection.
- *                              // For example: https://www.mydomain.com/magento/
+ *                              // For example: https://www.mydomain.com/openmage/
  * --use_secure_admin           // optional, Run admin interface with SSL
  * Backend interface options:
  * --enable_charts              // optional, Enables Charts on the backend's dashboard
@@ -119,7 +119,7 @@
  */
 
 if (version_compare(phpversion(), '7.0.0', '<')===true) {
-    die('ERROR: Whoops, it looks like you have an invalid PHP version. Magento supports PHP 7.0.0 or newer.');
+    die('ERROR: Whoops, it looks like you have an invalid PHP version. OpenMage supports PHP 7.0.0 or newer.');
 }
 set_include_path(dirname(__FILE__) . PATH_SEPARATOR . get_include_path());
 require 'app/bootstrap.php';


### PR DESCRIPTION
In OpenMage root several files contains Magento word. For example, "Magento supports PHP 7.0.0 or newer", "Magento using PHP-CGI as a work-around". This PR replaces Magento words with OpenMage in all phrases that appear in Frontend.