### PR TITLE
Update php.ini.sample

### DIFF
--- a/php.ini.sample
+++ b/php.ini.sample
@@ -1,38 +1,31 @@
-; This file is for CGI/FastCGI installations.
-; Try copying it to php5.ini, if it doesn't work
+; This file is for CGI/FastCGI installations
+; Try copying it to php7.ini or php8 if it doesn't work
 
-; adjust memory limit
+; Adjust memory limit
 
 memory_limit = 64M
-
 max_execution_time = 18000
 
-; disable magic quotes for php request vars
+; Disable magic quotes for PHP request vars
 
 magic_quotes_gpc = off
 
-; disable automatic session start
-; before autoload was initialized
+; Disable automatic session start before autoload was initialized
 
 flag session.auto_start = off
 
-; enable resulting html compression
+; Enable resulting html compression
 
 zlib.output_compression = on
 
-; disable user agent verification to not break multiple image upload
+; Disable user agent verification to not break multiple image upload
 
 suhosin.session.cryptua = off
 
-; turn off compatibility with PHP4 when dealing with objects
-    
-zend.ze1_compatibility_mode = off
-
-; PHP for some reason ignores this setting in system php.ini 
-; and disables mcrypt if this line is missing in local php.ini
+; If this line is missing in local php.ini for some reason PHP ignores this setting in system php.ini and disables mcrypt 
 
 extension=mcrypt.so
 
-; Disable PHP errors, notices and warnings output in production mode to prevent exposing sensitive information.
+; Disable PHP errors, notices and warnings output in production mode to prevent exposing sensitive information
 
 display_errors = Off


### PR DESCRIPTION
This PR updates php.ini.sample file content located in root.

By its content it appears as a suggestion from the time when PHP was at version 5. For this reason I removed the line regarding compatibility with version 4. I did not analyze this file, but if it is no longer updated for long time it can be deleted like many other "legacies" of the Magento.
