### PR TITLE
Revert "Some more room for the category menu"

### DIFF
--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -578,9 +578,10 @@ td.divider              { font-size:1px; line-height:0; }
 .middle { min-height:450px; background:url(images/simple_container_bg.gif) repeat-x #fff; padding:23px 27px 0 27px; }
 .middle-popup { border-bottom:3px solid #fff; background:url(images/middle_bg.gif) repeat-x 0 100% #fff; padding:0 0 0 0; background:yellow; }
 .container-collapsed { padding:1.8em 2.2em 1.8em 2em; padding-top:0; }
+.columns {background:url(images/side_col_bg.gif) repeat-y 217px 0; }
 
-div.side-col { float:left; width:280px; margin-right:-280px; padding-bottom:25px; }
-div.main-col { margin-left:280px; min-height:450px; padding:0 0 25px 25px; border-left: 2px solid #dedede; }
+div.side-col { float:left; width:220px; margin-right:-220px; padding-bottom:25px; }
+div.main-col { margin-left:220px; min-height:450px; padding:0 0 25px 25px; }
 div.main-col-inner { float:left; /* Fixes some inner clears in the liquid main-col */ width:100%; }
 
 .footer { clear:both; background:url(images/footer_bg.gif) repeat-x #e6e6e6; padding:105px 2.8em 2.8em 2.8em; font-size:.95em; text-align:center; }


### PR DESCRIPTION
Reverts OpenMage/magento-lts#1314.

PR initially solved a reported issue, namely the too small container width for the category tree. Unfortunately, it generated a new issue, increasing the width of the tabs on the left. The change was not complicated at all but in a new PR it must be done better. It was discussed  here #2251 too. I am sorry I approved that PR without testing it in more detail.