### PR TITLE
Fix xml validation problems

### DIFF
--- a/app/code/core/Mage/Api/Model/Wsdl/Config/Base.php
+++ b/app/code/core/Mage/Api/Model/Wsdl/Config/Base.php
@@ -56,7 +56,7 @@ class Mage_Api_Model_Wsdl_Config_Base extends Varien_Simplexml_Config
         // set up default WSDL template variables
         $this->_wsdlVariables = new Varien_Object(
             array(
-                'name' => 'Magento',
+                'name' => 'OpenMage',
                 'url'  => Mage::helper('api')->getServiceUrl('*/*/*', array('_query' => $queryParams), true)
             )
         );

--- a/app/code/core/Mage/Api/etc/wsdl.xml
+++ b/app/code/core/Mage/Api/etc/wsdl.xml
@@ -3,7 +3,7 @@
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
-        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
 <!--            <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />-->
             <complexType name="FixedArray">
                 <complexContent>

--- a/app/code/core/Mage/Api/etc/wsdl.xml
+++ b/app/code/core/Mage/Api/etc/wsdl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns:typens="urn:{{var wsdl.name}}" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+<definitions xmlns:typens="urn:OpenMage" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
-    name="{{var wsdl.name}}" targetNamespace="urn:{{var wsdl.name}}">
+    name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
 <!--            <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />-->
@@ -113,77 +113,77 @@
         <operation name="call">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="multiCall">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="endSession">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="login">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="startSession">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="resources">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="globalFaults">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="resourceFaults">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
     </binding>
-    <service name="{{var wsdl.name}}Service">
+    <service name="OpenMageService">
         <port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}" />
         </port>

--- a/app/code/core/Mage/Api/etc/wsdl2.xml
+++ b/app/code/core/Mage/Api/etc/wsdl2.xml
@@ -3,7 +3,7 @@
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
-        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
+       <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="associativeEntity">
                 <all>

--- a/app/code/core/Mage/Api/etc/wsdl2.xml
+++ b/app/code/core/Mage/Api/etc/wsdl2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns:typens="urn:{{var wsdl.name}}" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+<definitions xmlns:typens="urn:OpenMage" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
-    name="{{var wsdl.name}}" targetNamespace="urn:{{var wsdl.name}}">
+    name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
@@ -182,59 +182,59 @@
         <operation name="endSession">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="login">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="startSession">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="resources">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="globalFaults">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="resourceFaults">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
     </binding>
-    <service name="{{var wsdl.name}}Service">
+    <service name="OpenMageService">
         <port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}" />
         </port>

--- a/app/code/core/Mage/Api/etc/wsi.xml
+++ b/app/code/core/Mage/Api/etc/wsi.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions xmlns:typens="urn:{{var wsdl.name}}"
+<wsdl:definitions xmlns:typens="urn:OpenMage"
              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
              xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
              xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-             name="{{var wsdl.name}}"
-             targetNamespace="urn:{{var wsdl.name}}">
+             name="OpenMage"
+             targetNamespace="OpenMage">
     <wsdl:types>
-        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:{{var wsdl.name}}">
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <xsd:complexType name="associativeEntity">
                 <xsd:sequence>
                     <xsd:element name="key" type="xsd:string" />
@@ -373,7 +373,7 @@
             </wsdl:output>
         </wsdl:operation>
     </wsdl:binding>
-    <wsdl:service name="{{var wsdl.name}}Service">
+    <wsdl:service name="OpenMageService">
         <wsdl:port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}" />
         </wsdl:port>

--- a/app/code/core/Mage/Catalog/etc/wsdl.xml
+++ b/app/code/core/Mage/Catalog/etc/wsdl.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns:typens="urn:{{var wsdl.name}}" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+<definitions xmlns:typens="urn:OpenMage" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
              xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
              xmlns="http://schemas.xmlsoap.org/wsdl/"
