### PR TITLE
Addendum to PR 2087

### DIFF
--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -62,19 +62,19 @@
                     </fields>
                 </csrf>
                 <cache>
-                    <label>Advanced Magento cache settings</label>
-                    <sort_order>10000</sort_order>
+                    <label>Advanced Cache Settings</label>
+                    <sort_order>1000</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
                     <show_in_store>0</show_in_store>
                     <fields>
                         <flush_cron_expr>
-                            <label>Cron expression for regular cache flushing</label>
+                            <label>Cron Expression for Flushing Cache</label>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
-                            <comment>Use 0 0 30 2 0 to never run cron, the recommended setting is 30 3 * * 6</comment>
+                            <comment>Valid format: minute hour day(month) month day(week). Recommended value is 30 3 * * 6. Never run value is 0 0 30 2 0.</comment>
                         </flush_cron_expr>
                     </fields>
                 </cache>

--- a/app/locale/en_US/Mage_Core.csv
+++ b/app/locale/en_US/Mage_Core.csv
@@ -14,6 +14,7 @@
 "Admin User Emails","Admin User Emails"
 "Admin routing compatibility mode for extensions","Admin routing compatibility mode for extensions"
 "Advanced","Advanced"
+"Advanced Cache Settings","Advanced Cache Settings"
 "After selecting a new media storage location, press the Synchronize button
                                 to transfer all media to that location. Media will not be available in the new
                                 location until the synchronization process is complete.","After selecting a new media storage location, press the Synchronize button
@@ -73,6 +74,7 @@
 "Create Store View","Create Store View"
 "Create Website","Create Website"
 "Credit card number does not match credit card type.","Credit card number does not match credit card type."
+"Cron Expression for Flushing Cache","Cron Expression for Flushing Cache"
 "Current Package Name","Current Package Name"
 "Custom Admin Path","Custom Admin Path"
 "Custom Admin URL","Custom Admin URL"


### PR DESCRIPTION
@luigifab made a few remarks here https://github.com/OpenMage/magento-lts/pull/2087#pullrequestreview-979979388 after PR #2087 was merged.  I also requested a few small changes but which did not happen.

This PR adds the missing translation strings, removes word Magento, changes the label format with capitalize letters as it is throughout the Backend. It also adds a more explicit comment for novices. This comment does not need to be in the translation file as most comments are not found in the translation files. I did not find this an issue as long as the interface I use is in English, but I did not check if these comments when I change the language remain in English or not. Anyway, this is the subject of a separate discussion.

As an observation, the value for never run (0 0 30 2 0) is for February 30, a day that does not exist in calendar. I mentioned this in case anyone wonders why if it was not better to leave the input box empty. if it is empty the default value will be taken.

This is how the Backend implementation looks like if this PR is merged:

![advanced_cache](https://user-images.githubusercontent.com/8360474/176303827-23fad7a5-ba63-4cc7-924c-d7f8672cac94.jpg)