### PR TITLE
Fix mod_php8 wrong notation in .htaccess files

### DIFF
--- a/media/.htaccess
+++ b/media/.htaccess
@@ -7,32 +7,27 @@ Options All -Indexes
     php_flag engine 0
 </IfModule>
 
-<IfModule mod_php8.c>
+<IfModule mod_php.c>
     php_flag engine 0
 </IfModule>
 
 ############################################
-## Don't permit execution of CGI scripts
+## Forbid execution of CGI scripts
 
-    AddHandler cgi-script .php .pl .py .jsp .asp .sh .cgi
-    Options -ExecCGI
-
-<IfModule mod_rewrite.c>
+AddHandler cgi-script .php .pl .py .jsp .asp .sh .cgi
+Options -ExecCGI
 
 ############################################
-## Enable rewrites
+## URL rewrite configurations
 
+<IfModule mod_rewrite.c>
+    # Enable rewrites
     Options +FollowSymLinks
     RewriteEngine on
 
-############################################
-## Never rewrite for existing files
-
+    # Never rewrite for existing files
     RewriteCond %{REQUEST_FILENAME} !-f
 
-############################################
-## Rewrite everything else to get.php
-
+    # Rewrite everything else to get.php
     RewriteRule (.*) ../get.php [L]
-
 </IfModule>

--- a/skin/.htaccess
+++ b/skin/.htaccess
@@ -5,12 +5,12 @@
     php_flag engine 0
 </IfModule>
 
-<IfModule mod_php8.c>
+<IfModule mod_php.c>
     php_flag engine 0
 </IfModule>
 
 ############################################
-## Don't permit execution of CGI scripts
+## Forbid execution of CGI scripts
 
-    AddHandler cgi-script .php .pl .py .jsp .asp .sh .cgi
-    Options -ExecCGI
+AddHandler cgi-script .php .pl .py .jsp .asp .sh .cgi
+Options -ExecCGI


### PR DESCRIPTION
Lately "mod_php8" instructions were added to some htaccess but they don't work, the right notation is mod_php:
https://github.com/nextcloud/server/issues/26569

I also did a bit of reformatting, hope you like it.

Note: the diff looks complicated (dunno why) but if you check the 2 files:
- https://github.com/fballiano/openmage/blob/fix/skin/.htaccess
- https://github.com/fballiano/openmage/blob/fix/media/.htaccess
you'll see they're pretty straightforward

### Manual testing scenarios (*)

Enable apache's mod_php for php8 and test some php_value directives present in htaccess files, they won't work now, they work after this patch.