### PR TITLE
Added "number" validation to minimum order amount in the backend

### DIFF
--- a/app/code/core/Mage/Sales/etc/system.xml
+++ b/app/code/core/Mage/Sales/etc/system.xml
@@ -181,6 +181,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <comment>Subtotal after discount.</comment>
+                            <validate>validate-number</validate>
                         </amount>
                         <description translate="label comment">
                             <label>Description Message</label>


### PR DESCRIPTION
Since PHP8 validates types more strictly than php7 I found out that I had a serialized object in the sales/minimum_order/amount configuration entry on the core_config_data table.

With php7 I didn't have any problem, the minimum order amount wasn't working but it was ok (kinda), on php8 I got an exception in the cartcontroller.

At the moment I didn't add a "cast" to the cartcontroller but I think for sure we need a "number" validation for the backend configuration.