### PR TITLE
Enable website config cache

### DIFF
--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -59,7 +59,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
         'crontab'   => 0,
         'install'   => 0,
         'stores'    => 1,
-        'websites'  => 0
+        'websites'  => 1
     );
 
     /**


### PR DESCRIPTION
This PR seems to be a big performance improvement for multiwebsite setups. @luigifab and me, while debugging some performance issues about the "addtocart" feature, discovered that "website based configs" seems not to be cached (while "store based configs" are).

I'll try to explain, when adding to cart we found out that that `Mage_Catalog_Model_Product_Attribute_Backend_Groupprice_Abstract::_getWebsiteCurrencyRates()` was called but wasn't using the cache to extract the values that it needed, in fact if you check blackfire you'll see it keep loading the configuration xml (and this is with hot cache):
<img width="316" alt="Schermata 2022-08-02 alle 11 09 36" src="https://user-images.githubusercontent.com/909743/182395763-fb10dbaf-cacc-424c-baa2-ba63503af4db.png">

After a big debugging session it all came out to enabling website config cache in `app/code/core/Mage/Core/Model/Config.php`. I've no idea why it was disabled (git blame tells that code is 13 years old) but enabling it result in a conspicuous performance improvement, which is mostly visible only in multiwebsite environments.

After applying the patch all "website level configurations" get cached and you can see that, the same blackfire test as before, doesn't call the xml anymore and it's so much faster:
<img width="346" alt="Schermata 2022-08-02 alle 15 16 29" src="https://user-images.githubusercontent.com/909743/182396769-710b6d19-e160-47e7-9647-68ff29ad7e64.png">

A small issue with this PR (reason why I targeted for v20) is that the cache size will increase depending on how many websites the project has.

### Related Pull Requests
https://github.com/OpenMage/magento-lts/pull/2351

### Manual testing scenarios (*)

This is tricky. One of the possible tests is:
- have a multiwebsite environment where prices are "per website" and not "global" (this way OM has to search for the website base currency and will trigger the problem)
- time a `Mage::getModel("catalog/product")->load(SOMEPRODUCTID)` with and without the patch (multiple times, so that the cache is hot)

I had a much more complicated test but it should be possible to verify the problem with this one.