### PR TITLE
Flush Magento Cache - button and message changes

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Cache.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cache.php
@@ -36,7 +36,7 @@ class Mage_Adminhtml_Block_Cache extends Mage_Adminhtml_Block_Widget_Grid_Contai
         parent::__construct();
         $this->_removeButton('add');
         $this->_addButton('flush_magento', array(
-            'label'     => Mage::helper('core')->__('Flush Magento Cache'),
+            'label'     => Mage::helper('core')->__('Flush OpenMage Cache'),
             'onclick'   => 'setLocation(\'' . $this->getFlushSystemUrl() .'\')',
             'class'     => 'delete',
         ));

--- a/app/code/core/Mage/Adminhtml/controllers/CacheController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/CacheController.php
@@ -66,7 +66,7 @@ class Mage_Adminhtml_CacheController extends Mage_Adminhtml_Controller_Action
     {
         Mage::app()->cleanCache();
         Mage::dispatchEvent('adminhtml_cache_flush_system');
-        $this->_getSession()->addSuccess(Mage::helper('adminhtml')->__("The Magento cache storage has been flushed."));
+        $this->_getSession()->addSuccess(Mage::helper('adminhtml')->__("The OpenMage cache storage has been flushed."));
         $this->_redirect('*/*');
     }
 

--- a/app/locale/en_US/Mage_Adminhtml.csv
+++ b/app/locale/en_US/Mage_Adminhtml.csv
@@ -1022,7 +1022,7 @@
 "The Layered Navigation indexing queue has been canceled.","The Layered Navigation indexing queue has been canceled."
 "The Layered Navigation indices were refreshed.","The Layered Navigation indices were refreshed."
 "The Layered Navigation process has been queued to be killed.","The Layered Navigation process has been queued to be killed."
-"The Magento cache storage has been flushed.","The Magento cache storage has been flushed."
+"The OpenMage cache storage has been flushed.","The OpenMage cache storage has been flushed."
 "The Special Price is active only when lower than the Actual Price.","The Special Price is active only when lower than the Actual Price."
 "The URL Rewrite has been deleted.","The URL Rewrite has been deleted."
 "The URL Rewrite has been saved.","The URL Rewrite has been saved."

--- a/app/locale/en_US/Mage_Core.csv
+++ b/app/locale/en_US/Mage_Core.csv
@@ -145,7 +145,7 @@
 "File with an extension ""%value%"" is protected and cannot be uploaded","File with an extension ""%value%"" is protected and cannot be uploaded"
 "First Day of Week","First Day of Week"
 "Flush Cache Storage","Flush Cache Storage"
-"Flush Magento Cache","Flush Magento Cache"
+"Flush OpenMage Cache","Flush OpenMage Cache"
 "Footer","Footer"
 "Forgot Password Email Sender","Forgot Password Email Sender"
 "Forgot Password Email Template","Forgot Password Email Template"


### PR DESCRIPTION
This PR replaces Magento word with OpenMage for [Flush Magento Cache] actions in Backend > System > Cache Management. 

Here is the result:

![flush_cache](https://user-images.githubusercontent.com/8360474/176286280-3dd18c85-acd7-44c2-a1f4-aee97779326c.jpg)

PS - I know that some will say that it is better to make the change only in the translation file. This time let's do it as it should by modifying the PHP files.