### PR TITLE
Revert "Add basic text for Ukraine (#2074)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 <img src="https://github.com/openmage/magento-lts/actions/workflows/unit-tests.yml/badge.svg" alt="Unit Tests workflow badge" />
 </p>
 
-<img src="skin/adminhtml/default/default/images/flag-ua.svg?raw=true" width="20" align="top" alt=""> Stop russian war. **Free Ukraine!** ([Read more](https://en.wikipedia.org/wiki/2022_Russian_invasion_of_Ukraine))
-
 # Magento - Long Term Support
 
 This repository is the home of an **unofficial** community-driven project. It's goal is to be a dependable alternative

--- a/app/design/adminhtml/default/default/template/notification/toolbar.phtml
+++ b/app/design/adminhtml/default/default/template/notification/toolbar.phtml
@@ -24,12 +24,6 @@
  * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-
-<div class="notification-global ua">
-    Stop russian war. <strong>Free Ukraine!</strong>
-    <a href="https://en.wikipedia.org/wiki/2022_Russian_invasion_of_Ukraine" onclick="this.target='_blank';"><?php echo $this->__('Read details') ?></a>
-</div>
-
 <?php
 /**
  * @var $this Mage_Adminhtml_Block_Notification_Toolbar

--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -283,7 +283,6 @@ ul.tabs-horiz li a.active       { border-bottom:1px solid #fff; background:#fff;
 /* MESSAGES
 *******************************************************************************/
 .notification-global { padding:5px 27px 5px 47px; background:#fff9e9 url(images/error_msg_icon.gif) 27px 5px no-repeat; border-bottom:1px solid #eee2be; border-top:1px solid #eee2be; font-size:11px; line-height:16px; margin:0 0 -3px; color:#444; position:relative; }
-.notification-global.ua { background:#fff9e9 url(images/flag-ua.svg) 28px 5px no-repeat; background-size: 14px; }
 .notification-global-notice { background-image:url(images/note_msg_icon.gif); }
 .notification-global .label { color:#eb5e00; }
 .notification-global .clickable { cursor:pointer; }

--- a/skin/adminhtml/default/default/images/flag-ua.svg
+++ b/skin/adminhtml/default/default/images/flag-ua.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 540 540">
-<rect width="540" height="270" fill="#005BBB"/>
-<rect width="540" height="270" y="270" fill="#FFD500"/>
-</svg>


### PR DESCRIPTION
Our customers' backends don't need to have an undismissable message like the one that was introduces with #2074.
That same message could have been delivered in the notification feed, instead of hardcoding it and adding an image file to our repository (while at the same time we create BC PRs to remove a few characters from file names).

#2074 will not help that cause in any way and it's only creating a disservice to the users of OM's backend.