### PR TITLE
Removed deprecation notice for Mage_Catalog_Model_Resource_Product_Attribute_Backend_Urlkey

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Urlkey.php
@@ -25,6 +25,7 @@
  * @category    Mage
  * @package     Mage_Catalog
  * @author      Magento Core Team <core@magentocommerce.com>
+ * @deprecated
  */
 class Mage_Catalog_Model_Resource_Eav_Mysql4_Product_Attribute_Backend_Urlkey extends Mage_Catalog_Model_Resource_Product_Attribute_Backend_Urlkey
 {

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Urlkey.php
@@ -25,7 +25,6 @@
  * @category    Mage
  * @package     Mage_Catalog
  * @author      Magento Core Team <core@magentocommerce.com>
- * @deprecated
  */
 class Mage_Catalog_Model_Resource_Eav_Mysql4_Product_Attribute_Backend_Urlkey extends Mage_Catalog_Model_Resource_Product_Attribute_Backend_Urlkey
 {

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Urlkey.php
@@ -25,7 +25,6 @@
  * @category    Mage
  * @package     Mage_Catalog
  * @author      Magento Core Team <core@magentocommerce.com>
- * @deprecated since 1.7.0.2
  */
 class Mage_Catalog_Model_Resource_Product_Attribute_Backend_Urlkey extends Mage_Eav_Model_Entity_Attribute_Backend_Abstract
 {


### PR DESCRIPTION
Mage_Catalog_Model_Resource_Product_Attribute_Backend_Urlkey was deprecated in M1 1.7.0.2 but
- it was never removed or replaced
- there's no mention of why this was done in the release notes https://web.archive.org/web/20120825222617/http://www.magentocommerce.com/download/release_notes#Release%20Notes%20-%20Magento%201.7.0.2%20(Jul%205,%202012)
- it's still used in some places:
<img width="1288" alt="Schermata 2022-08-21 alle 15 32 02" src="https://user-images.githubusercontent.com/909743/185796260-b5eca46b-a4e7-494e-ab0b-294c009bf5fc.png">
and
<img width="649" alt="Schermata 2022-08-21 alle 15 36 20" src="https://user-images.githubusercontent.com/909743/185796312-e6fefc12-34f1-423b-a581-580f6f43179b.png">

So I just think this class will never go away and, in that case, it shouldn't be marked as deprecated.