-             name="{{var wsdl.name}}" targetNamespace="urn:{{var wsdl.name}}">
+             name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/"
@@ -1562,775 +1562,775 @@
         <operation name="catalogCategoryCurrentStore">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogCategoryTree">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogCategoryLevel">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogCategoryInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogCategoryCreate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogCategoryUpdate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogCategoryMove">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogCategoryDelete">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogCategoryAssignedProducts">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogCategoryAssignProduct">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogCategoryUpdateProduct">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogCategoryRemoveProduct">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductCurrentStore">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductListOfAdditionalAttributes">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductCreate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductUpdate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductMultiUpdate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductSetSpecialPrice">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductGetSpecialPrice">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductDelete">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeCurrentStore">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeSetCreate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeOptions">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeSetRemove">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeSetList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeSetAttributeAdd">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeSetAttributeRemove">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeSetGroupAdd">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeSetGroupRename">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeSetGroupRemove">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeTypes">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeCreate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogCategoryAttributeCurrentStore">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeMediaCurrentStore">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeRemove">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeUpdate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeAddOption">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeRemoveOption">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductTypeList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeTierPriceInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeTierPriceUpdate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogCategoryAttributeList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogCategoryAttributeOptions">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeMediaList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeMediaInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeMediaTypes">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeMediaCreate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeMediaUpdate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductAttributeMediaRemove">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductLinkList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductLinkAssign">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductLinkUpdate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductLinkRemove">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductLinkTypes">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductLinkAttributes">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductCustomOptionAdd">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductCustomOptionUpdate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductCustomOptionInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductCustomOptionTypes">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductCustomOptionValueInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductCustomOptionValueList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductCustomOptionValueAdd">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductCustomOptionValueUpdate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductCustomOptionValueRemove">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductCustomOptionList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductCustomOptionRemove">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
     </binding>
-    <service name="{{var wsdl.name}}Service">
+    <service name="OpenMageService">
         <port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}"/>
         </port>

--- a/app/code/core/Mage/Catalog/etc/wsdl.xml
+++ b/app/code/core/Mage/Catalog/etc/wsdl.xml
@@ -5,7 +5,7 @@
              xmlns="http://schemas.xmlsoap.org/wsdl/"
              name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
-        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/"
                     schemaLocation="http://schemas.xmlsoap.org/soap/encoding/"/>
             <complexType name="catalogProductEntityArray">

--- a/app/code/core/Mage/Catalog/etc/wsi.xml
+++ b/app/code/core/Mage/Catalog/etc/wsi.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions xmlns:typens="urn:{{var wsdl.name}}"
+<wsdl:definitions xmlns:typens="urn:OpenMage"
              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
              xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
              xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-             name="{{var wsdl.name}}"
-             targetNamespace="urn:{{var wsdl.name}}">
+             name="OpenMage"
+             targetNamespace="urn:OpenMage">
     <wsdl:types>
-        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:{{var wsdl.name}}">
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <xsd:complexType name="catalogProductEntityArray">
                 <xsd:sequence>
                     <xsd:element minOccurs="0" maxOccurs="unbounded" name="complexObjectArray" type="typens:catalogProductEntity" />
@@ -3013,7 +3013,7 @@
             </wsdl:output>
         </wsdl:operation>
     </wsdl:binding>
-    <wsdl:service name="{{var wsdl.name}}Service">
+    <wsdl:service name="OpenMageService">
         <wsdl:port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}" />
         </wsdl:port>

--- a/app/code/core/Mage/CatalogInventory/etc/wsdl.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/wsdl.xml
@@ -3,7 +3,7 @@
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
-        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="catalogInventoryStockItemEntity">
                 <all>

--- a/app/code/core/Mage/CatalogInventory/etc/wsdl.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/wsdl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns:typens="urn:{{var wsdl.name}}" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+<definitions xmlns:typens="urn:OpenMage" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
-    name="{{var wsdl.name}}" targetNamespace="urn:{{var wsdl.name}}">
+    name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
@@ -98,34 +98,34 @@
         <operation name="catalogInventoryStockItemList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="catalogInventoryStockItemUpdate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="catalogInventoryStockItemMultiUpdate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
     </binding>
-    <service name="{{var wsdl.name}}Service">
+    <service name="OpenMageService">
         <port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}" />
         </port>

--- a/app/code/core/Mage/CatalogInventory/etc/wsi.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/wsi.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions xmlns:typens="urn:{{var wsdl.name}}"
+<wsdl:definitions xmlns:typens="urn:OpenMage"
              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
              xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
              xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-             name="{{var wsdl.name}}"
-             targetNamespace="urn:{{var wsdl.name}}">
+             name="OpenMage"
+             targetNamespace="urn:OpenMage">
     <wsdl:types>
