### PR TITLE
Mage_Catalog_Model_Product_Attribute_Backend_Groupprice_Abstract: avoid loading all websites when using only the current one

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice/Abstract.php
@@ -55,7 +55,7 @@ abstract class Mage_Catalog_Model_Product_Attribute_Backend_Groupprice_Abstract 
     /**
      * Retrieve websites currency rates and base currency codes
      *
-     * @param int $websiteId
+     * @param int|null $websiteId
      * @return array
      */
     protected function _getWebsiteCurrencyRates($websiteId = null)

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice/Abstract.php
@@ -55,14 +55,23 @@ abstract class Mage_Catalog_Model_Product_Attribute_Backend_Groupprice_Abstract 
     /**
      * Retrieve websites currency rates and base currency codes
      *
+     * @param int $websiteId
      * @return array
      */
-    protected function _getWebsiteCurrencyRates()
+    protected function _getWebsiteCurrencyRates($websiteId = null)
     {
         if (is_null($this->_rates)) {
             $this->_rates = array();
             $baseCurrency = Mage::app()->getBaseCurrencyCode();
-            foreach (Mage::app()->getWebsites() as $website) {
+
+            if (is_numeric($websiteId)) {
+                $website = Mage::app()->getWebsite($websiteId);
+                $websites = [$website];
+            } else {
+                $websites = Mage::app()->getWebsites();
+            }
+
+            foreach ($websites as $website) {
                 /* @var Mage_Core_Model_Website $website */
                 if ($website->getBaseCurrencyCode() != $baseCurrency) {
                     $rate = Mage::getModel('directory/currency')
@@ -189,7 +198,7 @@ abstract class Mage_Catalog_Model_Product_Attribute_Backend_Groupprice_Abstract 
      */
     public function preparePriceData(array $priceData, $productTypeId, $websiteId)
     {
-        $rates  = $this->_getWebsiteCurrencyRates();
+        $rates  = $this->_getWebsiteCurrencyRates($websiteId);
         $data   = array();
         $price  = Mage::getSingleton('catalog/product_type')->priceFactory($productTypeId);
         foreach ($priceData as $v) {


### PR DESCRIPTION
Method `Mage_Catalog_Model_Product_Attribute_Backend_Groupprice_Abstract::preparePriceData()` (which is this one):

```php
    public function preparePriceData(array $priceData, $productTypeId, $websiteId)
    {
        $rates  = $this->_getWebsiteCurrencyRates();
        $data   = [];
        $price  = Mage::getSingleton('catalog/product_type')->priceFactory($productTypeId);
        foreach ($priceData as $v) {
            $key = implode('-', array_merge([$v['cust_group']], $this->_getAdditionalUniqueFields($v)));
            if ($v['website_id'] == $websiteId) {
                $data[$key] = $v;
                $data[$key]['website_price'] = $v['price'];
            } elseif ($v['website_id'] == 0 && !isset($data[$key])) {
                $data[$key] = $v;
                $data[$key]['website_id'] = $websiteId;
                if ($this->_isPriceFixed($price)) {
                    $data[$key]['price'] = $v['price'] * $rates[$websiteId]['rate'];
                    $data[$key]['website_price'] = $v['price'] * $rates[$websiteId]['rate'];
                }
            }
        }

        return $data;
    }
```

calls `$this->_getWebsiteCurrencyRates()`, which is:

```php
    protected function _getWebsiteCurrencyRates()
    {
        if (is_null($this->_rates)) {
            $this->_rates = [];
            $baseCurrency = Mage::app()->getBaseCurrencyCode();
            foreach (Mage::app()->getWebsites() as $website) {
                /* @var Mage_Core_Model_Website $website */
                if ($website->getBaseCurrencyCode() != $baseCurrency) {
                    $rate = Mage::getModel('directory/currency')
                        ->load($baseCurrency)
                        ->getRate($website->getBaseCurrencyCode());
                    if (!$rate) {
                        $rate = 1;
                    }
                    $this->_rates[$website->getId()] = [
                        'code' => $website->getBaseCurrencyCode(),
                        'rate' => $rate
                    ];
                } else {
                    $this->_rates[$website->getId()] = [
                        'code' => $baseCurrency,
                        'rate' => 1
                    ];
                }
            }
        }
        return $this->_rates;
    }
```

as you can see `_getWebsiteCurrencyRates()` cycles all websites but that's useless when called by `preparePriceData()`, because preparePriceData only uses a single website (check the variable `$websiteId`).

This PR adds support for $websiteId to `_getWebsiteCurrencyRates()` so it only load the current websites and (in multiwebsite environment) can be a good performance benefit when loading products with `Mage_Catalog_Model_Product::load()`.