### PR TITLE
Fix phpdoc for saveAttribute()

### DIFF
--- a/.github/phpstan-baseline.neon
+++ b/.github/phpstan-baseline.neon
@@ -7011,11 +7011,6 @@ parameters:
 			path: ../app/code/core/Mage/Sales/Model/Recurring/Profile.php
 
 		-
-			message: "#^Variable \\$attribute in empty\\(\\) always exists and is not falsy\\.$#"
-			count: 1
-			path: ../app/code/core/Mage/Sales/Model/Resource/Order/Abstract.php
-
-		-
 			message: "#^Cannot call method updateOnRelatedRecordChanged\\(\\) on Mage_Core_Model_Resource_Db_Collection_Abstract\\|false\\.$#"
 			count: 1
 			path: ../app/code/core/Mage/Sales/Model/Resource/Order/Address.php

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Abstract.php
@@ -323,7 +323,7 @@ abstract class Mage_Sales_Model_Resource_Order_Abstract extends Mage_Sales_Model
      * Perform actions after object save
      *
      * @param Mage_Core_Model_Abstract $object
-     * @param string $attribute
+     * @param string|string[]|Mage_Eav_Model_Entity_Attribute_Abstract $attribute
      * @return $this
      */
     public function saveAttribute(Mage_Core_Model_Abstract $object, $attribute)


### PR DESCRIPTION
### Description (*)
`saveAttribute()` in Mage_Sales_Model_Resource_Order_Abstract only specifies `string` as type for `$attribute`. As you can see a few lines later, it also takes string arrays.

```php
public function saveAttribute(Mage_Core_Model_Abstract $object, $attribute)
{
    if ($attribute instanceof Mage_Eav_Model_Entity_Attribute_Abstract) {
        $attribute = $attribute->getAttributeCode();
    }

    if (is_string($attribute)) {
        $attribute = array($attribute);
    }

    if (is_array($attribute) && !empty($attribute)) {                    // <-- see the is_array() here
        $this->beginTransaction();
```


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
