### PR TITLE
Order add comment functionality in REST API

### DIFF
--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest.php
@@ -37,6 +37,7 @@ abstract class Mage_Sales_Model_Api2_Order_Comment_Rest extends Mage_Sales_Model
      * Parameters in request used in model (usually specified in route mask)
      */
     const PARAM_ORDER_ID = 'id';
+    const PARAM_COMMENT_ID = 'comment_id';
     /**#@-*/
 
     /**

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Admin/V1.php
@@ -33,4 +33,21 @@
  */
 class Mage_Sales_Model_Api2_Order_Comment_Rest_Admin_V1 extends Mage_Sales_Model_Api2_Order_Comment_Rest
 {
+    /**
+     * Retrieve order comment by id
+     * 
+     * @return array
+     */
+    protected function _retrieve()
+    {
+        $comment = Mage::getModel('sales/order_status_history')->load(
+            $this->getRequest()->getParam(self::PARAM_COMMENT_ID)
+        );
+
+        if (!$comment->getId()) {
+            $this->_critical(self::RESOURCE_NOT_FOUND);
+        }
+
+        return $comment->getData();
+    }
 }

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Admin/V1.php
@@ -34,6 +34,52 @@
 class Mage_Sales_Model_Api2_Order_Comment_Rest_Admin_V1 extends Mage_Sales_Model_Api2_Order_Comment_Rest
 {
     /**
+     * Add comment to order
+     * 
+     * @param array $data
+     * @return string
+     */
+    protected function _create(array $data)
+    {
+        $orderId = $this->getRequest()->getParam(self::PARAM_ORDER_ID);
+        $order   = $this->_loadOrderById($orderId);
+
+        $status         = $data['status'] ?? false;
+        $comment        = $data['comment'] ?? '';
+        $visibleOnFront = $data['is_visible_on_front'] ?? 0;
+        $notifyCustomer = array_key_exists('is_customer_notified', $data) ? $data['is_customer_notified'] : false;
+
+        $historyItem = $order->addStatusHistoryComment($comment, $status);
+        $historyItem->setIsCustomerNotified($notifyCustomer)
+            ->setIsVisibleOnFront((int) $visibleOnFront)
+            ->save();
+
+        try {
+            if ($notifyCustomer && $comment) {
+                $oldStore = Mage::getDesign()->getStore();
+                $oldArea = Mage::getDesign()->getArea();
+                Mage::getDesign()->setStore($order->getStoreId());
+                Mage::getDesign()->setArea('frontend');
+            }
+
+            $order->save();
+            $order->sendOrderUpdateEmail((bool) $notifyCustomer, $comment);
+
+            if ($notifyCustomer && $comment) {
+                Mage::getDesign()->setStore($oldStore);
+                Mage::getDesign()->setArea($oldArea);
+            }
+        } catch (Mage_Core_Exception $e) {
+            $this->_critical($e->getMessage(), self::RESOURCE_INTERNAL_ERROR);
+        } catch (Throwable $t) {
+            Mage::logException($t);
+            $this->_critical($t->getMessage(), self::RESOURCE_UNKNOWN_ERROR);
+        }
+
+        return $this->_getLocation($historyItem);
+    }
+
+    /**
      * Retrieve order comment by id
      * 
      * @return array

--- a/app/code/core/Mage/Sales/etc/api2.xml
+++ b/app/code/core/Mage/Sales/etc/api2.xml
@@ -328,6 +328,10 @@
                     </customer>
                 </force_attributes>
                 <routes>
+                    <route_entity>
+                        <route>/orders/comments/:comment_id</route>
+                        <action_type>entity</action_type>
+                    </route_entity>
                     <route_collection>
                         <route>/orders/:id/comments</route>
                         <action_type>collection</action_type>

--- a/app/code/core/Mage/Sales/etc/api2.xml
+++ b/app/code/core/Mage/Sales/etc/api2.xml
@@ -308,6 +308,7 @@
                 <title>Order Comments</title>
                 <privileges>
                     <admin>
+                        <create>1</create>
                         <retrieve>1</retrieve>
                     </admin>
                     <customer>


### PR DESCRIPTION
### Description (*)
This is the first out of many coming PRs where I will be adding some missing endpoints to the REST Api, this one will add the functionality for adding and retrieving order comments as an authenticated Admin user, as well as the ACL permissions.

I chose to target the `20.0` branch with these new features, but It's subject to change if there's demand. For people interested that can't use `v20` yet, I made an [extension](https://github.com/elidrissidev/magento-restextended) where I'll be porting the same changes for use with `v19` (we'll be using it in production in the next few weeks).

### Manual testing scenarios (*)
After applying this patch, you should be able to perform the following actions as Admin user:
- Retrieve a single comment: `GET /api/rest/orders/comments/<comment_id>`
- Add comment to an order (although all the fields in the body are optional, you can't omit all of them):
```
POST /api/rest/orders/<order_id>/comments HTTP/1.1
Host: <magento_host>
Accept: application/json
Content-Type: application/json
Authorization: ...

{
    "status": "pending", // defaults to false (current order status)
    "comment": "Test adding comment from REST API", // optional, defaults to an empty string
    "is_customer_notified": 0, // defaults to false (use null for non-applicable notification)
    "is_visible_on_front": 0 // defaults to 0
}
```

### Questions or comments
Testing is encouraged for people using OAuth as I didn't test with it.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list