### PR TITLE
Backend > Manage Products grid - More space for columns

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
@@ -154,6 +154,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
         $this->addColumn('name',
             array(
                 'header'=> Mage::helper('catalog')->__('Name'),
+                'width' => '300px',
                 'index' => 'name',
         ));
 
@@ -169,7 +170,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
         $this->addColumn('type',
             array(
                 'header'=> Mage::helper('catalog')->__('Type'),
-                'width' => '60px',
+                'width' => '150px',
                 'index' => 'type_id',
                 'type'  => 'options',
                 'options' => Mage::getSingleton('catalog/product_type')->getOptionArray(),
@@ -184,7 +185,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
         $this->addColumn('set_name',
             array(
                 'header'=> Mage::helper('catalog')->__('Attrib. Set Name'),
-                'width' => '100px',
+                'width' => '150px',
                 'index' => 'attribute_set_id',
                 'type'  => 'options',
                 'options' => $sets,
@@ -193,7 +194,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
         $this->addColumn('sku',
             array(
                 'header'=> Mage::helper('catalog')->__('SKU'),
-                'width' => '80px',
+                'width' => '150px',
                 'index' => 'sku',
         ));
 
@@ -219,7 +220,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
         $this->addColumn('visibility',
             array(
                 'header'=> Mage::helper('catalog')->__('Visibility'),
-                'width' => '70px',
+                'width' => '150px',
                 'index' => 'visibility',
                 'type'  => 'options',
                 'options' => Mage::getModel('catalog/product_visibility')->getOptionArray(),


### PR DESCRIPTION
The purpose of this PR is to solve a visual issue in the Manage Products grid. By default, the "**Type**", "**Attrib. Set Name**", "**SKU**" and "**Visibility**" columns are not wide enough. Thus the content uses instead of 1 row, 2 or even 3 rows and as an effect the grid increases vertically. 

Please note that for the "Type" and "Visibility" columns I used the longest strings in the dropdown lists in order to find out the proper width, these are "Downloadable Product" and "Not Visible individually".

An image is worth a thousand words. Below are screenshots of the Manage Products grid in OpenMage 20-14 for a few resolutions. The database used in testing is Magento Sample 1.9. The values in columns "Name", "Attrib. Set Name", "SKU", are not short at all but I found that their sizes cover the real situation in some of the stores I manage and where I did the implementation already.: 

**Screen Resolution Width: 960px**

![960px-default](https://user-images.githubusercontent.com/8360474/172127332-0af0f9e9-8c21-42ce-86e6-f0392666935b.jpg)

**Screen Resolution Width: 1280px**

![1280px-default](https://user-images.githubusercontent.com/8360474/172127354-d4dfdf53-fdba-4333-9de2-c1050d3545f4.jpg)

**Screen Resolution Width: 1437px**

![1437px-default](https://user-images.githubusercontent.com/8360474/172127373-d8b88fa6-15c7-435d-aade-2eadb723d6b6.jpg)

Bellow is what happens if this PR is merged. I personally consider it brings significant visual improvements:

**Screen Resolution Width: 960px**

![960px](https://user-images.githubusercontent.com/8360474/172125625-60b2491c-5a68-4487-a891-98fa93d15f68.jpg)

**Screen Resolution Width: 1280px**

![1280px](https://user-images.githubusercontent.com/8360474/172125756-fb9c4fb3-1eca-4ced-bf5c-a2df41ba09a9.jpg)

**Screen Resolution Width: 1437px** - starting with this width all the rows occupy a single row.

![1437px](https://user-images.githubusercontent.com/8360474/172125772-030e0938-a522-4fda-b047-77ed832cc140.jpg)

Please note for some columns the values cannot be removed, nor can smaller widths be set (e.g. ID, Price, Qty).

Also, these results were obtained by adding the width of 300px (missing from OM code) for the "Name" column, which is absolutely necessary in this situation. 

Anyone is welcome to play with the width values for these columns to cover the real situation in their stores. 