### PR TITLE
Removed deprecated string interpolation for PHP 8.2

### DIFF
--- a/app/code/core/Mage/Core/Model/Cookie.php
+++ b/app/code/core/Mage/Core/Model/Cookie.php
@@ -270,7 +270,7 @@ class Mage_Core_Model_Cookie
             );
         } else {
             if (!empty($sameSite)) {
-                $path.= "; samesite=${sameSite}";
+                $path.= "; samesite={$sameSite}";
             }
             setcookie($name, (string)$value, $expire, $path, $domain, $secure, $httponly);
         }


### PR DESCRIPTION
PHP 8.2 will deprecate `${var}` string interpolation notation: https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

I could find only one usage of this notation in our code and this PR should fix it.

Note: I didn't check lib/Zend and other 3rd party libraries in the process of being moved to composer.