### PR TITLE
Fix store id filter in `catalogProductList` SOAP method

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Api.php
@@ -90,7 +90,7 @@ class Mage_Catalog_Model_Product_Api extends Mage_Catalog_Model_Api_Resource
     public function items($filters = null, $store = null)
     {
         $collection = Mage::getModel('catalog/product')->getCollection()
-            ->addStoreFilter($this->_getStoreId($store))
+            ->setStoreId($this->_getStoreId($store))
             ->addAttributeToSelect('name');
 
         $apiHelper = Mage::helper('api');


### PR DESCRIPTION
### Description (*)
`_applyProductLimitations` (called by `addStoreFilter`) in product collection does not apply `store_id` filter if `category_id` and `visibility` filters are not set, so changing it with `setStoreId` which works fine and is also used in REST Api.

https://github.com/OpenMage/magento-lts/blob/27407244502611a467627fdd8271e31dc1e56c7b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php#L1848-L1852

### Fixed Issues (if relevant)

1. Fixes OpenMage/magento-lts#1576

### Manual testing scenarios (*)
You can use the following snippet assuming product name is different from the one in default store:
```php
$client = new SoapClient('http://<magentohost>/index.php/api/v2_soap/?wsdl');
$session = $client->login('<username>', '<password>');

$product = $client->catalogProductList($session, [
    'complex_filter' => [
        [
            'key' => 'entity_id', 
            'value' => ['key' => 'in', 'value' => '<product_id>']
        ]
    ]
], <store_id>);
echo $product[0]->name . PHP_EOL;
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->