-        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:{{var wsdl.name}}">
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <xsd:complexType name="catalogInventoryStockItemEntity">
                 <xsd:sequence>
                     <xsd:element name="product_id" type="xsd:string" minOccurs="0" />
@@ -166,7 +166,7 @@
             </wsdl:output>
         </wsdl:operation>
     </wsdl:binding>
-    <wsdl:service name="{{var wsdl.name}}Service">
+    <wsdl:service name="OpenMageService">
         <wsdl:port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}" />
         </wsdl:port>

--- a/app/code/core/Mage/Checkout/etc/wsdl.xml
+++ b/app/code/core/Mage/Checkout/etc/wsdl.xml
@@ -5,7 +5,7 @@
              xmlns="http://schemas.xmlsoap.org/wsdl/"
              name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
-        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <complexType name="shoppingCartAddressEntity">
                 <all>
                     <element name="address_id" type="xsd:string" minOccurs="0"/>

--- a/app/code/core/Mage/Checkout/etc/wsdl.xml
+++ b/app/code/core/Mage/Checkout/etc/wsdl.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns:typens="urn:{{var wsdl.name}}" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+<definitions xmlns:typens="urn:OpenMage" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
              xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
              xmlns="http://schemas.xmlsoap.org/wsdl/"
-             name="{{var wsdl.name}}" targetNamespace="urn:{{var wsdl.name}}">
+             name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
             <complexType name="shoppingCartAddressEntity">
@@ -580,198 +580,198 @@
         <operation name="shoppingCartCreate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartTotals">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartOrder">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartLicense">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartProductAdd">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartProductUpdate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartProductRemove">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartProductList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartProductMoveToCustomerQuote">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartCustomerSet">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartCustomerAddresses">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartShippingMethod">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartShippingList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartPaymentMethod">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartPaymentList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartCouponAdd">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="shoppingCartCouponRemove">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>

--- a/app/code/core/Mage/Checkout/etc/wsi.xml
+++ b/app/code/core/Mage/Checkout/etc/wsi.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions xmlns:typens="urn:{{var wsdl.name}}"
+<wsdl:definitions xmlns:typens="urn:OpenMage"
              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
              xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
              xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-             name="{{var wsdl.name}}"
-             targetNamespace="urn:{{var wsdl.name}}">
+             name="OpenMage"
+             targetNamespace="urn:OpenMage">
     <wsdl:types>
-        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:{{var wsdl.name}}">
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <xsd:complexType name="shoppingCartAddressEntity">
                 <xsd:sequence>
                     <xsd:element name="address_id" type="xsd:string" minOccurs="0"/>

--- a/app/code/core/Mage/Core/etc/wsdl.xml
+++ b/app/code/core/Mage/Core/etc/wsdl.xml
@@ -3,7 +3,7 @@
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
-        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="storeEntity">
                 <all>

--- a/app/code/core/Mage/Core/etc/wsdl.xml
+++ b/app/code/core/Mage/Core/etc/wsdl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns:typens="urn:{{var wsdl.name}}" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+<definitions xmlns:typens="urn:OpenMage" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
-    name="{{var wsdl.name}}" targetNamespace="urn:{{var wsdl.name}}">
+    name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
@@ -72,32 +72,32 @@
         <operation name="storeList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="storeInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="magentoInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
     </binding>
-    <service name="{{var wsdl.name}}Service">
+    <service name="OpenMageService">
         <port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}" />
         </port>

--- a/app/code/core/Mage/Core/etc/wsi.xml
+++ b/app/code/core/Mage/Core/etc/wsi.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions xmlns:typens="urn:{{var wsdl.name}}"
+<wsdl:definitions xmlns:typens="urn:OpenMage"
              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
              xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
              xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-             name="{{var wsdl.name}}"
-             targetNamespace="urn:{{var wsdl.name}}">
+             name="OpenMage"
+             targetNamespace="urn:OpenMage">
     <wsdl:types>
-        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:{{var wsdl.name}}">
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <xsd:complexType name="storeEntity">
                 <xsd:sequence>
                     <xsd:element name="store_id" type="xsd:int" />
@@ -140,7 +140,7 @@
             </wsdl:output>
         </wsdl:operation>
     </wsdl:binding>
-    <wsdl:service name="{{var wsdl.name}}Service">
+    <wsdl:service name="OpenMageService">
         <wsdl:port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}" />
         </wsdl:port>

