### PR TITLE
Backend grid heads - Remove colons after To, From and In words

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Date.php
@@ -50,7 +50,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Date
         $htmlId = $this->_getHtmlId() . microtime(true);
         $format = $this->getLocale()->getDateStrFormat(Mage_Core_Model_Locale::FORMAT_TYPE_SHORT);
         $html = '<div class="range"><div class="range-line date">'
-            . '<span class="label">' . Mage::helper('adminhtml')->__('From').':</span>'
+            . '<span class="label">' . Mage::helper('adminhtml')->__('From').'</span>'
             . '<input type="text" name="'.$this->_getHtmlName().'[from]" id="'.$htmlId.'_from"'
                 . ' value="'.$this->getEscapedValue('from').'" class="input-text no-changes"/>'
             . '<img src="' . Mage::getDesign()->getSkinUrl('images/grid-cal.gif') . '" alt="" class="v-middle"'
@@ -58,7 +58,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Date
                 . ' title="' . $this->escapeHtml(Mage::helper('adminhtml')->__('Date selector')) . '"/>'
             . '</div>';
         $html.= '<div class="range-line date">'
-            . '<span class="label">' . Mage::helper('adminhtml')->__('To').' :</span>'
+            . '<span class="label">' . Mage::helper('adminhtml')->__('To').'</span>'
             . '<input type="text" name="'.$this->_getHtmlName().'[to]" id="'.$htmlId.'_to"'
                 . ' value="'.$this->getEscapedValue('to').'" class="input-text no-changes"/>'
             . '<img src="' . Mage::getDesign()->getSkinUrl('images/grid-cal.gif') . '" alt="" class="v-middle"'

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
@@ -116,7 +116,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Datetime
         }
 
         $html = '<div class="range"><div class="range-line date">'
-            . '<span class="label">' . Mage::helper('adminhtml')->__('From').':</span>'
+            . '<span class="label">' . Mage::helper('adminhtml')->__('From').'</span>'
             . '<input type="text" name="'.$this->_getHtmlName().'[from]" id="'.$htmlId.'_from"'
                 . ' value="'.$this->getEscapedValue('from').'" class="input-text no-changes"/>'
             . '<img src="' . Mage::getDesign()->getSkinUrl('images/grid-cal.gif') . '" alt="" class="v-middle"'
@@ -124,7 +124,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Datetime
                 . ' title="'.$this->escapeHtml(Mage::helper('adminhtml')->__('Date selector')).'"/>'
             . '</div>';
         $html.= '<div class="range-line date">'
-            . '<span class="label">' . Mage::helper('adminhtml')->__('To').' :</span>'
+            . '<span class="label">' . Mage::helper('adminhtml')->__('To').'</span>'
             . '<input type="text" name="'.$this->_getHtmlName().'[to]" id="'.$htmlId.'_to"'
                 . ' value="'.$this->getEscapedValue('to').'" class="input-text no-changes"/>'
             . '<img src="' . Mage::getDesign()->getSkinUrl('images/grid-cal.gif') . '" alt="" class="v-middle"'

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Price.php
@@ -40,10 +40,10 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Price
     public function getHtml()
     {
         $html  = '<div class="range">';
-        $html .= '<div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('From').':</span> <input type="text" name="'.$this->_getHtmlName().'[from]" id="'.$this->_getHtmlId().'_from" value="'.$this->getEscapedValue('from').'" class="input-text no-changes"/></div>';
-        $html .= '<div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('To').': </span><input type="text" name="'.$this->_getHtmlName().'[to]" id="'.$this->_getHtmlId().'_to" value="'.$this->getEscapedValue('to').'" class="input-text no-changes"/></div>';
+        $html .= '<div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('From').'</span> <input type="text" name="'.$this->_getHtmlName().'[from]" id="'.$this->_getHtmlId().'_from" value="'.$this->getEscapedValue('from').'" class="input-text no-changes"/></div>';
+        $html .= '<div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('To').'</span><input type="text" name="'.$this->_getHtmlName().'[to]" id="'.$this->_getHtmlId().'_to" value="'.$this->getEscapedValue('to').'" class="input-text no-changes"/></div>';
         if ($this->getDisplayCurrencySelect())
-            $html .= '<div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('In').': </span>' . $this->_getCurrencySelectHtml() . '</div>';
+            $html .= '<div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('In').'</span>' . $this->_getCurrencySelectHtml() . '</div>';
         $html .= '</div>';
 
         return $html;

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
@@ -35,8 +35,8 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Range extends Mage_Adminhtm
 {
     public function getHtml()
     {
-        $html = '<div class="range"><div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('From').':</span> <input type="text" name="'.$this->_getHtmlName().'[from]" id="'.$this->_getHtmlId().'_from" value="'.$this->getEscapedValue('from').'" class="input-text no-changes"/></div>';
-        $html .= '<div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('To').': </span><input type="text" name="'.$this->_getHtmlName().'[to]" id="'.$this->_getHtmlId().'_to" value="'.$this->getEscapedValue('to').'" class="input-text no-changes"/></div></div>';
+        $html = '<div class="range"><div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('From').'</span> <input type="text" name="'.$this->_getHtmlName().'[from]" id="'.$this->_getHtmlId().'_from" value="'.$this->getEscapedValue('from').'" class="input-text no-changes"/></div>';
+        $html .= '<div class="range-line"><span class="label">' . Mage::helper('adminhtml')->__('To').'</span><input type="text" name="'.$this->_getHtmlName().'[to]" id="'.$this->_getHtmlId().'_to" value="'.$this->getEscapedValue('to').'" class="input-text no-changes"/></div></div>';
         return $html;
     }
 


### PR DESCRIPTION
This first PR removes colons that are after the words **From**, **To** and **In** in Backend grid heads to achieve a little more width space and a better visual improvement. 

In the next PR (it is ready but I am still testing) in the case of columns with date range the calendar button will be moved to the right. 

Both PR's will solve the issues reported here https://github.com/OpenMage/magento-lts/issues/2198 and https://github.com/OpenMage/magento-lts/issues/2239.

**Here is before:**

![before](https://user-images.githubusercontent.com/8360474/176717241-f7b540e7-058c-4b07-9989-64ec6d752fbd.png)

**Here is after:**

![after](https://user-images.githubusercontent.com/8360474/176717270-2c5c18c7-3971-4052-9a84-577e64a115d6.png)



**When both PR's will be merged this is the final result:**

![after](https://user-images.githubusercontent.com/8360474/172199723-fab41c0f-8361-4b0d-ba2b-aeb2788aba10.png)