### PR TITLE
Block access to all dot files.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -201,6 +201,10 @@
     Allow from all
 
 ###########################################
+## Deny access to all files starting with a .
+    RedirectMatch 404 /\.
+
+###########################################
 ## Deny access to release notes to prevent disclosure of the installed Magento version
 
     <Files RELEASE_NOTES.txt>

--- a/.htaccess
+++ b/.htaccess
@@ -100,6 +100,12 @@
     #RewriteBase /magento/
 
 ############################################
+## Prevent serving "hidden" files like git repository
+
+    RewriteCond %{REQUEST_URI} /\.
+    RewriteRule ^(.*)$ / [R=404,L]
+
+############################################
 ## uncomment next line to enable light API calls processing
 
 #    RewriteRule ^api/([a-z][0-9a-z_]+)/?$ api.php?type=$1 [QSA,L]
@@ -199,10 +205,6 @@
 
     Order allow,deny
     Allow from all
-
-###########################################
-## Deny access to all files starting with a .
-    RedirectMatch 404 /\.
 
 ###########################################
 ## Deny access to release notes to prevent disclosure of the installed Magento version


### PR DESCRIPTION
This isn't meant to be a full audit of the .htaccess file or security of access to non-public files but currently a vanilla installation exposes the .git directory which if nothing else throws up a red flag for common scanners.

Rather than blocking specific files and directories like .git, .github, etc this will block all dot files (edit: only in the base path) which I think is a very sane out of the box configuration.