### PR TITLE
Replaced deprecated method getRegionJson() with getRegionJsonByStore().

### DIFF
--- a/.github/phpstan-baseline.neon
+++ b/.github/phpstan-baseline.neon
@@ -291,11 +291,6 @@ parameters:
 			path: ../app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
 
 		-
-			message: "#^Call to an undefined method Mage_Core_Helper_Abstract\\:\\:getRegionJsonByStore\\(\\)\\.$#"
-			count: 1
-			path: ../app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Region.php
-
-		-
 			message: "#^Call to an undefined method Mage_Core_Helper_Abstract\\:\\:getNamePrefixOptions\\(\\)\\.$#"
 			count: 1
 			path: ../app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
@@ -4506,11 +4501,6 @@ parameters:
 			path: ../app/code/core/Mage/Dataflow/Model/Profile.php
 
 		-
-			message: "#^Call to an undefined method Mage_Core_Helper_Abstract\\:\\:getRegionJson\\(\\)\\.$#"
-			count: 1
-			path: ../app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Region/Updater.php
-
-		-
 			message: "#^Cannot call method addCountryFilter\\(\\) on Mage_Core_Model_Resource_Db_Collection_Abstract\\|false\\.$#"
 			count: 2
 			path: ../app/code/core/Mage/Directory/Block/Data.php
@@ -7334,11 +7324,6 @@ parameters:
 			message: "#^Cannot call method loadByTagCustomer\\(\\) on object\\|string\\.$#"
 			count: 1
 			path: ../app/code/core/Mage/Tag/Model/Tag/Relation.php
-
-		-
-			message: "#^Call to an undefined method Mage_Core_Helper_Abstract\\:\\:getRegionJson\\(\\)\\.$#"
-			count: 1
-			path: ../app/code/core/Mage/Tax/Block/Adminhtml/Frontend/Region/Updater.php
 
 		-
 			message: "#^Call to an undefined method Mage_Core_Helper_Abstract\\:\\:validateCatalogPricesAndFptConfiguration\\(\\)\\.$#"

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Region.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Region.php
@@ -59,9 +59,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Renderer_Region
     public function render(Varien_Data_Form_Element_Abstract $element)
     {
         $country = $element->getForm()->getElement('country_id');
-        if (!is_null($country)) {
-            $countryId = $country->getValue();
-        } else {
+        if (is_null($country)) {
             return $element->getDefaultHtml();
         }
 
@@ -84,7 +82,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Renderer_Region
         $html .= '<script type="text/javascript">' . "\n";
         $html .= '$("' . $selectId . '").setAttribute("defaultValue", "' . $regionId.'");' . "\n";
         $html .= 'new regionUpdater("' . $country->getHtmlId() . '", "' . $element->getHtmlId() . '", "' .
-            $selectId . '", ' . $this->helper('directory')->getRegionJsonByStore($quoteStoreId).');' . "\n";
+            $selectId . '", ' . Mage::helper('directory')->getRegionJsonByStore($quoteStoreId).');' . "\n";
         $html .= '</script>' . "\n";
 
         $html .= '</td></tr>' . "\n";

--- a/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Region/Updater.php
+++ b/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Region/Updater.php
@@ -33,7 +33,7 @@ class Mage_Directory_Block_Adminhtml_Frontend_Region_Updater extends Mage_Adminh
     protected function _getElementHtml(Varien_Data_Form_Element_Abstract $element)
     {
         $html = parent::_getElementHtml($element);
-        $html .= "<script type=\"text/javascript\">var updater = new RegionUpdater('tax_defaults_country', 'tax_region', 'tax_defaults_region', ".$this->helper('directory')->getRegionJson().", 'disable');</script>";
+        $html .= "<script type=\"text/javascript\">var updater = new RegionUpdater('tax_defaults_country', 'tax_region', 'tax_defaults_region', ".Mage::helper('directory')->getRegionJsonByStore().", 'disable');</script>";
 
         return $html;
     }

--- a/app/code/core/Mage/Tax/Block/Adminhtml/Frontend/Region/Updater.php
+++ b/app/code/core/Mage/Tax/Block/Adminhtml/Frontend/Region/Updater.php
@@ -48,7 +48,7 @@ class Mage_Tax_Block_Adminhtml_Frontend_Region_Updater extends Mage_Adminhtml_Bl
                }
                </script>';
 
-        $html .= sprintf($js, $this->helper('directory')->getRegionJson());
+        $html .= sprintf($js, Mage::helper('directory')->getRegionJsonByStore());
         return $html;
     }
 }

