### PR TITLE
Add `magento-composer-installer` to allowed plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,5 +48,10 @@
       "dev-main": "1.9.4.x-dev"
     },
     "magento-root-dir": "root"
+  },
+  "config": {
+    "allow-plugins": {
+      "magento-hackathon/magento-composer-installer": true
+    }
   }
 }


### PR DESCRIPTION
### Description (*)
A recent change in Composer regarding the `allow-plugins` config been causing the Sonar workflow to fail with error message: 
```
magento-hackathon/magento-composer-installer contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
```

This PR will add `magento-hackathon/magento-composer-installer` to allowed plugins in `composer.json`.

### Manual testing scenarios (*)
1. All tests should now pass, hopefully.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
