### PR TITLE
Use composer PHP script for PHP_CS setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
   },
   "scripts": {
     "set-phpcs-paths": [
-      "[ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility,vendor/magento-ecg/coding-standard",
-      "[ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs -i"
+      "OpenMage\\Scripts\\Devel::setupPhpCs"
     ],
     "post-install-cmd": [
       "@set-phpcs-paths"
@@ -73,6 +72,9 @@
   ],
   "autoload-dev": {
     "psr-4": { "OpenMage\\Tests\\Unit\\": "dev/tests/unit" }
+  },
+  "autoload": {
+    "psr-4": { "OpenMage\\Scripts\\": "dev/scripts" }
   },
   "extra": {
     "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "set-phpcs-paths": [
-      "OpenMage\\Scripts\\Devel::setupPhpCs"
+      "OpenMage\\Scripts\\Composer\\SetupPhpCs::run"
     ],
     "post-install-cmd": [
       "@set-phpcs-paths"
@@ -74,7 +74,7 @@
     "psr-4": { "OpenMage\\Tests\\Unit\\": "dev/tests/unit" }
   },
   "autoload": {
-    "psr-4": { "OpenMage\\Scripts\\": "dev/scripts" }
+    "psr-4": { "OpenMage\\Scripts\\Composer\\": "dev/scripts/composer" }
   },
   "extra": {
     "branch-alias": {

--- a/dev/scripts/Devel.php
+++ b/dev/scripts/Devel.php
@@ -35,6 +35,11 @@ class Devel
             return;
         }
 
+        if (!function_exists('exec')) {
+            echo "exec() has been disabled for security reasons, skipping...\n";
+            return;
+        }
+
         $phpcs = PHP_BINARY . ' ' . self::$binPath . DIRECTORY_SEPARATOR . 'phpcs';
 
         $paths = implode(',', [

--- a/dev/scripts/Devel.php
+++ b/dev/scripts/Devel.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace OpenMage\Scripts;
+
+use Composer\Script\Event;
+
+class Devel
+{
+    /** @var Composer\Composer $composer */
+    static $composer;
+
+    /** @var string $vendorPath */
+    static $vendorPath;
+
+    /** @var string $binPath */
+    static $binPath;
+
+    private static function _init(Event $event)
+    {
+        self::$composer = $event->getComposer();
+        self::$vendorPath = self::$composer->getConfig()->get('vendor-dir');
+        self::$binPath = self::$composer->getConfig()->get('bin-dir');
+    }
+
+    /**
+     * Setup PHP_CodeSniffer Environment
+     *
+     * @param Event $event
+     */
+    public static function setupPhpCs(Event $event)
+    {
+        self::_init($event);
+
+        if ($event->isDevMode() === false) {
+            return;
+        }
+
+        $phpcs = PHP_BINARY . ' ' . self::$binPath . DIRECTORY_SEPARATOR . 'phpcs';
+
+        $paths = implode(',', [
+            self::$vendorPath . '/phpcompatibility/php-compatibility',
+            self::$vendorPath . '/magento-ecg/coding-standard',
+        ]);
+
+        $output = [];
+
+        exec("$phpcs --config-set installed_paths $paths", $output);
+        exec("$phpcs -i", $output);
+
+        echo implode("\n", $output) . "\n";
+    }
+}

--- a/dev/scripts/composer/ScriptInterface.php
+++ b/dev/scripts/composer/ScriptInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace OpenMage\Scripts\Composer;
+
+use Composer\Script\Event;
+
+interface ScriptInterface
+{
+    public static function run(Event $event);
+}

--- a/dev/scripts/composer/SetupPhpCs.php
+++ b/dev/scripts/composer/SetupPhpCs.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace OpenMage\Scripts;
+namespace OpenMage\Scripts\Composer;
 
 use Composer\Script\Event;
 
-class Devel
+class SetupPhpCs implements ScriptInterface
 {
     /** @var Composer\Composer $composer */
     static $composer;
@@ -15,7 +15,7 @@ class Devel
     /** @var string $binPath */
     static $binPath;
 
-    private static function _init(Event $event)
+    private static function init(Event $event)
     {
         self::$composer = $event->getComposer();
         self::$vendorPath = self::$composer->getConfig()->get('vendor-dir');
@@ -27,9 +27,9 @@ class Devel
      *
      * @param Event $event
      */
-    public static function setupPhpCs(Event $event)
+    public static function run(Event $event)
     {
-        self::_init($event);
+        self::init($event);
 
         if ($event->isDevMode() === false) {
             return;


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
There were a few issues with the merge of #2400 
1. Hardcoded vendor dir (minor issue, [ref](https://github.com/OpenMage/magento-lts/pull/2400#discussion_r947325609))
2. Bash syntax caused an error on Windows ([ref](https://github.com/OpenMage/magento-lts/pull/2400#issuecomment-1221534161))
3. Global PHP version is called even if you do something like `/usr/local/opt/php@8.1/bin/php composer install` ([ref](https://github.com/OpenMage/magento-lts/pull/2400#issuecomment-1221546475)) 

I fixed this by making a PHP script that should be platform independent and fix all three issues.

### Related Pull Requests
<!-- related pull request placeholder -->
#2400

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Make sure it installs correctly on Linux as it did before -- @sreichel please check this, I don't know how to verify
2. Make sure `composer install` doesn't throw an error on Windows -- @ADDISON74 please check this
3. Make sure `composer install` works correctly when calling with a non-system php install -- @fballiano please check this

### Questions or comments
I added the `dev/scripts` directory and an autoload entry in `composer.json`. The new directory could be used for other composer scripts.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->