### PR TITLE
Fixed warning a non-numeric value encountered in /Mage/Catalog/Model/Resource/Product/Option.php

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option.php
@@ -140,7 +140,7 @@ class Mage_Catalog_Model_Resource_Product_Option extends Mage_Core_Model_Resourc
                             if (!$rate) {
                                 $rate=1;
                             }
-                            $newPrice = $object->getPrice() * $rate;
+                            $newPrice = (float) $object->getPrice() * $rate;
                         } else {
                             $newPrice = $object->getPrice();
                         }


### PR DESCRIPTION
… when saving a product with custom options.

<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
For for new object, `$object->getPrice()` can return null or empty string, which throws the warning.




