### PR TITLE
DHL International: PHP8: Cast $dimension before calling round()

### DIFF
--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
@@ -741,7 +741,7 @@ class Mage_Usa_Model_Shipping_Carrier_Dhl_International
 
         if ($configDimensionUnit != $countryDimensionUnit) {
             $dimension = (float) Mage::helper('usa')->convertMeasureDimension(
-                round($dimension, 3),
+                round((float)$dimension, 3),
                 $configDimensionUnit,
                 $countryDimensionUnit
             );

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
@@ -747,7 +747,7 @@ class Mage_Usa_Model_Shipping_Carrier_Dhl_International
             );
         }
 
-        return round($dimension, 3);
+        return round((float)$dimension, 3);
     }
 
     /**


### PR DESCRIPTION
On PHP8.0, with DHL module enabled I get this error when getting to checkout:

```
<b>Fatal error</b>:  Uncaught TypeError: round(): Argument #1 ($num) must be of type int\|float, string given in /Users/fab/Projects/aaaaa/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php:758
--
  | Stack trace:
  | #0 /Users/fab/Projects/aaaaa/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php(758): round('', 3)

```

so I just added a cast to float