### PR TITLE
Fixes a notice

### DIFF
--- a/app/code/core/Mage/Checkout/Model/Type/Onepage.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Onepage.php
@@ -730,7 +730,7 @@ class Mage_Checkout_Model_Type_Onepage
 
         Mage::helper('core')->copyFieldset('checkout_onepage_quote', 'to_customer', $quote, $customer);
         $customer->setPassword($customer->decryptPassword($quote->getPasswordHash()));
-        $passwordCreatedTime = $this->_checkoutSession->getData('_session_validator_data')['session_expire_timestamp']
+        $passwordCreatedTime = $_SESSION[Mage_Core_Model_Session_Abstract_Varien::VALIDATOR_KEY]['session_expire_timestamp']
             - Mage::getSingleton('core/cookie')->getLifetime();
         $customer->setPasswordCreatedAt($passwordCreatedTime);
         $quote->setCustomer($customer)

--- a/app/code/core/Mage/Checkout/Model/Type/Onepage.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Onepage.php
@@ -730,7 +730,7 @@ class Mage_Checkout_Model_Type_Onepage
 
         Mage::helper('core')->copyFieldset('checkout_onepage_quote', 'to_customer', $quote, $customer);
         $customer->setPassword($customer->decryptPassword($quote->getPasswordHash()));
-        $passwordCreatedTime = $_SESSION[Mage_Core_Model_Session_Abstract_Varien::VALIDATOR_KEY]['session_expire_timestamp']
+        $passwordCreatedTime = $this->_checkoutSession->getValidatorResult()['session_expire_timestamp']
             - Mage::getSingleton('core/cookie')->getLifetime();
         $customer->setPasswordCreatedAt($passwordCreatedTime);
         $quote->setCustomer($customer)

--- a/app/code/core/Mage/Checkout/Model/Type/Onepage.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Onepage.php
@@ -730,7 +730,7 @@ class Mage_Checkout_Model_Type_Onepage
 
         Mage::helper('core')->copyFieldset('checkout_onepage_quote', 'to_customer', $quote, $customer);
         $customer->setPassword($customer->decryptPassword($quote->getPasswordHash()));
-        $passwordCreatedTime = $this->_checkoutSession->getValidatorResult()['session_expire_timestamp']
+        $passwordCreatedTime = $this->_checkoutSession->getSessionValidatorData()['session_expire_timestamp']
             - Mage::getSingleton('core/cookie')->getLifetime();
         $customer->setPasswordCreatedAt($passwordCreatedTime);
         $quote->setCustomer($customer)

--- a/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
@@ -570,6 +570,14 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
 
         return $parts;
     }
+    
+    /**
+     * @return array
+     */
+    public function getValidatorResult()
+    {
+        return $_SESSION[self::VALIDATOR_KEY];
+    }
 
     /**
      * Regenerate session Id

--- a/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
@@ -574,7 +574,7 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
     /**
      * @return array
      */
-    public function getValidatorResult()
+    public function getSessionValidatorData()
     {
         return $_SESSION[self::VALIDATOR_KEY];
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
After this commit https://github.com/OpenMage/magento-lts/commit/de06e671c09b375605a956e100911396822e276a the code in the checkout has not been updated to look for the session validation data in the new location. As such a PHP notice is generated.

This PR avoids the notice by updating the code to fetch the session validation data in the correct place.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
Fixes issue #2285 

### Manual testing scenarios (*)
* Set PHP to display notices
* Setup Mageto to allow checking out as a guest
* Go to the checkout and choose to checkout and register a new account
* Submit the order
* You should see a notice about an array key which is not set, which is the key of the missing session validation data
* After applying this PR, the same scenario should create an order and register the new customer without any notice.



### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->