### PR TITLE
Replace Remaining join Alias Calls 

### DIFF
--- a/lib/Net/IDNA2.php
+++ b/lib/Net/IDNA2.php
@@ -2439,7 +2439,7 @@ class Net_IDNA2
                 $conv = $this->_decode($v);
                 if ($conv) $arr[$k] = $conv;
             }
-            $return = $email_pref . '@' . join('.', $arr);
+            $return = $email_pref . '@' . implode('.', $arr);
         } elseif (preg_match('![:\./]!', $input)) { // Or a complete domain name (with or without paths / parameters)
             // No no in strict mode
             if ($this->_strict_mode) {
@@ -2453,7 +2453,7 @@ class Net_IDNA2
                     $conv = $this->_decode($v);
                     if ($conv) $arr[$k] = $conv;
                 }
-                $parsed['host'] = join('.', $arr);
+                $parsed['host'] = implode('.', $arr);
                 if (isset($parsed['scheme'])) {
                     $parsed['scheme'] .= (strtolower($parsed['scheme']) == 'mailto') ? ':' : '://';
                 }
@@ -2464,7 +2464,7 @@ class Net_IDNA2
                     $conv = $this->_decode($v);
                     if ($conv) $arr[$k] = $conv;
                 }
-                $return = join('.', $arr);
+                $return = implode('.', $arr);
             }
         } else { // Otherwise we consider it being a pure domain name string
             $return = $this->_decode($input);

--- a/lib/Varien/Convert/Parser/Csv.php
+++ b/lib/Varien/Convert/Parser/Csv.php
@@ -139,7 +139,7 @@ class Varien_Convert_Parser_Csv extends Varien_Convert_Parser_Abstract
             foreach ($fields as $f) {
                 $line[] = $fEnc.str_replace(array('"', '\\'), array($fEsc.'"', $fEsc.'\\'), $f).$fEnc;
             }
-            $lines[] = join($fDel, $line);
+            $lines[] = implode($fDel, $line);
         }
         foreach ($data as $i=>$row) {
             $line = array();
@@ -154,9 +154,9 @@ class Varien_Convert_Parser_Csv extends Varien_Convert_Parser_Abstract
 
                 $line[] = $fEnc.$v.$fEnc;
             }
-            $lines[] = join($fDel, $line);
+            $lines[] = implode($fDel, $line);
         }
-        $result = join($lDel, $lines);
+        $result = implode($lDel, $lines);
         $this->setData($result);
 
         return $this;

--- a/lib/Varien/Convert/Parser/Xml/Excel.php
+++ b/lib/Varien/Convert/Parser/Xml/Excel.php
@@ -220,6 +220,6 @@ class Varien_Convert_Parser_Xml_Excel extends Varien_Convert_Parser_Abstract
         }
         $xmlData[] = '</Row>';
 
-        return join('', $xmlData);
+        return implode('', $xmlData);
     }
 }

--- a/lib/Varien/Data/Collection/Db.php
+++ b/lib/Varien/Data/Collection/Db.php
@@ -394,7 +394,7 @@ class Varien_Data_Collection_Db extends Varien_Data_Collection
                 );
             }
 
-            $resultCondition = '(' . join(') ' . Zend_Db_Select::SQL_OR . ' (', $conditions) . ')';
+            $resultCondition = '(' . implode(') ' . Zend_Db_Select::SQL_OR . ' (', $conditions) . ')';
         }
 
         $this->_select->where($resultCondition);

--- a/lib/Varien/Db/Adapter/Mysqli.php
+++ b/lib/Varien/Db/Adapter/Mysqli.php
@@ -262,7 +262,7 @@ class Varien_Db_Adapter_Mysqli extends Zend_Db_Adapter_Mysqli
             }
         }
 
-        return $this->raw_query('ALTER TABLE `'.$tableName.'` ' . join(', ', $alterDrop));
+        return $this->raw_query('ALTER TABLE `'.$tableName.'` ' . implode(', ', $alterDrop));
     }
 
     /**

--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -3535,7 +3535,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
         $query = sprintf('%s INTO %s', $query, $this->quoteIdentifier($table));
         if ($fields) {
             $columns = array_map(array($this, 'quoteIdentifier'), $fields);
-            $query = sprintf('%s (%s)', $query, join(', ', $columns));
+            $query = sprintf('%s (%s)', $query, implode(', ', $columns));
         }
 
         $query = sprintf('%s %s', $query, $select->assemble());
@@ -3572,7 +3572,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
                 }
             }
             if ($update) {
-                $query = sprintf('%s ON DUPLICATE KEY UPDATE %s', $query, join(', ', $update));
+                $query = sprintf('%s ON DUPLICATE KEY UPDATE %s', $query, implode(', ', $update));
             }
         }
 

--- a/lib/Varien/Debug.php
+++ b/lib/Varien/Debug.php
@@ -111,10 +111,10 @@ class Varien_Debug
                     $className,
                     isset($data['type']) ? $data['type'] : '->',
                     $data['function'],
-                    join(', ', $args)
+                    implode(', ', $args)
                 );
             } else if (isset($data['function'])) {
-                $methodName = sprintf('%s(%s)', $data['function'], join(', ', $args));
+                $methodName = sprintf('%s(%s)', $data['function'], implode(', ', $args));
             }
 
             if (isset($data['file'])) {
@@ -175,9 +175,9 @@ class Varien_Debug
                 foreach ($args as $k => $v) {
                     $arr[] = self::_formatCalledArgument($k) . ' => ' . $v;
                 }
-                $out .= 'array(' . join(', ', $arr) . ')';
+                $out .= 'array(' . implode(', ', $arr) . ')';
             } else {
-                $out .= 'array(' . join(', ', $args) . ')';
+                $out .= 'array(' . implode(', ', $args) . ')';
             }
         } else if (is_null($arg)) {
             $out .= 'NULL';


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
`join()` is an alias of `implode()` and should be replaced in favor of consistency. In 2021 there has been already an effort to adjust the majority of those cases. 
This PS replaces remaining occurrences of `join` with `count` (all in *lib/Varien*) **except** those in *lib/Zend* because there is currently an effort to replace *Zend1* with *ZF1-Future* (#2303) and I don't want to interfere here in any way. 

### Related Pull Requests
* #1394

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->