### PR TITLE
Error_Processor Refactoring

### DIFF
--- a/errors/default/report.phtml
+++ b/errors/default/report.phtml
@@ -18,9 +18,7 @@
  * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-/**
- * @var Error_Processor $this
- */
+/** @var Error_Processor $this */
 ?>
 <div class="col-main">
     <div class="page-title">

--- a/errors/default/report.phtml
+++ b/errors/default/report.phtml
@@ -17,6 +17,10 @@
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
  * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/**
+ * @var Error_Processor $this
+ */
 ?>
 <div class="col-main">
     <div class="page-title">
@@ -85,11 +89,11 @@
         </div>
         <p class="required">* Required Fields</p>
     </form>
-    <?php elseif ('' == $this->reportAction): ?>
+    <?php elseif ($this->reportAction === ''): ?>
         <p><em>Exception printing is disabled by default for security reasons.</em></p>
     <?php endif ?>
 
-    <?php if ($this->reportAction == 'print'): ?>
+    <?php if ($this->reportAction === 'print'): ?>
     <div class="trace-container">
         <div class="trace">
             <pre><?php echo $this->reportData[0] ?><br />

--- a/errors/processor.php
+++ b/errors/processor.php
@@ -247,19 +247,19 @@ class Error_Processor
             $this->_setSkin($skin, $config);
         }
         if ($local !== null) {
-            if (($action = (string)$local->report->action)) {
+            if ($action = (string)$local->report->action) {
                 $config->action = $action;
             }
-            if (($subject = (string)$local->report->subject)) {
+            if ($subject = (string)$local->report->subject) {
                 $config->subject = $subject;
             }
-            if (($emailAddress = (string)$local->report->email_address)) {
+            if ($emailAddress = (string)$local->report->email_address) {
                 $config->email_address = $emailAddress;
             }
-            if (($trash = (string)$local->report->trash)) {
+            if ($trash = (string)$local->report->trash) {
                 $config->trash = $trash;
             }
-            if (($localSkin = (string)$local->skin)) {
+            if ($localSkin = (string)$local->skin) {
                 $this->_setSkin($localSkin, $config);
             }
         }

--- a/errors/processor.php
+++ b/errors/processor.php
@@ -28,69 +28,34 @@ class Error_Processor
     const MAGE_ERRORS_LOCAL_XML = 'local.xml';
     const MAGE_ERRORS_DESIGN_XML = 'design.xml';
     const DEFAULT_SKIN = 'default';
+    const DEFAULT_TRASH_MODE = 'leave';
     const ERROR_DIR = 'errors';
 
-    /**
-     * Page title
-     *
-     * @var string
-    */
+    /** @var string */
     public $pageTitle;
 
-    /**
-     * Skin URL
-     *
-     * @var string
-    */
-    public $skinUrl;
-
-    /**
-     * Base URL
-     *
-     * @var string
-    */
+    /** @var string */
     public $baseUrl;
 
-    /**
-     * Post data
-     *
-     * @var array
-    */
+    /** @var array */
     public $postData;
 
-    /**
-     * Report data
-     *
-     * @var array
-    */
+    /** @var array */
     public $reportData;
 
-    /**
-     * Report action
-     *
-     * @var string
-    */
+    /** @var string */
     public $reportAction;
 
-    /**
-     * Report ID
-     *
-     * @var int
-     */
+    /** @var int */
     public $reportId;
 
-    /**
-     * Report file
-     *
-     * @var string
-    */
+    /** @var string */
+    public $reportUrl;
+
+    /** @var string report file name */
     protected $_reportFile;
 
-    /**
-     * Show error message
-     *
-     * @var bool
-    */
+    /** @var bool */
     public $showErrorMsg;
 
     /**
@@ -100,11 +65,7 @@ class Error_Processor
     */
     public $showSentMsg;
 
-    /**
-     * Show form for sending
-     *
-     * @var bool
-    */
+    /** @var bool */
     public $showSendForm;
 
     /**
@@ -114,12 +75,17 @@ class Error_Processor
     */
     protected $_scriptName;
 
-    /**
-     * Is root
-     *
-     * @var bool
-    */
+    /** @var bool */
     protected $_root;
+
+    /** @var string */
+    protected $_errorDir;
+
+    /** @var string */
+    protected $_reportDir;
+
+    /** @var string */
+    protected $_indexDir;
 
     /**
      * Internal config object
@@ -130,7 +96,7 @@ class Error_Processor
 
     public function __construct()
     {
-        $this->_errorDir  = dirname(__FILE__) . '/';
+        $this->_errorDir  = __DIR__ . '/';
         $this->_reportDir = dirname($this->_errorDir) . '/var/report/';
 
         if (!empty($_SERVER['SCRIPT_NAME'])) {
@@ -190,29 +156,22 @@ class Error_Processor
         $this->reportAction = $this->_config->action;
         $this->_setReportUrl();
 
-        if($this->reportAction == 'email') {
+        if($this->reportAction === 'email') {
             $this->showSendForm = true;
             $this->sendReport();
         }
         $this->_renderPage('report.phtml');
     }
 
-    /**
-     * Retrieve skin URL
-     *
-     * @return string
-     */
-    public function getSkinUrl()
+    public function getSkinUrl(): string
     {
         return $this->getBaseUrl() . self::ERROR_DIR. '/' . $this->_config->skin . '/';
     }
 
     /**
      * Retrieve base host URL without path
-     *
-     * @return string
      */
-    public function getHostUrl()
+    public function getHostUrl(): string
     {
         /**
          * Define server http host
@@ -225,8 +184,9 @@ class Error_Processor
             $host = 'localhost';
         }
 
-        $isSecure = (!empty($_SERVER['HTTPS'])) && ($_SERVER['HTTPS'] != 'off');
-        $url = ($isSecure ? 'https://' : 'http://') . htmlspecialchars($host, ENT_COMPAT | ENT_HTML401, 'UTF-8');
+        $isSecure = (!empty($_SERVER['HTTPS'])) && ($_SERVER['HTTPS'] !== 'off');
+        $url = ($isSecure ? 'https://' : 'http://')
+            . htmlspecialchars($host, ENT_COMPAT | ENT_HTML401, 'UTF-8');
 
         if (!empty($_SERVER['SERVER_PORT'])
             && preg_match('/\d+/', $_SERVER['SERVER_PORT'])
@@ -237,12 +197,7 @@ class Error_Processor
         return  $url;
     }
 
-    /**
-     * Retrieve base URL
-     *
-     * @return string
-     */
-    public function getBaseUrl($param = false)
+    public function getBaseUrl(bool $param = false): string
     {
         $path = $this->_scriptName;
 
@@ -251,25 +206,18 @@ class Error_Processor
         }
 
         $basePath = str_replace('\\', '/', dirname($path));
-        return $this->getHostUrl() . ('/' == $basePath ? '' : $basePath) . '/';
+        return $this->getHostUrl() . ($basePath === '/' ? '' : $basePath) . '/';
     }
 
     /**
      * Retrieve client IP address
-     *
-     * @return string
      */
-    protected function _getClientIp()
+    protected function _getClientIp(): string
     {
-        return (isset($_SERVER['REMOTE_ADDR'])) ? $_SERVER['REMOTE_ADDR'] : 'undefined';
+        return $_SERVER['REMOTE_ADDR'] ?? 'undefined';
     }
 
-    /**
-     * Get index dir
-     *
-     * @return string
-     */
-    protected function _getIndexDir()
+    protected function _getIndexDir(): string
     {
         $documentRoot = '';
         if (!empty($_SERVER['DOCUMENT_ROOT'])) {
@@ -291,31 +239,31 @@ class Error_Processor
         $config->action         = '';
         $config->subject        = 'Store Debug Information';
         $config->email_address  = '';
-        $config->trash          = 'leave';
+        $config->trash          = self::DEFAULT_TRASH_MODE;
         $config->skin           = self::DEFAULT_SKIN;
 
         //combine xml data to one object
-        if (!is_null($design) && (string)$design->skin) {
-            $this->_setSkin((string)$design->skin, $config);
+        if ($design !== null && ($skin = (string)$design->skin)) {
+            $this->_setSkin($skin, $config);
         }
-        if (!is_null($local)) {
-            if ((string)$local->report->action) {
-                $config->action = $local->report->action;
+        if ($local !== null) {
+            if (($action = (string)$local->report->action)) {
+                $config->action = $action;
             }
-            if ((string)$local->report->subject) {
-                $config->subject = $local->report->subject;
+            if (($subject = (string)$local->report->subject)) {
+                $config->subject = $subject;
             }
-            if ((string)$local->report->email_address) {
-                $config->email_address = $local->report->email_address;
+            if (($emailAddress = (string)$local->report->email_address)) {
+                $config->email_address = $emailAddress;
             }
-            if ((string)$local->report->trash) {
-                $config->trash = $local->report->trash;
+            if (($trash = (string)$local->report->trash)) {
+                $config->trash = $trash;
             }
-            if ((string)$local->skin) {
-                $this->_setSkin((string)$local->skin, $config);
+            if (($localSkin = (string)$local->skin)) {
+                $this->_setSkin($localSkin, $config);
             }
         }
-        if ((string)$config->email_address == '' && (string)$config->action == 'email') {
+        if ($config->email_address === '' && $config->action === 'email') {
             $config->action = '';
         }
 
@@ -325,10 +273,10 @@ class Error_Processor
     /**
      * Load xml file
      *
-     * @param string $config
-     * return SimpleXMLElement
+     * @param string $xmlFile file name
+     * @return SimpleXMLElement|null
      */
-    protected function _loadXml($xmlFile)
+    protected function _loadXml(string $xmlFile)
     {
         $configPath = $this->_getFilePath($xmlFile);
         return ($configPath) ? simplexml_load_file($configPath) : null;
@@ -336,10 +284,8 @@ class Error_Processor
 
     /**
      * Send error headers
-     *
-     * @param int $statusCode
      */
-    protected function _sendHeaders($statusCode)
+    protected function _sendHeaders(int $statusCode)
     {
         $serverProtocol = !empty($_SERVER['SERVER_PROTOCOL']) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0';
         switch ($statusCode) {
@@ -358,9 +304,6 @@ class Error_Processor
         header(sprintf('Status: %s %s', $statusCode, $description), true, $statusCode);
     }
 
-    /**
-     * Render page
-     */
     protected function _renderPage($template)
     {
         $baseTemplate = $this->_getTemplatePath('page.phtml');
@@ -375,12 +318,12 @@ class Error_Processor
      * Find file path
      *
      * @param string $file
-     * @param array $directories
-     * return $string
+     * @param array|null $directories
+     * @return string|null
      */
-    protected function _getFilePath($file, $directories = null)
+    protected function _getFilePath(string $file, $directories = null)
     {
-        if (is_null($directories)) {
+        if ($directories === null) {
             $directories = array();
 
             if (!$this->_root) {
@@ -394,50 +337,46 @@ class Error_Processor
                 return $directory . $file;
             }
         }
+        return null;
     }
 
     /**
      * Find template path
      *
      * @param string $template
-     * return $string
+     * @return string|null
      */
-    protected function _getTemplatePath($template)
+    protected function _getTemplatePath(string $template)
     {
-        $directories = array();
+        $directories = [];
 
         if (!$this->_root) {
             $directories[] = $this->_indexDir . self::ERROR_DIR. '/'. $this->_config->skin . '/';
 
-            if ($this->_config->skin != self::DEFAULT_SKIN) {
+            if ($this->_config->skin !== self::DEFAULT_SKIN) {
                 $directories[] = $this->_indexDir . self::ERROR_DIR . '/'. self::DEFAULT_SKIN . '/';
             }
         }
 
         $directories[] = $this->_errorDir . $this->_config->skin . '/';
 
-        if ($this->_config->skin != self::DEFAULT_SKIN) {
+        if ($this->_config->skin !== self::DEFAULT_SKIN) {
             $directories[] = $this->_errorDir . self::DEFAULT_SKIN . '/';
         }
 
         return $this->_getFilePath($template, $directories);
     }
 
-    /**
-     * Set report data
-     *
-     * @param array $reportData
-     */
-    protected function _setReportData($reportData)
+    protected function _setReportData(array $reportData)
     {
         $this->reportData = $reportData;
 
-        if (!isset($reportData['url'])) {
-            $this->reportData['url'] = '';
+        if (isset($reportData['url'])) {
+            $this->reportData['url'] = $this->getHostUrl()
+                . htmlspecialchars($reportData['url'], ENT_COMPAT | ENT_HTML401, 'UTF-8');
         }
         else {
-            $this->reportData['url'] = $this->getHostUrl()
-                                    . htmlspecialchars($reportData['url'], ENT_COMPAT | ENT_HTML401, 'UTF-8');
+            $this->reportData['url'] = '';
         }
 
         if (isset($this->reportData['script_name'])) {
@@ -446,14 +385,12 @@ class Error_Processor
     }
 
     /**
-     * Create report
-     *
-     * @param array $reportData
+     * @throws Exception
      */
-    public function saveReport($reportData)
+    public function saveReport(array $reportData)
     {
         $this->reportData = $reportData;
-        $this->reportId   = abs(intval(microtime(true) * rand(100, 1000)));
+        $this->reportId   = abs((int)(microtime(true) * random_int(100, 1000)));
         $this->_reportFile = $this->_reportDir . '/' . $this->reportId;
         $this->_setReportData($reportData);
 
@@ -465,33 +402,31 @@ class Error_Processor
         @file_put_contents($this->_reportFile, serialize($reportData));
         @chmod($this->_reportFile, 0640);
 
-        if (isset($reportData['skin']) && self::DEFAULT_SKIN != $reportData['skin']) {
+        if (isset($reportData['skin']) && self::DEFAULT_SKIN !== $reportData['skin']) {
             $this->_setSkin($reportData['skin']);
         }
         $this->_setReportUrl();
 
         if (headers_sent()) {
-            print '<script type="text/javascript">';
-            print "window.location.href = encodeURI('{$this->reportUrl}');";
-            print '</script>';
-            exit;
+            echo '<script type="text/javascript">';
+            echo "window.location.href = encodeURI('{$this->reportUrl}');";
+            echo '</script>';
+            exit();
         }
     }
 
     /**
-     * Get report
-     *
-     * @param int $reportId
+     * @return void|no-return
      */
-    public function loadReport($reportId)
+    public function loadReport(int $reportId)
     {
         $reportData = false;
         $this->reportId = $reportId;
         $this->_reportFile = $this->_reportDir . '/' . $reportId;
 
         if (!file_exists($this->_reportFile) || !is_readable($this->_reportFile)) {
-            header("Location: " . $this->getBaseUrl());
-            die();
+            header('Location: ' . $this->getBaseUrl());
+            exit();
         }
 
         $reportContent = file_get_contents($this->_reportFile);
@@ -504,8 +439,7 @@ class Error_Processor
     }
 
     /**
-     * Send report
-     *
+     * @return void
      */
     public function sendReport()
     {
@@ -532,8 +466,8 @@ class Error_Processor
                     $msg .= "Comment: {$this->postData['comment']}\n";
                 }
 
-                $subject = sprintf('%s [%s]', (string)$this->_config->subject, $this->reportId);
-                @mail((string)$this->_config->email_address, $subject, $msg);
+                $subject = sprintf('%s [%s]', $this->_config->subject, $this->reportId);
+                @mail($this->_config->email_address, $subject, $msg);
 
                 $this->showSendForm = false;
                 $this->showSentMsg  = true;
@@ -549,10 +483,10 @@ class Error_Processor
                 . "Error:\n{$this->reportData[0]}\n\n"
                 . "Trace:\n{$this->reportData[1]}";
 
-            $subject = sprintf('%s [%s]', (string)$this->_config->subject, $this->reportId);
-            @mail((string)$this->_config->email_address, $subject, $msg);
+            $subject = sprintf('%s [%s]', $this->_config->subject, $this->reportId);
+            @mail($this->_config->email_address, $subject, $msg);
 
-            if ($this->_config->trash == 'delete') {
+            if ($this->_config->trash === 'delete') {
                 @unlink($this->_reportFile);
             }
         }
@@ -560,29 +494,26 @@ class Error_Processor
 
     /**
      * Validate submitted post data
-     *
-     * @return bool
      */
-    protected function _validate()
+    protected function _validate(): bool
     {
-        $email = preg_match('/^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3})$/',
-            $this->postData['email']);
+        $email = preg_match(
+            '/^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3})$/',
+            $this->postData['email']
+        );
         return ($this->postData['firstName'] && $this->postData['lastName'] && $email);
     }
 
     /**
-     * Skin setter
-     *
-     * @param string $value
-     * @param stdClass $config
+     * @return void
      */
-    protected function _setSkin($value, stdClass $config = null)
+    protected function _setSkin(string $value, stdClass $config = null)
     {
-        if (preg_match('/^[a-z0-9_]+$/i', $value) && is_dir($this->_indexDir . self::ERROR_DIR . '/' . $value)) {
-            if (!$config) {
-                if ($this->_config) {
-                    $config = $this->_config;
-                }
+        if (preg_match('/^[a-z0-9_]+$/i', $value)
+            && is_dir($this->_indexDir . self::ERROR_DIR . '/' . $value)
+        ) {
+            if (!$config && $this->_config) {
+                $config = $this->_config;
             }
             if ($config) {
                 $config->skin = $value;
@@ -592,13 +523,16 @@ class Error_Processor
 
     /**
      * Set current report URL from current params
+     * @return void
      */
     protected function _setReportUrl()
     {
         if ($this->reportId && $this->_config && isset($this->_config->skin)) {
-            $this->reportUrl = "{$this->getBaseUrl(true)}errors/report.php?" . http_build_query(array(
-                'id' => $this->reportId, 'skin' => $this->_config->skin
-            ));
+            $this->reportUrl = sprintf(
+                '%serrors/report.php?%s',
+                $this->getBaseUrl(true),
+                http_build_query(['id' => $this->reportId, 'skin' => $this->_config->skin])
+            );
         }
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The `Error_Processor` class in `errors/processor.php` is an old component (last significant changes are from 2016). With this PR I want to give the class a basic refactor and refresh with our current max language level PHP 7.0 (PHPStorm is in PHP 7.0 feature level mode to avoid complications here) and its features in mind. In part this is a preliminary PR for some feature additions I would like to introduce to `Error_Processor` in the future. 
In detail this PR changes: 
* Due to the way `_prepareConfig()` worked, settings from `local.xml` were loaded as `SimpleXMLElement` but some PHPDoc comments implied differently. Subsequent comparisons relied on type juggeling and the fact that `SimpleXMLElement` has a `__toString()` method. The defaults for the config were set as string directly though. 
Config parameters are set as string directly now in the config object. This allows strict comparison and PHPDoc comments match the real program state. 
* PHPDoc is replaced in favor of typing for parameters and return types wherever possible. At the same time redundant PHPDoc comments are removed completely (e.g. Method descriptions containing only the words in the method name or paraphrase the verb). 
* Previously Dynamically used members are introduced, one unused member is removed. 
* General modernization (null comparison instead of `is_null`, Null-Coalescing operator etc.) and formatting

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->