### PR TITLE
Create .htaccess file in js directory (OM-20 only)

### DIFF
--- a/js/.htaccess
+++ b/js/.htaccess
@@ -1,0 +1,16 @@
+############################################
+## Disable PHP code execution
+
+<IfModule mod_php7.c>
+    php_flag engine 0
+</IfModule>
+
+<IfModule mod_php8.c>
+    php_flag engine 0 
+</IfModule>
+
+############################################
+## Don't permit execution of CGI scripts
+
+    AddHandler cgi-script .php .pl .py .jsp .asp .sh .cgi
+    Options -ExecCGI


### PR DESCRIPTION
This PR creates missing .htaccess file in /js directory. Its content doesn't permit executing PHP and CGI scripts like in /js.

In OM-19 in /js directory is still executed index.php file. Because this file was removed from OM-20 the change is only available in in this version. 

