### PR TITLE
Fixed lowercase for constants true/false/null

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid.php
@@ -396,7 +396,7 @@ class Mage_Adminhtml_Block_Report_Grid extends Mage_Adminhtml_Block_Widget_Grid
          * recalc totals if we have average
          */
         foreach ($this->getColumns() as $key=>$_column) {
-            if (strpos($_column->getTotal(), '/') !== FALSE) {
+            if (strpos($_column->getTotal(), '/') !== false) {
                 list($t1, $t2) = explode('/', $_column->getTotal());
                 if ($this->getGrandTotals()->getData($t2) != 0) {
                     $this->getGrandTotals()->setData(

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Longtext.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Longtext.php
@@ -48,7 +48,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Longtext
             $truncateLength = $this->getColumn()->getTruncate();
         }
         $text = Mage::helper('core/string')->truncate(parent::_getValue($row), $truncateLength);
-        if ($this->getColumn()->getEscape() !== FALSE) {
+        if ($this->getColumn()->getEscape() !== false) {
             $text = $this->escapeHtml($text);
         }
         if ($this->getColumn()->getNl2br()) {

--- a/app/code/core/Mage/Authorizenet/controllers/Directpost/PaymentController.php
+++ b/app/code/core/Mage/Authorizenet/controllers/Directpost/PaymentController.php
@@ -183,7 +183,7 @@ class Mage_Authorizenet_Directpost_PaymentController extends Mage_Core_Controlle
                     ->load($order->getQuoteId());
                 if ($quote->getId()) {
                     $quote->setIsActive(1)
-                        ->setReservedOrderId(NULL)
+                        ->setReservedOrderId(null)
                         ->save();
                     $this->_getCheckout()->replaceQuote($quote);
                 }

--- a/app/code/core/Mage/Core/Block/Template.php
+++ b/app/code/core/Mage/Core/Block/Template.php
@@ -163,7 +163,7 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
      */
     public function setScriptPath($dir)
     {
-        if (strpos($dir, '..') === FALSE && ($dir === Mage::getBaseDir('design') || strpos(realpath($dir), realpath(Mage::getBaseDir('design'))) === 0)) {
+        if (strpos($dir, '..') === false && ($dir === Mage::getBaseDir('design') || strpos(realpath($dir), realpath(Mage::getBaseDir('design'))) === 0)) {
             $this->_viewDir = $dir;
         } else {
             Mage::log('Not valid script path:' . $dir, Zend_Log::CRIT, null, null, true);
@@ -251,7 +251,7 @@ HTML;
 
         try {
             if (
-                strpos($this->_viewDir . DS . $fileName, '..') === FALSE
+                strpos($this->_viewDir . DS . $fileName, '..') === false
                 &&
                 ($this->_viewDir == Mage::getBaseDir('design') || strpos(realpath($this->_viewDir), realpath(Mage::getBaseDir('design'))) === 0)
             ) {
@@ -366,6 +366,6 @@ HTML;
      */
     protected function _getAllowSymlinks()
     {
-        return FALSE;
+        return false;
     }
 }

--- a/app/code/core/Mage/Core/Model/Resource/File/Storage/File.php
+++ b/app/code/core/Mage/Core/Model/Resource/File/Storage/File.php
@@ -202,7 +202,7 @@ class Mage_Core_Model_Resource_File_Storage_File
             // If we already opened the file using lockCreateFile method
             if ($this->filePointer) {
                 $fp = $this->filePointer;
-                $this->filePointer = NULL;
+                $this->filePointer = null;
                 if (@fwrite($fp, $content) !== false && @fflush($fp) && @flock($fp, LOCK_UN) && @fclose($fp)) {
                     return true;
                 }
@@ -283,7 +283,7 @@ class Mage_Core_Model_Resource_File_Storage_File
         $fullPath = $path . DS . $filename;
         if ($this->filePointer) {
             $fp = $this->filePointer;
-            $this->filePointer = NULL;
+            $this->filePointer = null;
             @flock($fp, LOCK_UN);
             @fclose($fp);
         }
@@ -294,7 +294,7 @@ class Mage_Core_Model_Resource_File_Storage_File
             foreach ($this->_createdDirectories as $directory) {
                 @rmdir($directory); // Allowed to fail when the directory cannot be removed (non-empty)
             }
-            $this->_createdDirectories = NULL;
+            $this->_createdDirectories = null;
         }
 
         // Clean up all empty directories

--- a/app/code/core/Mage/Page/Block/Html/Topmenu/Renderer.php
+++ b/app/code/core/Mage/Page/Block/Html/Topmenu/Renderer.php
@@ -47,7 +47,7 @@ class Mage_Page_Block_Html_Topmenu_Renderer extends Mage_Page_Block_Html_Topmenu
         }
 
         $includeFilePath = realpath(Mage::getBaseDir('design') . DS . $this->getTemplateFile());
-        if (strpos($this->getTemplateFile(), '..') === FALSE) {
+        if (strpos($this->getTemplateFile(), '..') === false) {
             $this->_templateFile = $includeFilePath;
         } else {
             throw new Exception('Not valid template file:' . $this->_templateFile);

--- a/app/code/core/Zend/Locale/Math/PhpMath.php
+++ b/app/code/core/Zend/Locale/Math/PhpMath.php
@@ -184,7 +184,7 @@ class Zend_Locale_Math_PhpMath extends Zend_Locale_Math
         $op1 = self::normalize($op1);
         $result = sqrt($op1);
         if (is_nan($result)) {
-            return NULL;
+            return null;
         }
 
         return self::round(self::normalize($result), $scale);
@@ -196,12 +196,12 @@ class Zend_Locale_Math_PhpMath extends Zend_Locale_Math
             $op1 = 0;
         }
         if (empty($op2)) {
-            return NULL;
+            return null;
         }
         $op1 = self::normalize($op1);
         $op2 = self::normalize($op2);
         if ((int)$op2 == 0) {
-            return NULL;
+            return null;
         }
         $result = $op1 % $op2;
         if (is_nan($result)  ||  (($op1 - $result) % $op2 != 0)) {

--- a/lib/Mage/Cache/Backend/File.php
+++ b/lib/Mage/Cache/Backend/File.php
@@ -66,7 +66,7 @@ class Mage_Cache_Backend_File extends Zend_Cache_Backend_File
         'read_control'           => false,   // Use a checksum to detect corrupt data
         'read_control_type'      => 'crc32', // If read_control is enabled, which checksum algorithm to use
         'hashed_directory_level' => 2,       // How many characters should be used to create sub-directories
-        'use_chmod' => FALSE,              // Do not use chmod on files and directories (should use umask() to control permissions)
+        'use_chmod' => false,              // Do not use chmod on files and directories (should use umask() to control permissions)
         'file_mode' => 0660,               // Filesystem permissions for created files (requires use_chmod)
         'directory_mode' => 0770,          // Filesystem permissions for created directories (requires use_chmod)
         'file_name_prefix'       => 'mage',  // Prefix for cache directories created
@@ -94,7 +94,7 @@ class Mage_Cache_Backend_File extends Zend_Cache_Backend_File
 
         // Auto-enable chmod if modes are specified.
         if (isset($options['directory_mode']) || isset($options['file_mode'])) {
-            $options['use_chmod'] = TRUE;
+            $options['use_chmod'] = true;
         }
 
         // Don't use parent constructor

--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -371,7 +371,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
         }
 
 
-        $hostInfo = $this->_getHostInfo(isset($this->_config['host']) ? $this->_config['host'] : (isset($this->_config['unix_socket']) ? $this->_config['unix_socket'] : NULL));
+        $hostInfo = $this->_getHostInfo(isset($this->_config['host']) ? $this->_config['host'] : (isset($this->_config['unix_socket']) ? $this->_config['unix_socket'] : null));
 
         switch ($hostInfo->getAddressType()) {
             case self::ADDRESS_TYPE_UNIX_SOCKET:
@@ -1710,7 +1710,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
              */
             $affected = array('tinyint', 'smallint', 'mediumint', 'int', 'bigint');
             foreach ($ddl as $key => $columnData) {
-                if (($columnData['DEFAULT'] === '') && (array_search($columnData['DATA_TYPE'], $affected) !== FALSE)) {
+                if (($columnData['DEFAULT'] === '') && (array_search($columnData['DATA_TYPE'], $affected) !== false)) {
                     $ddl[$key]['DEFAULT'] = null;
                 }
             }

--- a/lib/Varien/Db/Tree.php
+++ b/lib/Varien/Db/Tree.php
@@ -359,7 +359,7 @@ class Varien_Db_Tree
 
         if ($eId == $pId || $leftId == $leftIdP || ($leftIdP >= $leftId && $leftIdP <= $rightId) || ($level == $levelP+1 && $leftId > $leftIdP && $rightId < $rightIdP)) {
             echo "alert('cant_move_tree');";
-            return FALSE;
+            return false;
         }
 
         if ($leftIdP < $leftId && $rightIdP > $rightId && $levelP < $level - 1) {

--- a/lib/Varien/Io/Ftp.php
+++ b/lib/Varien/Io/Ftp.php
@@ -314,7 +314,7 @@ class Varien_Io_Ftp extends Varien_Io_Abstract
     protected function _tmpFilename($new=false)
     {
         if ($new || !$this->_tmpFilename) {
-            $this->_tmpFilename = tempnam( md5(uniqid(rand(), TRUE)), '' );
+            $this->_tmpFilename = tempnam( md5(uniqid(rand(), true)), '' );
         }
         return $this->_tmpFilename;
     }


### PR DESCRIPTION
PHPCS tells us that true/false/null should always be lowercase:
https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/casing/constant_case.rst
This PR fixes this.