### PR TITLE
Allow custom acl path in adminhtml.xml by using <acl> tag

### DIFF
--- a/app/code/core/Mage/Admin/Model/Roles.php
+++ b/app/code/core/Mage/Admin/Model/Roles.php
@@ -152,7 +152,7 @@ class Mage_Admin_Model_Roles extends Mage_Core_Model_Abstract
             $level = -1;
         } else {
             $resourceName = $parentName;
-            if (!in_array($resource->getName(), array('title', 'sort_order', 'children', 'disabled'))) {
+            if (!in_array($resource->getName(), array('title', 'sort_order', 'children', 'disabled', 'acl'))) {
                 $resourceName = (is_null($parentName) ? '' : $parentName . '/') . $resource->getName();
 
                 //assigning module for its' children nodes
@@ -160,16 +160,22 @@ class Mage_Admin_Model_Roles extends Mage_Core_Model_Abstract
                     $module = (string)$resource->getAttribute('module');
                 }
 
+                if ($resource->acl) {
+                    $aclpath = (string)$resource->acl;
+                } else {
+                    $aclpath = $resourceName;
+                }
+
                 if ($rawNodes) {
-                    $resource->addAttribute("aclpath", $resourceName);
+                    $resource->addAttribute("aclpath", $aclpath);
                     $resource->addAttribute("module_c", $module);
                 }
 
                 if (is_null($represent2Darray)) {
-                    $result[$resourceName]['name']  = Mage::helper($module)->__((string)$resource->title);
-                    $result[$resourceName]['level'] = $level;
+                    $result[$aclpath]['name']  = Mage::helper($module)->__((string)$resource->title);
+                    $result[$aclpath]['level'] = $level;
                 } else {
-                    $result[] = $resourceName;
+                    $result[] = $aclpath;
                 }
             }
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
I have not fully tested this change yet, but wanted to seek feedback on if this is a good idea or not.

This PR will let you set a custom ACL `resource_id` in `adminhtml.xml` that is different than the XML structure. For example:

```xml
<acl>
    <resources>
        <admin>
            <children>
                <catalog translate="title" module="catalog">
                    <title>Catalog</title>
                    <sort_order>30</sort_order>
                    <children>
                        <attributes translate="title">
                            <title>Attributes</title>
                            <children>
                                <product translate="title">
                                    <title>Products</title>
                                    <children>
                                        <attributes translate="title">
                                            <title>Attributes</title>
                                            <acl>admin/catalog/attributes/attributes</acl>
                                        </attributes>
                                        <sets translate="title">
                                            <title>Attribute Sets</title>
                                            <acl>admin/catalog/attributes/sets</acl>
                                        </sets>
                                    </children>
                                </product>
                                <category translate="title">
                                    <title>Categories</title>
                                    <children>
                                        <attributes translate="title">
                                            <title>Attributes</title>
                                            <acl>admin/eav/catalog_category/attributes</acl>
                                        </attributes>
                                        <sets translate="title">
                                            <title>Attribute Sets</title>
                                            <acl>admin/eav/catalog_category/sets</acl>
                                        </sets>
                                    </children>
                                </category>
                            </children>
                        </attributes>
                    </children>
                </catalog>
            </children>
        </admin>
    </resources>
</acl>
```

Note the lines:
```xml
<acl>admin/catalog/attributes/attributes</acl>
<acl>admin/catalog/attributes/sets</acl>
<acl>admin/eav/catalog_category/attributes</acl>
<acl>admin/eav/catalog_category/sets</acl>
```

~~I think this could be a useful addition because in PR #2317 we may want to change the menu structure, but do not want to break current ACL permissions. Also, that PR expects to find generic EAV permissions at `admin/eav/$ENTITY/attributes` and `admin/eav/$ENTITY/sets` but we don't want to force the user to conform to our menu or ACL structure.~~

Edit: this PR is actually not necessary for #2317 but I will leave this PR open in case there might be other use-cases for changing the ACL path.

### Related Pull Requests
#2317 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
1. Create a role with `Catalog > Attributes > Attributes` & `Catalog > Attributes > Sets` allowed
2. Update the `Mage/Catalog/etc/adminhtml.xml` to reflect a different menu and ACL structure
3. Apply this patch and make sure the permissions are still allowed

I also should test to make sure nothing else breaks with the API/API2 module. I honestly don't use either of those API modules nor do I use ACL often, so if anyone can see where this might break something, please let me know. I do not expect this PR to be merged quickly.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->