### PR TITLE
Added cron to remove old index events for manual indexers

### DIFF
--- a/app/code/core/Mage/Index/Model/Indexer.php
+++ b/app/code/core/Mage/Index/Model/Indexer.php
@@ -282,10 +282,10 @@ class Mage_Index_Model_Indexer
      * @param   Varien_Object $entity
      * @param   string $entityType
      * @param   string $eventType
-     * @throws Exception
      * @return  Mage_Index_Model_Indexer
+     * @throws Exception|Throwable
      */
-    public function processEntityAction(Varien_Object $entity, $entityType, $eventType)
+    public function processEntityAction(Varien_Object $entity, $entityType, $eventType): Mage_Index_Model_Indexer
     {
         $event = $this->logEvent($entity, $entityType, $eventType, false);
         /**

--- a/app/code/core/Mage/Index/Model/Observer.php
+++ b/app/code/core/Mage/Index/Model/Observer.php
@@ -19,6 +19,9 @@
  */
 class Mage_Index_Model_Observer
 {
+    public const OLD_INDEX_EVENT_THRESHOLD_SECONDS = 24 * 60 * 60;
+    public const OLD_INDEX_EVENT_DELETE_COUNT = 1000;
+
     /**
      * Indexer model
      *
@@ -35,6 +38,7 @@ class Mage_Index_Model_Observer
      * Store after commit observer. Process store related indexes
      *
      * @param Varien_Event_Observer $observer
+     * @throws Throwable
      */
     public function processStoreSave(Varien_Event_Observer $observer)
     {
@@ -50,6 +54,7 @@ class Mage_Index_Model_Observer
      * Store group after commit observer. Process store group related indexes
      *
      * @param Varien_Event_Observer $observer
+     * @throws Throwable
      */
     public function processStoreGroupSave(Varien_Event_Observer $observer)
     {
@@ -65,6 +70,7 @@ class Mage_Index_Model_Observer
      * Website save after commit observer. Process website related indexes
      *
      * @param Varien_Event_Observer $observer
+     * @throws Throwable
      */
     public function processWebsiteSave(Varien_Event_Observer $observer)
     {
@@ -80,6 +86,7 @@ class Mage_Index_Model_Observer
      * Store after commit observer. Process store related indexes
      *
      * @param Varien_Event_Observer $observer
+     * @throws Throwable
      */
     public function processStoreDelete(Varien_Event_Observer $observer)
     {
@@ -95,6 +102,7 @@ class Mage_Index_Model_Observer
      * Store group after commit observer. Process store group related indexes
      *
      * @param Varien_Event_Observer $observer
+     * @throws Throwable
      */
     public function processStoreGroupDelete(Varien_Event_Observer $observer)
     {
@@ -110,6 +118,7 @@ class Mage_Index_Model_Observer
      * Website save after commit observer. Process website related indexes
      *
      * @param Varien_Event_Observer $observer
+     * @throws Throwable
      */
     public function processWebsiteDelete(Varien_Event_Observer $observer)
     {
@@ -125,6 +134,7 @@ class Mage_Index_Model_Observer
      * Config data after commit observer.
      *
      * @param Varien_Event_Observer $observer
+     * @throws Throwable
      */
     public function processConfigDataSave(Varien_Event_Observer $observer)
     {
@@ -134,5 +144,58 @@ class Mage_Index_Model_Observer
             Mage_Core_Model_Config_Data::ENTITY,
             Mage_Index_Model_Event::TYPE_SAVE
         );
+    }
+
+    /**
+     * Clean old index events for indexers in manual mode
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function cleanOutdatedEvents()
+    {
+        $manualIndexProcessCollection = Mage::getSingleton('index/indexer')
+            ->getProcessesCollection()
+            ->addFieldToFilter('mode', Mage_Index_Model_Process::MODE_MANUAL);
+
+        $now = new DateTime();
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $dateInterval = new DateInterval('PT' . self::OLD_INDEX_EVENT_THRESHOLD_SECONDS . 'S');
+        $oldEventsThreshold = $now
+            ->sub($dateInterval)
+            ->format(Varien_Db_Adapter_Pdo_Mysql::TIMESTAMP_FORMAT);
+
+        $coreResource = Mage::getSingleton('core/resource');
+        $writeConnection = $coreResource->getConnection('core_write');
+        $indexEventTableName = $coreResource->getTableName('index/event');
+
+        /** @var Mage_Index_Model_Process $process */
+        foreach ($manualIndexProcessCollection as $process) {
+            $unprocessedEventsCollection = $process
+                ->getUnprocessedEventsCollection()
+                ->addFieldToFilter('created_at', ['lt' => $oldEventsThreshold])
+                ->load();
+
+            $i = 0;
+            $eventList = [];
+            /** @var Mage_Index_Model_Event $unprocessedEvent */
+            foreach ($unprocessedEventsCollection as $unprocessedEvent) {
+                $i++;
+                $eventList[] = $unprocessedEvent->getId();
+                if ($i === self::OLD_INDEX_EVENT_DELETE_COUNT) {
+                    break;
+                }
+            }
+
+            if (!empty($eventList)) {
+                $where = new Zend_Db_Expr(
+                    sprintf(
+                        'event_id in (%s)',
+                        implode(',', $eventList)
+                    )
+                );
+                $writeConnection->delete($indexEventTableName, $where);
+            }
+        }
     }
 }

--- a/app/code/core/Mage/Index/etc/config.xml
+++ b/app/code/core/Mage/Index/etc/config.xml
@@ -20,6 +20,18 @@
             <version>1.6.0.0</version>
         </Mage_Index>
     </modules>
+    <crontab>
+        <jobs>
+            <index_clean_events>
+                <schedule>
+                    <cron_expr>30 */4 * * *</cron_expr>
+                </schedule>
+                <run>
+                    <model>index/observer::cleanOutdatedEvents</model>
+                </run>
+            </index_clean_events>
+        </jobs>
+    </crontab>
     <global>
         <helpers>
             <index>


### PR DESCRIPTION
### Description (*)

As discussed in https://github.com/OpenMage/magento-lts/pull/199 I created a new PR which tackles the problem from another direction: Instead of completely omitting to write the index event to the database I created a cron that will delete these events if they are not processed.
This way we maintain BC and avoid filling the DB with garbage that might not be needed.

### Related Pull Requests
https://github.com/OpenMage/magento-lts/pull/199

### Manual testing scenarios (*)
1. Set index mode to manual in admin
2. Save a product
3. Execute select count(*) from index_event
4. Wait 24 hours
5. Run php cron.php (I executed the job from Aoe_Scheduler but the result should be the same)
6. Execute select count(*) from index_event

### Questions or comments
I would gladly discuss the introduction of `Mage_Index_Model_Observer::OLD_INDEX_EVENT_THRESHOLD_SECONDS`, in my opinion this is a quick-and-dirty way to start this PR but I do not expect it to be in the final merge.
I would prefer a config but Mage_Index does not have a system.xml - so where would be good place for it?
If we add a config: what should be the default value?
Is one day a sufficient threshold for e.g. the Hackathon_AsyncIndex (on my workplace we index every day even if we have over 100.000 products and thousand categories)?

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
