### PR TITLE
Product reviews backend: fixed grid ID typo preventing save button to show

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Review/Add.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Add.php
@@ -68,7 +68,7 @@ class Mage_Adminhtml_Block_Review_Add extends Mage_Adminhtml_Block_Widget_Form_C
 
                     showForm : function() {
                         toggleParentVis("add_review_form");
-                        toggleVis("productGrid");
+                        toggleVis("reviewProductGrid");
                         toggleVis("save_button");
                         toggleVis("reset_button");
                     },


### PR DESCRIPTION
It was reported (https://github.com/OpenMage/magento-lts/pull/1769#issuecomment-1212864929) that because of https://github.com/OpenMage/magento-lts/pull/1769 it's not possible to create a product review from backend anymore.

This is because we changed grid ID but we didn't notice that the formed ID was used in a javascript.

With this PR we're fixing this ID too so that the original functionality is restored.