--- a/app/design/adminhtml/default/default/template/tax/rate/form.phtml
+++ b/app/design/adminhtml/default/default/template/tax/rate/form.phtml
@@ -29,5 +29,5 @@
 </div>
 <?php echo $this->getChildHtml('form_after');?>
 <script type="text/javascript">
-var updater = new RegionUpdater('tax_country_id', 'tax_region', 'tax_region_id', <?php echo $this->helper('directory')->getRegionJson() ?>, 'disable');
+var updater = new RegionUpdater('tax_country_id', 'tax_region', 'tax_region_id', <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>, 'disable');
 </script>

--- a/app/design/adminhtml/default/default/template/weee/renderer/tax.phtml
+++ b/app/design/adminhtml/default/default/template/weee/renderer/tax.phtml
@@ -114,7 +114,7 @@
             $(data.prefix + '_weee_tax_row_'+data.index+'_country').value = data.country;
             $(data.prefix + '_weee_tax_row_'+data.index+'_website').value = data.website_id;
 
-            updater = new RegionUpdater(data.prefix + '_weee_tax_row_'+data.index+'_country', null, data.prefix + '_weee_tax_row_'+data.index+'_state', <?php echo $this->helper('directory')->getRegionJson() ?>, 'disable', true);
+            updater = new RegionUpdater(data.prefix + '_weee_tax_row_'+data.index+'_country', null, data.prefix + '_weee_tax_row_'+data.index+'_state', <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>, 'disable', true);
             updater.update();
 
             $(data.prefix + '_weee_tax_row_'+data.index+'_state').value   = data.state;

--- a/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
@@ -74,7 +74,7 @@
         </form>
         <script type="text/javascript">
         //<![CDATA[
-            new RegionUpdater('country', 'region', 'region_id', <?php echo $this->helper('directory')->getRegionJson() ?>);
+            new RegionUpdater('country', 'region', 'region_id', <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>);
         //]]>
         </script>
 

--- a/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
@@ -220,6 +220,6 @@
     //billingForm.setElementsRelation('billing:country_id', 'billing:region', '<?php echo $this->getUrl('directory/json/childRegion') ?>', '<?php echo $this->__('Select State/Province...') ?>');
     $('billing-address-select') && billing.newAddress(!$('billing-address-select').value);
 
-    var billingRegionUpdater = new RegionUpdater('billing:country_id', 'billing:region', 'billing:region_id', <?php echo $this->helper('directory')->getRegionJson() ?>, undefined, 'billing:postcode');
+    var billingRegionUpdater = new RegionUpdater('billing:country_id', 'billing:region', 'billing:region_id', <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>, undefined, 'billing:postcode');
 //]]>
 </script>

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping.phtml
@@ -152,6 +152,6 @@
     //shippingForm.setElementsRelation('shipping:country_id', 'shipping:region', '<?php echo $this->getUrl('directory/json/childRegion') ?>', '<?php echo Mage::helper('core')->jsQuoteEscape($this->__('Select State/Province...')) ?>');
     $('shipping-address-select') && shipping.newAddress(!$('shipping-address-select').value);
 
-    var shippingRegionUpdater = new RegionUpdater('shipping:country_id', 'shipping:region', 'shipping:region_id', <?php echo $this->helper('directory')->getRegionJson() ?>, undefined, 'shipping:postcode');
+    var shippingRegionUpdater = new RegionUpdater('shipping:country_id', 'shipping:region', 'shipping:region_id', <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>, undefined, 'shipping:postcode');
 //]]>
 </script>

--- a/app/design/frontend/base/default/template/customer/address/edit.phtml
+++ b/app/design/frontend/base/default/template/customer/address/edit.phtml
@@ -160,6 +160,6 @@
 <script type="text/javascript">
 //<![CDATA[
     var dataForm = new VarienForm('form-validate', true);
-    new RegionUpdater('country', 'region', 'region_id', <?php echo $this->helper('directory')->getRegionJson() ?>, undefined, 'zip');
+    new RegionUpdater('country', 'region', 'region_id', <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>, undefined, 'zip');
 //]]>
 </script>

--- a/app/design/frontend/base/default/template/customer/form/address.phtml
+++ b/app/design/frontend/base/default/template/customer/form/address.phtml
@@ -24,7 +24,7 @@
  * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<script type="text/javascript">countryRegions = <?php echo $this->helper('directory')->getRegionJson() ?></script>
