### PR TITLE
Fixed bug on mini login form.

### DIFF
--- a/app/code/core/Mage/Customer/Block/Form/Login.php
+++ b/app/code/core/Mage/Customer/Block/Form/Login.php
@@ -92,4 +92,24 @@ class Mage_Customer_Block_Form_Login extends Mage_Core_Block_Template
         }
         return $this->_username;
     }
+
+    /**
+     * Can show the login form?
+     *
+     * @return bool
+     */
+    public function canShowLogin()
+    {
+        if (Mage::helper('customer')->isLoggedIn()) {
+            return false;
+        }
+
+        // Set redirect URL after login
+        $url = Mage::getStoreConfigFlag(Mage_Customer_Helper_Data::XML_PATH_CUSTOMER_STARTUP_REDIRECT_TO_DASHBOARD)
+            ? Mage::helper('customer')->getDashboardUrl()
+            : Mage::getUrl('*/*/*', ['_current' => true]);
+        Mage::getSingleton('customer/session')->setBeforeAuthUrl($url);
+
+        return true;
+    }
 }

--- a/app/code/core/Mage/Customer/Block/Form/Login.php
+++ b/app/code/core/Mage/Customer/Block/Form/Login.php
@@ -111,7 +111,7 @@ class Mage_Customer_Block_Form_Login extends Mage_Core_Block_Template
         } else {
             /** @var string $pathInfo 'something.html'|'/'|'/path0'|'/path0/path1/'|'/path0/path1/path2'|etc */
             $pathInfo = $this->getRequest()->getOriginalPathInfo();
-            if (strtolower(substr($pathInfo, -5)) == '.html') {
+            if (strtolower(substr($pathInfo, -5)) === '.html') {
                 // For URL rewrite, preserve the path without considering query or post.
                 $url = Mage::getBaseUrl() . ltrim($pathInfo, '/');
             } else {

--- a/app/design/frontend/base/default/template/customer/form/mini.login.phtml
+++ b/app/design/frontend/base/default/template/customer/form/mini.login.phtml
@@ -33,7 +33,6 @@
         <div class="block-content">
             <label for="mini-login"><?php echo $this->__('Email:') ?></label><input type="text" name="login[username]" id="mini-login" class="input-text" />
             <label for="mini-password"><?php echo $this->__('Password:') ?></label><input type="password" name="login[password]" id="mini-password" class="input-text" />
-            <a href="<?php echo $this->getForgotPasswordUrl() ?>" class="f-left"><?php echo $this->__('Forgot Your Password?') ?></a>
             <div class="actions">
                 <button type="submit" class="button"><span><span><?php echo $this->__('Login') ?></span></span></button>
             </div>

--- a/app/design/frontend/base/default/template/customer/form/mini.login.phtml
+++ b/app/design/frontend/base/default/template/customer/form/mini.login.phtml
@@ -33,6 +33,7 @@
         <div class="block-content">
             <label for="mini-login"><?php echo $this->__('Email:') ?></label><input type="text" name="login[username]" id="mini-login" class="input-text" />
             <label for="mini-password"><?php echo $this->__('Password:') ?></label><input type="password" name="login[password]" id="mini-password" class="input-text" />
+            <a href="<?php echo $this->getForgotPasswordUrl() ?>" class="f-left"><?php echo $this->__('Forgot Your Password?') ?></a>
             <div class="actions">
                 <button type="submit" class="button"><span><span><?php echo $this->__('Login') ?></span></span></button>
             </div>

--- a/app/design/frontend/base/default/template/customer/form/mini.login.phtml
+++ b/app/design/frontend/base/default/template/customer/form/mini.login.phtml
@@ -18,17 +18,26 @@
  * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
+<?php
+/**
+ * @var Mage_Customer_Block_Form_Login $this
+ */
+?>
+<?php if ($this->canShowLogin()): ?>
 <div class="block block-login">
     <div class="block-title">
         <strong><span><?php echo $this->__('Login') ?></span></strong>
     </div>
     <form action="<?php echo $this->getPostActionUrl() ?>" method="post">
+        <?php echo $this->getBlockHtml('formkey') ?>
         <div class="block-content">
             <label for="mini-login"><?php echo $this->__('Email:') ?></label><input type="text" name="login[username]" id="mini-login" class="input-text" />
             <label for="mini-password"><?php echo $this->__('Password:') ?></label><input type="password" name="login[password]" id="mini-password" class="input-text" />
+            <a href="<?php echo $this->getForgotPasswordUrl() ?>" class="f-left"><?php echo $this->__('Forgot Your Password?') ?></a>
             <div class="actions">
                 <button type="submit" class="button"><span><span><?php echo $this->__('Login') ?></span></span></button>
             </div>
         </div>
     </form>
 </div>
+<?php endif ?>

--- a/app/design/frontend/rwd/default/template/customer/form/mini.login.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/mini.login.phtml
@@ -18,17 +18,26 @@
  * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
+<?php
+/**
+ * @var Mage_Customer_Block_Form_Login $this
+ */
+?>
+<?php if ($this->canShowLogin()): ?>
 <div class="block block-login">
     <div class="block-title">
         <strong><span><?php echo $this->__('Login') ?></span></strong>
     </div>
     <form action="<?php echo $this->getPostActionUrl() ?>" method="post">
+        <?php echo $this->getBlockHtml('formkey') ?>
         <div class="block-content">
             <label for="mini-login"><?php echo $this->__('Email:') ?></label><input type="email" autocapitalize="off" autocorrect="off" spellcheck="false" name="login[username]" id="mini-login" class="input-text" />
             <label for="mini-password"><?php echo $this->__('Password:') ?></label><input type="password" name="login[password]" id="mini-password" class="input-text" />
+            <a href="<?php echo $this->getForgotPasswordUrl() ?>" class="f-left"><?php echo $this->__('Forgot Your Password?') ?></a>
             <div class="actions">
                 <button type="submit" class="button"><span><span><?php echo $this->__('Login') ?></span></span></button>
             </div>
         </div>
     </form>
 </div>
+<?php endif ?>

--- a/app/design/frontend/rwd/default/template/customer/form/mini.login.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/mini.login.phtml
@@ -33,7 +33,6 @@
         <div class="block-content">
             <label for="mini-login"><?php echo $this->__('Email:') ?></label><input type="email" autocapitalize="off" autocorrect="off" spellcheck="false" name="login[username]" id="mini-login" class="input-text" />
             <label for="mini-password"><?php echo $this->__('Password:') ?></label><input type="password" name="login[password]" id="mini-password" class="input-text" />
-            <a href="<?php echo $this->getForgotPasswordUrl() ?>" class="f-left"><?php echo $this->__('Forgot Your Password?') ?></a>
             <div class="actions">
                 <button type="submit" class="button"><span><span><?php echo $this->__('Login') ?></span></span></button>
             </div>

--- a/app/design/frontend/rwd/default/template/customer/form/mini.login.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/mini.login.phtml
@@ -33,6 +33,7 @@
         <div class="block-content">
             <label for="mini-login"><?php echo $this->__('Email:') ?></label><input type="email" autocapitalize="off" autocorrect="off" spellcheck="false" name="login[username]" id="mini-login" class="input-text" />
             <label for="mini-password"><?php echo $this->__('Password:') ?></label><input type="password" name="login[password]" id="mini-password" class="input-text" />
+            <a href="<?php echo $this->getForgotPasswordUrl() ?>" class="f-left"><?php echo $this->__('Forgot Your Password?') ?></a>
             <div class="actions">
                 <button type="submit" class="button"><span><span><?php echo $this->__('Login') ?></span></span></button>
             </div>


### PR DESCRIPTION
### Description (*)
The mini login form should only be used on SSL enabled pages. But nowadays, the entire production site should be SSL enabled. Mini login form makes it easier to login from any page.

This PR does 3 things 

1. Fixed broken mini login form due to missing form key.
2. Do not show the mini login if customer is logged in.
3. Set redirect URL after login.
~4. Add forgot password link.~

### Manual testing scenarios (*)
To test, show the mini login with layout update in any CMS page, I set it on `home`, page ID 2:

```xml
<reference name="right">
        <block type="customer/form_login" name="customer_form_mini_login" before="-" template="customer/form/mini.login.phtml"/>
</reference>
```
It will show like this on the right column:
![image](https://user-images.githubusercontent.com/1106470/183277010-3f1b0355-0d9a-4dfb-abc6-d6f7b849ded3.png)

Now try to login, it will redirect to `customer/account/login`, due to missing form key.

With this PR, we can now login. It will also redirect to the page where it was login or to My Account depending on the configuration:
![image](https://user-images.githubusercontent.com/1106470/183277184-7ad2c5c5-6243-4def-8ea9-4b3458f18332.png)



