### PR TITLE
Backend > Orders grid - More space for columns

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
@@ -66,7 +66,7 @@ class Mage_Adminhtml_Block_Sales_Order_Grid extends Mage_Adminhtml_Block_Widget_
 
         $this->addColumn('real_order_id', array(
             'header' => Mage::helper('sales')->__('Order #'),
-            'width'  => '80px',
+            'width'  => '100px',
             'type'   => 'text',
             'index'  => 'increment_id',
             'escape' => true,
@@ -87,7 +87,7 @@ class Mage_Adminhtml_Block_Sales_Order_Grid extends Mage_Adminhtml_Block_Widget_
             'header' => Mage::helper('sales')->__('Purchased On'),
             'index' => 'created_at',
             'type' => 'datetime',
-            'width' => '100px',
+            'width' => '150px',
         ));
 
         $this->addColumn('billing_name', array(
@@ -118,7 +118,7 @@ class Mage_Adminhtml_Block_Sales_Order_Grid extends Mage_Adminhtml_Block_Widget_
             'header' => Mage::helper('sales')->__('Status'),
             'index' => 'status',
             'type'  => 'options',
-            'width' => '70px',
+            'width' => '150px',
             'options' => Mage::getSingleton('sales/order_config')->getStatuses(),
         ));
 


### PR DESCRIPTION
The purpose of this PR is to solve a visual issue in the **Orders** grids. By default, the "**Order #**", "**Purchased On**" and "**Status**" columns are not wide enough. Thus the content uses instead of 1 row, 2 or even 3 rows and as an effect the grid increases vertically. 

Please note that for the "Status" column I used the longest string in the list in order to find out the proper width (PayPal Canceled Reversal). If you use only Pending, Processing, Complete, Cancel it can look wider than necessary.

This is how the Orders grid in OpenMage is now:

![orders-grid-before](https://user-images.githubusercontent.com/8360474/171281326-538bafac-ed8c-460e-b790-816b445c4575.jpg)

This will be the Orders grid if the PR is merged:

![orders-grid](https://user-images.githubusercontent.com/8360474/171281345-da293331-a6b7-45ec-bf6b-66290ce9f44d.jpg)