### PR TITLE
Add vendor folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@
 
 /var/*
 !/var/.htaccess
+
+/vendor


### PR DESCRIPTION
### Description (*)
This PR will add  /vendor folder to gitignore because it's annoying that you get all its files showing up in git when you install the dependencies to be able to run phpstan etc.. 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->