+<script type="text/javascript">countryRegions = <?php echo Mage::helper('directory')->getRegionJsonByStore() ?></script>
 
 <div class="page-title">
     <h1><?php if($data->getAddressId()): ?><?php echo $this->__('Edit Address Entry') ?><?php else: ?><?php echo $this->__('New Address Entry') ?><?php endif ?></h1>

--- a/app/design/frontend/base/default/template/customer/form/register.phtml
+++ b/app/design/frontend/base/default/template/customer/form/register.phtml
@@ -192,7 +192,7 @@
     //<![CDATA[
         var dataForm = new VarienForm('form-validate', true);
         <?php if($this->getShowAddressFields()): ?>
-        new RegionUpdater('country', 'region', 'region_id', <?php echo $this->helper('directory')->getRegionJson() ?>, undefined, 'zip');
+        new RegionUpdater('country', 'region', 'region_id', <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>, undefined, 'zip');
         <?php endif ?>
     //]]>
     </script>

--- a/app/design/frontend/base/default/template/persistent/checkout/onepage/billing.phtml
+++ b/app/design/frontend/base/default/template/persistent/checkout/onepage/billing.phtml
@@ -218,7 +218,7 @@
     //billingForm.setElementsRelation('billing:country_id', 'billing:region', '<?php echo $this->getUrl('directory/json/childRegion') ?>', '<?php echo Mage::helper('core')->jsQuoteEscape($this->__('Select State/Province...')) ?>');
     $('billing-address-select') && billing.newAddress(!$('billing-address-select').value);
 
