### PR TITLE
Added two indexes on sales_flat_order and sales_flat_order_item tables

### DIFF
--- a/app/code/core/Mage/Sales/etc/config.xml
+++ b/app/code/core/Mage/Sales/etc/config.xml
@@ -22,7 +22,7 @@
 <config>
     <modules>
         <Mage_Sales>
-            <version>1.6.0.10</version>
+            <version>1.6.0.11</version>
         </Mage_Sales>
     </modules>
     <global>

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
@@ -25,7 +25,7 @@ $installer->startSetup();
 
 // Add index to sales_flat_order on customer_email for fast lookup, only first 15 bytes
 $keyList = $installer->getConnection()->getIndexList($installer->getTable('sales/order'));
-if (!isset($keyList[strtoupper('customer_email')])) {
+if (!isset($keyList['IDX_SALES_FLAT_ORDER_CUSTOMER_EMAIL'])) {
     $installer->run("
         ALTER TABLE {$installer->getTable('sales/order')}
         ADD INDEX `IDX_SALES_FLAT_ORDER_CUSTOMER_EMAIL` (`customer_email` (15));

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * OpenMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * @category    Mage
+ * @package     Mage_Sales
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/* @var Mage_Sales_Model_Entity_Setup $installer */
+$installer = $this;
+
+$installer->startSetup();
+
+// Add index to sales_flat_order on customer_email for fast lookup, only first 15 bytes
+$keyList = $installer->getConnection()->getIndexList($installer->getTable('sales/order'));
+if (!isset($keyList[strtoupper('customer_email')])) {
+    $installer->run("
+        ALTER TABLE {$installer->getTable('sales/order')}
+        ADD INDEX `IDX_SALES_FLAT_ORDER_CUSTOMER_EMAIL` (`customer_email` (15));
+    ");
+}
+
+// Add index to sales_flat_order_item.product_id for fast join/lookup
+$this->getConnection()->addIndex(
+    $installer->getTable('sales/order_item'),
+    'IDX_SALES_FLAT_ORDER_ITEM_PRODUCT_ID',
+    ['product_id']
+);
+
+$installer->endSetup();

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
@@ -12,15 +12,14 @@
  * obtain it through the world-wide-web, please send an email
  * to license@magento.com so we can send you a copy immediately.
  *
- * @category    Mage
- * @package     Mage_Sales
+ * @category   Mage
+ * @package    Mage_Sales
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
- * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-/* @var Mage_Sales_Model_Entity_Setup $installer */
+/** @var Mage_Sales_Model_Entity_Setup $installer */
 $installer = $this;
-
 $installer->startSetup();
 
 // Add index to sales_flat_order on customer_email for fast lookup, only first 15 bytes

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
@@ -7,7 +7,7 @@
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
+ * https://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@magento.com so we can send you a copy immediately.


### PR DESCRIPTION
This solution was already discussed and agreed in issue https://github.com/OpenMage/magento-lts/issues/384 I just created the PR into the Mage_Sales module since in 2022 I don't see the need for a new dedicated module for this specific task (as discussed in the previously linked issue).