### PR TITLE
Remove deprecated utf8_encode() for PHP 8.2

### DIFF
--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl.php
@@ -519,7 +519,7 @@ class Mage_Usa_Model_Shipping_Carrier_Dhl
         }
 
         $request = $xml->asXML();
-        $request = utf8_encode($request);
+        $request = mb_convert_encoding($request, 'UTF-8', 'ISO-8859-1');
         $responseBody = $this->_getCachedQuotes($request);
         if ($responseBody === null) {
             $debugData = array('request' => $request);

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
@@ -834,7 +834,7 @@ class Mage_Usa_Model_Shipping_Carrier_Dhl_International
             'verifypeer' => $this->getConfigFlag('verify_peer'),
             'verifyhost' => 2,
         ));
-        $client->setRawData(utf8_encode($request));
+        $client->setRawData(mb_convert_encoding($request, 'UTF-8', 'ISO-8859-1'));
         return $client->request(Varien_Http_Client::POST)->getBody();
     }
 
@@ -1399,7 +1399,7 @@ class Mage_Usa_Model_Shipping_Carrier_Dhl_International
         $xml->addChild('LabelImageFormat', 'PDF', '');
 
         $request = $xml->asXML();
-        $request = utf8_encode($request);
+        $request = mb_convert_encoding($request, 'UTF-8', 'ISO-8859-1');
 
         $responseBody = $this->_getCachedQuotes($request);
         if ($responseBody === null) {
@@ -1594,7 +1594,7 @@ class Mage_Usa_Model_Shipping_Carrier_Dhl_International
         //$xml->addChild('PiecesEnabled', 'ALL_CHECK_POINTS');
 
         $request = $xml->asXML();
-        $request = utf8_encode($request);
+        $request = mb_convert_encoding($request, 'UTF-8', 'ISO-8859-1');
 
         $responseBody = $this->_getCachedQuotes($request);
         if ($responseBody === null) {


### PR DESCRIPTION
PHP 8.2 deprecated `utf8_encode()` and `utf8_decode()`: https://wiki.php.net/rfc/remove_utf8_decode_and_utf8_encode

This PR switched `utf8_encode()` calls to `mb_convert_encoding()` (it's the suggested method in the RFC above).

Notes:
- I didn't convert anything in `lib/Zend` or in the modules touched by https://github.com/OpenMage/magento-lts/pull/2138
- since the only usages of `utf8_decode()` (also deprecated) are in `lib/` I didn't touch them either