-    var billingRegionUpdater = new RegionUpdater('billing:country_id', 'billing:region', 'billing:region_id', <?php echo $this->helper('directory')->getRegionJson() ?>, undefined, 'billing:postcode');
+    var billingRegionUpdater = new RegionUpdater('billing:country_id', 'billing:region', 'billing:region_id', <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>, undefined, 'billing:postcode');
     if ($('onepage-guest-register-button')) {
         Event.observe($('onepage-guest-register-button'), 'click', function(event) {
             var billingRememberMe = $('co-billing-form').select('#remember-me-box');

--- a/app/design/frontend/base/default/template/persistent/customer/form/register.phtml
+++ b/app/design/frontend/base/default/template/persistent/customer/form/register.phtml
@@ -194,7 +194,7 @@
     //<![CDATA[
         var dataForm = new VarienForm('form-validate', true);
         <?php if($this->getShowAddressFields()): ?>
-        new RegionUpdater('country', 'region', 'region_id', <?php echo $this->helper('directory')->getRegionJson() ?>, undefined, 'zip');
+        new RegionUpdater('country', 'region', 'region_id', <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>, undefined, 'zip');
         <?php endif ?>
     //]]>
     </script>

--- a/app/design/frontend/default/iphone/template/paypal/express/review.phtml
+++ b/app/design/frontend/default/iphone/template/paypal/express/review.phtml
@@ -34,7 +34,7 @@ $shippingAddress = $this->getShippingAddress();
 <?php echo $this->getMessagesBlock()->toHtml() ?>
 <script type="text/javascript">
 //<![CDATA[
-    var countryRegions = <?php echo $this->helper('directory')->getRegionJson() ?>
+    var countryRegions = <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>
 //]]>
 </script>
 <div class="paypal-review-order">

--- a/app/design/frontend/rwd/default/template/checkout/cart/shipping.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/shipping.phtml
@@ -82,7 +82,7 @@
         </form>
         <script type="text/javascript">
         //<![CDATA[
-            new RegionUpdater('country', 'region', 'region_id', <?php echo $this->helper('directory')->getRegionJson() ?>);
+            new RegionUpdater('country', 'region', 'region_id', <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>);
         //]]>
         </script>
 

--- a/app/design/frontend/rwd/default/template/checkout/onepage/shipping.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/shipping.phtml
@@ -153,6 +153,6 @@
     //shippingForm.setElementsRelation('shipping:country_id', 'shipping:region', '<?php echo $this->getUrl('directory/json/childRegion') ?>', '<?php echo Mage::helper('core')->jsQuoteEscape($this->__('Select State/Province...')) ?>');
     $('shipping-address-select') && shipping.newAddress(!$('shipping-address-select').value);
 
-    var shippingRegionUpdater = new RegionUpdater('shipping:country_id', 'shipping:region', 'shipping:region_id', <?php echo $this->helper('directory')->getRegionJson() ?>, undefined, 'shipping:postcode');
+    var shippingRegionUpdater = new RegionUpdater('shipping:country_id', 'shipping:region', 'shipping:region_id', <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>, undefined, 'shipping:postcode');
 //]]>
 </script>

--- a/app/design/frontend/rwd/default/template/customer/address/edit.phtml
+++ b/app/design/frontend/rwd/default/template/customer/address/edit.phtml
@@ -161,6 +161,6 @@
 <script type="text/javascript">
 //<![CDATA[
     var dataForm = new VarienForm('form-validate', true);
-    new RegionUpdater('country', 'region', 'region_id', <?php echo $this->helper('directory')->getRegionJson() ?>, undefined, 'zip');
+    new RegionUpdater('country', 'region', 'region_id', <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>, undefined, 'zip');
 //]]>
 </script>

--- a/app/design/frontend/rwd/default/template/customer/form/address.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/address.phtml
@@ -24,7 +24,7 @@
  * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<script type="text/javascript">countryRegions = <?php echo $this->helper('directory')->getRegionJson() ?></script>
+<script type="text/javascript">countryRegions = <?php echo Mage::helper('directory')->getRegionJsonByStore() ?></script>
 
 <div class="page-title">
     <h1><?php if($data->getAddressId()): ?><?php echo $this->__('Edit Address Entry') ?><?php else: ?><?php echo $this->__('New Address Entry') ?><?php endif ?></h1>

--- a/app/design/frontend/rwd/default/template/paypal/express/review/address.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/review/address.phtml
@@ -146,7 +146,7 @@
 </div>
 <script type="text/javascript">
 //<![CDATA[
-    var <?php echo $prefix ?>RegionUpdater = new RegionUpdater('<?php echo $prefix ?>:country_id', '<?php echo $prefix ?>:region', '<?php echo $prefix ?>:region_id', <?php echo $this->helper('directory')->getRegionJson() ?>, undefined, '<?php echo $prefix ?>:postcode');
+    var <?php echo $prefix ?>RegionUpdater = new RegionUpdater('<?php echo $prefix ?>:country_id', '<?php echo $prefix ?>:region', '<?php echo $prefix ?>:region_id', <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>, undefined, '<?php echo $prefix ?>:postcode');
     <?php echo $prefix ?>RegionUpdater.update();
 //]]>
 </script>

--- a/app/design/frontend/rwd/default/template/persistent/checkout/onepage/billing.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/checkout/onepage/billing.phtml
@@ -220,7 +220,7 @@
     //billingForm.setElementsRelation('billing:country_id', 'billing:region', '<?php echo $this->getUrl('directory/json/childRegion') ?>', '<?php echo $this->jsQuoteEscape($this->__('Select State/Province...')) ?>');
     $('billing-address-select') && billing.newAddress(!$('billing-address-select').value);
 
-    var billingRegionUpdater = new RegionUpdater('billing:country_id', 'billing:region', 'billing:region_id', <?php echo $this->helper('directory')->getRegionJson() ?>, undefined, 'billing:postcode');
+    var billingRegionUpdater = new RegionUpdater('billing:country_id', 'billing:region', 'billing:region_id', <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>, undefined, 'billing:postcode');
     if ($('onepage-guest-register-button')) {
         Event.observe($('onepage-guest-register-button'), 'click', function(event) {
             var billingRememberMe = $('co-billing-form').select('#remember-me-box');

--- a/app/design/frontend/rwd/default/template/persistent/customer/form/register.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/customer/form/register.phtml
@@ -190,7 +190,7 @@
     //<![CDATA[
         var dataForm = new VarienForm('form-validate', true);
         <?php if($this->getShowAddressFields()): ?>
-        new RegionUpdater('country', 'region', 'region_id', <?php echo $this->helper('directory')->getRegionJson() ?>, undefined, 'zip');
+        new RegionUpdater('country', 'region', 'region_id', <?php echo Mage::helper('directory')->getRegionJsonByStore() ?>, undefined, 'zip');
         <?php endif ?>
     //]]>
     </script>


### PR DESCRIPTION
### Description (*)

https://github.com/OpenMage/magento-lts/blob/aa909dba88dc0459c88dfbd85c459409113d60c9/app/code/core/Mage/Directory/Helper/Data.php#L136-L146

Even though the method was deprecated, it's used in both phtml and php files. 

To fix PHPStan error, `$this->helper('directory')` is replaced with `Mage::helper('directory')`.

