### PR TITLE
Fix targetNamespace in WS-I Compliant

### DIFF
--- a/app/code/core/Mage/Api/etc/wsi.xml
+++ b/app/code/core/Mage/Api/etc/wsi.xml
@@ -5,7 +5,7 @@
              xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
              xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
              name="OpenMage"
-             targetNamespace="OpenMage">
+             targetNamespace="urn:OpenMage">
     <wsdl:types>
         <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
             <xsd:complexType name="associativeEntity">


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

Fixing bad targetNamespace for WS-I Soap

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Bad targetNamespace was used in Mage/Api/etc/wsi.xml


<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Fixes OpenMage/magento-lts#2399

