### PR TITLE
Fix some email template resources

### DIFF
--- a/app/code/core/Mage/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.1-1.6.0.2.php
@@ -60,7 +60,7 @@ $newsletterContent = <<<EOD
         <table class="columns">
             <tr>
                 <td>
-                    <img width="600" src="http://placehold.it/600x200" class="main-image">
+                    <img width="600" src="https://via.placeholder.com/600x200" class="main-image">
                 </td>
                 <td class="expander"></td>
             </tr>

--- a/skin/frontend/base/default/css/email-non-inline.css
+++ b/skin/frontend/base/default/css/email-non-inline.css
@@ -16,7 +16,7 @@
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
  * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
-@import url(http://fonts.googleapis.com/css?family=Raleway:400,500,700);
+@import url(https://fonts.googleapis.com/css?family=Raleway:400,500,700);
 /* Font Styles */
 /* Media Queries */
 /* Setting the Web Font inside a media query so that Outlook doesn't try to render the web font */

--- a/skin/frontend/rwd/default/scss/email-non-inline.scss
+++ b/skin/frontend/rwd/default/scss/email-non-inline.scss
@@ -27,7 +27,7 @@
 @import "framework";
 
 /* Font Styles */
-@import url(http://fonts.googleapis.com/css?family=Raleway:400,500,700);
+@import url(https://fonts.googleapis.com/css?family=Raleway:400,500,700);
 
 /* Media Queries */
 /* Setting the Web Font inside a media query so that Outlook doesn't try to render the web font */


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
First, we change to load google fonts via https. I am not sure if any email clients require this, but it does fix previewing a template from https://store.example.com/index.php/admin/newsletter_template/edit/id/1/ 

Second, the placeholder URL in the default email template is broken. I only did change this in the install script so it won't update stores that have already run the install script, but it will fix new installs.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->