### PR TITLE
Method Annotation Improvement Mage_Catalog_Model_Product_Option_Type_Date 

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
@@ -24,6 +24,9 @@
  * @category   Mage
  * @package    Mage_Catalog
  * @author     Magento Core Team <core@magentocommerce.com>
+ *
+ * @method array|null getUserValue()
+ * @method $this setUserValue(array|null $userValue)
  */
 class Mage_Catalog_Model_Product_Option_Type_Date extends Mage_Catalog_Model_Product_Option_Type_Default
 {


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Parent class (`Mage_Catalog_Model_Product_Option_Type_Default`) types `getUserValue()/setUserValue()` with int but child implementation for dates (`Mage_Catalog_Model_Product_Option_Type_Date`) uses and sets user value clearly as array:
 
![image](https://user-images.githubusercontent.com/2728018/184365026-e3b1f71f-cdb9-4ef1-ab6a-91bfbd44a1a3.png)
![image](https://user-images.githubusercontent.com/2728018/184365028-03266135-d52d-40ca-887f-8116cbfc8f6a.png)

To avoid false-positive warnings and notices by IDEs/static analyzing tools this PR overrides method annotation for child class. 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 