### PR TITLE
Removed deprecated method Mage::setIsDownloader()

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -1057,14 +1057,4 @@ final class Mage
 
         return $baseUrl;
     }
-
-    /**
-     * Set is downloader flag
-     *
-     * @deprecated
-     */
-    public static function setIsDownloader()
-    {
-
-    }
 }


### PR DESCRIPTION
Mage:: setIsDownloader() is deprecated and unused in the whole code and it can be safely removed. This PR targets v20.