### PR TITLE
Backend grid heads - Align the elements for range and date types

### DIFF
--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -206,10 +206,10 @@ table.actions td                { vertical-align:top; }
 .grid tr.filter select           { width:100%; }
 .grid tr.filter .range .range-line { margin-bottom:3px; width:100px; }
 .grid tr.filter .range div.date  { min-width:121px; }
-.grid tr.filter .range input     { float:right; width:50px !important; margin-top:0; }
-.grid tr.filter .range select    { float:right; width:56px !important; margin-top:0; }
-.grid tr.filter .range .label    { display:block; width:36px; float:left; padding-left:2px; }
-.grid tr.filter .date img        { width:15px; height:15px; cursor:pointer; vertical-align:middle; }
+.grid tr.filter .range input     { width:60px !important; margin-top:0; }
+.grid tr.filter .range select    { float:right; width:65px !important; margin-top:0; }
+.grid tr.filter .range .label    { display:block; width:30px; float:left; padding-right:3px; text-align:right; }
+.grid tr.filter .date img        { width:15px; height:15px; cursor:pointer; vertical-align:middle; padding-left:3px; }
 .grid .head-massaction select    { width:auto !important; max-width:90px; }
 .grid select.select-export-filter,
 .grid select.multiselect-export-filter { width:278px; }


### PR DESCRIPTION
This PR is the last part of the implementation of the solution that solves the issue reported here #2198. The first part has already been merged into 1.9.4.x here #2267.

What changes does it bring?

- the text labels (From, To, In) are aligned to the right to avoid the annoying space up to the input box.
- the inputs have been increased in width in order to make the selected date visible in the box.
- the new widths are optimal so that no grid in the Backend is affected.
- 3px padding around the input is identical to that set by the Magento team (see Reports> Orders section for calendar image). a 4px padding will break the arrangement and affect all grids.

I visited one by one all the pages in Backend where there are grids twice and I didn't identify any issue. Here you may see the visual results:

![date_range](https://user-images.githubusercontent.com/8360474/179933517-c40b1846-bcb3-4566-a467-d5853e394237.jpg)

![products](https://user-images.githubusercontent.com/8360474/179933539-964a1a1a-b98c-4b25-a73e-f9305434ca48.jpg)

Unfortunately the issue reported here #2239 will have to be solved, that inconsistency of the column width, which had to be solved in CSS first and only if it was necessary to add values in the Grid.php files. I reopened that post because it was not resolved by PR #2267.

Please do not approve this PR without testing it. If necessary changes can be made by anyone because it allows editing by those who have this right. Also, if a better implementation is requested the PR can be closed as well. I will not participate in discussions and I will not make changes if requested. Thank you for understanding.