### PR TITLE
All .gitignore files in one place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,30 @@
 /app/etc/local.xml
-/media/catalog
-/media/captcha
-/media/css
-/media/css_secure
-/media/email/logo
-/media/favicon
-/media/js
-/media/sales/store/logo
-/media/sales/store/logo_html
-/media/wysiwyg
+
+# Add a base setup for running unit Tests with code coverage and send them to SonarCloud
+# https://github.com/OpenMage/magento-lts/pull/1836
+/dev/testfield
+/dev/tests/clover.xml
+/dev/tests/crap4j.xml
+/dev/tests/junit.xml
+
+# Add Gitpod online IDE config
+# https://github.com/OpenMage/magento-lts/pull/1836
+/dev/gitpod/docker-magento
+/dev/gitpod/.env
+
+# Add development environment setup files and README
+# https://github.com/OpenMage/magento-lts/pull/1012
+/dev/openmage/docker-magento
+/dev/openmage/.env
 /dev/tests/functional/generated
 /dev/tests/functional/vendor
+
+/media/*
+!/media/.htaccess
+!/media/custom_options/.htaccess
+!/media/customer/.htaccess
+!/media/dhl/logo.jpg
+!/media/downloadable/.htaccess
+
+/var/*
+!/var/.htaccess

--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -1,4 +1,0 @@
-/testfield
-/tests/clover.xml
-/tests/crap4j.xml
-/tests/junit.xml

--- a/dev/gitpod/.gitignore
+++ b/dev/gitpod/.gitignore
@@ -1,2 +1,0 @@
-docker-magento/
-.env

--- a/dev/openmage/.gitignore
+++ b/dev/openmage/.gitignore
@@ -1,2 +1,0 @@
-docker-magento/
-.env

--- a/var/.gitignore
+++ b/var/.gitignore
@@ -1,6 +1,0 @@
-*
-.*
-!package
-!package/*
-!.htaccess
-!.gitignore


### PR DESCRIPTION
This PR aims to bring all .gitignore files in one place, in the OpenMage root directory. This allows us faster and better control what is ignored and what is not by Git. 

I have accompanied with explanations certain sections for those who want to know more about those changes in /dev directory. Also, I made updates for the /media and /var directories.

I took into account the following:

- the template provided by GitHub when you create a new Magento based repository

- the content of the /media directory shipped with OpenMage and when it is in production with all modules in use.