### PR TITLE
Removed unused constant GALLERY_IMAGE_TABLE

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Media.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Media.php
@@ -30,7 +30,6 @@ class Mage_Catalog_Model_Resource_Product_Attribute_Backend_Media extends Mage_C
 {
     const GALLERY_TABLE       = 'catalog/product_attribute_media_gallery';
     const GALLERY_VALUE_TABLE = 'catalog/product_attribute_media_gallery_value';
-    const GALLERY_IMAGE_TABLE = 'catalog/product_attribute_media_gallery_image';
 
     protected $_eventPrefix = 'catalog_product_attribute_backend_media';
 


### PR DESCRIPTION
Mage_Catalog_Model_Resource_Product_Attribute_Backend_Media::GALLERY_IMAGE_TABLE is never used in the whole codebase and it refers to a table that never existed, so I removed it.
