### PR TITLE
Fix qty for bundles items

### DIFF
--- a/app/code/core/Mage/Sales/Model/Service/Order.php
+++ b/app/code/core/Mage/Sales/Model/Service/Order.php
@@ -111,13 +111,39 @@ class Mage_Sales_Model_Service_Order
         $this->updateLocaleNumbers($qtys);
         $invoice = $this->_convertor->toInvoice($this->_order);
         $totalQty = 0;
+
         foreach ($this->_order->getAllItems() as $orderItem) {
             if (!$this->_canInvoiceItem($orderItem, [])) {
                 continue;
             }
+
             $item = $this->_convertor->itemToInvoiceItem($orderItem);
+
             if ($orderItem->isDummy()) {
-                $qty = $orderItem->getQtyOrdered() ? $orderItem->getQtyOrdered() : 1;
+                $qty = $orderItem->getQtyOrdered() - $orderItem->getQtyInvoiced() - $orderItem->getQtyCanceled(); // default value, but can be wrong for bundle items
+
+                $parentItem = $orderItem->getParentItem();
+                if (isset($qtys[$orderItem->getParentItemId()])) {
+                    $parentQty = $qtys[$orderItem->getParentItemId()];
+                } else {
+                    $parentQty = $parentItem->getQtyOrdered() - $parentItem->getQtyInvoiced() - $parentItem->getQtyCanceled();
+                }
+
+                if (!empty($parentQty)) {
+                    $productOptions = $orderItem->getProductOptions();
+                    if (isset($productOptions['bundle_selection_attributes'])) {
+                        $bundleSelectionAttributes = unserialize($productOptions['bundle_selection_attributes'], ['allowed_classes' => false]);
+                        if ($bundleSelectionAttributes) {
+                            $qty = $bundleSelectionAttributes['qty'] * $parentQty;
+                            $qty = min($qty, $orderItem->getQtyOrdered() - $orderItem->getQtyInvoiced() - $orderItem->getQtyCanceled());
+                            $item->setQty($qty);
+                            $invoice->addItem($item);
+                            continue;
+                        }
+                    } elseif ($parentItem->getData('product_type') == 'configurable') {
+                        $qty = $parentQty;
+                    }
+                }
             } else {
                 if (isset($qtys[$orderItem->getId()])) {
                     $qty = (float) $qtys[$orderItem->getId()];
@@ -149,8 +175,9 @@ class Mage_Sales_Model_Service_Order
     public function prepareShipment($qtys = [])
     {
         $this->updateLocaleNumbers($qtys);
-        $totalQty = 0;
         $shipment = $this->_convertor->toShipment($this->_order);
+        $totalQty = 0;
+
         foreach ($this->_order->getAllItems() as $orderItem) {
             if (!$this->_canShipItem($orderItem, $qtys)) {
                 continue;
@@ -159,25 +186,26 @@ class Mage_Sales_Model_Service_Order
             $item = $this->_convertor->itemToShipmentItem($orderItem);
 
             if ($orderItem->isDummy(true)) {
-                $qty = 0;
+                $qty = 0; // default value, but can be wrong for bundle items
+
                 if (isset($qtys[$orderItem->getParentItemId()])) {
+                    $parentQty = $qtys[$orderItem->getParentItemId()];
+                } else {
+                    $parentQty = $orderItem->getParentItem()->getSimpleQtyToShip();
+                }
+
+                if (!empty($parentQty)) {
                     $productOptions = $orderItem->getProductOptions();
                     if (isset($productOptions['bundle_selection_attributes'])) {
                         $bundleSelectionAttributes = unserialize($productOptions['bundle_selection_attributes'], ['allowed_classes' => false]);
-
                         if ($bundleSelectionAttributes) {
-                            $qty = $bundleSelectionAttributes['qty'] * $qtys[$orderItem->getParentItemId()];
+                            $qty = $bundleSelectionAttributes['qty'] * $parentQty;
                             $qty = min($qty, $orderItem->getSimpleQtyToShip());
-
                             $item->setQty($qty);
                             $shipment->addItem($item);
                             continue;
-                        } else {
-                            $qty = 1;
                         }
                     }
-                } else {
-                    $qty = 1;
                 }
             } else {
                 if (isset($qtys[$orderItem->getId()])) {
@@ -188,6 +216,7 @@ class Mage_Sales_Model_Service_Order
                     continue;
                 }
             }
+
             $totalQty += $qty;
             $item->setQty($qty);
             $shipment->addItem($item);
@@ -217,8 +246,29 @@ class Mage_Sales_Model_Service_Order
 
             $item = $this->_convertor->itemToCreditmemoItem($orderItem);
             if ($orderItem->isDummy()) {
-                $qty = 1;
+                $qty = $orderItem->getQtyToRefund(); // default value, but can be wrong for bundle items
                 $orderItem->setLockedDoShip(true);
+
+                if (isset($qtys[$orderItem->getParentItemId()])) {
+                    $parentQty = $qtys[$orderItem->getParentItemId()];
+                } else {
+                    $parentQty = $orderItem->getParentItem()->getQtyToRefund();
+                }
+
+                if (!empty($parentQty)) {
+                    $productOptions = $orderItem->getProductOptions();
+                    if (isset($productOptions['bundle_selection_attributes'])) {
+                        $bundleSelectionAttributes = unserialize($productOptions['bundle_selection_attributes'], ['allowed_classes' => false]);
+                        if ($bundleSelectionAttributes) {
+                            $qty = $bundleSelectionAttributes['qty'] * $parentQty;
+                            $item->setQty($qty);
+                            $creditmemo->addItem($item);
+                            continue;
+                        }
+                    } elseif ($orderItem->getParentItem()->getData('product_type') == 'configurable') {
+                        $qty = $parentQty;
+                    }
+                }
             } else {
                 if (isset($qtys[$orderItem->getId()])) {
                     $qty = (float) $qtys[$orderItem->getId()];
@@ -228,15 +278,16 @@ class Mage_Sales_Model_Service_Order
                     continue;
                 }
             }
+
             $totalQty += $qty;
             $item->setQty($qty);
             $creditmemo->addItem($item);
         }
+
         $creditmemo->setTotalQty($totalQty);
-
         $this->_initCreditmemoData($creditmemo, $data);
-
         $creditmemo->collectTotals();
+
         return $creditmemo;
     }
 
@@ -291,7 +342,31 @@ class Mage_Sales_Model_Service_Order
 
             $item = $this->_convertor->itemToCreditmemoItem($orderItem);
             if ($orderItem->isDummy()) {
-                $qty = 1;
+                $qty = $orderItem->getQtyToRefund(); // default value, but can be wrong for bundle items
+
+                if (isset($qtys[$orderItem->getParentItemId()])) {
+                    $parentQty = $qtys[$orderItem->getParentItemId()];
+                } else {
+                    $parentQty = $orderItem->getParentItem()->getQtyToRefund();
+                }
+
+                if (!empty($parentQty)) {
+                    $productOptions = $orderItem->getProductOptions();
+                    if (isset($productOptions['bundle_selection_attributes'])) {
+                        $bundleSelectionAttributes = unserialize($productOptions['bundle_selection_attributes'], ['allowed_classes' => false]);
+                        if ($bundleSelectionAttributes) {
+                            $qty = $bundleSelectionAttributes['qty'] * $parentQty;
+                            if (isset($invoiceQtysRefundLimits[$orderItem->getId()])) {
+                                $qty = min($qty, $invoiceQtysRefundLimits[$orderItem->getId()]);
+                            }
+                            $item->setQty($qty);
+                            $creditmemo->addItem($item);
+                            continue;
+                        }
+                    } elseif ($orderItem->getParentItem()->getData('product_type') == 'configurable') {
+                        $qty = $parentQty;
+                    }
+                }
             } else {
                 if (isset($qtys[$orderItem->getId()])) {
                     $qty = (float) $qtys[$orderItem->getId()];

--- a/app/code/core/Mage/Sales/Model/Service/Order.php
+++ b/app/code/core/Mage/Sales/Model/Service/Order.php
@@ -120,7 +120,8 @@ class Mage_Sales_Model_Service_Order
             $item = $this->_convertor->itemToInvoiceItem($orderItem);
 
             if ($orderItem->isDummy()) {
-                $qty = $orderItem->getQtyOrdered() - $orderItem->getQtyInvoiced() - $orderItem->getQtyCanceled(); // default value, but can be wrong for bundle items
+                // default value, but can be wrong for bundle items
+                $qty = $orderItem->getQtyOrdered() - $orderItem->getQtyInvoiced() - $orderItem->getQtyCanceled();
 
                 $parentItem = $orderItem->getParentItem();
                 if (isset($qtys[$orderItem->getParentItemId()])) {
@@ -186,7 +187,8 @@ class Mage_Sales_Model_Service_Order
             $item = $this->_convertor->itemToShipmentItem($orderItem);
 
             if ($orderItem->isDummy(true)) {
-                $qty = 0; // default value, but can be wrong for bundle items
+                // default value, but can be wrong for bundle items
+                $qty = 0;
 
                 if (isset($qtys[$orderItem->getParentItemId()])) {
                     $parentQty = $qtys[$orderItem->getParentItemId()];
@@ -246,7 +248,8 @@ class Mage_Sales_Model_Service_Order
 
             $item = $this->_convertor->itemToCreditmemoItem($orderItem);
             if ($orderItem->isDummy()) {
-                $qty = $orderItem->getQtyToRefund(); // default value, but can be wrong for bundle items
+                // default value, but can be wrong for bundle items
+                $qty = $orderItem->getQtyToRefund();
                 $orderItem->setLockedDoShip(true);
 
                 if (isset($qtys[$orderItem->getParentItemId()])) {
@@ -342,7 +345,8 @@ class Mage_Sales_Model_Service_Order
 
             $item = $this->_convertor->itemToCreditmemoItem($orderItem);
             if ($orderItem->isDummy()) {
-                $qty = $orderItem->getQtyToRefund(); // default value, but can be wrong for bundle items
+                // default value, but can be wrong for bundle items
+                $qty = $orderItem->getQtyToRefund();
 
                 if (isset($qtys[$orderItem->getParentItemId()])) {
                     $parentQty = $qtys[$orderItem->getParentItemId()];

--- a/shell/fix-qtys.php
+++ b/shell/fix-qtys.php
@@ -1,0 +1,266 @@
+<?php
+
+// DO NOT RUN DIRECTLY IN YOUR PRODUCTION ENVIRONMENT!
+// This script is distributed in the hope that it will be useful, but without any warranty.
+
+chdir(dirname(__DIR__, 1));
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+if (PHP_SAPI != 'cli') {
+    exit(0);
+}
+if (is_file('app/bootstrap.php')) {
+    require_once('app/bootstrap.php');
+}
+
+require_once('app/Mage.php');
+Mage::app('admin')->setUseSessionInUrl(false);
+Mage::app()->addEventArea('crontab');
+Mage::setIsDeveloperMode(true);
+
+echo 'start: ', date('c'), "\n";
+
+
+// nice -n 15 su - www-data -s /bin/bash -c 'php /var/www/.../fix-qtys.php'
+$runNumb = (int) end($argv);
+
+ini_set('memory_limit', '1G'); // memory limit
+exec('nproc', $core);
+$core  = max(1, (int) trim(implode($core))); // number of cpu core
+$limit = 1000; // number of orders per thread
+$stop  = Mage::getBaseDir('var').'/fixqtys.stop';
+
+
+if (is_file($stop)) {
+    echo 'Stop file is here: ',$stop,' - Exiting now.',"\n";
+    exit(-1);
+}
+
+if (empty($runNumb)) {
+    echo 'Starting process in 25 seconds...',"\n";
+    echo 'You can stop it at any moment by creating the stop file: '.$stop,"\n";
+    file_put_contents($stop, 'checking');
+    sleep(25);
+    unlink($stop);
+    echo 'Go!',"\n";
+
+    $core = max(1, $core - 5);
+    $pids = [];
+    $cmds = [];
+
+    $runNumb = ceil(Mage::getResourceModel('sales/order_collection')->getSize() / $limit);
+    while ($runNumb > 0) {
+        $cmds[] = PHP_BINARY.' '.getcwd().'/shell/'.basename($argv[0]).' '.$runNumb;
+        $runNumb--;
+    }
+
+    while (!empty($cmds)) {
+        if (is_file($stop)) {
+            break;
+        }
+
+        $pids[] = exec($cmd = array_shift($cmds).' >/dev/null 2>&1 & echo $!');
+        echo $cmd,"\n";
+        while (count($pids) >= $core) {
+            sleep(10);
+            foreach ($pids as $key => $pid) {
+                if (!file_exists('/proc/'.$pid)) {
+                    unset($pids[$key]);
+                } else {
+                    clearstatcache('/proc/'.$pid);
+                }
+            }
+        }
+    }
+
+    while (count($pids) > 0) {
+        sleep(10);
+        foreach ($pids as $key => $pid) {
+            if (!file_exists('/proc/'.$pid)) {
+                unset($pids[$key]);
+            } else {
+                clearstatcache('/proc/'.$pid);
+            }
+        }
+    }
+} else {
+    $cron = Mage::getModel('cron/schedule');
+    $cron->setData('job_code', 'manual_fixqtys_'.$runNumb);
+    $cron->setData('created_at', date('Y-m-d H:i:s'));
+    $cron->setData('scheduled_at', date('Y-m-d H:i:s'));
+    $cron->setData('executed_at', date('Y-m-d H:i:s'));
+    $cron->setData('status', 'running');
+    $cron->save();
+
+    $count   = 0;
+    $results = ['success' => [], 'error' => []];
+    $orders  = Mage::getResourceModel('sales/order_collection')
+        ->setOrder('entity_id', 'asc')
+        ->setPageSize($limit)
+        ->setCurPage($runNumb);
+
+    foreach ($orders as $order) {
+        if (is_file($stop)) {
+            $results['error'][] = ($runNumb > 0) ? 'Interrupted by '.$stop.' file (thread#'.$runNumb.').' : 'Interrupted by '.$stop.' file.';
+            break;
+        }
+
+        try {
+            $changes   = false;
+            $invoices  = $order->getInvoiceCollection();
+            $refunds   = $order->getCreditmemosCollection();
+            $shipments = $order->getShipmentsCollection();
+
+            // items of order
+            foreach ($order->getAllItems() as $item) {
+                $parentItem = $item->getParentItem();
+                if (is_object($parentItem)) {
+                    if ($parentItem->getData('qty_invoiced') == $parentItem->getData('qty_ordered')) {
+                        // parent item full invoiced
+                        $item->setData('qty_invoiced', $item->getData('qty_ordered'));
+                    } elseif ($parentItem->getData('qty_invoiced') > 0) {
+                        $productOptions = $item->getProductOptions();
+                        if (isset($productOptions['bundle_selection_attributes'])) {
+                            $bundleSelectionAttrs = unserialize($productOptions['bundle_selection_attributes'], ['allowed_classes' => false]);
+                            if ($bundleSelectionAttrs) {
+                                $item->setData('qty_invoiced', $parentItem->getData('qty_invoiced') * $bundleSelectionAttrs['qty']);
+                            }
+                        } elseif ($parentItem->getData('product_type') == 'configurable') {
+                            $item->setData('qty_invoiced', $parentItem->getData('qty_invoiced'));
+                        }
+                    }
+
+                    if ($parentItem->getData('qty_refunded') == $parentItem->getData('qty_ordered')) {
+                        // parent item full refunded
+                        $item->setData('qty_refunded', $item->getData('qty_ordered'));
+                    } elseif ($parentItem->getData('qty_refunded') > 0) {
+                        $productOptions = $item->getProductOptions();
+                        if (isset($productOptions['bundle_selection_attributes'])) {
+                            $bundleSelectionAttrs = unserialize($productOptions['bundle_selection_attributes'], ['allowed_classes' => false]);
+                            if ($bundleSelectionAttrs) {
+                                $item->setData('qty_refunded', $parentItem->getData('qty_refunded') * $bundleSelectionAttrs['qty']);
+                            }
+                        } elseif ($parentItem->getData('product_type') == 'configurable') {
+                            $item->setData('qty_refunded', $parentItem->getData('qty_refunded'));
+                        }
+                    }
+
+                    if ($parentItem->getData('qty_shipped') == $parentItem->getData('qty_ordered')) {
+                        // parent item full shipped
+                        if (in_array($item->getData('product_type'), ['downloadable', 'virtual'])) {
+                            $item->setData('qty_shipped', 0);
+                        } else {
+                            $item->setData('qty_shipped', $item->getData('qty_ordered'));
+                        }
+                    } elseif ($parentItem->getData('qty_shipped') > 0) {
+                        $productOptions = $item->getProductOptions();
+                        if (in_array($item->getData('product_type'), ['downloadable', 'virtual'])) {
+                            $item->setData('qty_shipped', 0);
+                        } elseif (isset($productOptions['bundle_selection_attributes'])) {
+                            $bundleSelectionAttrs = unserialize($productOptions['bundle_selection_attributes'], ['allowed_classes' => false]);
+                            if ($bundleSelectionAttrs) {
+                                $item->setData('qty_shipped', $parentItem->getData('qty_shipped') * $bundleSelectionAttrs['qty']);
+                            }
+                        } elseif ($parentItem->getData('product_type') == 'configurable') {
+                            $item->setData('qty_shipped', $parentItem->getData('qty_shipped'));
+                        }
+                    }
+
+                    if ($item->hasDataChanges()) {
+                        $changes = true;
+                        $item->save();
+                    }
+                }
+            }
+
+            // items of invoices
+            $nb = count($invoices);
+            foreach ($invoices as $invoice) {
+                foreach ($invoice->getAllItems() as $item) {
+                    $orderItem = $item->getOrderItem();
+                    if ($nb == 1) {
+                        $item->setData('qty', $orderItem->getData('qty_invoiced'));
+                    }
+                    if ($item->hasDataChanges()) {
+                        $changes = true;
+                        $item->save();
+                    }
+                }
+            }
+
+            // items of creditmemos
+            $nb = count($refunds);
+            foreach ($refunds as $refund) {
+                foreach ($refund->getAllItems() as $item) {
+                    $orderItem = $item->getOrderItem();
+                    if ($nb == 1) {
+                        $item->setData('qty', $orderItem->getData('qty_refunded'));
+                    }
+                    if ($item->hasDataChanges()) {
+                        $changes = true;
+                        $item->save();
+                    }
+                }
+            }
+
+            // items of shipments
+            $nb = count($shipments);
+            foreach ($shipments as $shipment) {
+                foreach ($shipment->getAllItems() as $item) {
+                    $orderItem  = $item->getOrderItem();
+                    $parentItem = $orderItem->getParentItem();
+
+                    if ($nb == 1) {
+                        $item->setData('qty', $orderItem->getData('qty_shipped'));
+                    }
+
+                    if (is_object($parentItem) && ($parentItem->getData('product_type') == 'configurable')) {
+                        $changes = true;
+                        $item->delete();
+                    } elseif ($item->hasDataChanges()) {
+                        $changes = true;
+                        $item->save();
+                    }
+                }
+            }
+
+            if ($changes) {
+                $results['success'][] = $order->getId();
+            }
+        } catch (Throwable $t) {
+            $results['error'][] = $order->getId().'#'.$t->getMessage();
+        }
+
+        if ((++$count % 200) == 0) {
+            saveCron($cron, $results, false);
+        }
+    }
+
+    saveCron($cron, $results, true);
+}
+
+function saveCron(object $cron, array $results, bool $end)
+{
+    if (!empty($results['success']) || !empty($results['error'])) {
+        $textok = trim(str_replace(['    ', ' => Array', "\n\n"], [' ', '', "\n"], preg_replace('#\s+[()]#', '', print_r($results['success'], true))));
+        $textko = trim(str_replace(['    ', ' => Array', "\n\n"], [' ', '', "\n"], preg_replace('#\s+[()]#', '', print_r($results['error'], true))));
+
+        if ($end) {
+            $cron->setData('finished_at', date('Y-m-d H:i:s'));
+            $cron->setData('status', empty($results['error']) ? 'success' : 'error');
+        }
+
+        $cron->setData('messages', 'memory: '.((int) (memory_get_peak_usage(true) / 1024 / 1024)).'M (max: '.ini_get('memory_limit').')'."\n".'success: '.$textok."\n".'error: '.$textko);
+        $cron->save();
+    } elseif ($end) {
+        // should never happen
+        $cron->setData('finished_at', date('Y-m-d H:i:s'));
+        $cron->setData('status', 'error');
+        $cron->setData('messages', 'nothing to do');
+        $cron->save();
+    }
+}
+
+
+exit(0);

--- a/shell/fix-qtys.php
+++ b/shell/fix-qtys.php
@@ -1,8 +1,19 @@
 <?php
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   Mage
+ * @package    Mage_Shell
+ * @copyright  Copyright (c) 2023 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 
-// DO NOT RUN DIRECTLY IN YOUR PRODUCTION ENVIRONMENT!
-// This script is distributed in the hope that it will be useful, but without any warranty.
-
+// TEST IT BEFORE RUN IN YOUR PRODUCTION ENVIRONMENT!
+// See https://github.com/OpenMage/magento-lts/pull/2395
 chdir(dirname(__DIR__, 1));
 error_reporting(E_ALL);
 ini_set('display_errors', 1);


### PR DESCRIPTION
### Description

Fix qty_invoiced qty_shipped qty_refunded for bundle order items, qty for bundle invoice/shipment/creditmemo items.
Fix qty_refunded for configurable order items, qty for configurable creditmemo items.

todo: better description

### Fixed Issues
1. Fixes OpenMage/magento-lts#2310

### Manual testing scenarios

Create a bundle product (sku _-646_ on screenshots) associated with:
- a simple product, qty 1 (sku _-140_ on screenshots)
- a simple product, qty 2 (sku _-141_ on screenshots)
- a simple product, qty 3 (sku _-552_ on screenshots)
- a downloadable product, qty 1 (sku _FPDF_ on screenshots)
- a downloadable product, qty 2 (sku _-PDF_ on screenshots)

Create also a configurable product (sku _-125-M_ on screenshots).

Some screenshots (before/after):

Create invoice + shipment + refund from API:
[0-api-simple-before](https://user-images.githubusercontent.com/31816829/183735103-4eab364e-7621-4ee0-a0a4-807c22bef157.png)
[1-api-simple-after](https://user-images.githubusercontent.com/31816829/183735110-cdba5e35-3029-4704-9e74-b16080f7a33e.png)

Create invoice + shipment + refund from backend:
[2-backend-simple-before](https://user-images.githubusercontent.com/31816829/183735116-266391b4-1ebb-42a6-8ed5-bf2223486852.png)
[3-backend-simple-after](https://user-images.githubusercontent.com/31816829/183735120-fc61f58c-18ee-407e-b743-c53d44bf01a5.png)

Create invoice + shipment + refund on invoice from backend:
[4-backend-simple-before-ref-inv](https://user-images.githubusercontent.com/31816829/183735125-210c6713-935f-41dd-a4cc-2956256c03b8.png)
[5-backend-simple-after-ref-inv](https://user-images.githubusercontent.com/31816829/183735127-0be8be6f-cf69-499c-9fbb-17ccefa5ca76.png)

Create invoice + shipment + refund from API:
[6-api-double-before](https://user-images.githubusercontent.com/31816829/183735134-e484e04b-6d0e-47ca-8a01-4d453f8ed54c.png)
[7-api-double-after](https://user-images.githubusercontent.com/31816829/183735140-c21e2a89-daa6-435b-9783-3525766cefc4.png)

Create invoice + shipment + refund from backend:
[8-backend-double-before](https://user-images.githubusercontent.com/31816829/183735144-8c7815cb-c487-47d7-84d4-e01d106140cb.png)
[9-backend-double-after](https://user-images.githubusercontent.com/31816829/183735152-20be3e8d-82b1-4619-98c6-3d3b44823e03.png)

Create invoice + shipment + refund on invoice from backend:
[10-backend-double-before-ref-inv](https://user-images.githubusercontent.com/31816829/183735154-9ef35a03-6ffc-40f3-8f4e-8e28a1439019.png)
[11-backend-double-after-ref-inv](https://user-images.githubusercontent.com/31816829/183735161-78dfc603-d714-4dbc-9f1a-b0bb17aae155.png)

Create invoice + shipment + refund from backend:
[12-backend-double-2x-before](https://user-images.githubusercontent.com/31816829/183735165-e035dd4e-7b26-49a6-bf32-fcbc94175fc7.png)
[13-backend-double-2x-after](https://user-images.githubusercontent.com/31816829/183735173-df31cc6c-0ce8-4345-bc76-373f13431695.png)

Create invoice + shipment + refund on invoice from backend:
[14-backend-double-2x-before-ref-inv](https://user-images.githubusercontent.com/31816829/183735180-57c74d98-5deb-4226-a4d3-aa168d3c903d.png)
[15-backend-double-2x-after-ref-inv](https://user-images.githubusercontent.com/31816829/183735184-0df53ef4-ebe2-4213-8825-cdbff0781eb1.png)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
