### PR TITLE
Throw exception when trying to modifying address that does not belong to logged in user

### DIFF
--- a/app/code/core/Mage/Customer/controllers/AddressController.php
+++ b/app/code/core/Mage/Customer/controllers/AddressController.php
@@ -118,6 +118,8 @@ class Mage_Customer_AddressController extends Mage_Core_Controller_Front_Action
                 $existsAddress = $customer->getAddressById($addressId);
                 if ($existsAddress->getId() && $existsAddress->getCustomerId() == $customer->getId()) {
                     $address->setId($existsAddress->getId());
+                } else {
+                    throw new Exception($this->__('Provided address does not belong to the logged in customer.'));
                 }
             }
 

--- a/app/locale/en_US/Mage_Customer.csv
+++ b/app/locale/en_US/Mage_Customer.csv
@@ -307,6 +307,7 @@
 "Product Name","Product Name"
 "Product Reviews","Product Reviews"
 "Product Tags","Product Tags"
+"Provided address does not belong to the logged in customer.","Provided address does not belong to the logged in customer."
 "Purchase On","Purchase On"
 "Purchased On","Purchased On"
 "Qty","Qty"


### PR DESCRIPTION
Mage_Customer_AddressController::formPostAction() checks that the submitted address (the one that the user is trying to modify) belongs to the user, but in case it doesn't no exception was thrown (ending up in a new address record been created).

### Fixed Issues

1. [Fixes OpenMage/magento-lts#<issue_number>](https://github.com/OpenMage/magento-lts/issues/1511)

### Manual testing scenarios (*)

Explained in https://github.com/OpenMage/magento-lts/issues/1511