### PR TITLE
Allow automatic full invoice from API

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
@@ -120,7 +120,7 @@ class Mage_Sales_Model_Order_Invoice_Api extends Mage_Sales_Model_Api_Resource
      * @param boolean $includeComment
      * @return string
      */
-    public function create($orderIncrementId, $itemsQty, $comment = null, $email = false, $includeComment = false)
+    public function create($orderIncrementId, $itemsQty = [], $comment = null, $email = false, $includeComment = false)
     {
         $order = Mage::getModel('sales/order')->loadByIncrementId($orderIncrementId);
 

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Api/V2.php
@@ -37,7 +37,7 @@ class Mage_Sales_Model_Order_Invoice_Api_V2 extends Mage_Sales_Model_Order_Invoi
      * @param bool $includeComment
      * @return string
      */
-    public function create($invoiceIncrementId, $itemsQty, $comment = null, $email = false, $includeComment = false)
+    public function create($invoiceIncrementId, $itemsQty = [], $comment = null, $email = false, $includeComment = false)
     {
         $order = Mage::getModel('sales/order')->loadByIncrementId($invoiceIncrementId);
         $itemsQty = $this->_prepareItemQtyData($itemsQty);


### PR DESCRIPTION
### Description

This PR allow to full invoice an order from API, like you can already create full shipment or full credit memo.

```php
$proxy = new SoapClient('...', ['trace' => 1, 'user_agent' => 'Local/Test']);
$sessionId = $proxy->login('covid', $pass);
var_dump($proxy->call($sessionId, 'sales_order.info', 'increment_id'));
var_dump($proxy->call($sessionId, 'sales_order_invoice.create', 'increment_id'));
var_dump($proxy->call($sessionId, 'sales_order_shipment.create', 'increment_id'));
var_dump($proxy->call($sessionId, 'sales_order_creditmemo.create', 'increment_id'));
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list