### PR TITLE
Removed memory_limit checks for better performance

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Image.php
@@ -232,6 +232,7 @@ class Mage_Catalog_Model_Product_Image extends Mage_Core_Model_Abstract
     }
 
     /**
+     * @deprecated
      * @param null $file
      * @return bool
      */
@@ -241,6 +242,7 @@ class Mage_Catalog_Model_Product_Image extends Mage_Core_Model_Abstract
     }
 
     /**
+     * @deprecated
      * @return float|int|string
      */
     protected function _getMemoryLimit()
@@ -264,6 +266,7 @@ class Mage_Catalog_Model_Product_Image extends Mage_Core_Model_Abstract
     }
 
     /**
+     * @deprecated
      * @return int
      */
     protected function _getMemoryUsage()
@@ -275,6 +278,7 @@ class Mage_Catalog_Model_Product_Image extends Mage_Core_Model_Abstract
     }
 
     /**
+     * @deprecated
      * @param string $file
      * @return float|int
      */
@@ -343,7 +347,7 @@ class Mage_Catalog_Model_Product_Image extends Mage_Core_Model_Abstract
             $file = null;
         }
         if ($file) {
-            if ((!$this->_fileExists($baseDir . $file)) || !$this->_checkMemory($baseDir . $file)) {
+            if ((!$this->_fileExists($baseDir . $file))) {
                 $file = null;
             }
         }

--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -18,7 +18,6 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-
 class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
 {
     protected $_requiredExtensions = Array("gd");
@@ -64,15 +63,13 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
         $this->_fileName = $filename;
         $this->getMimeType();
         $this->_getFileAttributes();
-        if ($this->_isMemoryLimitReached()) {
-            throw new Varien_Exception('Memory limit has been reached.');
-        }
         $this->_imageHandler = call_user_func($this->_getCallback('create'), $this->_fileName);
     }
 
     /**
      * Checks whether memory limit is reached.
      *
+     * @deprecated
      * @return bool
      */
     protected function _isMemoryLimitReached()
@@ -95,11 +92,10 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
      * Notation in value is supported only for PHP
      * Shorthand byte options are case insensitive
      *
+     * @deprecated
      * @param string $memoryValue
-     *
      * @throws Varien_Exception
      * @see http://php.net/manual/en/faq.using.php#faq.using.shorthandbytes
-     *
      * @return int
      */
     protected function _convertToByte($memoryValue)


### PR DESCRIPTION
All credits go to @woutersamaey since this PR was his idea. It was mostly implemented in https://github.com/OpenMage/magento-lts/pull/1749 but I couldn't rebase it to 1.9.4.x without breaking it so I opened this one instead, hopefully implementing everything that was discussed in the original thread.

Now the PR just removes checking for memory limit but keeps all the methods marking them as deprecated.