### PR TITLE
Fixed documentation link for "store scope" in store switcher (backend)

### DIFF
--- a/app/code/core/Mage/Adminhtml/etc/config.xml
+++ b/app/code/core/Mage/Adminhtml/etc/config.xml
@@ -226,7 +226,7 @@
         </general>
         <hints>
             <store_switcher>
-                <url><![CDATA[http://merch.docs.magento.com/ce/user_guide/configuration/scope.html]]></url>
+                <url><![CDATA[https://web.archive.org/web/20170529192915/http://docs.magento.com/m1/ce/user_guide/configuration/scope.html]]></url>
                 <enabled>1</enabled>
             </store_switcher>
         </hints>


### PR DESCRIPTION
Everything is explained in ISSUE https://github.com/OpenMage/magento-lts/issues/2255, this PR only fixes the URL of the documentation that got broken during the years