### PR TITLE
Avoid getting lock on frontend for flat catalog indexes

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Category.php
@@ -173,8 +173,9 @@ class Mage_Catalog_Model_Category extends Mage_Catalog_Model_Abstract
     protected function _construct()
     {
         // If Flat Data enabled then use it but only on frontend
+        /** @var Mage_Catalog_Helper_Category_Flat $flatHelper */
         $flatHelper = Mage::helper('catalog/category_flat');
-        if ($flatHelper->isAvailable() && !Mage::app()->getStore()->isAdmin() && $flatHelper->isBuilt(true)
+        if ($flatHelper->isAccessible() && !Mage::app()->getStore()->isAdmin() && $flatHelper->isBuilt(true)
             && !$this->getDisableFlat()
         ) {
             $this->_init('catalog/category_flat');

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
@@ -329,8 +329,9 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
         }
         $storeId = $this->getStoreId();
         if (!isset($this->_flatEnabled[$storeId])) {
+            /** @var Mage_Catalog_Helper_Product_Flat $flatHelper */
             $flatHelper = $this->getFlatHelper();
-            $this->_flatEnabled[$storeId] = $flatHelper->isAvailable() && $flatHelper->isBuilt($storeId);
+            $this->_flatEnabled[$storeId] = $flatHelper->isAccessible() && $flatHelper->isBuilt($storeId);
         }
         return $this->_flatEnabled[$storeId];
     }


### PR DESCRIPTION
At the moment, if flat catalog is enable, a lock operation is called also on frontend when browsing the website.
This makes an I/O operation on file system (if the locking mechanism in use is "file") every single time and should not happen.

### Description (*)

There was a very long discussion about this in https://github.com/OpenMage/magento-lts/issues/1245 and I strongly suggest you check it out since it's important that we don't break anything here.

What has been coded in this PR is reply replacing the `$flatHelper->isAvailable()` with `$flatHelper->isAccessible()` in both `Mage_Catalog_Model_Category` and `Mage_Catalog_Model_Resource_Product_Collection`.

The `isAvailable()` called the `isAccessible()` but also checked that the indexes didn't have an active lock (which triggers the lock file creation) and it shouldn't be needed in the frontend.

### Related Pull Requests
- https://github.com/OpenMage/magento-lts/issues/1150

### Fixed Issues (if relevant)
- https://github.com/OpenMage/magento-lts/issues/1245

### Manual testing scenarios (*)
1. enable flat catalog
2. check var/locks for lock files
3. be sure that crons are not running
4. reset cache
5. browse a category page (without PR you'll find 2 lock files, with PR no lock files)
