### PR TITLE
Removed useless returns

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
@@ -206,7 +206,6 @@ class Mage_Adminhtml_Api_RoleController extends Mage_Adminhtml_Controller_Action
         }
 
         $this->_redirect('*/*/editrole', ['rid' => $rid]);
-        return;
     }
 
     public function editrolegridAction()

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/ReviewController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/ReviewController.php
@@ -360,7 +360,6 @@ class Mage_Adminhtml_Catalog_Product_ReviewController extends Mage_Adminhtml_Con
             }
         }
         $this->getResponse()->setRedirect($this->getUrl('*/*/'));
-        return;
     }
 
     public function ratingItemsAction()

--- a/app/code/core/Mage/Adminhtml/controllers/DashboardController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/DashboardController.php
@@ -78,7 +78,6 @@ class Mage_Adminhtml_DashboardController extends Mage_Adminhtml_Controller_Actio
             $output = $this->getLayout()->createBlock('adminhtml/dashboard_' . $blockTab)->toHtml();
         }
         $this->getResponse()->setBody($output);
-        return;
     }
 
     public function tunnelAction()

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/RoleController.php
@@ -260,7 +260,6 @@ class Mage_Adminhtml_Permissions_RoleController extends Mage_Adminhtml_Controlle
 
         //$this->getResponse()->setRedirect($this->getUrl("*/*/editrole/rid/$rid"));
         $this->_redirect('*/*/');
-        return;
     }
 
     /**
@@ -353,6 +352,5 @@ class Mage_Adminhtml_Permissions_RoleController extends Mage_Adminhtml_Controlle
         }
 
         $this->_redirect('*/*/');
-        return;
     }
 }

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Billing/AgreementController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Billing/AgreementController.php
@@ -69,7 +69,6 @@ class Mage_Adminhtml_Sales_Billing_AgreementController extends Mage_Adminhtml_Co
         }
 
         $this->_redirect('*/*/');
-        return;
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/controllers/System/VariableController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/VariableController.php
@@ -155,7 +155,6 @@ class Mage_Adminhtml_System_VariableController extends Mage_Adminhtml_Controller
             }
         }
         $this->_redirect('*/*/', []);
-        return;
     }
 
     /**
@@ -178,7 +177,6 @@ class Mage_Adminhtml_System_VariableController extends Mage_Adminhtml_Controller
             }
         }
         $this->_redirect('*/*/', []);
-        return;
     }
 
     /**

--- a/app/code/core/Mage/Paypal/Model/Api/Standard.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Standard.php
@@ -173,7 +173,6 @@ class Mage_Paypal_Model_Api_Standard extends Mage_Paypal_Model_Api_Abstract
      */
     public function debugRequest($request)
     {
-        return;
     }
 
     /**

--- a/app/code/core/Mage/Persistent/controllers/IndexController.php
+++ b/app/code/core/Mage/Persistent/controllers/IndexController.php
@@ -65,7 +65,6 @@ class Mage_Persistent_IndexController extends Mage_Core_Controller_Front_Action
             $this->_cleanup();
         }
         $this->_redirect('customer/account/login');
-        return;
     }
 
     /**

--- a/app/code/core/Mage/Sales/controllers/OrderController.php
+++ b/app/code/core/Mage/Sales/controllers/OrderController.php
@@ -82,6 +82,5 @@ class Mage_Sales_OrderController extends Mage_Sales_Controller_Abstract
     public function viewOldAction()
     {
         $this->_forward('noRoute');
-        return;
     }
 }

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Tax.php
@@ -518,7 +518,6 @@ class Mage_Tax_Model_Sales_Total_Quote_Tax extends Mage_Sales_Model_Quote_Addres
         }
         $this->_addAmount($item->getTaxAmount());
         $this->_addBaseAmount($item->getBaseTaxAmount());
-        return;
     }
 
     /**
@@ -789,7 +788,6 @@ class Mage_Tax_Model_Sales_Total_Quote_Tax extends Mage_Sales_Model_Quote_Addres
         }
         $this->_addAmount($item->getTaxAmount());
         $this->_addBaseAmount($item->getBaseTaxAmount());
-        return;
     }
 
     /**
@@ -1076,7 +1074,6 @@ class Mage_Tax_Model_Sales_Total_Quote_Tax extends Mage_Sales_Model_Quote_Addres
         if ($rate > 0) {
             $itemTaxGroups[$item->getId()] = $appliedRates;
         }
-        return;
     }
 
     /**
@@ -1337,7 +1334,6 @@ class Mage_Tax_Model_Sales_Total_Quote_Tax extends Mage_Sales_Model_Quote_Addres
                 );
             }
         }
-        return;
     }
 
     /**

--- a/app/code/core/Mage/Widget/controllers/Adminhtml/Widget/InstanceController.php
+++ b/app/code/core/Mage/Widget/controllers/Adminhtml/Widget/InstanceController.php
@@ -217,7 +217,6 @@ class Mage_Widget_Adminhtml_Widget_InstanceController extends Mage_Adminhtml_Con
             }
         }
         $this->_redirect('*/*/');
-        return;
     }
 
     /**

--- a/app/code/core/Zend/Db/Statement.php
+++ b/app/code/core/Zend/Db/Statement.php
@@ -125,7 +125,6 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
      */
     protected function _prepare($sql)
     {
-        return;
     }
 
     /**


### PR DESCRIPTION
PHPCS says that there should not be any "useless return":
https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/return_notation/no_useless_return.rst
which is a `return;` at the end of a function/method.