### PR TITLE
Update robots.txt.sample

### DIFF
--- a/robots.txt.sample
+++ b/robots.txt.sample
@@ -1,8 +1,8 @@
 ############################################
-## For more information about the robots.txt standard, see:
+## For more information about the robots.txt standard visit:
 ## http://www.robotstxt.org/orig.html
 ##
-## For syntax checking, see:
+## For syntax checking visit:
 ## http://tool.motoricerca.info/robots-checker.phtml
 
 ############################################
@@ -15,8 +15,14 @@
 
 User-agent: *
 
+## How many seconds a crawler should wait before loading and crawling page content
+## Set a custom crawl rate if you are experiencing traffic issues with your server
+
+Crawl-delay: 60
+
 ############################################
 ## Allow to crawl paging (paging inside a listing with more params are disallowed below)
+
 Allow: /*?p=
 
 ############################################
@@ -27,7 +33,11 @@ Disallow: */catalog/product_compare/
 Disallow: */catalog/category/view/
 Disallow: */catalog/product/view/
 Disallow: */catalog/product/gallery/
-Disallow: */catalogsearch/
+Disallow: */catalogsearch/advanced
+Disallow: */catalogsearch/result
+Disallow: */catalogsearch/seo_sitemap
+Disallow: */catalogsearch/term/popular
+Disallow: */checkout/
 Disallow: */control/
 Disallow: */contacts/
 Disallow: */customer/
@@ -35,6 +45,7 @@ Disallow: */customize/
 Disallow: */newsletter/
 Disallow: */poll/
 Disallow: */review/
+Disallow: */sales/
 Disallow: */sendfriend/
 Disallow: */tag/
 Disallow: */wishlist/
@@ -59,3 +70,16 @@ Disallow: /*?q=*
 Disallow: /*?p=*&
 Disallow: /*.php$
 Disallow: /*?SID=
+
+############################################
+## Do not allow media indexing for the following bots
+# User-agent: baiduspider-image
+# Disallow: /
+# User-agent: baiduspider-video
+# Disallow: /
+# User-agent: msnbot-media
+# Disallow: /
+# User-agent: Googlebot-Image
+# Disallow: /
+# User-agent: Googlebot-Video
+# Disallow: /


### PR DESCRIPTION
This is an update to the robots.txt.sample file that was recently added to OpenMage (PR #1024). 

A short brief of the changes:

- added the Crawl-delay option for the situation in which a good crawler could create traffic issues.
- added a few URL paths that I found in frontend pages such as checkout, sales
- added the option to disallow indexing the media for known bots

The file can be used in production without any issues. Both the initial version and this updated version have been tested by me for a long time. You have to take in consideration that only a good bot will take this file into account. For bad bots, those which skip the robots.txt file content and crawling everything, I will post a new PR these days.