### PR TITLE
Remove hideit input field from Contact form

### DIFF
--- a/app/code/core/Mage/Contacts/controllers/IndexController.php
+++ b/app/code/core/Mage/Contacts/controllers/IndexController.php
@@ -80,10 +80,6 @@ class Mage_Contacts_IndexController extends Mage_Core_Controller_Front_Action
                     $error = true;
                 }
 
-                if (Zend_Validate::is(trim($post['hideit']), 'NotEmpty')) {
-                    $error = true;
-                }
-
                 if ($error) {
                     throw new Exception();
                 }

--- a/app/design/frontend/base/default/template/contacts/form.phtml
+++ b/app/design/frontend/base/default/template/contacts/form.phtml
@@ -56,7 +56,6 @@
     </div>
     <div class="buttons-set">
         <p class="required"><?php echo Mage::helper('contacts')->__('* Required Fields') ?></p>
-        <input type="text" name="hideit" id="hideit" value="" style="display:none !important;" />
         <button type="submit" title="<?php echo Mage::helper('core')->quoteEscape(Mage::helper('contacts')->__('Submit')) ?>" class="button"><span><span><?php echo Mage::helper('contacts')->__('Submit') ?></span></span></button>
     </div>
 </form>

--- a/app/design/frontend/rwd/default/template/contacts/form.phtml
+++ b/app/design/frontend/rwd/default/template/contacts/form.phtml
@@ -56,7 +56,6 @@
         </ul>
     </div>
     <div class="buttons-set">
-        <input type="text" name="hideit" id="hideit" value="" style="display:none !important;" />
         <button type="submit" title="<?php echo Mage::helper('core')->quoteEscape(Mage::helper('contacts')->__('Submit')) ?>" class="button"><span><span><?php echo Mage::helper('contacts')->__('Submit') ?></span></span></button>
     </div>
 </form>


### PR DESCRIPTION
This bait field in the Contact form is useless and its name cannot be changed in the Backend without getting your hands dirty with code. Since it is not mandatory to fill in and especially knowing its name, it is easy to be bypassed by bots. In almost 10 years since I've been using Magento 1 platform I have found records in system.log about 2 times, like the one bellow, most likely generated by a bot that accessed the controller directly:

```
2020-07-12T13:00:18+00:00 ERR (3): Notice: Undefined index: hideit  in /home/XXXXXXX/public_html/app/code/core/Mage/Contacts/controllers/IndexController.php on line 89
```

Recently, PR #2347 was proposed to introduce formkey validation for the Contact form. It is by far the best protection option if reCaptcha is not used. In addition, abusive usage of the controller with the curl command is blocked (not completely).

I recommend using the https://github.com/magento-hackathon/HoneySpam extension that adds and customizes this bait field in the Contact form. I have been using HoneySpam for about 2 years in all my installations and I can say that it is a must-have extension that does the job it was created for. It also has the advantage that its records in the webserver log together with Fail2Ban can block IPs that fill in those hidden bait fields (Customer Account, Newsletter, Contact forms).