### PR TITLE
Version bump only for v20

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -222,7 +222,7 @@ final class Mage
             return array(
                 'major'     => '20',
                 'minor'     => '0',
-                'patch'     => '15',
+                'patch'     => '16',
                 'stability' => '', // beta,alpha,rc
                 'number'    => '', // 1,2,3,0.3.7,x.7.z.92 @see https://semver.org/#spec-item-9
             );


### PR DESCRIPTION
Since we found a problem with release 20.0.15 we'll need to re-release it soon.

This PR bumps the release number, only for v20, on branch 1.9.4.x (I know it may seem confusing).