### PR TITLE
Removed deprecated setLanguageCode javascript function

### DIFF
--- a/js/varien/js.js
+++ b/js/varien/js.js
@@ -33,41 +33,6 @@ function setPLocation(url, setFocus){
 }
 
 /**
- * @deprecated
- */
-function setLanguageCode(code, fromCode){
-    //TODO: javascript cookies have different domain and path than php cookies
-    var href = window.location.href;
-    var after = '', dash;
-    if (dash = href.match(/\#(.*)$/)) {
-        href = href.replace(/\#(.*)$/, '');
-        after = dash[0];
-    }
-
-    if (href.match(/[?]/)) {
-        var re = /([?&]store=)[a-z0-9_]*/;
-        if (href.match(re)) {
-            href = href.replace(re, '$1'+code);
-        } else {
-            href += '&store='+code;
-        }
-
-        var re = /([?&]from_store=)[a-z0-9_]*/;
-        if (href.match(re)) {
-            href = href.replace(re, '');
-        }
-    } else {
-        href += '?store='+code;
-    }
-    if (typeof(fromCode) != 'undefined') {
-        href += '&from_store='+fromCode;
-    }
-    href += after;
-
-    setLocation(href);
-}
-
-/**
  * Add classes to specified elements.
  * Supported classes are: 'odd', 'even', 'first', 'last'
  *


### PR DESCRIPTION
`setLanguageCode()` in `js/varien/js.js` is deprecated since 2016:

<img width="740" alt="Schermata 2022-08-22 alle 14 07 24" src="https://user-images.githubusercontent.com/909743/185928932-14f5d821-9b2e-48be-9b23-3e88442fd5a7.png">

and it seems to be totally unused:

<img width="639" alt="Schermata 2022-08-22 alle 14 09 47" src="https://user-images.githubusercontent.com/909743/185929053-8b16c314-42d8-42c1-9b36-cf86e8822560.png">

so I think it could be safely removed.