### PR TITLE
Improvements in cron scripts

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -46,6 +46,8 @@ umask(0);
 $disabledFuncs = array_map('trim', explode(',', strtolower(ini_get('disable_functions'))));
 $isShellDisabled = is_array($disabledFuncs) ? in_array('shell_exec', $disabledFuncs) : true;
 $isShellDisabled = (stripos(PHP_OS, 'win') === false) ? $isShellDisabled : true;
+if (!$isShellDisabled && !shell_exec('which ps 2>/dev/null')) $isShellDisabled = true;
+if (!$isShellDisabled && !shell_exec('which sed 2>/dev/null')) $isShellDisabled = true;
 
 try {
     if (stripos(PHP_OS, 'win') === false) {
@@ -62,8 +64,8 @@ try {
             $fileName = escapeshellarg(basename(__FILE__));
             $cronPath = escapeshellarg(__DIR__ . '/cron.sh');
 
-            shell_exec(escapeshellcmd("/bin/sh $cronPath $fileName -mdefault 1") . " > /dev/null 2>&1 &");
-            shell_exec(escapeshellcmd("/bin/sh $cronPath $fileName -malways 1") . " > /dev/null 2>&1 &");
+            shell_exec(escapeshellcmd("/bin/sh $cronPath $fileName -mdefault 1") . " &");
+            shell_exec(escapeshellcmd("/bin/sh $cronPath $fileName -malways 1") . " &");
             exit;
         }
     }

--- a/cron.php
+++ b/cron.php
@@ -43,6 +43,7 @@ umask(0);
 $disabledFuncs = array_map('trim', preg_split("/,|\s+/", strtolower(ini_get('disable_functions'))));
 $isShellDisabled = in_array('shell_exec', $disabledFuncs)
     || !str_contains(strtolower(PHP_OS), 'win')
+    || !shell_exec('which expr 2>/dev/null')
     || !shell_exec('which ps 2>/dev/null')
     || !shell_exec('which sed 2>/dev/null');
 

--- a/cron.php
+++ b/cron.php
@@ -18,9 +18,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-// Change current directory to the directory of current script
 chdir(__DIR__);
-
 require 'app/bootstrap.php';
 require 'app/Mage.php';
 
@@ -29,8 +27,7 @@ if (!Mage::isInstalled()) {
     exit;
 }
 
-// Only for urls
-// Don't remove this
+// Only for urls, don't remove this
 $_SERVER['SCRIPT_NAME'] = str_replace(basename(__FILE__), 'index.php', $_SERVER['SCRIPT_NAME']);
 $_SERVER['SCRIPT_FILENAME'] = str_replace(basename(__FILE__), 'index.php', $_SERVER['SCRIPT_FILENAME']);
 

--- a/cron.php
+++ b/cron.php
@@ -43,11 +43,11 @@ try {
 
 umask(0);
 
-$disabledFuncs = array_map('trim', explode(',', strtolower(ini_get('disable_functions'))));
-$isShellDisabled = is_array($disabledFuncs) ? in_array('shell_exec', $disabledFuncs) : true;
-$isShellDisabled = (stripos(PHP_OS, 'win') === false) ? $isShellDisabled : true;
-if (!$isShellDisabled && !shell_exec('which ps 2>/dev/null')) $isShellDisabled = true;
-if (!$isShellDisabled && !shell_exec('which sed 2>/dev/null')) $isShellDisabled = true;
+$disabledFuncs = array_map('trim', preg_split("/,|\s+/", strtolower(ini_get('disable_functions'))));
+$isShellDisabled = in_array('shell_exec', $disabledFuncs)
+    || !str_contains(strtolower(PHP_OS), 'win')
+    || !shell_exec('which ps 2>/dev/null')
+    || !shell_exec('which sed 2>/dev/null');
 
 try {
     if (stripos(PHP_OS, 'win') === false) {

--- a/cron.sh
+++ b/cron.sh
@@ -36,7 +36,7 @@ PHP_BIN=`which php`
 INSTALLDIR=`echo $0 | sed 's/cron\.sh//g'`
 
 # prepend the installation path if not given an absolute path
-if [ "$INSTALLDIR" != "" -a ${CRONSCRIPT:0:1} != "/" ];then
+if [ "$INSTALLDIR" != "" -a "`expr index $CRONSCRIPT /`" != "1" ];then
     if ! ps auxwww | grep "$INSTALLDIR$CRONSCRIPT$MODE" | grep -v grep 1>/dev/null 2>/dev/null ; then
     	$PHP_BIN $INSTALLDIR$CRONSCRIPT$MODE &
     fi

--- a/cron.sh
+++ b/cron.sh
@@ -36,7 +36,7 @@ PHP_BIN=`which php`
 INSTALLDIR=`echo $0 | sed 's/cron\.sh//g'`
 
 # prepend the installation path if not given an absolute path
-if [ "$INSTALLDIR" != "" -a "`expr index $CRONSCRIPT /`" != "1" ];then
+if [ "$INSTALLDIR" != "" -a ${CRONSCRIPT:0:1} != "1" ];then
     if ! ps auxwww | grep "$INSTALLDIR$CRONSCRIPT$MODE" | grep -v grep 1>/dev/null 2>/dev/null ; then
     	$PHP_BIN $INSTALLDIR$CRONSCRIPT$MODE &
     fi

--- a/cron.sh
+++ b/cron.sh
@@ -36,7 +36,7 @@ PHP_BIN=`which php`
 INSTALLDIR=`echo $0 | sed 's/cron\.sh//g'`
 
 # prepend the installation path if not given an absolute path
-if [ "$INSTALLDIR" != "" -a ${CRONSCRIPT:0:1} != "1" ];then
+if [ "$INSTALLDIR" != "" -a ${CRONSCRIPT:0:1} != "/" ];then
     if ! ps auxwww | grep "$INSTALLDIR$CRONSCRIPT$MODE" | grep -v grep 1>/dev/null 2>/dev/null ; then
     	$PHP_BIN $INSTALLDIR$CRONSCRIPT$MODE &
     fi


### PR DESCRIPTION
`cron.php` scripts hides some errors redirecting output to /dev/null, it should be avoided since it caused issue https://github.com/OpenMage/magento-lts/issues/1675

In the meanwhile I added a check for the availability of the `ps`, `sed` and `expr` commands.

### Fixed Issues
1. Fixes https://github.com/OpenMage/magento-lts/issues/1675