### PR TITLE
Fix editing special price in product mass attribute update

### DIFF
--- a/js/prototype/validation.js
+++ b/js/prototype/validation.js
@@ -682,6 +682,7 @@ Validation.addAllThese([
         // Passed on non-related validators conditions (to not change order of validation)
         if(
             !priceInput
+            || !$F(priceInput)
             || Validation.get('IsEmpty').test(v)
             || !Validation.get('validate-number').test(v)
         ) {


### PR DESCRIPTION
Everything is explained in https://github.com/OpenMage/magento-lts/issues/2286

This PR modified the "special-price-validation" checking that the "original price" input has a value (before it would only check that the original price existed).