### PR TITLE
Remove useless array_column function polyfill

### DIFF
--- a/.github/phpstan-baseline.neon
+++ b/.github/phpstan-baseline.neon
@@ -1331,11 +1331,6 @@ parameters:
 			path: ../app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale.php
 
 		-
-			message: "#^Inner named functions are not supported by PHPStan\\. Consider refactoring to an anonymous function, class method, or a top\\-level\\-defined function\\. See issue \\#165 \\(https\\://github\\.com/phpstan/phpstan/issues/165\\) for more details\\.$#"
-			count: 1
-			path: ../app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale.php
-
-		-
 			message: "#^Method Mage_Adminhtml_Model_System_Config_Backend_Serialized\\:\\:_afterLoad\\(\\) should return \\$this\\(Mage_Adminhtml_Model_System_Config_Backend_Serialized\\) but return statement is missing\\.$#"
 			count: 1
 			path: ../app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Serialized.php

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale.php
@@ -39,39 +39,6 @@ class Mage_Adminhtml_Model_System_Config_Backend_Locale extends Mage_Core_Model_
         $allCurrenciesOptions = Mage::getSingleton('adminhtml/system_config_source_locale_currency_all')
             ->toOptionArray(true);
 
-        if (!function_exists('array_column')) {
-            function array_column(array $allCurrenciesOptions, $columnKey, $indexKey = null)
-            {
-                $array = array();
-                foreach ($allCurrenciesOptions as $allCurrenciesOption) {
-                    if (!array_key_exists($columnKey, $allCurrenciesOption)) {
-                        Mage::getSingleton('adminhtml/session')->addError(
-                            Mage::helper('adminhtml')->__("Key %s does not exist in array", $columnKey)
-                        );
-                        return false;
-                    }
-                    if (is_null($indexKey)) {
-                        $array[] = $allCurrenciesOption[$columnKey];
-                    } else {
-                        if (!array_key_exists($indexKey, $allCurrenciesOption)) {
-                            Mage::getSingleton('adminhtml/session')->addError(
-                                Mage::helper('adminhtml')->__("Key %s does not exist in array", $indexKey)
-                            );
-                            return false;
-                        }
-                        if (!is_scalar($allCurrenciesOption[$indexKey])) {
-                            Mage::getSingleton('adminhtml/session')->addError(
-                                Mage::helper('adminhtml')->__("Key %s does not contain scalar value", $indexKey)
-                            );
-                            return false;
-                        }
-                        $array[$allCurrenciesOption[$indexKey]] = $allCurrenciesOption[$columnKey];
-                    }
-                }
-                return $array;
-            }
-        }
-
         $allCurrenciesValues = array_column($allCurrenciesOptions, 'value');
 
         foreach ($this->getValue() as $currency) {


### PR DESCRIPTION
### Description (*)

[`array_column`](https://www.php.net/manual/en/function.array-column.php) function exists starting from PHP 5.5 so this polyfill is never used.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list