### PR TITLE
Fixed "Is Required" custom option attribute always set "Yes" in PHP8.1

### DIFF
--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
@@ -73,7 +73,7 @@ var productOption = {
         }
 
         //set selected is_require
-        if (typeof data.is_require !== 'undefined') {
+        if (data.hasOwnProperty('is_require')) {
             $A($('<?php echo $this->getFieldId() ?>_'+data.id+'_is_require').options).each(function(option){
                 if (option.value==data.is_require) option.selected = true;
             });

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
@@ -73,7 +73,7 @@ var productOption = {
         }
 
         //set selected is_require
-        if (data.is_require) {
+        if (typeof data.is_require !== 'undefined') {
             $A($('<?php echo $this->getFieldId() ?>_'+data.id+'_is_require').options).each(function(option){
                 if (option.value==data.is_require) option.selected = true;
             });


### PR DESCRIPTION
Explained in https://github.com/OpenMage/magento-lts/issues/2440, in PHP8.1, when editing a product (from backend) with custom options, the "is required" was always shown as "yes".

After this PR the "is required" works as expected.