### PR TITLE
Fix "Variable might not be defined" PHPStan error

### DIFF
--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Admin/V1.php
@@ -55,9 +55,10 @@ class Mage_Sales_Model_Api2_Order_Comment_Rest_Admin_V1 extends Mage_Sales_Model
             ->save();
 
         try {
+            $oldStore = Mage::getDesign()->getStore();
+            $oldArea = Mage::getDesign()->getArea();
+
             if ($notifyCustomer && $comment) {
-                $oldStore = Mage::getDesign()->getStore();
-                $oldArea = Mage::getDesign()->getArea();
                 Mage::getDesign()->setStore($order->getStoreId());
                 Mage::getDesign()->setArea('frontend');
             }


### PR DESCRIPTION
### Description (*)
This PHPStan error originated from my last PR but it didn't show up because the composer error made the workflow not run fully.

### Related Pull Requests
1. See OpenMage/magento-lts#2315

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list