### PR TITLE
Add null check before method_exists

### DIFF
--- a/lib/Varien/Data/Form/Element/Editor.php
+++ b/lib/Varien/Data/Form/Element/Editor.php
@@ -374,7 +374,7 @@ class Varien_Data_Form_Element_Editor extends Varien_Data_Form_Element_Textarea
     public function translate($string)
     {
         $translator = $this->getConfig('translator');
-        if (method_exists($translator, '__')) {
+        if ($translator && method_exists($translator, '__')) {
             $result = $translator->__($string);
             if (is_string($result)) {
                 return $result;


### PR DESCRIPTION
Beginning with version 8.0, PHP throws a type error if the first parameter is neither an object or a class, so the translate method breaks if the translator key is not set to the editor config (which can be the case by the way). 

We could also use an early return to fix the issue here, but in my opinion the translation method stays understandable and simple enough so the additional check for an existing translator can be added to the IF-statement.