### PR TITLE
Fixed detect changes in custom options section (product edit)

### DIFF
--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/selection.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/selection.phtml
@@ -196,6 +196,11 @@ Bundle.Selection.prototype = {
                 }
             );
         }
+
+        var inputs = $$('#bundle_option_' + data.parentIndex + ' input');
+        inputs.each(function(el) { Event.observe(el, 'change', el.setHasChanges.bind(el));  } )
+        var inputs = $$('#bundle_option_' + data.parentIndex + ' button.delete');
+        inputs.each(function(el) { Event.observe(el, 'click', el.setHasChanges.bind(el));  } )
     },
 
     bindScopeCheckbox : function(){

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
@@ -316,8 +316,6 @@ if($('option_panel')){
     $('option_panel').remove();
 }
 
-productOption.bindRemoveButtons();
-
 if($('<?php echo $this->getAddButtonId() ?>')){
     Event.observe('<?php echo $this->getAddButtonId() ?>', 'click', productOption.add.bind(productOption));
 }
@@ -336,6 +334,8 @@ Validation.addAllThese([
     productOption.add(<?php echo $_value->toJson() ?>);
     productOptionType.addDataToValues(<?php echo $_value->toJson() ?>);
 <?php endforeach ?>
+
+productOption.bindRemoveButtons();
 
 //bind scope checkboxes
 productOptionScope.bindScopeCheckbox();

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
@@ -117,6 +117,8 @@ var productOption = {
         }
         <?php else: ?>
             inputs.each(function(el) { Event.observe(el, 'change', el.setHasChanges.bind(el));  } )
+            var inputs = $$('div.product-custom-options button');
+            inputs.each(function(el) { Event.observe(el, 'click', el.setHasChanges.bind(el));  } )
         <?php endif ?>
     }
 }

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/select.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/select.phtml
@@ -67,7 +67,6 @@ selectOptionType = {
     templateSyntax : /(^|.|\r|\n)({{(\w+)}})/,
     templateText : OptionTemplateSelectRow,
     add : function(data) {
-
         this.template = new Template(this.templateText, this.templateSyntax);
 
         if (data.target || data.srcElement) {//data is Event (work in IE and Firefox)
@@ -85,6 +84,11 @@ selectOptionType = {
         data.id  = optionId;
 
         Element.insert($(this.div+'_'+data.id), {'bottom':this.template.evaluate(data)});
+
+        var inputs = $$('#product_option_'+data.id+'_select_'+data.select_id+' input', '#product_option_'+data.id+'_select_'+data.select_id+' select', '#product_option_'+data.id+'_select_'+data.select_id+' textarea');
+        inputs.each(function(el) { Event.observe(el, 'change', el.setHasChanges.bind(el)); });
+        var inputs = $$('#product_option_'+data.id+'_select_'+data.select_id+' button');
+        inputs.each(function(el) { Event.observe(el, 'click', el.setHasChanges.bind(el));  });
 
         if (data.checkboxScopeTitle) {
             //set disabled

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/price/group.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/price/group.phtml
@@ -131,6 +131,9 @@ var groupPriceControl = {
         $('<?php echo $_htmlId; ?>_container').select('input', 'select').each(function(element) {
             Event.observe(element, 'change', element.setHasChanges.bind(element));
         });
+        $('<?php echo $_htmlId; ?>_container').select('button.delete').each(function(element) {
+            Event.observe(element, 'click', element.setHasChanges.bind(element));
+        });
         <?php endif ?>
     },
     disableElement: function(element) {

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/price/tier.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/price/tier.phtml
@@ -136,6 +136,7 @@ var tierPriceControl = {
         $('<?php echo $_htmlId ?>_container').up('table').select('button').each(this.disableElement);
         <?php else: ?>
         $('<?php echo $_htmlId ?>_container').select('input', 'select').each(function(el){ Event.observe(el, 'change', el.setHasChanges.bind(el)); });
+        $('<?php echo $_htmlId ?>_container').select('button.delete').each(function(el){ Event.observe(el, 'click', el.setHasChanges.bind(el)); });
         <?php endif ?>
     },
     disableElement: function(el) {

--- a/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/links.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/links.phtml
@@ -100,7 +100,7 @@
 
 <script type="text/javascript">
 //<![CDATA[
-var linkTemplate = '<tr>'+
+var linkTemplate = '<tr id="downloadable_link_{{id}}">'+
     '<td>'+
         '<input type="hidden" class="__delete__" name="downloadable[link][{{id}}][is_delete]" value="" />'+
         '<input type="hidden" name="downloadable[link][{{id}}][link_id]" value="{{link_id}}" />'+
@@ -310,6 +310,11 @@ var linkItems = {
         this.itemCount++;
         this.togglePriceFields();
         this.bindRemoveButtons();
+
+        var inputs = $$('#downloadable_link_' + data.id + ' input');
+        inputs.each(function(el) { Event.observe(el, 'change', el.setHasChanges.bind(el));  } )
+        var inputs = $$('#downloadable_link_' + data.id + ' button.delete');
+        inputs.each(function(el) { Event.observe(el, 'click', el.setHasChanges.bind(el));  } )
     },
     remove : function(event){
         var element = $(Event.findElement(event, 'tr'));

--- a/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/samples.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/samples.phtml
@@ -187,7 +187,9 @@ var sampleItems = {
         alertAlreadyDisplayed = false;
         if(element){
             element.down('input[type="hidden"].__delete__').value = '1';
-            element.down('div.flex').remove();
+            Element.select(element, 'div.flex').each(function(elm){
+                elm.remove();
+            });
             element.addClassName('no-display');
             element.addClassName('ignore-validate');
             element.hide();

--- a/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/samples.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/samples.phtml
@@ -75,7 +75,7 @@
 </div>
 <script type="text/javascript">
 //<![CDATA[>
-var sampleTemplate = '<tr>'+
+var sampleTemplate = '<tr id="downloadable_sample_{{id}}">'+
                         '<td>'+
                             '<input type="hidden" class="__delete__" name="downloadable[sample][{{id}}][is_delete]" value="" />'+
                             '<input type="hidden" name="downloadable[sample][{{id}}][sample_id]" value="{{sample_id}}" />'+
@@ -176,6 +176,11 @@ var sampleItems = {
 
         this.itemCount++;
         this.bindRemoveButtons();
+
+        var inputs = $$('#downloadable_sample_' + data.id + ' input');
+        inputs.each(function(el) { Event.observe(el, 'change', el.setHasChanges.bind(el));  } )
+        var inputs = $$('#downloadable_sample_' + data.id + ' button.delete');
+        inputs.each(function(el) { Event.observe(el, 'click', el.setHasChanges.bind(el));  } )
     },
     remove : function(event){
         var element = $(Event.findElement(event, 'tr'));

--- a/js/mage/adminhtml/product.js
+++ b/js/mage/adminhtml/product.js
@@ -744,8 +744,17 @@ Product.Configurable.prototype = {
         this.updateSaveInput();
     },
     updateSaveInput : function() {
-        $(this.idPrefix + 'save_attributes').value = Object.toJSON(this.attributes);
-        $(this.idPrefix + 'save_links').value = Object.toJSON(this.links);
+        var oldSaveAttributesValue = $(this.idPrefix + 'save_attributes').value;
+        var oldSaveLinksValue = $(this.idPrefix + 'save_links').value;
+        var newSaveAttributesValue = Object.toJSON(this.attributes);
+        var newSaveLinksValue = Object.toJSON(this.links);
+        $(this.idPrefix + 'save_attributes').value = newSaveAttributesValue;
+        $(this.idPrefix + 'save_links').value = newSaveLinksValue;
+        if (oldSaveAttributesValue != newSaveAttributesValue || oldSaveLinksValue != newSaveLinksValue) {
+            try {
+                document.getElementById('configurable_save_attributes').setHasChanges();
+            } catch (e) {}
+        }
     },
     initializeAdvicesForSimpleForm : function() {
         if ($(this.idPrefix + 'simple_form').advicesInited) {


### PR DESCRIPTION
This PR should fix https://github.com/OpenMage/magento-lts/issues/1693, when editing custom options for a product (in the backend) changes (the floppy disk icon appearing in the left sidebar) are not always detected correctly.

In `app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml` I moved this line:
```
productOption.bindRemoveButtons();
```
a little later in the code, so that it gets executed when the custom option's options are already rendered.

plus I added some more "check if element is changed" to the `app/design/adminhtml/default/default/template/catalog/product/edit/options/type/select.phtml` file