--- a/app/code/core/Mage/Customer/etc/wsdl.xml
+++ b/app/code/core/Mage/Customer/etc/wsdl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns:typens="urn:{{var wsdl.name}}" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+<definitions xmlns:typens="urn:OpenMage" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
-    name="{{var wsdl.name}}" targetNamespace="urn:{{var wsdl.name}}">
+    name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
@@ -260,100 +260,100 @@
         <operation name="customerCustomerList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="customerCustomerCreate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="customerCustomerInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="customerCustomerUpdate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="customerCustomerDelete">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="customerGroupList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="customerAddressList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="customerAddressCreate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="customerAddressInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="customerAddressUpdate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="customerAddressDelete">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
     </binding>

--- a/app/code/core/Mage/Customer/etc/wsdl.xml
+++ b/app/code/core/Mage/Customer/etc/wsdl.xml
@@ -3,7 +3,7 @@
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
-        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="customerCustomerEntityToCreate">
                 <all>

--- a/app/code/core/Mage/Customer/etc/wsi.xml
+++ b/app/code/core/Mage/Customer/etc/wsi.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions xmlns:typens="urn:{{var wsdl.name}}"
+<wsdl:definitions xmlns:typens="urn:OpenMage"
              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
              xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
              xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-             name="{{var wsdl.name}}"
-             targetNamespace="urn:{{var wsdl.name}}">
+             name="OpenMage"
+             targetNamespace="urn:OpenMage">
     <wsdl:types>
-        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:{{var wsdl.name}}">
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <xsd:complexType name="customerCustomerEntityToCreate">
                 <xsd:sequence>
                     <xsd:element name="customer_id" type="xsd:int" minOccurs="0" />

--- a/app/code/core/Mage/Directory/etc/wsdl.xml
+++ b/app/code/core/Mage/Directory/etc/wsdl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns:typens="urn:{{var wsdl.name}}" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+<definitions xmlns:typens="urn:OpenMage" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
-    name="{{var wsdl.name}}" targetNamespace="urn:{{var wsdl.name}}">
+    name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
@@ -66,23 +66,23 @@
         <operation name="directoryCountryList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="directoryRegionList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
     </binding>
-    <service name="{{var wsdl.name}}Service">
+    <service name="OpenMageService">
         <port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}" />
         </port>

--- a/app/code/core/Mage/Directory/etc/wsdl.xml
+++ b/app/code/core/Mage/Directory/etc/wsdl.xml
@@ -3,7 +3,7 @@
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
-        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="directoryCountryEntity">
                 <all>

--- a/app/code/core/Mage/Directory/etc/wsi.xml
+++ b/app/code/core/Mage/Directory/etc/wsi.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions xmlns:typens="urn:{{var wsdl.name}}"
+<wsdl:definitions xmlns:typens="urn:OpenMage"
              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
              xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
              xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-             name="{{var wsdl.name}}"
-             targetNamespace="urn:{{var wsdl.name}}">
+             name="OpenMage"
+             targetNamespace="urn:OpenMage">
     <wsdl:types>
-        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:{{var wsdl.name}}">
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <xsd:complexType name="directoryCountryEntity">
                 <xsd:sequence>
                     <xsd:element name="country_id" type="xsd:string" />
@@ -111,7 +111,7 @@
             </wsdl:output>
         </wsdl:operation>
     </wsdl:binding>
-    <wsdl:service name="{{var wsdl.name}}Service">
+    <wsdl:service name="OpenMageService">
         <wsdl:port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}" />
         </wsdl:port>

--- a/app/code/core/Mage/Downloadable/etc/wsdl.xml
+++ b/app/code/core/Mage/Downloadable/etc/wsdl.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns:typens="urn:{{var wsdl.name}}" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+<definitions xmlns:typens="urn:OpenMage" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
              xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
              xmlns="http://schemas.xmlsoap.org/wsdl/"
-             name="{{var wsdl.name}}" targetNamespace="urn:{{var wsdl.name}}">
+             name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/"
@@ -154,38 +154,38 @@
         <operation name="catalogProductDownloadableLinkAdd">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductDownloadableLinkList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
         <operation name="catalogProductDownloadableLinkRemove">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action"/>
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded"
+                <soap:body namespace="urn:OpenMage" use="encoded"
                            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
             </output>
         </operation>
     </binding>
