### PR TITLE
Include exception message when generating error report

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -982,7 +982,7 @@ final class Mage
         } else {
 
             $reportData = array(
-                !empty($extra) ? $extra . "\n\n" : '' . $e->getMessage(),
+                (!empty($extra) ? $extra . "\n\n" : '') . $e->getMessage(),
                 $e->getTraceAsString()
             );
 


### PR DESCRIPTION
### Description (*)
Magento provides the ability to print exceptions by using `Mage#printException` method, which prints the exception message, the stacktrace, and any extra data provided. If Developer Mode is not active however, this information is not printed and is saved in error report files (in `var/report` dir). These error reports did not include the exception message if any extra data is provided, leaving out an important puzzle piece to debugging the issue.

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#2279

### Manual testing scenarios (*)
1. Make sure Developer Mode is disabled and purposefully trigger an exception (example in linked issue).
2. The error report should include enough information to debug the issue, including the exception message.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 