### PR TITLE
Color swatches work with disparate product IDs

### DIFF
--- a/skin/frontend/rwd/default/js/configurableswatches/product-media.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/product-media.js
@@ -28,23 +28,9 @@ var ConfigurableMediaImages = {
     productImages: {},
     imageObjects: {},
 
+    // deprecated - use Array.prototype.intersect instead
     arrayIntersect: function(a, b) {
-        var ai=0, bi=0;
-        var result = new Array();
-
-        while( ai < a.length && bi < b.length )
-        {
-            if      (a[ai] < b[bi] ){ ai++; }
-            else if (a[ai] > b[bi] ){ bi++; }
-            else /* they're equal */
-            {
-                result.push(a[ai]);
-                ai++;
-                bi++;
-            }
-        }
-
-        return result;
+        return a.intersect(b);
     },
 
     getCompatibleProductImages: function(productFallback, selectedLabels) {


### PR DESCRIPTION
This is https://github.com/OpenMage/magento-lts/pull/497, but on 1.9.4.x instead of 1.9.3.x.