### PR TITLE
Fix ACL resource name typo in Api2 roles page

### DIFF
--- a/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/RoleController.php
+++ b/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/RoleController.php
@@ -293,7 +293,7 @@ class Mage_Api2_Adminhtml_Api2_RoleController extends Mage_Adminhtml_Controller_
     {
         /** @var Mage_Admin_Model_Session $session */
         $session = Mage::getSingleton('admin/session');
-        return $session->isAllowed('system/api/roles_rest');
+        return $session->isAllowed('system/api/rest_roles');
     }
 
     /**


### PR DESCRIPTION
Fix ACL resource name typo in Api2 roles page when calling `isAllowed`

### Description (*)
This PR fixes a typo in ACL resource name supplied to `isAllowed` call on Api2 Roles controller, it was preventing from accessing the page even though the permission is granted to the current user's role.

### Manual testing scenarios (*)
1. Go to `System -> Permissions -> Roles` and select your current user role from the grid.
2. Click the "Role Resources" tab and make sure "Resource Access" is set to "Custom".
3. Select as many sections from the tree as you want (keep System checked to not lock yourself out), but make sure "REST Roles" and its children are all checked.
4. Now try to access "REST Roles" page, you should see Access denied error page.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list