### PR TITLE
Force describeTable() to use read DB adapter

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
@@ -665,7 +665,7 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
         $helper = Mage::getResourceHelper('catalog');
         $columns = array();
         $columnsToSkip = array('entity_type_id', 'attribute_set_id');
-        $describe = $this->_getWriteAdapter()->describeTable($this->getTable('catalog/category'));
+        $describe = $this->_getReadAdapter()->describeTable($this->getTable('catalog/category'));
 
         foreach ($describe as $column) {
             if (in_array($column['COLUMN_NAME'], $columnsToSkip)) {
@@ -1161,7 +1161,7 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
     {
         $table = $this->getMainStoreTable($category->getStoreId());
         $this->_getWriteAdapter()->resetDdlCache($table);
-        $table = $this->_getWriteAdapter()->describeTable($table);
+        $table = $this->_getReadAdapter()->describeTable($table);
         $data = array();
         $idFieldName = Mage::getSingleton('catalog/category')->getIdFieldName();
         foreach ($table as $column => $columnData) {

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Flat.php
@@ -118,7 +118,7 @@ class Mage_Catalog_Model_Resource_Product_Flat extends Mage_Core_Model_Resource_
      */
     public function getAttributeForSelect($attributeCode)
     {
-        $describe = $this->_getWriteAdapter()->describeTable($this->getFlatTableName());
+        $describe = $this->_getReadAdapter()->describeTable($this->getFlatTableName());
         if (!isset($describe[$attributeCode])) {
             return null;
         }
@@ -140,7 +140,7 @@ class Mage_Catalog_Model_Resource_Product_Flat extends Mage_Core_Model_Resource_
      */
     public function getAttributeSortColumn($attributeCode)
     {
-        $describe = $this->_getWriteAdapter()->describeTable($this->getFlatTableName());
+        $describe = $this->_getReadAdapter()->describeTable($this->getFlatTableName());
         if (!isset($describe[$attributeCode])) {
             return null;
         }
@@ -158,7 +158,7 @@ class Mage_Catalog_Model_Resource_Product_Flat extends Mage_Core_Model_Resource_
      */
     public function getAllTableColumns()
     {
-        $describe = $this->_getWriteAdapter()->describeTable($this->getFlatTableName());
+        $describe = $this->_getReadAdapter()->describeTable($this->getFlatTableName());
         return array_keys($describe);
     }
 

--- a/app/code/core/Mage/Core/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Abstract.php
@@ -211,7 +211,7 @@ abstract class Mage_Core_Model_Resource_Abstract
     protected function _prepareDataForTable(Varien_Object $object, $table)
     {
         $data = array();
-        $fields = $this->_getWriteAdapter()->describeTable($table);
+        $fields = $this->_getReadAdapter()->describeTable($table);
         foreach (array_keys($fields) as $field) {
             if ($object->hasData($field)) {
                 $fieldValue = $object->getData($field);

--- a/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
@@ -618,7 +618,7 @@ abstract class Mage_Core_Model_Resource_Db_Abstract extends Mage_Core_Model_Reso
             return true;
         }
 
-        $fields = $this->_getWriteAdapter()->describeTable($this->getMainTable());
+        $fields = $this->_getReadAdapter()->describeTable($this->getMainTable());
         foreach (array_keys($fields) as $field) {
             if ($object->getOrigData($field) != $object->getData($field)) {
                 return true;

--- a/app/code/core/Mage/Eav/Model/Entity/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Abstract.php
@@ -1167,7 +1167,7 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
             $origData = array();
         }
 
-        $staticFields   = $this->_getWriteAdapter()->describeTable($this->getEntityTable());
+        $staticFields   = $this->_getReadAdapter()->describeTable($this->getEntityTable());
         $staticFields   = array_keys($staticFields);
         $attributeCodes = array_keys($this->_attributesByCode);
 

--- a/app/code/core/Mage/Index/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Resource/Abstract.php
@@ -145,7 +145,7 @@ abstract class Mage_Index_Model_Resource_Abstract extends Mage_Core_Model_Resour
             $sourceColumns = array_keys($this->_getReadAdapter()->describeTable($sourceTable));
             $targetColumns = array_keys($this->_getReadAdapter()->describeTable($destTable));
         } else {
-            $sourceColumns = array_keys($this->_getReadAdapter()->describeTable($sourceTable));
+            $sourceColumns = array_keys($this->_getIndexAdapter()->describeTable($sourceTable));
             $targetColumns = array_keys($this->_getReadAdapter()->describeTable($destTable));
         }
         $select = $this->_getIndexAdapter()->select()->from($sourceTable, $sourceColumns);

--- a/app/code/core/Mage/Index/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Resource/Abstract.php
@@ -142,11 +142,11 @@ abstract class Mage_Index_Model_Resource_Abstract extends Mage_Core_Model_Resour
     public function insertFromTable($sourceTable, $destTable, $readToIndex = true)
     {
         if ($readToIndex) {
-            $sourceColumns = array_keys($this->_getWriteAdapter()->describeTable($sourceTable));
-            $targetColumns = array_keys($this->_getWriteAdapter()->describeTable($destTable));
+            $sourceColumns = array_keys($this->_getReadAdapter()->describeTable($sourceTable));
+            $targetColumns = array_keys($this->_getReadAdapter()->describeTable($destTable));
         } else {
-            $sourceColumns = array_keys($this->_getIndexAdapter()->describeTable($sourceTable));
-            $targetColumns = array_keys($this->_getWriteAdapter()->describeTable($destTable));
+            $sourceColumns = array_keys($this->_getReadAdapter()->describeTable($sourceTable));
+            $targetColumns = array_keys($this->_getReadAdapter()->describeTable($destTable));
         }
         $select = $this->_getIndexAdapter()->select()->from($sourceTable, $sourceColumns);
 


### PR DESCRIPTION
This PR should solve issue https://github.com/OpenMage/magento-lts/issues/1158 where a lot of describeTable() calls are done using the writeAdapter instead of the readAdapter