### PR TITLE
Allow setting optional product attributes to `null` in REST API

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Admin/V1.php
@@ -328,7 +328,7 @@ class Mage_Catalog_Model_Api2_Product_Rest_Admin_V1 extends Mage_Catalog_Model_A
             }
 
             if ($this->_isAllowedAttribute($attribute)) {
-                if (isset($productData[$attribute->getAttributeCode()])) {
+                if (array_key_exists($attribute->getAttributeCode(), $productData)) {
                     $product->setData(
                         $attribute->getAttributeCode(),
                         $productData[$attribute->getAttributeCode()]


### PR DESCRIPTION

### Description (*)
REST API doesn't allow setting optional product attributes to `null` because all attributes are checked with `isset` before calling `$product->setData()`. This PR changes the condition to use `array_key_exists` which doesn't care if the value is `null` as long as it exists in the request body.

This shouldn't affect mandatory attributes such as `sku`, and you should still get validation errors if you try and set those to `null`.

### Fixed Issues (if relevant)

1. Fixes OpenMage/magento-lts#805

### Manual testing scenarios (*)
1. Setup authentication with OAuth or use [my Basic Auth extension](https://github.com/elidrissidev/magento-api2basicauth).
2. Given a product with an optional attribute set to a non-null value, try setting it to `null`, for example `meta_title`:
```sh
$ curl -X PUT -H 'Content-Type: application/json' -H 'Authorization: ...' -d '{"meta_title":null}' http://<magento_host>/api/rest/products/402
```
3. Now request the same product again and you should see that the attribute wasn't updated.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
