### PR TITLE
Addendum to #2426 - Adminhtml loader

### DIFF
--- a/app/design/adminhtml/default/default/template/catalog/category/edit.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/edit.phtml
@@ -183,10 +183,7 @@
 
     function displayLoadingMask()
     {
-       var loaderArea = $$('#html-body .wrapper')[0]; // Blocks all page
-        Position.clone($(loaderArea), $('loading-mask'), {offsetLeft:-2});
-        toggleSelectsUnderBlock($('loading-mask'), false);
-        Element.show('loading-mask');
+        showLoader();
     }
 //]]>
 </script>

--- a/app/design/adminhtml/default/default/template/importexport/import/form/before.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/import/form/before.phtml
@@ -43,16 +43,14 @@
                 });
             }
 
-            // show mask, temporary set new target and submit form
-            var loadingMask = $('loading-mask');
+            // show mask
+            showLoader();
+
+            // temporary set new target and submit form
             var formElem    = $(this.formId);
             var oldTarget   = formElem.target;
             var oldAction   = formElem.action;
 
-            Element.clonePosition(loadingMask, $$('#html-body .wrapper')[0], {offsetLeft:-2})
-            toggleSelectsUnderBlock(loadingMask, false);
-            loadingMask.show();
-            setLoaderPosition();
             formElem.target = this.ifrElemName;
 
             if (newActionUrl) {
@@ -74,10 +72,8 @@
      */
     varienForm.prototype.postToFrameComplete = function(response)
     {
-        var loadingMask = $('loading-mask');
         $(this.ifrElemName).remove();
-        toggleSelectsUnderBlock(loadingMask, true);
-        loadingMask.hide();
+        hideLoader();
         this.postToFrameProcessResponse(response);
     };
 

--- a/app/design/adminhtml/default/default/template/newsletter/preview/iframeswitcher.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/preview/iframeswitcher.phtml
@@ -43,13 +43,15 @@
     <?php echo $this->getChildHtml('preview_form'); ?>
 </div>
 <div id="loading-mask" style="display:none">
-    <p class="loader" id="loading_mask_loader"><img src="<?php echo $this->getSkinUrl('images/ajax-loader-tr.gif') ?>" alt="<?php echo Mage::helper('core')->quoteEscape(Mage::helper('adminhtml')->__('Loading...')) ?>"/><br/><?php echo Mage::helper('adminhtml')->__('Please wait...') ?></p>
+    <div class="backdrop"></div>
+    <p class="loader" id="loading_mask_loader">
+        <img src="<?php echo $this->getSkinUrl('images/ajax-loader-tr.gif') ?>" alt="<?php echo Mage::helper('core')->quoteEscape(Mage::helper('adminhtml')->__('Loading...')) ?>"/><br/><?php echo Mage::helper('adminhtml')->__('Please wait...') ?>
+    </p>
 </div>
 
 <script type="text/javascript">
 //<![CDATA[
 var previewForm = $('preview_form');
-var loadingMask = $('loading-mask');
 var previewIframe = $('preview_iframe');
 
 function preview() {
@@ -59,22 +61,11 @@ function preview() {
 }
 
 function blockPreview() {
-    var cumulativeOffset = $('preview').cumulativeOffset();
-    $('loading-mask').setStyle({
-        top:  ( cumulativeOffset.top ) + 'px',
-        left: ( cumulativeOffset.left ) + 'px',
-        width: $('preview').getWidth() + 'px',
-        height: $('preview').getHeight() + 'px'
-    });
-
-    toggleSelectsUnderBlock($('loading-mask'), false);
-    Element.show('loading-mask');
-    setLoaderPosition();
+    showLoader($('preview'));
 }
 
 function unBlockPreview() {
-    toggleSelectsUnderBlock(loadingMask, true);
-    Element.hide(loadingMask);
+    hideLoader();
 }
 
 Event.observe(window, 'load', preview);

--- a/app/design/adminhtml/default/default/template/page.phtml
+++ b/app/design/adminhtml/default/default/template/page.phtml
@@ -76,8 +76,8 @@
     <?php echo $this->getChildHtml('js') ?>
     <?php echo $this->getChildHtml('profiler') ?>
 <div id="loading-mask" style="display:none">
-    <div class="backdrop" style="display:none"></div>
-    <p class="loader" id="loading_mask_loader" style="display:none">
+    <div class="backdrop"></div>
+    <p class="loader" id="loading_mask_loader">
         <img src="<?php echo $this->getSkinUrl('images/ajax-loader-tr.gif') ?>" alt="<?php echo Mage::helper('core')->quoteEscape(Mage::helper('adminhtml')->__('Loading...')) ?>"/><br/><?php echo Mage::helper('adminhtml')->__('Please wait...') ?>
     </p>
 </div>

--- a/app/design/adminhtml/default/default/template/popup.phtml
+++ b/app/design/adminhtml/default/default/template/popup.phtml
@@ -66,7 +66,10 @@
     <?php echo $this->getChildHtml('js') ?>
     <?php echo $this->getChildHtml('profiler') ?>
     <div id="loading-mask" style="display:none;">
-        <p class="loader" id="loading_mask_loader"><img src="<?php echo $this->getSkinUrl('images/ajax-loader-tr.gif') ?>" alt="<?php echo Mage::helper('core')->quoteEscape(Mage::helper('adminhtml')->__('Loading...')) ?>" /><br /><?php echo Mage::helper('adminhtml')->__('Please wait...') ?></p>
+        <div class="backdrop"></div>
+        <p class="loader" id="loading_mask_loader">
+            <img src="<?php echo $this->getSkinUrl('images/ajax-loader-tr.gif') ?>" alt="<?php echo Mage::helper('core')->quoteEscape(Mage::helper('adminhtml')->__('Loading...')) ?>"/><br/><?php echo Mage::helper('adminhtml')->__('Please wait...') ?>
+        </p>
     </div>
 </div>
 <?php echo $this->getChildHtml('before_body_end') ?>

--- a/js/mage/adminhtml/loader.js
+++ b/js/mage/adminhtml/loader.js
@@ -202,16 +202,18 @@ function showLoader(loaderArea) {
     if($(loaderArea) === undefined) {
         loaderArea = $$('#html-body .wrapper')[0]; // Blocks all page
     }
-    Element.clonePosition($('loading-mask'), $(loaderArea), {offsetLeft:-2});
-    toggleSelectsUnderBlock($('loading-mask'), false);
-    Element.show('loading-mask');
-    Element.childElements('loading-mask').invoke('hide');
-    setLoaderPosition();
-    if(!loaderTimeout) {
-        loaderTimeout = setTimeout(function() {
-            Element.childElements('loading-mask').invoke('show');
-        }, typeof window.LOADING_TIMEOUT === 'undefined' ? 200 : window.LOADING_TIMEOUT);
+    var loadingMask = $('loading-mask');
+    if(Element.visible(loadingMask)) {
+        return;
     }
+    Element.clonePosition(loadingMask, loaderArea, {offsetLeft:-2});
+    toggleSelectsUnderBlock(loadingMask, false);
+    Element.show(loadingMask);
+    Element.childElements(loadingMask).invoke('hide');
+    setLoaderPosition();
+    loaderTimeout = setTimeout(function() {
+        Element.childElements(loadingMask).invoke('show');
+    }, typeof window.LOADING_TIMEOUT === 'undefined' ? 200 : window.LOADING_TIMEOUT);
 }
 
 function hideLoader() {

--- a/js/mage/adminhtml/loader.js
+++ b/js/mage/adminhtml/loader.js
@@ -187,36 +187,41 @@ varienLoaderHandler.handler = {
         if(request.options.loaderArea===false){
             return;
         }
-
-        request.options.loaderArea = $$('#html-body .wrapper')[0]; // Blocks all page
-
-        if(request && request.options.loaderArea){
-            Element.clonePosition($('loading-mask'), $(request.options.loaderArea), {offsetLeft:-2});
-            toggleSelectsUnderBlock($('loading-mask'), false);
-            Element.show('loading-mask');
-            Element.childElements('loading-mask').invoke('hide');
-            setLoaderPosition();
-            if(this.timeout) {
-                clearTimeout(this.timeout);
-            }
-            this.timeout = setTimeout(function() {
-                Element.childElements('loading-mask').invoke('show');
-            }, typeof window.LOADING_TIMEOUT === 'undefined' ? 200 : window.LOADING_TIMEOUT);
-        }
+        showLoader();
     },
-
     onComplete: function(transport) {
         if(Ajax.activeRequestCount == 0) {
-            toggleSelectsUnderBlock($('loading-mask'), true);
-            Element.hide('loading-mask');
-            Element.childElements('loading-mask').invoke('hide');
-            if(this.timeout) {
-                clearTimeout(this.timeout);
-                this.timeout = null;
-            }
+            hideLoader();
         }
     }
 };
+
+var loaderTimeout = null;
+
+function showLoader(loaderArea) {
+    if($(loaderArea) === undefined) {
+        loaderArea = $$('#html-body .wrapper')[0]; // Blocks all page
+    }
+    Element.clonePosition($('loading-mask'), $(loaderArea), {offsetLeft:-2});
+    toggleSelectsUnderBlock($('loading-mask'), false);
+    Element.show('loading-mask');
+    Element.childElements('loading-mask').invoke('hide');
+    setLoaderPosition();
+    if(!loaderTimeout) {
+        loaderTimeout = setTimeout(function() {
+            Element.childElements('loading-mask').invoke('show');
+        }, typeof window.LOADING_TIMEOUT === 'undefined' ? 200 : window.LOADING_TIMEOUT);
+    }
+}
+
+function hideLoader() {
+    toggleSelectsUnderBlock($('loading-mask'), true);
+    Element.hide('loading-mask');
+    if(loaderTimeout) {
+        clearTimeout(loaderTimeout);
+        loaderTimeout = null;
+    }
+}
 
 /**
  * @todo need calculate middle of visible area and scroll bind

--- a/js/mage/directpost.js
+++ b/js/mage/directpost.js
@@ -116,8 +116,7 @@ directPost.prototype = {
                             this.returnQuote();
                         } else {
                             this.changeInputOptions('disabled', false);
-                            toggleSelectsUnderBlock($('loading-mask'), true);
-                            $('loading-mask').hide();
+                            hideLoader();
                             enableElements('save');
                         }
                     }
@@ -164,8 +163,7 @@ directPost.prototype = {
                     case 'sales_order_edit':
                     case 'sales_order_create':
                         this.changeInputOptions('disabled', false);
-                        toggleSelectsUnderBlock($('loading-mask'), true);
-                        $('loading-mask').hide();
+                        hideLoader();
                         enableElements('save');
                         break;
                 }
@@ -252,9 +250,7 @@ directPost.prototype = {
             });
             this.hasError = false;
             if (paymentMethodEl.value == this.code) {
-                toggleSelectsUnderBlock($('loading-mask'), false);
-                $('loading-mask').show();
-                setLoaderPosition();
+                showLoader();
                 this.changeInputOptions('disabled', 'disabled');
                 this.paymentRequestSent = true;
                 this.orderRequestSent = true;

--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -74,6 +74,10 @@
 #loading-mask {
     background:url(images/blank.gif) repeat;
     position:absolute;
+    top:0;
+    right:0;
+    bottom:0;
+    left:0;
     color:#d85909;
     font-size:1.1em;
     font-weight:bold;


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
I was working on a few things and noticed I needed a few fixes for #2426.

Issues:
- Some places called `Element.show('loading-mask');` directly. Because I hid the child elements, that broke the loader showing. I removed the `style="display:none"` from those child elements to fix it.
- In any case, I removed those direct calls and introduced a new methods to show and hide the loader from anywhere. This has the benefit of making the loader show up with a timeout in other places besides AJAX calls.
- Updated the loader html in a few other templates that I missed.

### Related Pull Requests
#2426 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Test similar tasks as in #2426, such as sorting an admin grid
2. Test Manage Categories page, try saving a category

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
I apologize about the breakage, I somehow missed that the loader was displayed manually in places.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->