### PR TITLE
An Exception is thrown and logged if file is not found while merging

### DIFF
--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -774,7 +774,10 @@ XML;
                 } else {
                     $targetMtime = filemtime($targetFile);
                     foreach ($srcFiles as $file) {
-                        if (!file_exists($file) || @filemtime($file) > $targetMtime) {
+                        if (!file_exists($file)) {
+                            // no translation intentionally
+                            throw new Exception(sprintf('File %s not found.', dirname($file)));
+                        } elseif (@filemtime($file) > $targetMtime) {
                             $shouldMerge = true;
                             break;
                         }

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -776,7 +776,7 @@ XML;
                     foreach ($srcFiles as $file) {
                         if (!file_exists($file)) {
                             // no translation intentionally
-                            throw new Exception(sprintf('File %s not found.', dirname($file)));
+                            throw new Exception(sprintf('File %s not found.', $file));
                         } elseif (@filemtime($file) > $targetMtime) {
                             $shouldMerge = true;
                             break;


### PR DESCRIPTION
If css/js merging is enabled but one of the files doesn't exist on the file system, the merging was re-done at every request, as explained in https://github.com/OpenMage/magento-lts/issues/874

This should be avoided and an exception should be logged.

On line 837 of app/code/core/Mage/Core/Helper/Data.php all the exceptions are logged and I've added that message (with the comment above) to be consistent with the rest of the code.