### PR TITLE
Fix for "reset filter" breaking grid sorting

### DIFF
--- a/js/mage/adminhtml/grid.js
+++ b/js/mage/adminhtml/grid.js
@@ -296,8 +296,6 @@ varienGrid.prototype = {
         }
     },
     resetFilter : function(){
-        this.addVarToUrl(this.sortVar, '');
-        this.addVarToUrl(this.dirVar, '');
         this.addVarToUrl(this.pageVar, 1);
         this.reload(this.addVarToUrl(this.filterVar, ''));
     },


### PR DESCRIPTION
Pressing "reset filters" on a backend grid also loses the sorting, this PR fixes is so that pressing "reset filters" resets all filters but keeps the sorting (both field and direction).

### Manual testing scenarios (*)

Go to product grid, search for something, reset filters and note that the sorting is no longer there.