-    <service name="{{var wsdl.name}}Service">
+    <service name="OpenMageService">
         <port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}"/>
         </port>

--- a/app/code/core/Mage/Downloadable/etc/wsdl.xml
+++ b/app/code/core/Mage/Downloadable/etc/wsdl.xml
@@ -5,7 +5,7 @@
              xmlns="http://schemas.xmlsoap.org/wsdl/"
              name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
-        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/"
                     schemaLocation="http://schemas.xmlsoap.org/soap/encoding/"/>
             <complexType name="catalogProductDownloadableLinkFileEntity">

--- a/app/code/core/Mage/Downloadable/etc/wsi.xml
+++ b/app/code/core/Mage/Downloadable/etc/wsi.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions xmlns:typens="urn:{{var wsdl.name}}"
+<wsdl:definitions xmlns:typens="urn:OpenMage"
              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
              xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
              xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-             name="{{var wsdl.name}}"
-             targetNamespace="urn:{{var wsdl.name}}">
+             name="OpenMage"
+             targetNamespace="urn:OpenMage">
     <wsdl:types>
-        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:{{var wsdl.name}}">
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <xsd:complexType name="catalogProductDownloadableLinkFileEntity">
                 <xsd:sequence>
                     <xsd:element name="name" type="xsd:string" minOccurs="0" />

--- a/app/code/core/Mage/GiftMessage/etc/wsdl.xml
+++ b/app/code/core/Mage/GiftMessage/etc/wsdl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns:typens="urn:{{var wsdl.name}}" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+<definitions xmlns:typens="urn:OpenMage" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
-    name="{{var wsdl.name}}" targetNamespace="urn:{{var wsdl.name}}">
+    name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
@@ -90,32 +90,32 @@
         <operation name="giftMessageSetForQuote">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="giftMessageSetForQuoteItem">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="giftMessageSetForQuoteProduct">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
     </binding>
-    <service name="{{var wsdl.name}}Service">
+    <service name="OpenMageService">
         <port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}" />
         </port>

--- a/app/code/core/Mage/GiftMessage/etc/wsdl.xml
+++ b/app/code/core/Mage/GiftMessage/etc/wsdl.xml
@@ -3,7 +3,7 @@
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
-        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="giftMessageEntity">
                 <sequence>

--- a/app/code/core/Mage/GiftMessage/etc/wsi.xml
+++ b/app/code/core/Mage/GiftMessage/etc/wsi.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions xmlns:typens="urn:{{var wsdl.name}}"
+<wsdl:definitions xmlns:typens="urn:OpenMage"
              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
              xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
              xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-             name="{{var wsdl.name}}"
-             targetNamespace="urn:{{var wsdl.name}}">
+             name="OpenMage"
+             targetNamespace="urn:OpenMage">
     <wsdl:types>
-        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:{{var wsdl.name}}">
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <xsd:complexType name="giftMessageEntity">
                 <xsd:sequence>
                     <xsd:element name="from" type="xsd:string" minOccurs="0" />

--- a/app/code/core/Mage/Sales/etc/wsdl.xml
+++ b/app/code/core/Mage/Sales/etc/wsdl.xml
@@ -3,7 +3,7 @@
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
-        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="salesOrderEntity">
                 <all>

--- a/app/code/core/Mage/Sales/etc/wsdl.xml
+++ b/app/code/core/Mage/Sales/etc/wsdl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns:typens="urn:{{var wsdl.name}}" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+<definitions xmlns:typens="urn:OpenMage" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
-    name="{{var wsdl.name}}" targetNamespace="urn:{{var wsdl.name}}">
+    name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
@@ -1107,239 +1107,239 @@
         <operation name="salesOrderList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderAddComment">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderHold">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderUnhold">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderCancel">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderShipmentList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderShipmentInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderShipmentCreate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderShipmentAddComment">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderShipmentAddTrack">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderShipmentSendInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderShipmentRemoveTrack">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderShipmentGetCarriers">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderInvoiceList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderInvoiceInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderInvoiceCreate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderInvoiceAddComment">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderInvoiceCapture">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderInvoiceVoid">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderInvoiceCancel">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderCreditmemoList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderCreditmemoInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderCreditmemoCreate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderCreditmemoAddComment">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
         <operation name="salesOrderCreditmemoCancel">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
     </binding>
