### PR TITLE
Fixed issue #2212 SQLSTATE[42S22]: Column not found: 1054 Unknown col…

### DIFF
--- a/app/code/core/Mage/Customer/Model/Resource/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Customer.php
@@ -368,18 +368,31 @@ class Mage_Customer_Model_Resource_Customer extends Mage_Eav_Model_Entity_Abstra
 
     /**
      * Get password created at timestamp for a customer by id
+     * If attribute password_created_at is empty, return created_at timestamp
      *
      * @param int $customerId
-     * @return string
+     * @return int|false
      */
     public function getPasswordTimestamp($customerId)
     {
-        $field = $this->_getReadAdapter()->getIfNullSql('password_created_at', 'created_at');
+        $field = $this->_getReadAdapter()->getIfNullSql('t2.value', 't0.created_at');
         $select = $this->_getReadAdapter()->select()
-            ->from($this->getEntityTable(), ['password_created_at' => $field])
-            ->where($this->getEntityIdField() . ' =?', $customerId);
+            ->from(['t0' => $this->getEntityTable()], ['password_created_at' => $field])
+            ->joinLeft(
+                ['t1' => $this->getTable('eav/attribute')],
+                't0.entity_type_id = t1.entity_type_id',
+                []
+            )
+            ->joinLeft(
+                ['t2' => $this->getTable(['customer/entity', 'datetime'])],
+                't1.attribute_id = t2.attribute_id',
+                []
+            )
+            ->where('t0.entity_id = ?', $customerId)
+            ->where('t1.attribute_code = ?', 'password_created_at');
+
         $value = $this->_getReadAdapter()->fetchOne($select);
-        if ($value && ! is_numeric($value)) { // Convert created_at string to unix timestamp
+        if ($value && !is_numeric($value)) { // Convert created_at string to unix timestamp
             $value = Varien_Date::toTimestamp($value);
         }
         return $value;


### PR DESCRIPTION
…umn 'password_created_at' in 'field list'

<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

The exception is because `password_created_at` is not a static attribute, it's not in the `customer_entity` table,

### Related Pull Requests
<!-- related pull request placeholder -->
PR #546

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Issue #2212 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

