### PR TITLE
Fix wishlist share email validation

### DIFF
--- a/.github/phpstan-baseline.neon
+++ b/.github/phpstan-baseline.neon
@@ -6559,8 +6559,3 @@ parameters:
 			message: "#^Comparison operation \"\\!\\=\" between int and \\(array\\|string\\) results in an error\\.$#"
 			count: 1
 			path: ../app/code/core/Mage/Wishlist/controllers/IndexController.php
-
-		-
-			message: "#^Variable \\$emails in empty\\(\\) always exists and is not falsy\\.$#"
-			count: 1
-			path: ../app/code/core/Mage/Wishlist/controllers/IndexController.php

--- a/app/code/core/Mage/Wishlist/controllers/IndexController.php
+++ b/app/code/core/Mage/Wishlist/controllers/IndexController.php
@@ -637,7 +637,7 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
             return $this->norouteAction();
         }
 
-        $emails  = array_filter(explode(',', $this->getRequest()->getPost('emails')));
+        $emails  = array_filter(explode(',', $this->getRequest()->getPost('emails', '')));
         $message = nl2br(htmlspecialchars((string) $this->getRequest()->getPost('message')));
         $error   = false;
         if (empty($emails)) {

--- a/app/code/core/Mage/Wishlist/controllers/IndexController.php
+++ b/app/code/core/Mage/Wishlist/controllers/IndexController.php
@@ -637,7 +637,7 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
             return $this->norouteAction();
         }
 
-        $emails  = explode(',', $this->getRequest()->getPost('emails'));
+        $emails  = array_filter(explode(',', $this->getRequest()->getPost('emails')));
         $message = nl2br(htmlspecialchars((string) $this->getRequest()->getPost('message')));
         $error   = false;
         if (empty($emails)) {


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

`if (empty($emails)) {` is always `false`, so this check does not work.

```
        $emails  = explode(',', $this->getRequest()->getPost('emails'));
        ...
        if (empty($emails)) {
            $error = $this->__('Email address can\'t be empty.');
```

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. add product to wishlist, go there
2. remove css classes with browser editor to bypass js validation for email recipients  field
3. try to share with empty field
4. `'Please input a valid email address.'` instead of `Email address can\'t be empty.`

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->