-    <service name="{{var wsdl.name}}Service">
+    <service name="OpenMageService">
         <port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}" />
         </port>

--- a/app/code/core/Mage/Sales/etc/wsi.xml
+++ b/app/code/core/Mage/Sales/etc/wsi.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions xmlns:typens="urn:{{var wsdl.name}}"
+<wsdl:definitions xmlns:typens="urn:OpenMage"
              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
              xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
              xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-             name="{{var wsdl.name}}"
-             targetNamespace="urn:{{var wsdl.name}}">
+             name="OpenMage"
+             targetNamespace="urn:OpenMage">
     <wsdl:types>
-        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:{{var wsdl.name}}">
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <xsd:complexType name="salesOrderEntity">
                 <xsd:sequence>
                     <xsd:element name="increment_id" type="xsd:string" minOccurs="0" />
@@ -1679,7 +1679,7 @@
             </wsdl:output>
         </wsdl:operation>
     </wsdl:binding>
-    <wsdl:service name="{{var wsdl.name}}Service">
+    <wsdl:service name="OpenMageService">
         <wsdl:port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}" />
         </wsdl:port>

--- a/app/code/core/Mage/Tag/etc/wsdl.xml
+++ b/app/code/core/Mage/Tag/etc/wsdl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns:typens="urn:{{var wsdl.name}}" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+<definitions xmlns:typens="urn:OpenMage" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
-    name="{{var wsdl.name}}" targetNamespace="urn:{{var wsdl.name}}">
+    name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
@@ -125,10 +125,10 @@
         <operation name="catalogProductTagList">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
     </binding>
@@ -137,10 +137,10 @@
         <operation name="catalogProductTagInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
     </binding>
@@ -149,10 +149,10 @@
         <operation name="catalogProductTagAdd">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
     </binding>
@@ -161,10 +161,10 @@
         <operation name="catalogProductTagUpdate">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
     </binding>
@@ -173,15 +173,15 @@
         <operation name="catalogProductTagRemove">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </input>
             <output>
-                <soap:body namespace="urn:{{var wsdl.name}}" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+                <soap:body namespace="urn:OpenMage" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
     </binding>
 
-    <service name="{{var wsdl.name}}Service">
+    <service name="OpenMageService">
         <port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}" />
         </port>

--- a/app/code/core/Mage/Tag/etc/wsdl.xml
+++ b/app/code/core/Mage/Tag/etc/wsdl.xml
@@ -3,7 +3,7 @@
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
-        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="catalogProductTagListEntity">
                 <all>

--- a/app/code/core/Mage/Tag/etc/wsi.xml
+++ b/app/code/core/Mage/Tag/etc/wsi.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions xmlns:typens="urn:{{var wsdl.name}}"
+<wsdl:definitions xmlns:typens="urn:OpenMage"
              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
              xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
              xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-             name="{{var wsdl.name}}"
-             targetNamespace="urn:{{var wsdl.name}}">
+             name="OpenMage"
+             targetNamespace="urn:OpenMage">
 
     <wsdl:types>
-        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:{{var wsdl.name}}">
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <xsd:complexType name="catalogProductTagListEntity">
                 <xsd:sequence>
                     <xsd:element name="tag_id" type="xsd:string" minOccurs="1" maxOccurs="1" />
@@ -254,7 +254,7 @@
         </wsdl:operation>
     </wsdl:binding>
 
-    <wsdl:service name="{{var wsdl.name}}Service">
+    <wsdl:service name="OpenMageService">
         <wsdl:port name="{{var wsdl.handler}}Port" binding="typens:{{var wsdl.handler}}Binding">
             <soap:address location="{{var wsdl.url}}" />
         </wsdl:port>


### PR DESCRIPTION
We're trying to introduce XML validation as a github workflow, the commonly used technique is running xmllit with something like:

`find . -type f -iname '*.xml' | xargs -I '{}' xmllint --noout '{}'`

problem is, xmllint is broken because our XMLs have a "name" variable in some places.

Since that variable was always replaced with "Magento" I figured to:
- change the Magento name in OpenMage
- hardcode the OpenMage name in the XMLs so that xmllint works without problems

### Fixed Issues (if relevant)
This PR is part of the fix for https://github.com/OpenMage/magento-lts/issues/1918

### Manual testing scenarios (*)

You've the command line in the task description.
Also check that APIs work.