### PR TITLE
Add "apt update" to XML validation workflow

### DIFF
--- a/.github/workflows/xml_validate.yml
+++ b/.github/workflows/xml_validate.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - name: "Checkout repository"
       uses: actions/checkout@master
+    - name: "Update APT repositories"
+      run: "sudo apt update"
     - name: "Install xmllint"
       run: "sudo apt-get -y install libxml2-utils"
     - name: "Validate XMLs"


### PR DESCRIPTION
Since a few days ubuntu's repositories changed and the XML validation workflow broke. This PR adds an "apt update" command to the workflow to fix the issue from now and theoretically for the future.

Example of a broken run: https://github.com/OpenMage/magento-lts/runs/7705939784?check_suite_focus=true

Example of a fixed run after this PR: https://github.com/fballiano/openmage/runs/7706168829?check_suite_focus=true