### PR TITLE
PHPCS: applied rules space_after_semicolon and no_spaces_inside_parenthesis

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -181,9 +181,9 @@ final class Mage
     {
         $i = self::getOpenMageVersionInfo();
         $versionString = "{$i['major']}.{$i['minor']}.{$i['patch']}";
-        if ( $i['stability'] || $i['number'] ) {
+        if ($i['stability'] || $i['number']) {
             $versionString .= "-";
-            if ( $i['stability'] && $i['number'] ) {
+            if ($i['stability'] && $i['number']) {
                 $versionString .= implode('.', [$i['stability'], $i['number']]);
             } else {
                 $versionString .= implode('', [$i['stability'], $i['number']]);
@@ -877,7 +877,7 @@ final class Mage
                     ',',
                     (string) self::getConfig()->getNode('dev/log/allowedFileExtensions', Mage_Core_Model_Store::DEFAULT_CODE)
                 );
-                if ( ! ($extension = pathinfo($file, PATHINFO_EXTENSION)) || ! in_array($extension, $_allowedFileExtensions)) {
+                if (! ($extension = pathinfo($file, PATHINFO_EXTENSION)) || ! in_array($extension, $_allowedFileExtensions)) {
                     return;
                 }
 

--- a/app/code/core/Mage/Adminhtml/Block/Api/Buttons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Buttons.php
@@ -85,7 +85,7 @@ class Mage_Adminhtml_Block_Api_Buttons extends Mage_Adminhtml_Block_Template
 
     public function getDeleteButtonHtml()
     {
-        if( intval($this->getRequest()->getParam('rid')) == 0 ) {
+        if(intval($this->getRequest()->getParam('rid')) == 0) {
             return;
         }
         return $this->getChildHtml('deleteButton');

--- a/app/code/core/Mage/Adminhtml/Block/Api/Editroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Editroles.php
@@ -46,7 +46,7 @@ class Mage_Adminhtml_Block_Api_Editroles extends Mage_Adminhtml_Block_Widget_Tab
             'content'   => $this->getLayout()->createBlock('adminhtml/api_tab_rolesedit')->toHtml(),
         ]);
 
-        if( intval($roleId) > 0 ) {
+        if(intval($roleId) > 0) {
             $this->addTab('roles', [
                 'label'     => Mage::helper('adminhtml')->__('Role Users'),
                 'title'     => Mage::helper('adminhtml')->__('Role Users'),

--- a/app/code/core/Mage/Adminhtml/Block/Api/Edituser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Edituser.php
@@ -34,7 +34,7 @@ class Mage_Adminhtml_Block_Api_Edituser extends Mage_Adminhtml_Block_Widget_Tabs
             'content'   => $this->getLayout()->createBlock('adminhtml/api_tab_useredit')->toHtml(),
             'active'    => true
         ]);
-        if( $this->getUser()->getUserId() ) {
+        if($this->getUser()->getUserId()) {
             $this->addTab('roles', [
                 'label'     => Mage::helper('adminhtml')->__('Roles'),
                 'title'     => Mage::helper('adminhtml')->__('Roles'),

--- a/app/code/core/Mage/Adminhtml/Block/Api/Role/Grid/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Role/Grid/User.php
@@ -151,7 +151,7 @@ class Mage_Adminhtml_Block_Api_Role_Grid_User extends Mage_Adminhtml_Block_Widge
         if ($this->getRequest()->getParam('in_role_user') != "") {
             return (int)$this->getRequest()->getParam('in_role_user');
         }
-        $roleId = ( $this->getRequest()->getParam('rid') > 0 ) ? $this->getRequest()->getParam('rid') : Mage::registry('RID');
+        $roleId = ($this->getRequest()->getParam('rid') > 0) ? $this->getRequest()->getParam('rid') : Mage::registry('RID');
         $users  = Mage::getModel('api/roles')->setId($roleId)->getRoleUsers();
         if (count($users)) {
             if ($json) {

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tab/Roles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tab/Roles.php
@@ -97,7 +97,7 @@ class Mage_Adminhtml_Block_Api_User_Edit_Tab_Roles extends Mage_Adminhtml_Block_
 
     protected function _getSelectedRoles($json=false)
     {
-        if ( $this->getRequest()->getParam('user_roles') != "" ) {
+        if ($this->getRequest()->getParam('user_roles') != "") {
             return $this->getRequest()->getParam('user_roles');
         }
         $uRoles = Mage::registry('api_user')->getRoles();

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formgroup.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formgroup.php
@@ -74,7 +74,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Attribute_Set_Main_Formgroup extends 
 
     protected function _getSetId()
     {
-        return ( intval($this->getRequest()->getParam('id')) > 0 )
+        return (intval($this->getRequest()->getParam('id')) > 0)
                     ? intval($this->getRequest()->getParam('id'))
                     : Mage::getModel('eav/entity_type')
                         ->load(Mage::registry('entityType'))

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formset.php
@@ -51,7 +51,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Attribute_Set_Main_Formset extends Ma
             'value' => $data->getAttributeSetName()
         ]);
 
-        if( !$this->getRequest()->getParam('id', false) ) {
+        if(!$this->getRequest()->getParam('id', false)) {
             $fieldset->addField('gotoEdit', 'hidden', [
                 'name' => 'gotoEdit',
                 'value' => '1'

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Simple.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Simple.php
@@ -111,7 +111,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Super_Config_Simple
         $usedAttributes = $this->_getProduct()->getTypeInstance(true)->getUsedProductAttributes($this->_getProduct());
         foreach ($usedAttributes as $attribute) {
             $attributeCode =  $attribute->getAttributeCode();
-            $fieldset->addField( 'simple_product_' . $attributeCode, 'select',  [
+            $fieldset->addField('simple_product_' . $attributeCode, 'select',  [
                 'label' => $attribute->getFrontend()->getLabel(),
                 'name'  => $attributeCode,
                 'values' => $attribute->getSource()->getAllOptions(true, true),

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs.php
@@ -56,7 +56,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tabs extends Mage_Adminhtml_Bloc
                 // do not add groups without attributes
 
                 foreach ($attributes as $key => $attribute) {
-                    if( !$attribute->getIsVisible() ) {
+                    if(!$attribute->getIsVisible()) {
                         unset($attributes[$key]);
                     }
                 }
@@ -133,7 +133,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tabs extends Mage_Adminhtml_Bloc
                 ]);
             }
 
-            if( $this->getRequest()->getParam('id', false) ) {
+            if($this->getRequest()->getParam('id', false)) {
                 if (Mage::helper('catalog')->isModuleEnabled('Mage_Review')) {
                     if (Mage::getSingleton('admin/session')->isAllowed('admin/catalog/reviews_ratings')){
                         $this->addTab('reviews', [

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Frontend/Product/Watermark.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Frontend/Product/Watermark.php
@@ -42,7 +42,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Frontend_Product_Watermark extends Ma
              */
             $field = new Varien_Data_Form_Element_Text();
             $field->setName("groups[watermark][fields][{$key}_size][value]")
-                ->setForm( $this->getForm() )
+                ->setForm($this->getForm())
                 ->setLabel(Mage::helper('adminhtml')->__('Size for %s', $attribute['title']))
                 ->setRenderer($renderer);
             $html.= $field->toHtml();
@@ -52,7 +52,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Frontend_Product_Watermark extends Ma
              */
             $field = new Varien_Data_Form_Element_Imagefile();
             $field->setName("groups[watermark][fields][{$key}_image][value]")
-                ->setForm( $this->getForm() )
+                ->setForm($this->getForm())
                 ->setLabel(Mage::helper('adminhtml')->__('Watermark File for %s', $attribute['title']))
                 ->setRenderer($renderer);
             $html.= $field->toHtml();
@@ -62,7 +62,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Frontend_Product_Watermark extends Ma
              */
             $field = new Varien_Data_Form_Element_Select();
             $field->setName("groups[watermark][fields][{$key}_position][value]")
-                ->setForm( $this->getForm() )
+                ->setForm($this->getForm())
                 ->setLabel(Mage::helper('adminhtml')->__('Position of Watermark for %s', $attribute['title']))
                 ->setRenderer($renderer)
                 ->setValues(Mage::getSingleton('adminhtml/system_config_source_watermark_position')->toOptionArray());

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Tag.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Tag.php
@@ -42,8 +42,8 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_Tag extends Mage_Adminhtml_Block_Wi
     {
         $tagId = Mage::registry('tagId');
 
-        if( $this->getCustomerId() instanceof Mage_Customer_Model_Customer ) {
-            $this->setCustomerId( $this->getCustomerId()->getId() );
+        if($this->getCustomerId() instanceof Mage_Customer_Model_Customer) {
+            $this->setCustomerId($this->getCustomerId()->getId());
         }
 
         $collection = Mage::getResourceModel('tag/customer_collection')

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
@@ -72,7 +72,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_View
      */
     public function getCreateDate()
     {
-        if ( ! $this->getCustomer()->getCreatedAt()) {
+        if (! $this->getCustomer()->getCreatedAt()) {
             return null;
         }
         return $this->_getCoreHelper()->formatDate($this->getCustomer()->getCreatedAt(),
@@ -81,7 +81,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_View
 
     public function getStoreCreateDate()
     {
-        if ( ! $this->getCustomer()->getCreatedAt()) {
+        if (! $this->getCustomer()->getCreatedAt()) {
             return null;
         }
         $date = Mage::app()->getLocale()->storeDate(

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tabs.php
@@ -118,7 +118,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Tabs extends Mage_Adminhtml_Block_Widge
     protected function _updateActiveTab()
     {
         $tabId = $this->getRequest()->getParam('tab');
-        if( $tabId ) {
+        if($tabId) {
             $tabId = preg_replace("#{$this->getId()}_#", '', $tabId);
             if($tabId) {
                 $this->setActiveTab($tabId);

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit/Form.php
@@ -51,7 +51,7 @@ class Mage_Adminhtml_Block_Customer_Group_Edit_Form extends Mage_Adminhtml_Block
             ]
         );
 
-        if ($customerGroup->getId()==0 && $customerGroup->getCustomerGroupCode() ) {
+        if ($customerGroup->getId()==0 && $customerGroup->getCustomerGroupCode()) {
             $name->setDisabled(true);
         }
 
@@ -76,7 +76,7 @@ class Mage_Adminhtml_Block_Customer_Group_Edit_Form extends Mage_Adminhtml_Block
             );
         }
 
-        if( Mage::getSingleton('adminhtml/session')->getCustomerGroupData() ) {
+        if(Mage::getSingleton('adminhtml/session')->getCustomerGroupData()) {
             $form->addValues(Mage::getSingleton('adminhtml/session')->getCustomerGroupData());
             Mage::getSingleton('adminhtml/session')->setCustomerGroupData(null);
         } else {

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Type.php
@@ -30,7 +30,7 @@ class Mage_Adminhtml_Block_Customer_Online_Grid_Renderer_Type extends Mage_Admin
 
     public function render(Varien_Object $row)
     {
-        return ($row->getCustomerId() > 0 ) ? Mage::helper('customer')->__('Customer') : Mage::helper('customer')->__('Visitor') ;
+        return ($row->getCustomerId() > 0) ? Mage::helper('customer')->__('Customer') : Mage::helper('customer')->__('Visitor') ;
     }
 
 }

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit.php
@@ -249,6 +249,6 @@ class Mage_Adminhtml_Block_Newsletter_Queue_Edit extends Mage_Adminhtml_Block_Te
      */
     public function getHeaderText()
     {
-        return ( $this->getIsPreview() ? Mage::helper('newsletter')->__('View Newsletter') : Mage::helper('newsletter')->__('Edit Newsletter'));
+        return ($this->getIsPreview() ? Mage::helper('newsletter')->__('View Newsletter') : Mage::helper('newsletter')->__('Edit Newsletter'));
     }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Buttons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Buttons.php
@@ -85,7 +85,7 @@ class Mage_Adminhtml_Block_Permissions_Buttons extends Mage_Adminhtml_Block_Temp
 
     public function getDeleteButtonHtml()
     {
-        if( intval($this->getRequest()->getParam('rid')) == 0 ) {
+        if(intval($this->getRequest()->getParam('rid')) == 0) {
             return;
         }
         return $this->getChildHtml('deleteButton');

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Edituser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Edituser.php
@@ -34,7 +34,7 @@ class Mage_Adminhtml_Block_Permissions_Edituser extends Mage_Adminhtml_Block_Wid
             'content'   => $this->getLayout()->createBlock('adminhtml/permissions_tab_useredit')->toHtml(),
             'active'    => true
         ]);
-        if( $this->getUser()->getUserId() ) {
+        if($this->getUser()->getUserId()) {
             $this->addTab('roles', [
                 'label'     => Mage::helper('adminhtml')->__('Roles'),
                 'title'     => Mage::helper('adminhtml')->__('Roles'),

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Role/Grid/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Role/Grid/User.php
@@ -150,13 +150,13 @@ class Mage_Adminhtml_Block_Permissions_Role_Grid_User extends Mage_Adminhtml_Blo
 
     protected function _getUsers($json=false)
     {
-        if ( $this->getRequest()->getParam('in_role_user') != "" ) {
+        if ($this->getRequest()->getParam('in_role_user') != "") {
             return $this->getRequest()->getParam('in_role_user');
         }
-        $roleId = ( $this->getRequest()->getParam('rid') > 0 ) ? $this->getRequest()->getParam('rid') : Mage::registry('RID');
+        $roleId = ($this->getRequest()->getParam('rid') > 0) ? $this->getRequest()->getParam('rid') : Mage::registry('RID');
         $users  = Mage::getModel('admin/roles')->setId($roleId)->getRoleUsers();
         if (count($users)) {
-            if ( $json ) {
+            if ($json) {
                 $jsonUsers = [];
                 foreach($users as $usrid) $jsonUsers[$usrid] = 0;
                 return Mage::helper('core')->jsonEncode((object)$jsonUsers);
@@ -164,7 +164,7 @@ class Mage_Adminhtml_Block_Permissions_Role_Grid_User extends Mage_Adminhtml_Blo
                 return array_values($users);
             }
         } else {
-            if ( $json ) {
+            if ($json) {
                 return '{}';
             } else {
                 return [];

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tab/Roles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tab/Roles.php
@@ -97,7 +97,7 @@ class Mage_Adminhtml_Block_Permissions_User_Edit_Tab_Roles extends Mage_Adminhtm
 
     protected function _getSelectedRoles($json=false)
     {
-        if ( $this->getRequest()->getParam('user_roles') != "" ) {
+        if ($this->getRequest()->getParam('user_roles') != "") {
             return $this->getRequest()->getParam('user_roles');
         }
         /** @var Mage_Admin_Model_User $user */

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Answer/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Answer/Edit.php
@@ -36,7 +36,7 @@ class Mage_Adminhtml_Block_Poll_Answer_Edit extends Mage_Adminhtml_Block_Widget_
         $this->_objectId = 'id';
         $this->_controller = 'poll_answer';
 
-        if( $this->getRequest()->getParam($this->_objectId) ) {
+        if($this->getRequest()->getParam($this->_objectId)) {
             $answerData = Mage::getModel('poll/poll_answer')
                 ->load($this->getRequest()->getParam($this->_objectId));
             Mage::register('answer_data', $answerData);

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit.php
@@ -43,7 +43,7 @@ class Mage_Adminhtml_Block_Poll_Edit extends Mage_Adminhtml_Block_Widget_Form_Co
 
     public function getHeaderText()
     {
-        if( Mage::registry('poll_data') && Mage::registry('poll_data')->getId() ) {
+        if(Mage::registry('poll_data') && Mage::registry('poll_data')->getId()) {
             return Mage::helper('poll')->__("Edit Poll '%s'", $this->escapeHtml(Mage::registry('poll_data')->getPollTitle()));
         } else {
             return Mage::helper('poll')->__('New Poll');

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/List.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/List.php
@@ -33,7 +33,7 @@ class Mage_Adminhtml_Block_Poll_Edit_Tab_Answers_List extends Mage_Adminhtml_Blo
 
     protected function _toHtml()
     {
-        if( !Mage::registry('poll_data') ) {
+        if(!Mage::registry('poll_data')) {
             $this->assign('answers', false);
             return parent::_toHtml();
         }

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Form.php
@@ -74,10 +74,10 @@ class Mage_Adminhtml_Block_Poll_Edit_Tab_Form extends Mage_Adminhtml_Block_Widge
             Mage::registry('poll_data')->setStoreIds(Mage::app()->getStore(true)->getId());
         }
 
-        if( Mage::getSingleton('adminhtml/session')->getPollData() ) {
+        if(Mage::getSingleton('adminhtml/session')->getPollData()) {
             $form->setValues(Mage::getSingleton('adminhtml/session')->getPollData());
             Mage::getSingleton('adminhtml/session')->setPollData(null);
-        } elseif( Mage::registry('poll_data') ) {
+        } elseif(Mage::registry('poll_data')) {
             $form->setValues(Mage::registry('poll_data')->getData());
 
             $fieldset->addField('was_closed', 'hidden', [

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit.php
@@ -37,7 +37,7 @@ class Mage_Adminhtml_Block_Rating_Edit extends Mage_Adminhtml_Block_Widget_Form_
         $this->_updateButton('save', 'label', Mage::helper('rating')->__('Save Rating'));
         $this->_updateButton('delete', 'label', Mage::helper('rating')->__('Delete Rating'));
 
-        if( $this->getRequest()->getParam($this->_objectId) ) {
+        if($this->getRequest()->getParam($this->_objectId)) {
 
             $ratingData = Mage::getModel('rating/rating')
                 ->load($this->getRequest()->getParam($this->_objectId));
@@ -49,7 +49,7 @@ class Mage_Adminhtml_Block_Rating_Edit extends Mage_Adminhtml_Block_Widget_Form_
 
     public function getHeaderText()
     {
-        if( Mage::registry('rating_data') && Mage::registry('rating_data')->getId() ) {
+        if(Mage::registry('rating_data') && Mage::registry('rating_data')->getId()) {
             return Mage::helper('rating')->__("Edit Rating", $this->escapeHtml(Mage::registry('rating_data')->getRatingCode()));
         } else {
             return Mage::helper('rating')->__('New Rating');

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tab/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tab/Options.php
@@ -32,25 +32,25 @@ class Mage_Adminhtml_Block_Rating_Edit_Tab_Options extends Mage_Adminhtml_Block_
 
         $fieldset = $form->addFieldset('options_form', ['legend'=>Mage::helper('rating')->__('Assigned Options')]);
 
-        if( Mage::registry('rating_data') ) {
+        if(Mage::registry('rating_data')) {
             $collection = Mage::getModel('rating/rating_option')
                 ->getResourceCollection()
                 ->addRatingFilter(Mage::registry('rating_data')->getId())
                 ->load();
 
             $i = 1;
-            foreach( $collection->getItems() as $item ) {
+            foreach($collection->getItems() as $item) {
                 $fieldset->addField('option_code_' . $item->getId() , 'text', [
                                         'label'     => Mage::helper('rating')->__('Option Label'),
                                         'required'  => true,
                                         'name'      => 'option_title[' . $item->getId() . ']',
-                                        'value'     => ( $item->getCode() ) ? $item->getCode() : $i,
+                                        'value'     => ($item->getCode()) ? $item->getCode() : $i,
                     ]
                 );
                 $i ++;
             }
         } else {
-            for( $i=1;$i<=5;$i++ ) {
+            for($i=1; $i<=5; $i++) {
                 $fieldset->addField('option_code_' . $i, 'text', [
                                         'label'     => Mage::helper('rating')->__('Option Title'),
                                         'required'  => true,

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Grid.php
@@ -54,7 +54,7 @@ class Mage_Adminhtml_Block_Report_Product_Downloads_Grid extends Mage_Adminhtml_
             ->addAttributeToFilter('type_id', [Mage_Downloadable_Model_Product_Type::TYPE_DOWNLOADABLE])
             ->addSummary();
 
-        if( $storeId ) {
+        if($storeId) {
             $collection->addStoreFilter($storeId);
         }
 

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Renderer/Purchases.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Renderer/Purchases.php
@@ -36,7 +36,7 @@ class Mage_Adminhtml_Block_Report_Product_Downloads_Renderer_Purchases
      */
     public function render(Varien_Object $row)
     {
-        if ( ($value = $row->getData($this->getColumn()->getIndex())) > 0) {
+        if (($value = $row->getData($this->getColumn()->getIndex())) > 0) {
             return $value;
         }
         return $this->__('Unlimited');

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Lowstock/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Lowstock/Grid.php
@@ -60,7 +60,7 @@ class Mage_Adminhtml_Block_Report_Product_Lowstock_Grid extends Mage_Adminhtml_B
             ->useNotifyStockQtyFilter($storeId)
             ->setOrder('qty', Varien_Data_Collection::SORT_ORDER_ASC);
 
-        if( $storeId ) {
+        if($storeId) {
             $collection->addStoreFilter($storeId);
         }
 

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Abandoned/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Abandoned/Grid.php
@@ -57,7 +57,7 @@ class Mage_Adminhtml_Block_Report_Shopcart_Abandoned_Grid extends Mage_Adminhtml
 
     protected function _addColumnFilterToCollection($column)
     {
-        $field = ( $column->getFilterIndex() ) ? $column->getFilterIndex() : $column->getIndex();
+        $field = ($column->getFilterIndex()) ? $column->getFilterIndex() : $column->getIndex();
         $skip = ['subtotal', 'customer_name', 'email'/*, 'created_at', 'updated_at'*/];
 
         if (in_array($field, $skip)) {

--- a/app/code/core/Mage/Adminhtml/Block/Review/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Edit.php
@@ -39,7 +39,7 @@ class Mage_Adminhtml_Block_Review_Edit extends Mage_Adminhtml_Block_Widget_Form_
         $this->_updateButton('save', 'id', 'save_button');
         $this->_updateButton('delete', 'label', Mage::helper('review')->__('Delete Review'));
 
-        if( $this->getRequest()->getParam('productId', false) ) {
+        if($this->getRequest()->getParam('productId', false)) {
             $this->_updateButton(
                 'back',
                 'onclick',
@@ -52,7 +52,7 @@ class Mage_Adminhtml_Block_Review_Edit extends Mage_Adminhtml_Block_Widget_Form_
             );
         }
 
-        if( $this->getRequest()->getParam('customerId', false) ) {
+        if($this->getRequest()->getParam('customerId', false)) {
             $this->_updateButton(
                 'back',
                 'onclick',
@@ -65,8 +65,8 @@ class Mage_Adminhtml_Block_Review_Edit extends Mage_Adminhtml_Block_Widget_Form_
             );
         }
 
-        if( $this->getRequest()->getParam('ret', false) == 'pending' ) {
-            $this->_updateButton('back', 'onclick', 'setLocation(\'' . $this->getUrl('*/*/pending') .'\')' );
+        if($this->getRequest()->getParam('ret', false) == 'pending') {
+            $this->_updateButton('back', 'onclick', 'setLocation(\'' . $this->getUrl('*/*/pending') .'\')');
             $this->_updateButton(
                 'delete',
                 'onclick',
@@ -88,7 +88,7 @@ class Mage_Adminhtml_Block_Review_Edit extends Mage_Adminhtml_Block_Widget_Form_
             Mage::register('ret', 'pending');
         }
 
-        if( $this->getRequest()->getParam($this->_objectId) ) {
+        if($this->getRequest()->getParam($this->_objectId)) {
             $reviewData = Mage::getModel('review/review')
                 ->load($this->getRequest()->getParam($this->_objectId));
             Mage::register('review_data', $reviewData);
@@ -121,7 +121,7 @@ class Mage_Adminhtml_Block_Review_Edit extends Mage_Adminhtml_Block_Widget_Form_
 
     public function getHeaderText()
     {
-        if( Mage::registry('review_data') && Mage::registry('review_data')->getId() ) {
+        if(Mage::registry('review_data') && Mage::registry('review_data')->getId()) {
             return Mage::helper('review')->__("Edit Review '%s'", $this->escapeHtml(Mage::registry('review_data')->getTitle()));
         } else {
             return Mage::helper('review')->__('New Review');

--- a/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
@@ -87,7 +87,7 @@ class Mage_Adminhtml_Block_Review_Grid extends Mage_Adminhtml_Block_Widget_Grid
             'index'         => 'review_created_at',
         ]);
 
-        if( !Mage::registry('usePendingFilter') ) {
+        if(!Mage::registry('usePendingFilter')) {
             $this->addColumn('status', [
                 'header'        => Mage::helper('review')->__('Status'),
                 'align'         => 'left',
@@ -183,7 +183,7 @@ class Mage_Adminhtml_Block_Review_Grid extends Mage_Adminhtml_Block_Widget_Grid
                             'params'=> [
                                 'productId' => $this->getProductId(),
                                 'customerId' => $this->getCustomerId(),
-                                'ret'       => ( Mage::registry('usePendingFilter') ) ? 'pending' : null
+                                'ret'       => (Mage::registry('usePendingFilter')) ? 'pending' : null
                             ]
                         ],
                          'field'   => 'id'
@@ -244,13 +244,13 @@ class Mage_Adminhtml_Block_Review_Grid extends Mage_Adminhtml_Block_Widget_Grid
             'id' => $row->getReviewId(),
             'productId' => $this->getProductId(),
             'customerId' => $this->getCustomerId(),
-            'ret'       => ( Mage::registry('usePendingFilter') ) ? 'pending' : null,
+            'ret'       => (Mage::registry('usePendingFilter')) ? 'pending' : null,
         ]);
     }
 
     public function getGridUrl()
     {
-        if( $this->getProductId() || $this->getCustomerId() ) {
+        if($this->getProductId() || $this->getCustomerId()) {
             return $this->getUrl(
                 '*/catalog_product_review/' . (Mage::registry('usePendingFilter') ? 'pending' : ''),
                 [

--- a/app/code/core/Mage/Adminhtml/Block/Review/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Main.php
@@ -49,7 +49,7 @@ class Mage_Adminhtml_Block_Review_Main extends Mage_Adminhtml_Block_Widget_Grid_
             $productName =  $this->escapeHtml($product->getName());
         }
 
-        if( Mage::registry('usePendingFilter') === true ) {
+        if(Mage::registry('usePendingFilter') === true) {
             if ($customerName) {
                 $this->_headerText = Mage::helper('review')->__('Pending Reviews of Customer `%s`', $customerName);
             } else {

--- a/app/code/core/Mage/Adminhtml/Block/Review/Rating/Detailed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Rating/Detailed.php
@@ -33,15 +33,15 @@ class Mage_Adminhtml_Block_Review_Rating_Detailed extends Mage_Adminhtml_Block_T
     {
         parent::__construct();
         $this->setTemplate('rating/detailed.phtml');
-        if( Mage::registry('review_data') ) {
+        if(Mage::registry('review_data')) {
             $this->setReviewId(Mage::registry('review_data')->getReviewId());
         }
     }
 
     public function getRating()
     {
-        if( !$this->getRatingCollection() ) {
-            if( Mage::registry('review_data') ) {
+        if(!$this->getRatingCollection()) {
+            if(Mage::registry('review_data')) {
                 $stores = Mage::registry('review_data')->getStores();
 
                 $stores = array_diff($stores, [0]);
@@ -90,7 +90,7 @@ class Mage_Adminhtml_Block_Review_Rating_Detailed extends Mage_Adminhtml_Block_T
                         ->addRatingOptions();
                 }
             }
-            $this->setRatingCollection( ( $ratingCollection->getSize() ) ? $ratingCollection : false );
+            $this->setRatingCollection(($ratingCollection->getSize()) ? $ratingCollection : false);
         }
         return $this->getRatingCollection();
     }

--- a/app/code/core/Mage/Adminhtml/Block/Review/Rating/Summary.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Rating/Summary.php
@@ -36,20 +36,20 @@ class Mage_Adminhtml_Block_Review_Rating_Summary extends Mage_Adminhtml_Block_Te
 
     public function getRating()
     {
-        if( !$this->getRatingCollection() ) {
+        if(!$this->getRatingCollection()) {
             $ratingCollection = Mage::getModel('rating/rating_option_vote')
                 ->getResourceCollection()
                 ->setReviewFilter($this->getReviewId())
                 ->addRatingInfo()
                 ->load();
-            $this->setRatingCollection( ( $ratingCollection->getSize() ) ? $ratingCollection : false );
+            $this->setRatingCollection(($ratingCollection->getSize()) ? $ratingCollection : false);
         }
         return $this->getRatingCollection();
     }
 
     public function getRatingSummary()
     {
-        if( !$this->getRatingSummaryCache() ) {
+        if(!$this->getRatingSummaryCache()) {
             $this->setRatingSummaryCache(Mage::getModel('rating/rating')->getReviewSummary($this->getReviewId()));
         }
 

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Abstract.php
@@ -533,7 +533,7 @@ class  Mage_Adminhtml_Block_Sales_Items_Abstract extends Mage_Adminhtml_Block_Te
         if (!is_null($item)) {
             if (!$item->hasCanReturnToStock()) {
                 $product = Mage::getModel('catalog/product')->load($item->getOrderItem()->getProductId());
-                if ( $product->getId() && $product->getStockItem()->getManageStock() ) {
+                if ($product->getId() && $product->getStockItem()->getManageStock()) {
                     $item->setCanReturnToStock(true);
                 }
                 else {
@@ -553,10 +553,10 @@ class  Mage_Adminhtml_Block_Sales_Items_Abstract extends Mage_Adminhtml_Block_Te
     {
         $canReturnToStock = Mage::getStoreConfig(Mage_CatalogInventory_Model_Stock_Item::XML_PATH_CAN_SUBTRACT);
         if (!is_null($item)) {
-            if ( $item->getCreditmemo()->getOrder()->hasCanReturnToStock() ) {
+            if ($item->getCreditmemo()->getOrder()->hasCanReturnToStock()) {
                 $canReturnToStock = $item->getCreditmemo()->getOrder()->getCanReturnToStock();
             }
-        } elseif ( $this->getOrder()->hasCanReturnToStock() ) {
+        } elseif ($this->getOrder()->hasCanReturnToStock()) {
             $canReturnToStock = $this->getOrder()->getCanReturnToStock();
         }
         return $canReturnToStock;

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Configurable.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Configurable.php
@@ -30,6 +30,6 @@ class Mage_Adminhtml_Block_Sales_Items_Renderer_Configurable extends  Mage_Admin
 
     public function getItem()
     {
-        return $this->_getData('item');//->getOrderItem();
+        return $this->_getData('item'); //->getOrderItem();
     }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Default.php
@@ -29,6 +29,6 @@ class Mage_Adminhtml_Block_Sales_Items_Renderer_Default extends Mage_Adminhtml_B
 {
     public function getItem()
     {
-        return $this->_getData('item');//->getOrderItem();
+        return $this->_getData('item'); //->getOrderItem();
     }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Subtotal.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Subtotal.php
@@ -47,7 +47,7 @@ class Mage_Adminhtml_Block_Sales_Order_Create_Totals_Subtotal extends
         if ($displayBoth) {
             // Verify that the value for 'subtotal including tax' (or excluding tax) exists
             $value = $this->getTotal()->getValueInclTax();
-            $displayBoth = isset( $value );
+            $displayBoth = isset($value);
         }
         return $displayBoth;
     }

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Items.php
@@ -181,7 +181,7 @@ class Mage_Adminhtml_Block_Sales_Order_Creditmemo_Create_Items extends Mage_Admi
                 $canReturnToStock = false;
                 foreach ($this->getCreditmemo()->getAllItems() as $item) {
                     $product = Mage::getModel('catalog/product')->load($item->getOrderItem()->getProductId());
-                    if ( $product->getId() && $product->getStockItem()->getManageStock() ) {
+                    if ($product->getId() && $product->getStockItem()->getManageStock()) {
                         $item->setCanReturnToStock($canReturnToStock = true);
                     } else {
                         $item->setCanReturnToStock(false);

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Tabs.php
@@ -103,7 +103,7 @@ class Mage_Adminhtml_Block_System_Config_Tabs extends Mage_Adminhtml_Block_Widge
                     $this->_addBreadcrumb($label, '', $url->getUrl('*/*/*', ['section'=>$code]));
                 }
             }
-            if ( $sectionAllowed && $hasChildren) {
+            if ($sectionAllowed && $hasChildren) {
                 $this->addSection($code, (string)$section->tab, [
                     'class'     => (string)$section->class,
                     'label'     => $label,
@@ -326,7 +326,7 @@ class Mage_Adminhtml_Block_System_Config_Tabs extends Mage_Adminhtml_Block_Widge
         }
 
         $showTab = false;
-        if ( $permissions->isAllowed('system/config/'.$code) ) {
+        if ($permissions->isAllowed('system/config/'.$code)) {
             $showTab = true;
         }
         return $showTab;

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Grid.php
@@ -52,7 +52,7 @@ class Mage_Adminhtml_Block_System_Convert_Profile_Grid extends Mage_Adminhtml_Bl
             'width'     => '50px',
             'index'     => 'profile_id',
         ]);
-        $this->addColumn( 'name', [
+        $this->addColumn('name', [
             'header'    => Mage::helper('adminhtml')->__('Profile Name'),
             'index'     => 'name',
         ]);

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Matrix.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Matrix.php
@@ -42,15 +42,15 @@ class Mage_Adminhtml_Block_System_Currency_Rate_Matrix extends Mage_Adminhtml_Bl
         $defaultCurrencies = $currencyModel->getConfigBaseCurrencies();
         $oldCurrencies = $this->_prepareRates($currencyModel->getCurrencyRates($defaultCurrencies, $currencies));
 
-        foreach( $currencies as $currency ) {
-            foreach( $oldCurrencies as $key => $value ) {
-                if( !array_key_exists($currency, $oldCurrencies[$key]) ) {
+        foreach($currencies as $currency) {
+            foreach($oldCurrencies as $key => $value) {
+                if(!array_key_exists($currency, $oldCurrencies[$key])) {
                     $oldCurrencies[$key][$currency] = '';
                 }
             }
         }
 
-        foreach( $oldCurrencies as $key => $value ) {
+        foreach($oldCurrencies as $key => $value) {
             ksort($oldCurrencies[$key]);
         }
 
@@ -71,17 +71,17 @@ class Mage_Adminhtml_Block_System_Currency_Rate_Matrix extends Mage_Adminhtml_Bl
 
     protected function _prepareRates($array)
     {
-        if( !is_array($array) ) {
+        if(!is_array($array)) {
             return $array;
         }
 
         foreach ($array as $key => $rate) {
             foreach ($rate as $code => $value) {
                 $parts = explode('.', $value);
-                if( count($parts) === 2 ) {
+                if(count($parts) === 2) {
                     $parts[1] = str_pad(rtrim($parts[1], 0), 4, '0', STR_PAD_RIGHT);
                     $array[$key][$code] = implode('.', $parts);
-                } elseif( $value > 0 ) {
+                } elseif($value > 0) {
                     $array[$key][$code] = number_format($value, 4);
                 } else {
                     $array[$key][$code] = null;

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Customer.php
@@ -33,7 +33,7 @@ class Mage_Adminhtml_Block_Tag_Customer extends Mage_Adminhtml_Block_Widget_Grid
     {
         parent::__construct();
 
-        switch( $this->getRequest()->getParam('ret') ) {
+        switch($this->getRequest()->getParam('ret')) {
             case 'all':
                 $url = $this->getUrl('*/*/');
                 break;

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Form.php
@@ -96,11 +96,11 @@ class Mage_Adminhtml_Block_Tag_Edit_Form extends Mage_Adminhtml_Block_Widget_For
             'after_element_html' => ' ' . Mage::helper('tag')->__('[STORE VIEW]'),
         ]);
 
-        if (!$model->getId() && !Mage::getSingleton('adminhtml/session')->getTagData() ) {
+        if (!$model->getId() && !Mage::getSingleton('adminhtml/session')->getTagData()) {
             $model->setStatus(Mage_Tag_Model_Tag::STATUS_APPROVED);
         }
 
-        if ( Mage::getSingleton('adminhtml/session')->getTagData() ) {
+        if (Mage::getSingleton('adminhtml/session')->getTagData()) {
             $form->addValues(Mage::getSingleton('adminhtml/session')->getTagData());
             Mage::getSingleton('adminhtml/session')->setTagData(null);
         } else {

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Grid/All.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Grid/All.php
@@ -90,7 +90,7 @@ class Mage_Adminhtml_Block_Tag_Grid_All extends Mage_Adminhtml_Block_Widget_Grid
     {
         if ($this->getCollection() && $column->getFilter()->getValue()) {
             if($column->getIndex()=='stores') {
-                $this->getCollection()->addAttributeToFilter( $column->getIndex(), $column->getFilter()->getCondition());
+                $this->getCollection()->addAttributeToFilter($column->getIndex(), $column->getFilter()->getCondition());
             } else {
                 $this->getCollection()->addStoreFilter($column->getFilter()->getCondition());
             }

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Product.php
@@ -32,7 +32,7 @@ class Mage_Adminhtml_Block_Tag_Product extends Mage_Adminhtml_Block_Widget_Grid_
     {
         parent::__construct();
 
-        switch( $this->getRequest()->getParam('ret') ) {
+        switch($this->getRequest()->getParam('ret')) {
             case 'all':
                 $url = $this->getUrl('*/*/');
                 break;

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit.php
@@ -37,16 +37,16 @@ class Mage_Adminhtml_Block_Tag_Tag_Edit extends Mage_Adminhtml_Block_Widget_Form
 
         parent::__construct();
 
-        if( $this->getRequest()->getParam('product_id') ) {
+        if($this->getRequest()->getParam('product_id')) {
             $this->_updateButton('back', 'onclick', "setLocation('" . $this->getUrl('*/catalog_product/edit', ['id' => $this->getRequest()->getParam('product_id')]) . "')");
         }
 
-        if( $this->getRequest()->getParam('customer_id') ) {
+        if($this->getRequest()->getParam('customer_id')) {
             $this->_updateButton('back', 'onclick', "setLocation('" . $this->getUrl('*/customer/edit', ['id' => $this->getRequest()->getParam('customer_id')]) . "')");
         }
 
-        if( $this->getRequest()->getParam('ret', false) == 'pending' ) {
-            $this->_updateButton('back', 'onclick', 'setLocation(\'' . $this->getUrl('*/*/pending') .'\')' );
+        if($this->getRequest()->getParam('ret', false) == 'pending') {
+            $this->_updateButton('back', 'onclick', 'setLocation(\'' . $this->getUrl('*/*/pending') .'\')');
             $this->_updateButton('delete', 'onclick', 'deleteConfirm(\''
                 . Mage::helper('core')->jsQuoteEscape(
                     Mage::helper('tag')->__('Are you sure you want to do this?')

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit/Form.php
@@ -75,7 +75,7 @@ class Mage_Adminhtml_Block_Tag_Tag_Edit_Form extends Mage_Adminhtml_Block_Widget
 
         $form->setValues($model->getData());
         $form->setUseContainer(true);
-        $form->setAction( $this->getUrl($form->getAction(), [
+        $form->setAction($this->getUrl($form->getAction(), [
             'ret' => $this->getRequest()->getParam('ret'),
             'customer_id' => $this->getRequest()->getParam('customer_id'),
             'product_id' => $this->getRequest()->getParam('product_id'),

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Toolbar/Save.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Toolbar/Save.php
@@ -116,7 +116,7 @@ class Mage_Adminhtml_Block_Tax_Rate_Toolbar_Save extends Mage_Adminhtml_Block_Te
      */
     public function getDeleteButtonHtml()
     {
-        if( intval($this->getRequest()->getParam('rate')) == 0 ) {
+        if(intval($this->getRequest()->getParam('rate')) == 0) {
             return;
         }
         return $this->getChildHtml('deleteButton');

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Edit/Form.php
@@ -142,7 +142,7 @@ class Mage_Adminhtml_Block_Tax_Rule_Edit_Form extends Mage_Adminhtml_Block_Widge
             ]
         );
 
-        if ($model->getId() > 0 ) {
+        if ($model->getId() > 0) {
             $fieldset->addField('tax_calculation_rule_id', 'hidden',
                 [
                     'name'      => 'tax_calculation_rule_id',

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
@@ -173,7 +173,7 @@ class Mage_Adminhtml_Block_Widget_Form extends Mage_Adminhtml_Block_Widget
             if (!$attribute || ($attribute->hasIsVisible() && !$attribute->getIsVisible())) {
                 continue;
             }
-            if ( ($inputType = $attribute->getFrontend()->getInputType())
+            if (($inputType = $attribute->getFrontend()->getInputType())
                  && !in_array($attribute->getAttributeCode(), $exclude)
                  && ($inputType != 'media_image')
                  ) {

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
@@ -141,7 +141,7 @@ class Mage_Adminhtml_Block_Widget_Form_Container extends Mage_Adminhtml_Block_Wi
 
     public function getFormInitScripts()
     {
-        if ( !empty($this->_formInitScripts) && is_array($this->_formInitScripts) ) {
+        if (!empty($this->_formInitScripts) && is_array($this->_formInitScripts)) {
             return '<script type="text/javascript">' . implode("\n", $this->_formInitScripts) . '</script>';
         }
         return '';
@@ -149,7 +149,7 @@ class Mage_Adminhtml_Block_Widget_Form_Container extends Mage_Adminhtml_Block_Wi
 
     public function getFormScripts()
     {
-        if ( !empty($this->_formScripts) && is_array($this->_formScripts) ) {
+        if (!empty($this->_formScripts) && is_array($this->_formScripts)) {
             return '<script type="text/javascript">' . implode("\n", $this->_formScripts) . '</script>';
         }
         return '';

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Date.php
@@ -117,7 +117,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Date
     {
         if ($index) {
             if ($data = $this->getData('value', 'orig_' . $index)) {
-                return $data;//date('Y-m-d', strtotime($data));
+                return $data; //date('Y-m-d', strtotime($data));
             }
             return null;
         }

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
@@ -36,7 +36,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Datetime
     {
         if ($index) {
             if ($data = $this->getData('value', 'orig_'.$index)) {
-                return $data;//date('Y-m-d', strtotime($data));
+                return $data; //date('Y-m-d', strtotime($data));
             }
             return null;
         }
@@ -132,7 +132,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Datetime
                 inputField : "'.$htmlId.'_from",
                 ifFormat : "'.$format.'",
                 button : "'.$htmlId.'_from_trig",
-                showsTime: '. ( $this->getColumn()->getFilterTime() ? 'true' : 'false') .',
+                showsTime: '. ($this->getColumn()->getFilterTime() ? 'true' : 'false') .',
                 align : "Bl",
                 singleClick : true
             });
@@ -140,7 +140,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Datetime
                 inputField : "'.$htmlId.'_to",
                 ifFormat : "'.$format.'",
                 button : "'.$htmlId.'_to_trig",
-                showsTime: '. ( $this->getColumn()->getFilterTime() ? 'true' : 'false') .',
+                showsTime: '. ($this->getColumn()->getFilterTime() ? 'true' : 'false') .',
                 align : "Bl",
                 singleClick : true
             });

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Massaction.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Massaction.php
@@ -30,10 +30,10 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Massaction extends Mage_Adm
     public function getCondition()
     {
         if ($this->getValue()) {
-            return ['in'=> ( $this->getColumn()->getSelected() ? $this->getColumn()->getSelected() : [0])];
+            return ['in'=> ($this->getColumn()->getSelected() ? $this->getColumn()->getSelected() : [0])];
         }
         else {
-            return ['nin'=> ( $this->getColumn()->getSelected() ? $this->getColumn()->getSelected() : [0])];
+            return ['nin'=> ($this->getColumn()->getSelected() ? $this->getColumn()->getSelected() : [0])];
         }
     }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Select.php
@@ -38,7 +38,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Select extends Mage_Adminht
         }
 
         $colOptions = $this->getColumn()->getOptions();
-        if (!empty($colOptions) && is_array($colOptions) ) {
+        if (!empty($colOptions) && is_array($colOptions)) {
             $options = [$emptyOption];
             foreach ($colOptions as $value => $label) {
                 $options[] = ['value' => $value, 'label' => $label];
@@ -57,7 +57,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Select extends Mage_Adminht
      */
     protected function _renderOption($option, $value)
     {
-        $selected = (($option['value'] == $value && (!is_null($value))) ? ' selected="selected"' : '' );
+        $selected = (($option['value'] == $value && (!is_null($value))) ? ' selected="selected"' : '');
         return '<option value="'. $this->escapeHtml($option['value']).'"'.$selected.'>'.$this->escapeHtml($option['label']).'</option>';
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Action.php
@@ -38,13 +38,13 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Action
     public function render(Varien_Object $row)
     {
         $actions = $this->getColumn()->getActions();
-        if ( empty($actions) || !is_array($actions) ) {
+        if (empty($actions) || !is_array($actions)) {
             return '&nbsp;';
         }
 
         if(count($actions) === 1 && !$this->getColumn()->getNoLink()) {
             foreach ($actions as $action) {
-                if ( is_array($action) ) {
+                if (is_array($action)) {
                     return $this->_toLinkHtml($action, $row);
                 }
             }
@@ -55,7 +55,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Action
         $i = 0;
         foreach ($actions as $action){
             $i++;
-            if ( is_array($action) ) {
+            if (is_array($action)) {
                 $out .= $this->_toOptionHtml($action, $row);
             }
         }
@@ -117,7 +117,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Action
      */
     protected function _transformActionData(&$action, &$actionCaption, Varien_Object $row)
     {
-        foreach ( $action as $attribute => $value ) {
+        foreach ($action as $attribute => $value) {
             if(isset($action[$attribute]) && !is_array($action[$attribute])) {
                 $this->getColumn()->setFormat($action[$attribute]);
                 $action[$attribute] = parent::render($row);

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Select.php
@@ -42,7 +42,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Select
         $html = '<select name="' . $this->escapeHtml($name) . '" ' . $this->getColumn()->getValidateClass() . '>';
         $value = $row->getData($this->getColumn()->getIndex());
         foreach ($this->getColumn()->getOptions() as $val => $label){
-            $selected = ( ($val == $value && (!is_null($value))) ? ' selected="selected"' : '' );
+            $selected = (($val == $value && (!is_null($value))) ? ' selected="selected"' : '');
             $html .= '<option value="' . $this->escapeHtml($val) . '"' . $selected . '>';
             $html .= $this->escapeHtml($label) . '</option>';
         }

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Text.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Text.php
@@ -44,7 +44,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Text
      */
     public function _getValue(Varien_Object $row)
     {
-        $format = ( $this->getColumn()->getFormat() ) ? $this->getColumn()->getFormat() : null;
+        $format = ($this->getColumn()->getFormat()) ? $this->getColumn()->getFormat() : null;
         $defaultValue = $this->getColumn()->getDefault();
         if (is_null($format)) {
             // If no format and it column not filtered specified return data as is.

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Container.php
@@ -55,9 +55,9 @@ class Mage_Adminhtml_Block_Widget_Grid_Container extends Mage_Adminhtml_Block_Wi
 
     protected function _prepareLayout()
     {
-        $this->setChild( 'grid',
-            $this->getLayout()->createBlock( $this->_blockGroup.'/' . $this->_controller . '_grid',
-            $this->_controller . '.grid')->setSaveParametersInSession(true) );
+        $this->setChild('grid',
+            $this->getLayout()->createBlock($this->_blockGroup.'/' . $this->_controller . '_grid',
+            $this->_controller . '.grid')->setSaveParametersInSession(true));
         return parent::_prepareLayout();
     }
 

--- a/app/code/core/Mage/Adminhtml/Controller/Action.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Action.php
@@ -201,7 +201,7 @@ class Mage_Adminhtml_Controller_Action extends Mage_Core_Controller_Varien_Actio
                 if (!$_isValidFormKey){
                     Mage::getSingleton('adminhtml/session')->addError($_keyErrorMsg);
                 }
-                $this->_redirect( Mage::getSingleton('admin/session')->getUser()->getStartupPageUrl() );
+                $this->_redirect(Mage::getSingleton('admin/session')->getUser()->getStartupPageUrl());
             }
             return $this;
         }

--- a/app/code/core/Mage/Adminhtml/Helper/Help/Mapping.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Help/Mapping.php
@@ -218,7 +218,7 @@ abstract class Mage_Adminhtml_Helper_Help_Mapping extends Mage_Core_Helper_Abstr
      */
     protected function findInMapping($frontModule, $controllerName, $actionName)
     {
-        if ($actionName === 'index' ) {
+        if ($actionName === 'index') {
             $targetToFind = $controllerName;
         } else {
             $targetToFind = $controllerName . '/' . $actionName;

--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Random.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Random.php
@@ -136,7 +136,7 @@ class Mage_Adminhtml_Model_Sales_Order_Random
         }
         $this->_quote->getPayment()->setMethod('checkmo');
 
-        $this->_quote->getShippingAddress()->setShippingMethod('freeshipping_freeshipping');//->collectTotals()->save();
+        $this->_quote->getShippingAddress()->setShippingMethod('freeshipping_freeshipping'); //->collectTotals()->save();
         $this->_quote->getShippingAddress()->setCollectShippingRates(true);
         $this->_quote->collectTotals()
             ->save();

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/File.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/File.php
@@ -55,7 +55,7 @@ class Mage_Adminhtml_Model_System_Config_Backend_File extends Mage_Core_Model_Co
                 $uploader = new Mage_Core_Model_File_Uploader($file);
                 $uploader->setAllowedExtensions($this->_getAllowedExtensions());
                 $uploader->setAllowRenameFiles(true);
-                $this->addValidators( $uploader );
+                $this->addValidators($uploader);
                 $result = $uploader->save($uploadDir);
 
             } catch (Exception $e) {

--- a/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
@@ -85,7 +85,7 @@ class Mage_Adminhtml_Api_RoleController extends Mage_Adminhtml_Controller_Action
         $this->_initAction();
 
         $roleId = $this->getRequest()->getParam('rid');
-        if( intval($roleId) > 0 ) {
+        if(intval($roleId) > 0) {
             $breadCrumb = $this->__('Edit Role');
             $breadCrumbTitle = $this->__('Edit Role');
             $this->_title($this->__('Edit Role'));
@@ -232,7 +232,7 @@ class Mage_Adminhtml_Api_RoleController extends Mage_Adminhtml_Controller_Action
         $user = Mage::getModel("api/user")->load($userId);
         $user->setRoleId($roleId)->setUserId($userId);
 
-        if( $user->roleUserExists() === true ) {
+        if($user->roleUserExists() === true) {
             return false;
         } else {
             $user->add();

--- a/app/code/core/Mage/Adminhtml/controllers/Api/UserController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Api/UserController.php
@@ -153,7 +153,7 @@ class Mage_Adminhtml_Api_UserController extends Mage_Adminhtml_Controller_Action
 
             try {
                 $model->save();
-                if ( $uRoles = $this->getRequest()->getParam('roles', false) ) {
+                if ($uRoles = $this->getRequest()->getParam('roles', false)) {
                     if (count($uRoles) === 1) {
                         $model->setRoleIds($uRoles)
                             ->setRoleUserId($model->getUserId())
@@ -163,7 +163,7 @@ class Mage_Adminhtml_Api_UserController extends Mage_Adminhtml_Controller_Action
                         //@TODO:  make proper DB upgrade in the future revisions.
                         $rs = [];
                         $rs[0] = $uRoles[0];
-                        $model->setRoleIds( $rs )->setRoleUserId( $model->getUserId() )->saveRelations();
+                        $model->setRoleIds($rs)->setRoleUserId($model->getUserId())->saveRelations();
                     }
                 }
                 Mage::getSingleton('adminhtml/session')->addSuccess($this->__('The user has been saved.'));

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GroupController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GroupController.php
@@ -36,7 +36,7 @@ class Mage_Adminhtml_Catalog_Product_GroupController extends Mage_Adminhtml_Cont
         $model->setAttributeGroupName($this->getRequest()->getParam('attribute_group_name'))
               ->setAttributeSetId($this->getRequest()->getParam('attribute_set_id'));
 
-        if( $model->itemExists() ) {
+        if($model->itemExists()) {
             Mage::getSingleton('adminhtml/session')->addError(Mage::helper('catalog')->__('A group with the same name already exists.'));
         } else {
             try {

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/ReviewController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/ReviewController.php
@@ -181,7 +181,7 @@ class Mage_Adminhtml_Catalog_Product_ReviewController extends Mage_Adminhtml_Con
                 ->delete();
 
             $session->addSuccess(Mage::helper('catalog')->__('The review has been deleted'));
-            if( $this->getRequest()->getParam('ret') == 'pending' ) {
+            if($this->getRequest()->getParam('ret') == 'pending') {
                 $this->getResponse()->setRedirect($this->getUrl('*/*/pending'));
             } else {
                 $this->getResponse()->setRedirect($this->getUrl('*/*/'));
@@ -296,7 +296,7 @@ class Mage_Adminhtml_Catalog_Product_ReviewController extends Mage_Adminhtml_Con
     {
         $response = new Varien_Object();
         $id = $this->getRequest()->getParam('id');
-        if( intval($id) > 0 ) {
+        if(intval($id) > 0) {
             $product = Mage::getModel('catalog/product')
                 ->load($id);
 
@@ -346,7 +346,7 @@ class Mage_Adminhtml_Catalog_Product_ReviewController extends Mage_Adminhtml_Con
                 $review->aggregate();
 
                 $session->addSuccess(Mage::helper('catalog')->__('The review has been saved.'));
-                if( $this->getRequest()->getParam('ret') == 'pending' ) {
+                if($this->getRequest()->getParam('ret') == 'pending') {
                     $this->getResponse()->setRedirect($this->getUrl('*/*/pending'));
                 } else {
                     $this->getResponse()->setRedirect($this->getUrl('*/*/'));

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/RoleController.php
@@ -168,7 +168,7 @@ class Mage_Adminhtml_Permissions_RoleController extends Mage_Adminhtml_Controlle
 
         $currentUser = Mage::getModel('admin/user')->setId(Mage::getSingleton('admin/session')->getUser()->getId());
 
-        if (in_array($role->getId(), $currentUser->getRoles()) ) {
+        if (in_array($role->getId(), $currentUser->getRoles())) {
             Mage::getSingleton('adminhtml/session')->addError($this->__('Self-assigned roles cannot be deleted.'));
             $this->_redirect('*/*/editrole', ['rid' => $role->getId()]);
             return;
@@ -306,7 +306,7 @@ class Mage_Adminhtml_Permissions_RoleController extends Mage_Adminhtml_Controlle
         $user = Mage::getModel('admin/user')->load($userId);
         $user->setRoleId($roleId)->setUserId($userId);
 
-        if( $user->roleUserExists() === true ) {
+        if($user->roleUserExists() === true) {
             return false;
         } else {
             $user->add();

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
@@ -155,7 +155,7 @@ class Mage_Adminhtml_Permissions_UserController extends Mage_Adminhtml_Controlle
                 if (Mage::getStoreConfigFlag('admin/security/crate_admin_user_notification') && $isNew) {
                     Mage::getModel('admin/user')->sendAdminNotification($model);
                 }
-                if ( $uRoles = $this->getRequest()->getParam('roles', false) ) {
+                if ($uRoles = $this->getRequest()->getParam('roles', false)) {
                     if (count($uRoles) === 1) {
                         $model->setRoleIds($uRoles)
                             ->setRoleUserId($model->getUserId())
@@ -165,7 +165,7 @@ class Mage_Adminhtml_Permissions_UserController extends Mage_Adminhtml_Controlle
                         //@TODO:  make proper DB upgrade in the future revisions.
                         $rs = [];
                         $rs[0] = $uRoles[0];
-                        $model->setRoleIds( $rs )->setRoleUserId( $model->getUserId() )->saveRelations();
+                        $model->setRoleIds($rs)->setRoleUserId($model->getUserId())->saveRelations();
                     }
                 }
                 Mage::getSingleton('adminhtml/session')->addSuccess($this->__('The user has been saved.'));
@@ -202,7 +202,7 @@ class Mage_Adminhtml_Permissions_UserController extends Mage_Adminhtml_Controlle
         $currentUser = Mage::getSingleton('admin/session')->getUser();
 
         if ($id = $this->getRequest()->getParam('user_id')) {
-            if ( $currentUser->getId() == $id ) {
+            if ($currentUser->getId() == $id) {
                 Mage::getSingleton('adminhtml/session')->addError($this->__('You cannot delete your own account.'));
                 $this->_redirect('*/*/edit', ['user_id' => $id]);
                 return;

--- a/app/code/core/Mage/Adminhtml/controllers/Poll/AnswerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Poll/AnswerController.php
@@ -52,7 +52,7 @@ class Mage_Adminhtml_Poll_AnswerController extends Mage_Adminhtml_Controller_Act
     public function saveAction()
     {
         //print '@@';
-        if ( $post = $this->getRequest()->getPost() ) {
+        if ($post = $this->getRequest()->getPost()) {
             try {
                 $model = Mage::getModel('poll/poll_answer');
                 $model->setData($post)
@@ -85,10 +85,10 @@ class Mage_Adminhtml_Poll_AnswerController extends Mage_Adminhtml_Controller_Act
         $response = new Varien_Object();
         $response->setError(0);
 
-        if ( $post = $this->getRequest()->getPost() ) {
+        if ($post = $this->getRequest()->getPost()) {
             $data = Zend_Json::decode($post['data']);
             try {
-                if( trim($data['answer_title']) == '' ) {
+                if(trim($data['answer_title']) == '') {
                     throw new Exception(Mage::helper('poll')->__('Invalid Answer.'));
                 }
                 $model = Mage::getModel('poll/poll_answer');
@@ -99,7 +99,7 @@ class Mage_Adminhtml_Poll_AnswerController extends Mage_Adminhtml_Controller_Act
                 $response->setMessage($e->getMessage());
             }
         }
-        $this->getResponse()->setBody( $response->toJson() );
+        $this->getResponse()->setBody($response->toJson());
     }
 
     public function jsonDeleteAction()
@@ -107,7 +107,7 @@ class Mage_Adminhtml_Poll_AnswerController extends Mage_Adminhtml_Controller_Act
         $response = new Varien_Object();
         $response->setError(0);
 
-        if ( $id = $this->getRequest()->getParam('id') ) {
+        if ($id = $this->getRequest()->getParam('id')) {
             try {
                 $model = Mage::getModel('poll/poll_answer');
                 $model->setId(Zend_Json::decode($id))
@@ -120,6 +120,6 @@ class Mage_Adminhtml_Poll_AnswerController extends Mage_Adminhtml_Controller_Act
             $response->setError(1);
             $response->setMessage(Mage::helper('poll')->__('Unable to find an answer to delete.'));
         }
-        $this->getResponse()->setBody( $response->toJson() );
+        $this->getResponse()->setBody($response->toJson());
     }
 }

--- a/app/code/core/Mage/Adminhtml/controllers/PollController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/PollController.php
@@ -112,27 +112,27 @@ class Mage_Adminhtml_PollController extends Mage_Adminhtml_Controller_Action
         $response = new Varien_Object();
         $response->setError(false);
 
-        if ( $this->getRequest()->getPost() ) {
+        if ($this->getRequest()->getPost()) {
             try {
                 $pollModel = Mage::getModel('poll/poll');
 
                 $now = Varien_Date::now();
-                if( !$this->getRequest()->getParam('id') ) {
+                if(!$this->getRequest()->getParam('id')) {
                     $pollModel->setDatePosted($now);
                 }
 
-                if( $this->getRequest()->getParam('closed') && !$this->getRequest()->getParam('was_closed') ) {
+                if($this->getRequest()->getParam('closed') && !$this->getRequest()->getParam('was_closed')) {
                     $pollModel->setDateClosed($now);
                 }
 
-                if( !$this->getRequest()->getParam('closed') ) {
+                if(!$this->getRequest()->getParam('closed')) {
                     $pollModel->setDateClosed(new Zend_Db_Expr('null'));
                 }
 
                 $pollModel->setPollTitle($this->getRequest()->getParam('poll_title'))
                       ->setClosed($this->getRequest()->getParam('closed'));
 
-                if( $this->getRequest()->getParam('id') > 0 ) {
+                if($this->getRequest()->getParam('id') > 0) {
                     $pollModel->setId($this->getRequest()->getParam('id'));
                 }
 
@@ -149,7 +149,7 @@ class Mage_Adminhtml_PollController extends Mage_Adminhtml_Controller_Action
                             continue;
                         }
                         foreach($storeIdList as $storeId) {
-                            if( $storeId > 0 ) {
+                            if($storeId > 0) {
                                 $storeIds[] = $storeId;
                             }
                         }
@@ -162,20 +162,20 @@ class Mage_Adminhtml_PollController extends Mage_Adminhtml_Controller_Action
 
                 $answers = $this->getRequest()->getParam('answer');
 
-                if( !is_array($answers) || !count($answers) ) {
+                if(!is_array($answers) || !count($answers)) {
                     Mage::throwException(Mage::helper('adminhtml')->__('Please, add some answers to this poll first.'));
                 }
 
-                if( is_array($answers) ) {
+                if(is_array($answers)) {
                     $_titles = [];
-                    foreach( $answers as $key => $answer ) {
-                        if( in_array($answer['title'], $_titles) ) {
+                    foreach($answers as $key => $answer) {
+                        if(in_array($answer['title'], $_titles)) {
                             Mage::throwException(Mage::helper('adminhtml')->__('Your answers contain duplicates.'));
                         }
                         $_titles[] = $answer['title'];
 
                         $answerModel = Mage::getModel('poll/poll_answer');
-                        if( intval($key) > 0 ) {
+                        if(intval($key) > 0) {
                             $answerModel->setId($key);
                         }
                         $answerModel->setAnswerTitle($answer['title'])
@@ -190,8 +190,8 @@ class Mage_Adminhtml_PollController extends Mage_Adminhtml_Controller_Action
                 Mage::register('current_poll_model', $pollModel);
 
                 $answersDelete = $this->getRequest()->getParam('deleteAnswer');
-                if( is_array($answersDelete) ) {
-                    foreach( $answersDelete as $answer ) {
+                if(is_array($answersDelete)) {
+                    foreach($answersDelete as $answer) {
                         $answerModel = Mage::getModel('poll/poll_answer');
                         $answerModel->setId($answer)
                             ->delete();

--- a/app/code/core/Mage/Adminhtml/controllers/RatingController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/RatingController.php
@@ -128,7 +128,7 @@ class Mage_Adminhtml_RatingController extends Mage_Adminhtml_Controller_Action
 
     public function deleteAction()
     {
-        if( $this->getRequest()->getParam('id') > 0 ) {
+        if($this->getRequest()->getParam('id') > 0) {
             try {
                 $model = Mage::getModel('rating/rating');
                 /** @var Mage_Rating_Model_Rating $model */

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreateController.php
@@ -516,13 +516,13 @@ class Mage_Adminhtml_Sales_Order_CreateController extends Mage_Adminhtml_Control
         } catch (Mage_Payment_Model_Info_Exception $e) {
             $this->_getOrderCreateModel()->saveQuote();
             $message = $e->getMessage();
-            if( !empty($message) ) {
+            if(!empty($message)) {
                 $this->_getSession()->addError($message);
             }
             $this->_redirect('*/*/');
         } catch (Mage_Core_Exception $e){
             $message = $e->getMessage();
-            if( !empty($message) ) {
+            if(!empty($message)) {
                 $this->_getSession()->addError($message);
             }
             $this->_redirect('*/*/');

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
@@ -393,7 +393,7 @@ class Mage_Adminhtml_Sales_Order_ShipmentController extends Mage_Adminhtml_Contr
             ];
         }
 
-        if ( is_object($response)){
+        if (is_object($response)){
             $className = Mage::getConfig()->getBlockClassName('adminhtml/template');
             $block = new $className();
             $block->setType('adminhtml/template')

--- a/app/code/core/Mage/Adminhtml/controllers/System/AccountController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/AccountController.php
@@ -59,7 +59,7 @@ class Mage_Adminhtml_System_AccountController extends Mage_Adminhtml_Controller_
             ->setFirstname($this->getRequest()->getParam('firstname', false))
             ->setLastname($this->getRequest()->getParam('lastname', false))
             ->setEmail(strtolower($this->getRequest()->getParam('email', false)));
-        if ( $this->getRequest()->getParam('new_password', false) ) {
+        if ($this->getRequest()->getParam('new_password', false)) {
             $user->setNewPassword($this->getRequest()->getParam('new_password', false));
         }
 

--- a/app/code/core/Mage/Adminhtml/controllers/System/CurrencyController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/CurrencyController.php
@@ -66,7 +66,7 @@ class Mage_Adminhtml_System_CurrencyController extends Mage_Adminhtml_Controller
         try {
             $service = $this->getRequest()->getParam('rate_services');
             $this->_getSession()->setCurrencyRateService($service);
-            if( !$service ) {
+            if(!$service) {
                 throw new Exception(Mage::helper('adminhtml')->__('Invalid Import Service Specified'));
             }
             try {
@@ -98,13 +98,13 @@ class Mage_Adminhtml_System_CurrencyController extends Mage_Adminhtml_Controller
     public function saveRatesAction()
     {
         $data = $this->getRequest()->getParam('rate');
-        if( is_array($data) ) {
+        if(is_array($data)) {
             try {
                 foreach ($data as $currencyCode => $rate) {
-                    foreach( $rate as $currencyTo => $value ) {
+                    foreach($rate as $currencyTo => $value) {
                         $value = abs(Mage::getSingleton('core/locale')->getNumber($value));
                         $data[$currencyCode][$currencyTo] = $value;
-                        if( $value == 0 ) {
+                        if($value == 0) {
                             Mage::getSingleton('adminhtml/session')->addWarning(Mage::helper('adminhtml')->__('Invalid input data for %s => %s rate', $currencyCode, $currencyTo));
                         }
                     }

--- a/app/code/core/Mage/Api2/Model/Resource/Validator/Eav.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Validator/Eav.php
@@ -219,7 +219,7 @@ class Mage_Api2_Model_Resource_Validator_Eav extends Mage_Api2_Model_Resource_Va
         // business asked to avoid additional validation message, so we filter it here
         $errors        = [];
         $requiredAttrs = [];
-        $isRequiredRE  = '/^' . str_replace('%s', '(.+)', preg_quote(Mage::helper('eav')->__('"%s" is a required value.'), '/') ) . '$/';
+        $isRequiredRE  = '/^' . str_replace('%s', '(.+)', preg_quote(Mage::helper('eav')->__('"%s" is a required value.'), '/')) . '$/';
         $greaterThanRE = '/^' . str_replace(
             '%s',
             '(.+)',

--- a/app/code/core/Mage/Authorizenet/controllers/Adminhtml/Authorizenet/Directpost/PaymentController.php
+++ b/app/code/core/Mage/Authorizenet/controllers/Adminhtml/Authorizenet/Directpost/PaymentController.php
@@ -126,7 +126,7 @@ class Mage_Authorizenet_Adminhtml_Authorizenet_Directpost_PaymentController
             }
             catch (Mage_Core_Exception $e) {
                 $message = $e->getMessage();
-                if( !empty($message) ) {
+                if(!empty($message)) {
                     $this->_getSession()->addError($message);
                 }
                 $isError = true;

--- a/app/code/core/Mage/Backup/Helper/Data.php
+++ b/app/code/core/Mage/Backup/Helper/Data.php
@@ -144,7 +144,7 @@ class Mage_Backup_Helper_Data extends Mage_Core_Helper_Abstract
      * @return boolean
      */
     public function isRollbackAllowed(){
-        return Mage::getSingleton('admin/session')->isAllowed('system/tools/backup/rollback' );
+        return Mage::getSingleton('admin/session')->isAllowed('system/tools/backup/rollback');
     }
 
     /**

--- a/app/code/core/Mage/Backup/Model/Backup.php
+++ b/app/code/core/Mage/Backup/Model/Backup.php
@@ -150,8 +150,8 @@ class Mage_Backup_Model_Backup extends Varien_Object
         }
 
         $rawContent = '';
-        if ( $compress ) {
-            $rawContent = gzcompress( $content, self::COMPRESS_RATE );
+        if ($compress) {
+            $rawContent = gzcompress($content, self::COMPRESS_RATE);
         } else {
             $rawContent = $content;
         }

--- a/app/code/core/Mage/Catalog/Helper/Product.php
+++ b/app/code/core/Mage/Catalog/Helper/Product.php
@@ -177,7 +177,7 @@ class Mage_Catalog_Helper_Product extends Mage_Core_Helper_Url
     public function getStatuses()
     {
         if (is_null($this->_statuses)) {
-            $this->_statuses = [];//Mage::getModel('catalog/product_status')->getResourceCollection()->load();
+            $this->_statuses = []; //Mage::getModel('catalog/product_status')->getResourceCollection()->load();
         }
 
         return $this->_statuses;

--- a/app/code/core/Mage/Catalog/Model/Api/Resource.php
+++ b/app/code/core/Mage/Catalog/Model/Api/Resource.php
@@ -70,7 +70,7 @@ class Mage_Catalog_Model_Api_Resource extends Mage_Api_Model_Resource_Abstract
         }
 
         if (is_array($attributes)
-            && !( in_array($attribute->getAttributeCode(), $attributes)
+            && !(in_array($attribute->getAttributeCode(), $attributes)
                   || in_array($attribute->getAttributeId(), $attributes))) {
             return false;
         }

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api.php
@@ -53,7 +53,7 @@ class Mage_Catalog_Model_Product_Attribute_Tierprice_Api extends Mage_Catalog_Mo
 
         foreach ($tierPrices as $tierPrice) {
             $row = [];
-            $row['customer_group_id'] = (empty($tierPrice['all_groups']) ? $tierPrice['cust_group'] : 'all' );
+            $row['customer_group_id'] = (empty($tierPrice['all_groups']) ? $tierPrice['cust_group'] : 'all');
             $row['website']           = ($tierPrice['website_id'] ?
                             Mage::app()->getWebsite($tierPrice['website_id'])->getCode() :
                             'all'

--- a/app/code/core/Mage/CatalogSearch/Block/Term.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Term.php
@@ -61,7 +61,7 @@ class Mage_CatalogSearch_Block_Term extends Mage_Core_Block_Template
             $this->_maxPopularity = reset($terms)->getPopularity();
             $this->_minPopularity = end($terms)->getPopularity();
             $range = $this->_maxPopularity - $this->_minPopularity;
-            $range = ( $range == 0 ) ? 1 : $range;
+            $range = ($range == 0) ? 1 : $range;
             /** @var Mage_CatalogSearch_Model_Query $term */
             foreach ($terms as $term) {
                 if (!$term->getPopularity()) {

--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -568,14 +568,14 @@ abstract class Mage_Core_Controller_Varien_Action
      */
     public function norouteAction($coreRoute = null)
     {
-        $status = ( $this->getRequest()->getParam('__status__') )
+        $status = ($this->getRequest()->getParam('__status__'))
             ? $this->getRequest()->getParam('__status__')
             : new Varien_Object();
 
         Mage::dispatchEvent('controller_action_noroute', ['action'=>$this, 'status'=>$status]);
         if ($status->getLoaded() !== true
             || $status->getForwarded() === true
-            || !is_null($coreRoute) ) {
+            || !is_null($coreRoute)) {
             $this->loadLayout(['default', 'noRoute']);
             $this->renderLayout();
         } else {

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -668,7 +668,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
                     Mage::throwException(Mage::helper('core')->__('Unknown scope "%s".', $scope));
                 }
             }
-            $path = $scope . ($scopeCode ? '/' . $scopeCode : '' ) . (empty($path) ? '' : '/' . $path);
+            $path = $scope . ($scopeCode ? '/' . $scopeCode : '') . (empty($path) ? '' : '/' . $path);
         }
 
         /**

--- a/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
@@ -152,7 +152,7 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
             $cookieValue = $cookie->get($secureCookieName);
           
             // Migrate old cookie from 'frontend'
-            if ( ! $cookieValue
+            if (! $cookieValue
                 && $sessionName === \Mage_Core_Controller_Front_Action::SESSION_NAMESPACE
                 && $cookie->get('frontend_cid')
             ) {

--- a/app/code/core/Mage/Customer/Model/Api/Resource.php
+++ b/app/code/core/Mage/Customer/Model/Api/Resource.php
@@ -51,7 +51,7 @@ class Mage_Customer_Model_Api_Resource extends Mage_Api_Model_Resource_Abstract
     protected function _isAllowedAttribute($attribute, array $filter = null)
     {
         if (!is_null($filter)
-            && !( in_array($attribute->getAttributeCode(), $filter)
+            && !(in_array($attribute->getAttributeCode(), $filter)
                   || in_array($attribute->getAttributeId(), $filter))) {
             return false;
         }

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Io.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Io.php
@@ -49,7 +49,7 @@ class Mage_Dataflow_Model_Convert_Adapter_Io extends Mage_Dataflow_Model_Convert
                           . DS . $ioConfig['filename'];
                     /** @var Mage_Core_Model_File_Validator_AvailablePath $validator */
                     $validator = Mage::getModel('core/file_validator_availablePath');
-                    $validator->setPaths( Mage::getStoreConfig(self::XML_PATH_EXPORT_LOCAL_VALID_PATH) );
+                    $validator->setPaths(Mage::getStoreConfig(self::XML_PATH_EXPORT_LOCAL_VALID_PATH));
                     if (!$validator->isValid($path)) {
                         foreach ($validator->getMessages() as $message) {
                             Mage::throwException($message);

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Csv.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Csv.php
@@ -244,7 +244,7 @@ class Mage_Dataflow_Model_Convert_Parser_Csv extends Mage_Dataflow_Model_Convert
                 $str2 = $enclosure;
                 $escaped = 0;
                 $len = strlen($value);
-                for ($i=0;$i<$len;$i++) {
+                for ($i=0; $i<$len; $i++) {
                     if ($value[$i] == $escapeChar) {
                         $escaped = 1;
                     } else if (!$escaped && $value[$i] == $enclosure) {

--- a/app/code/core/Mage/Downloadable/Model/Observer.php
+++ b/app/code/core/Mage/Downloadable/Model/Observer.php
@@ -215,7 +215,7 @@ class Mage_Downloadable_Model_Observer
                 ) {
                     if ($item->getStatusId() == Mage_Sales_Model_Order_Item::STATUS_BACKORDERED &&
                         $orderItemStatusToEnable == Mage_Sales_Model_Order_Item::STATUS_PENDING &&
-                        !in_array(Mage_Sales_Model_Order_Item::STATUS_BACKORDERED, $availableStatuses, true) ) {
+                        !in_array(Mage_Sales_Model_Order_Item::STATUS_BACKORDERED, $availableStatuses, true)) {
                         $availableStatuses[] = Mage_Sales_Model_Order_Item::STATUS_BACKORDERED;
                     }
 

--- a/app/code/core/Mage/Media/Model/Image.php
+++ b/app/code/core/Mage/Media/Model/Image.php
@@ -157,7 +157,7 @@ class Mage_Media_Model_Image extends Mage_Core_Model_Abstract
         }
 
         return $this->getConfig()->getBaseMediaPath() . DS . $this->getName() . $changes . '.'
-             . ( ( $useParams && $this->getParam('extension')) ? $this->getParam('extension') : $this->getExtension() );
+             . (($useParams && $this->getParam('extension')) ? $this->getParam('extension') : $this->getExtension());
     }
 
     /**
@@ -173,7 +173,7 @@ class Mage_Media_Model_Image extends Mage_Core_Model_Abstract
         }
 
         return $this->getConfig()->getBaseMediaUrl() . '/' . $this->getName() . $changes . '.'
-             . ( ( $useParams && $this->getParam('extension')) ? $this->getParam('extension') : $this->getExtension() );
+             . (($useParams && $this->getParam('extension')) ? $this->getParam('extension') : $this->getExtension());
     }
 
     /**

--- a/app/code/core/Mage/Paygate/Model/Authorizenet.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet.php
@@ -1310,7 +1310,7 @@ class Mage_Paygate_Model_Authorizenet extends Mage_Payment_Model_Method_Cc
                 ->setCustomerId($r[12])
                 ->setMd5Hash($r[37])
                 ->setCardCodeResponseCode($r[38])
-                ->setCAVVResponseCode( (isset($r[39])) ? $r[39] : null)
+                ->setCAVVResponseCode((isset($r[39])) ? $r[39] : null)
                 ->setSplitTenderId($r[52])
                 ->setAccNumber($r[50])
                 ->setCardType($r[51])

--- a/app/code/core/Mage/Paypal/Model/Api/Nvp.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Nvp.php
@@ -1184,7 +1184,7 @@ class Mage_Paypal_Model_Api_Nvp extends Mage_Paypal_Model_Api_Abstract
             $keyval=substr($nvpstr,$intial,$keypos);
             $valval=substr($nvpstr,$keypos+1,$valuepos-$keypos-1);
             //decoding the respose
-            $nvpArray[urldecode($keyval)] =urldecode( $valval);
+            $nvpArray[urldecode($keyval)] =urldecode($valval);
             $nvpstr=substr($nvpstr,$valuepos+1,strlen($nvpstr));
          }
         return $nvpArray;

--- a/app/code/core/Mage/Paypal/Model/Hostedpro/Request.php
+++ b/app/code/core/Mage/Paypal/Model/Hostedpro/Request.php
@@ -149,7 +149,7 @@ class Mage_Paypal_Model_Hostedpro_Request extends Varien_Object
     {
         $request = [
             'subtotal'      => $this->_formatPrice($order->getBaseSubtotal()),
-            'tax'           => $this->_formatPrice($order->getBaseTaxAmount() + $order->getHiddenTaxAmount() ),
+            'tax'           => $this->_formatPrice($order->getBaseTaxAmount() + $order->getHiddenTaxAmount()),
             'shipping'      => $this->_formatPrice($order->getBaseShippingAmount()),
             'invoice'       => $order->getIncrementId(),
             'address_override' => 'true',

--- a/app/code/core/Mage/Paypal/Model/Payflowpro.php
+++ b/app/code/core/Mage/Paypal/Model/Payflowpro.php
@@ -388,7 +388,7 @@ class Mage_Paypal_Model_Payflowpro extends  Mage_Payment_Model_Method_Cc
         if ($_isProxy) {
             $_config['proxy'] = $this->getConfigData('proxy_host')
                 . ':'
-                . $this->getConfigData('proxy_port');//http://proxy.shr.secureserver.net:3128',
+                . $this->getConfigData('proxy_port'); //http://proxy.shr.secureserver.net:3128',
             $_config['httpproxytunnel'] = true;
             $_config['proxytype'] = CURLPROXY_HTTP;
         }

--- a/app/code/core/Mage/Poll/Model/Poll/Answer.php
+++ b/app/code/core/Mage/Poll/Model/Poll/Answer.php
@@ -56,7 +56,7 @@ class Mage_Poll_Model_Poll_Answer extends Mage_Core_Model_Abstract
     public function countPercent($poll)
     {
         $this->setPercent(
-            round(($poll->getVotesCount() > 0 ) ? ($this->getVotesCount() * 100 / $poll->getVotesCount()) : 0, 2)
+            round(($poll->getVotesCount() > 0) ? ($this->getVotesCount() * 100 / $poll->getVotesCount()) : 0, 2)
         );
         return $this;
     }

--- a/app/code/core/Mage/Review/Block/Customer/View.php
+++ b/app/code/core/Mage/Review/Block/Customer/View.php
@@ -96,7 +96,7 @@ class Mage_Review_Block_Customer_View extends Mage_Catalog_Block_Product_Abstrac
                 ->setStoreFilter(Mage::app()->getStore()->getId())
                 ->load();
 
-            $this->setRatingCollection(( $ratingCollection->getSize() ) ? $ratingCollection : false);
+            $this->setRatingCollection(($ratingCollection->getSize()) ? $ratingCollection : false);
         }
 
         return $this->getRatingCollection();

--- a/app/code/core/Mage/Review/Block/View.php
+++ b/app/code/core/Mage/Review/Block/View.php
@@ -85,7 +85,7 @@ class Mage_Review_Block_View extends Mage_Catalog_Block_Product_Abstract
                 ->setStoreFilter(Mage::app()->getStore()->getId())
                 ->addRatingInfo(Mage::app()->getStore()->getId())
                 ->load();
-            $this->setRatingCollection(( $ratingCollection->getSize() ) ? $ratingCollection : false);
+            $this->setRatingCollection(($ratingCollection->getSize()) ? $ratingCollection : false);
         }
         return $this->getRatingCollection();
     }

--- a/app/code/core/Mage/Rss/Block/Catalog/Review.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Review.php
@@ -106,7 +106,7 @@ class Mage_Rss_Block_Catalog_Review extends Mage_Rss_Block_Abstract
                      . $this->__('Product: <a href="%s">%s</a> <br/>', $productUrl, $row['name'])
                      . $this->__('Summary of review: %s <br/>', $row['title'])
                      . $this->__('Review: %s <br/>', $row['detail'])
-                     . $this->__('Store: %s <br/>', $storeName )
+                     . $this->__('Store: %s <br/>', $storeName)
                      . $this->__('click <a href="%s">here</a> to view the review', $reviewUrl)
                      . '</p>';
         $data = [

--- a/app/code/core/Mage/Rss/Block/Catalog/Salesrule.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Salesrule.php
@@ -75,7 +75,7 @@ class Mage_Rss_Block_Catalog_Salesrule extends Mage_Rss_Block_Abstract
             $description = '<table><tr>'.
             '<td style="text-decoration:none;">'.$sr->getDescription().
             '<br/>Discount Start Date: '.$this->formatDate($sr->getFromDate(), 'medium').
-            ( $sr->getToDate() ? ('<br/>Discount End Date: '.$this->formatDate($sr->getToDate(), 'medium')):'').
+            ($sr->getToDate() ? ('<br/>Discount End Date: '.$this->formatDate($sr->getToDate(), 'medium')):'').
             ($sr->getCouponCode() ? '<br/> Coupon Code: '. $this->escapeHtml($sr->getCouponCode()).'' : '').
             '</td>'.
             '</tr></table>';

--- a/app/code/core/Mage/Rss/Block/Wishlist.php
+++ b/app/code/core/Mage/Rss/Block/Wishlist.php
@@ -80,7 +80,7 @@ class Mage_Rss_Block_Wishlist extends Mage_Wishlist_Block_Abstract
             $params = Mage::helper('core')->urlDecode($this->getRequest()->getParam('data'));
             $data   = explode(',', $params);
             $cId    = abs(intval($data[0]));
-            if ($cId && ($cId == Mage::getSingleton('customer/session')->getCustomerId()) ) {
+            if ($cId && ($cId == Mage::getSingleton('customer/session')->getCustomerId())) {
                 $this->_customer->load($cId);
             }
         }

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Discount.php
@@ -95,8 +95,8 @@ class Mage_Sales_Model_Quote_Address_Total_Discount extends Mage_Sales_Model_Quo
                          */
                         if (!$child->getDiscountAmount() && $item->getDiscountPercent()) {
                         }
-                        $totalDiscountAmount += $child->getDiscountAmount();//*$item->getQty();
-                        $baseTotalDiscountAmount += $child->getBaseDiscountAmount();//*$item->getQty();
+                        $totalDiscountAmount += $child->getDiscountAmount(); //*$item->getQty();
+                        $baseTotalDiscountAmount += $child->getBaseDiscountAmount(); //*$item->getQty();
 
                         $child->setRowTotalWithDiscount($child->getRowTotal()-$child->getDiscountAmount());
                         $child->setBaseRowTotalWithDiscount($child->getBaseRowTotal()-$child->getBaseDiscountAmount());

--- a/app/code/core/Mage/Tag/Block/All.php
+++ b/app/code/core/Mage/Tag/Block/All.php
@@ -53,7 +53,7 @@ class Mage_Tag_Block_All extends Mage_Core_Block_Template
             $this->_maxPopularity = reset($tags)->getPopularity();
             $this->_minPopularity = end($tags)->getPopularity();
             $range = $this->_maxPopularity - $this->_minPopularity;
-            $range = ( $range == 0 ) ? 1 : $range;
+            $range = ($range == 0) ? 1 : $range;
             /** @var Mage_Tag_Model_Tag $tag */
             foreach ($tags as $tag) {
                 $tag->setRatio(($tag->getPopularity()-$this->_minPopularity)/$range);

--- a/app/code/core/Mage/Tag/Block/Customer/Tags.php
+++ b/app/code/core/Mage/Tag/Block/Customer/Tags.php
@@ -55,7 +55,7 @@ class Mage_Tag_Block_Customer_Tags extends Mage_Customer_Block_Account_Dashboard
         $this->_maxPopularity = reset($tags)->getPopularity();
         $this->_minPopularity = end($tags)->getPopularity();
         $range = $this->_maxPopularity - $this->_minPopularity;
-        $range = ( $range == 0 ) ? 1 : $range;
+        $range = ($range == 0) ? 1 : $range;
 
         /** @var Mage_Tag_Model_Tag $tag */
         foreach ($tags as $tag) {

--- a/app/code/core/Mage/Tag/Model/Resource/Tag.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Tag.php
@@ -70,7 +70,7 @@ class Mage_Tag_Model_Resource_Tag extends Mage_Core_Model_Resource_Db_Abstract
                 ->where('name = :name');
             $data = $read->fetchRow($select, ['name' => $name]);
 
-            $model->setData(( is_array($data) ) ? $data : []);
+            $model->setData((is_array($data)) ? $data : []);
         } else {
             return false;
         }

--- a/app/code/core/Mage/Tag/Model/Resource/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Tag/Relation.php
@@ -70,7 +70,7 @@ class Mage_Tag_Model_Resource_Tag_Relation extends Mage_Core_Model_Resource_Db_A
                 $bind['sore_id'] = $model->getStoreId();
             }
             $data = $read->fetchRow($select, $bind);
-            $model->setData(( is_array($data) ) ? $data : []);
+            $model->setData((is_array($data)) ? $data : []);
         }
 
         return $this;

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex.php
@@ -1192,8 +1192,8 @@ class Mage_Usa_Model_Shipping_Carrier_Fedex
                           foreach ($xml->Package->Event as $event) {
                               $tempArr= [];
                               $tempArr['activity'] = (string)$event->Description;
-                              $tempArr['deliverydate'] = (string)$event->Date;//YYYY-MM-DD
-                              $tempArr['deliverytime'] = (string)$event->Time;//HH:MM:ss
+                              $tempArr['deliverydate'] = (string)$event->Date; //YYYY-MM-DD
+                              $tempArr['deliverytime'] = (string)$event->Time; //HH:MM:ss
                               $addArr= [];
                               if (isset($event->Address->City)) {
                                 $addArr[] = (string)$event->Address->City;

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
@@ -850,7 +850,7 @@ XMLRequest;
       <Shipper>
 XMLRequest;
 
-        if ($this->getConfigFlag('negotiated_active') && ($shipper = $this->getConfigData('shipper_number')) ) {
+        if ($this->getConfigFlag('negotiated_active') && ($shipper = $this->getConfigData('shipper_number'))) {
             $xmlRequest .= "<ShipperNumber>{$shipper}</ShipperNumber>";
         }
 
@@ -1236,21 +1236,21 @@ XMLAuth;
                             $addArr[] = (string)$activityTag->ActivityLocation->Address->CountryCode;
                         }
                         $dateArr = [];
-                        $date = (string)$activityTag->Date;//YYYYMMDD
+                        $date = (string)$activityTag->Date; //YYYYMMDD
                         $dateArr[] = substr($date,0,4);
                         $dateArr[] = substr($date,4,2);
                         $dateArr[] = substr($date,-2,2);
 
                         $timeArr = [];
-                        $time = (string)$activityTag->Time;//HHMMSS
+                        $time = (string)$activityTag->Time; //HHMMSS
                         $timeArr[] = substr($time,0,2);
                         $timeArr[] = substr($time,2,2);
                         $timeArr[] = substr($time,-2,2);
 
                         if($i==1){
                            $resultArr['status'] = (string)$activityTag->Status->StatusType->Description;
-                           $resultArr['deliverydate'] = implode('-',$dateArr);//YYYY-MM-DD
-                           $resultArr['deliverytime'] = implode(':',$timeArr);//HH:MM:SS
+                           $resultArr['deliverydate'] = implode('-',$dateArr); //YYYY-MM-DD
+                           $resultArr['deliverytime'] = implode(':',$timeArr); //HH:MM:SS
                            $resultArr['deliverylocation'] = (string)$activityTag->ActivityLocation->Description;
                            $resultArr['signedby'] = (string)$activityTag->ActivityLocation->SignedForByName;
                            if ($addArr) {
@@ -1259,8 +1259,8 @@ XMLAuth;
                         }else{
                            $tempArr= [];
                            $tempArr['activity'] = (string)$activityTag->Status->StatusType->Description;
-                           $tempArr['deliverydate'] = implode('-',$dateArr);//YYYY-MM-DD
-                           $tempArr['deliverytime'] = implode(':',$timeArr);//HH:MM:SS
+                           $tempArr['deliverydate'] = implode('-',$dateArr); //YYYY-MM-DD
+                           $tempArr['deliverytime'] = implode(':',$timeArr); //HH:MM:SS
                            if ($addArr) {
                             $tempArr['deliverylocation']=implode(', ',$addArr);
                            }
@@ -1377,7 +1377,7 @@ XMLAuth;
             // UPS Print Return Label
             $returnPart->addChild('Code', '9');
         }
-        $shipmentPart->addChild('Description', substr(implode(' ', $itemsDesc), 0, 35));//empirical
+        $shipmentPart->addChild('Description', substr(implode(' ', $itemsDesc), 0, 35)); //empirical
 
         $shipperPart = $shipmentPart->addChild('Shipper');
         if ($request->getIsReturn()) {
@@ -1465,7 +1465,7 @@ XMLAuth;
         $servicePart = $shipmentPart->addChild('Service');
         $servicePart->addChild('Code', $request->getShippingMethod());
         $packagePart = $shipmentPart->addChild('Package');
-        $packagePart->addChild('Description', substr(implode(' ', $itemsDesc), 0, 35));//empirical
+        $packagePart->addChild('Description', substr(implode(' ', $itemsDesc), 0, 35)); //empirical
         $packagePart->addChild('PackagingType')
             ->addChild('Code', $request->getPackagingType());
         $packageWeight = $packagePart->addChild('PackageWeight');

--- a/lib/Mage/Archive.php
+++ b/lib/Mage/Archive.php
@@ -115,7 +115,7 @@ class Mage_Archive
     {
         $archivers = $this->_getArchivers($destination);
         $interimSource = '';
-        for ($i=0; $i<count($archivers); $i++ ) {
+        for ($i=0; $i<count($archivers); $i++) {
             if ($i == (count($archivers) - 1)) {
                 $packed = $destination;
             } else {

--- a/lib/Mage/Cache/Backend/File.php
+++ b/lib/Mage/Cache/Backend/File.php
@@ -680,7 +680,7 @@ class Mage_Cache_Backend_File extends Zend_Cache_Backend_File
         } else {
             $ids = false;
         }
-        if( ! $ids) {
+        if(! $ids) {
             return array();
         }
         $ids = trim(substr($ids, 0, strrpos($ids, "\n")));
@@ -707,7 +707,7 @@ class Mage_Cache_Backend_File extends Zend_Cache_Backend_File
             if (file_exists($file)) {
                 if ($mode == 'diff' || (rand(1,100) == 1 && filesize($file) > 4096)) {
                     $file = $this->_tagFile($tag);
-                    if ( ! ($fd = fopen($file, 'rb+'))) {
+                    if (! ($fd = fopen($file, 'rb+'))) {
                         $result = false;
                         continue;
                     }

--- a/lib/Mage/HTTP/Client/Curl.php
+++ b/lib/Mage/HTTP/Client/Curl.php
@@ -175,8 +175,8 @@ implements Mage_HTTP_IClient
      */
     public function setCredentials($login, $pass)
     {
-        $val= base64_encode( "$login:$pass" );
-        $this->addHeader( "Authorization", "Basic $val" );
+        $val= base64_encode("$login:$pass");
+        $this->addHeader("Authorization", "Basic $val");
     }
 
     /**
@@ -268,7 +268,7 @@ implements Mage_HTTP_IClient
             return array();
         }
         $out = array();
-        foreach( $this->_responseHeaders['Set-Cookie'] as $row) {
+        foreach($this->_responseHeaders['Set-Cookie'] as $row) {
             $values = explode("; ", $row);
             $c = count($values);
             if(!$c) {
@@ -294,7 +294,7 @@ implements Mage_HTTP_IClient
             return array();
         }
         $out = array();
-        foreach( $this->_responseHeaders['Set-Cookie'] as $row) {
+        foreach($this->_responseHeaders['Set-Cookie'] as $row) {
             $values = explode("; ", $row);
             $c = count($values);
             if(!$c) {

--- a/lib/Mage/HTTP/Client/Socket.php
+++ b/lib/Mage/HTTP/Client/Socket.php
@@ -180,8 +180,8 @@ class Mage_HTTP_Client_Socket
      */
     public function setCredentials($login, $pass)
     {
-        $val= base64_encode( "$login:$pass" );
-        $this->addHeader( "Authorization", "Basic $val" );
+        $val= base64_encode("$login:$pass");
+        $this->addHeader("Authorization", "Basic $val");
     }
 
     /**
@@ -306,7 +306,7 @@ class Mage_HTTP_Client_Socket
             return array();
         }
         $out = array();
-        foreach( $this->_responseHeaders['Set-Cookie'] as $row) {
+        foreach($this->_responseHeaders['Set-Cookie'] as $row) {
             $values = explode("; ", $row);
             $c = count($values);
             if(!$c) {
@@ -332,7 +332,7 @@ class Mage_HTTP_Client_Socket
             return array();
         }
         $out = array();
-        foreach( $this->_responseHeaders['Set-Cookie'] as $row) {
+        foreach($this->_responseHeaders['Set-Cookie'] as $row) {
             $values = explode("; ", $row);
             $c = count($values);
             if(!$c) {

--- a/lib/Mage/System/Ftp.php
+++ b/lib/Mage/System/Ftp.php
@@ -375,7 +375,7 @@ class Mage_System_Ftp
      * @param bool $recursive
      * @return mixed
      */
-    public function rawlist( $dir = "/", $recursive = false )
+    public function rawlist($dir = "/", $recursive = false)
     {
         $this->checkConnected();
         $dir = $this->correctFilePath($dir);
@@ -391,8 +391,8 @@ class Mage_System_Ftp
     public static function byteconvert($bytes)
     {
         $symbol = array('B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB');
-        $exp = floor( log($bytes) / log(1024) );
-        return sprintf( '%.2f ' . $symbol[ $exp ], ($bytes / pow(1024, floor($exp))) );
+        $exp = floor(log($bytes) / log(1024));
+        return sprintf('%.2f ' . $symbol[ $exp ], ($bytes / pow(1024, floor($exp))));
     }
 
     /**

--- a/lib/Varien/Data/Form/Element/Abstract.php
+++ b/lib/Varien/Data/Form/Element/Abstract.php
@@ -272,7 +272,7 @@ abstract class Varien_Data_Form_Element_Abstract extends Varien_Data_Form_Abstra
     {
         if (!is_null($this->getLabel())) {
             $html = '<label for="'.$this->getHtmlId() . $idSuffix . '">' . $this->_escape($this->getLabel())
-                  . ( $this->getRequired() ? ' <span class="required">*</span>' : '' ) . '</label>' . "\n";
+                  . ($this->getRequired() ? ' <span class="required">*</span>' : '') . '</label>' . "\n";
         } else {
             $html = '';
         }
@@ -286,10 +286,10 @@ abstract class Varien_Data_Form_Element_Abstract extends Varien_Data_Form_Abstra
     {
         $html = $this->getData('default_html');
         if (is_null($html)) {
-            $html = ( $this->getNoSpan() === true ) ? '' : '<span class="field-row">'."\n";
+            $html = ($this->getNoSpan() === true) ? '' : '<span class="field-row">'."\n";
             $html.= $this->getLabelHtml();
             $html.= $this->getElementHtml();
-            $html.= ( $this->getNoSpan() === true ) ? '' : '</span>'."\n";
+            $html.= ($this->getNoSpan() === true) ? '' : '</span>'."\n";
         }
         return $html;
     }

--- a/lib/Varien/Data/Form/Element/Editor.php
+++ b/lib/Varien/Data/Form/Element/Editor.php
@@ -355,7 +355,7 @@ class Varien_Data_Form_Element_Editor extends Varien_Data_Form_Element_Textarea
      */
     public function getConfig($key = null)
     {
-        if ( !($this->_getData('config') instanceof Varien_Object) ) {
+        if (!($this->_getData('config') instanceof Varien_Object)) {
             $config = new Varien_Object();
             $this->setConfig($config);
         }

--- a/lib/Varien/Data/Form/Element/Image.php
+++ b/lib/Varien/Data/Form/Element/Image.php
@@ -52,7 +52,7 @@ class Varien_Data_Form_Element_Image extends Varien_Data_Form_Element_Abstract
         if ((string)$this->getValue()) {
             $url = $this->_getUrl();
 
-            if( !preg_match("/^http\:\/\/|https\:\/\//", $url) ) {
+            if(!preg_match("/^http\:\/\/|https\:\/\//", $url)) {
                 $url = Mage::getBaseUrl('media') . $url;
             }
 

--- a/lib/Varien/Data/Form/Element/Multiline.php
+++ b/lib/Varien/Data/Form/Element/Multiline.php
@@ -92,10 +92,10 @@ class Varien_Data_Form_Element_Multiline extends Varien_Data_Form_Element_Abstra
         $lineCount = $this->getLineCount();
 
         for ($i=0; $i<$lineCount; $i++){
-            $html.= ( $this->getNoSpan() === true ) ? '' : '<span class="field-row">'."\n";
+            $html.= ($this->getNoSpan() === true) ? '' : '<span class="field-row">'."\n";
             if ($i==0) {
                 $html.= '<label for="'.$this->getHtmlId().$i.'">'.$this->getLabel()
-                    .( $this->getRequired() ? ' <span class="required">*</span>' : '' ).'</label>'."\n";
+                    .($this->getRequired() ? ' <span class="required">*</span>' : '').'</label>'."\n";
                 if($this->getRequired()){
                     $this->setClass('input-text required-entry');
                 }
@@ -109,7 +109,7 @@ class Varien_Data_Form_Element_Multiline extends Varien_Data_Form_Element_Abstra
             if ($i==0) {
                 $html.= $this->getAfterElementHtml();
             }
-            $html.= ( $this->getNoSpan() === true ) ? '' : '</span>'."\n";
+            $html.= ($this->getNoSpan() === true) ? '' : '</span>'."\n";
         }
         return $html;
     }

--- a/lib/Varien/Data/Form/Element/Multiselect.php
+++ b/lib/Varien/Data/Form/Element/Multiselect.php
@@ -108,7 +108,7 @@ class Varien_Data_Form_Element_Multiselect extends Varien_Data_Form_Element_Abst
      */
     public function getDefaultHtml()
     {
-        $result = ( $this->getNoSpan() === true ) ? '' : '<span class="field-row">'."\n";
+        $result = ($this->getNoSpan() === true) ? '' : '<span class="field-row">'."\n";
         $result.= $this->getLabelHtml();
         $result.= $this->getElementHtml();
 
@@ -119,7 +119,7 @@ class Varien_Data_Form_Element_Multiselect extends Varien_Data_Form_Element_Abst
                 $this->getDeselectAll() . '</a>';
         }
 
-        $result.= ( $this->getNoSpan() === true ) ? '' : '</span>'."\n";
+        $result.= ($this->getNoSpan() === true) ? '' : '</span>'."\n";
 
         $result.= '<script type="text/javascript">' . "\n";
         $result.= '   var ' . $this->getJsObjectName() . ' = {' . "\n";

--- a/lib/Varien/Data/Form/Element/Time.php
+++ b/lib/Varien/Data/Form/Element/Time.php
@@ -60,9 +60,9 @@ class Varien_Data_Form_Element_Time extends Varien_Data_Form_Element_Abstract
         $value_min = 0;
         $value_sec = 0;
 
-        if( $value = $this->getValue() ) {
+        if($value = $this->getValue()) {
             $values = explode(',', $value);
-            if ( is_array($values) && count($values) == 3 ) {
+            if (is_array($values) && count($values) == 3) {
                 $value_hrs = $values[0];
                 $value_min = $values[1];
                 $value_sec = $values[2];
@@ -71,23 +71,23 @@ class Varien_Data_Form_Element_Time extends Varien_Data_Form_Element_Abstract
 
         $html = '<input type="hidden" id="' . $this->getHtmlId() . '" />';
         $html .= '<select name="'. $this->getName() . '" '.$this->serialize($this->getHtmlAttributes()).' style="width:40px">'."\n";
-        for( $i=0;$i<24;$i++ ) {
+        for($i=0; $i<24; $i++) {
             $hour = str_pad($i, 2, '0', STR_PAD_LEFT);
-            $html.= '<option value="'.$hour.'" '. ( ($value_hrs == $i) ? 'selected="selected"' : '' ) .'>' . $hour . '</option>';
+            $html.= '<option value="'.$hour.'" '. (($value_hrs == $i) ? 'selected="selected"' : '') .'>' . $hour . '</option>';
         }
         $html.= '</select>'."\n";
 
         $html.= '&nbsp;:&nbsp;<select name="'. $this->getName() . '" '.$this->serialize($this->getHtmlAttributes()).' style="width:40px">'."\n";
-        for( $i=0;$i<60;$i++ ) {
+        for($i=0; $i<60; $i++) {
             $hour = str_pad($i, 2, '0', STR_PAD_LEFT);
-            $html.= '<option value="'.$hour.'" '. ( ($value_min == $i) ? 'selected="selected"' : '' ) .'>' . $hour . '</option>';
+            $html.= '<option value="'.$hour.'" '. (($value_min == $i) ? 'selected="selected"' : '') .'>' . $hour . '</option>';
         }
         $html.= '</select>'."\n";
 
         $html.= '&nbsp;:&nbsp;<select name="'. $this->getName() . '" '.$this->serialize($this->getHtmlAttributes()).' style="width:40px">'."\n";
-        for( $i=0;$i<60;$i++ ) {
+        for($i=0; $i<60; $i++) {
             $hour = str_pad($i, 2, '0', STR_PAD_LEFT);
-            $html.= '<option value="'.$hour.'" '. ( ($value_sec == $i) ? 'selected="selected"' : '' ) .'>' . $hour . '</option>';
+            $html.= '<option value="'.$hour.'" '. (($value_sec == $i) ? 'selected="selected"' : '') .'>' . $hour . '</option>';
         }
         $html.= '</select>'."\n";
         $html.= $this->getAfterElementHtml();

--- a/lib/Varien/Data/Tree.php
+++ b/lib/Varien/Data/Tree.php
@@ -90,7 +90,7 @@ class Varien_Data_Tree
     {
         $this->_nodes->add($node);
         $node->setParent($parent);
-        if (!is_null($parent) && ($parent instanceof Varien_Data_Tree_Node) ) {
+        if (!is_null($parent) && ($parent instanceof Varien_Data_Tree_Node)) {
             $parent->addChild($node);
         }
         return $node;
@@ -173,7 +173,7 @@ class Varien_Data_Tree
      */
     public function getPath($node)
     {
-        if ($node instanceof Varien_Data_Tree_Node ) {
+        if ($node instanceof Varien_Data_Tree_Node) {
 
         } elseif (is_numeric($node)){
             if ($_node = $this->getNodeById($node)) {

--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -503,7 +503,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
             $this->_debugStat(self::DEBUG_QUERY, $sql, $bind);
 
             // Detect implicit rollback - MySQL SQLSTATE: ER_LOCK_WAIT_TIMEOUT or ER_LOCK_DEADLOCK
-            if( $this->_transactionLevel > 0
+            if($this->_transactionLevel > 0
                 && $e->getPrevious() && isset($e->getPrevious()->errorInfo[1])
                 && in_array($e->getPrevious()->errorInfo[1], [1205, 1213])
             ) {
@@ -2515,7 +2515,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
          *  where default value can be quoted already.
          *  We need to avoid "double-quoting" here
          */
-        if ( $cDefault !== null && strlen($cDefault)) {
+        if ($cDefault !== null && strlen($cDefault)) {
             $cDefault = str_replace("'", '', $cDefault);
         }
 

--- a/lib/Varien/Directory/Collection.php
+++ b/lib/Varien/Directory/Collection.php
@@ -332,7 +332,7 @@ class Varien_Directory_Collection extends Varien_Data_Collection implements IFac
      */
     public function toXml(&$xml,$recursionLevel=0,$addOpenTag=true,$rootName='Struct')
     {
-        if($recursionLevel==0 ){
+        if($recursionLevel==0){
             $xml = '';
             if($addOpenTag)
             $xml.= '<?xml version="1.0" encoding="UTF-8"?>'."\n";
@@ -342,7 +342,7 @@ class Varien_Directory_Collection extends Varien_Data_Collection implements IFac
         $xml.= str_repeat("\t",$recursionLevel+1)."<$this->_dirName>\n";
         $this->walk('toXml', array(&$xml,$recursionLevel,$addOpenTag,$rootName));
         $xml.= str_repeat("\t",$recursionLevel+1)."</$this->_dirName>"."\n";
-        if($recursionLevel==0 ){
+        if($recursionLevel==0){
             $xml.= '</'.$rootName.'>'."\n";
         }
     }

--- a/lib/Varien/File/Csv.php
+++ b/lib/Varien/File/Csv.php
@@ -141,7 +141,7 @@ class Varien_File_Csv
                 $str2 = $enclosure;
                 $escaped = 0;
                 $len = strlen($value);
-                for ($i=0;$i<$len;$i++) {
+                for ($i=0; $i<$len; $i++) {
                     if ($value[$i] == $escape_char) {
                         $escaped = 1;
                     } else if (!$escaped && $value[$i] == $enclosure) {

--- a/lib/Varien/File/Uploader.php
+++ b/lib/Varien/File/Uploader.php
@@ -516,7 +516,7 @@ class Varien_File_Uploader
             } elseif(!empty($fileId) && isset($_FILES[$fileId])) {
                 $this->_uploadType = self::SINGLE_STYLE;
                 $this->_file = $_FILES[$fileId];
-            } elseif( $fileId == '' ) {
+            } elseif($fileId == '') {
                 throw new Exception('Invalid parameter given. A valid $_FILES[] identifier is expected.');
             }
         }
@@ -544,7 +544,7 @@ class Varien_File_Uploader
         if (file_exists($destFile)) {
             $index = 1;
             $baseName = $fileInfo['filename'] . '.' . $fileInfo['extension'];
-            while( file_exists($fileInfo['dirname'] . DIRECTORY_SEPARATOR . $baseName) ) {
+            while(file_exists($fileInfo['dirname'] . DIRECTORY_SEPARATOR . $baseName)) {
                 $baseName = $fileInfo['filename']. '_' . $index . '.' . $fileInfo['extension'];
                 $index ++;
             }

--- a/lib/Varien/File/Uploader/Image.php
+++ b/lib/Varien/File/Uploader/Image.php
@@ -51,8 +51,8 @@ class Varien_File_Uploader_Image extends Varien_File_Uploader
     {
         $this->uploader->image_resize = true;
 
-        $this->uploader->image_ratio_x = ( $width == null ) ? true : false;
-        $this->uploader->image_ratio_y = ( $height == null ) ? true : false;
+        $this->uploader->image_ratio_x = ($width == null) ? true : false;
+        $this->uploader->image_ratio_y = ($height == null) ? true : false;
 
         $this->uploader->image_x = $width;
         $this->uploader->image_y = $height;
@@ -156,7 +156,7 @@ class Varien_File_Uploader_Image extends Varien_File_Uploader
      */
     public function addWatermark($fileName=null, $position="BL", $absoluteX=null, $absoluteY=null)
     {
-        if( !isset($fileName) ) {
+        if(!isset($fileName)) {
             return;
         }
 
@@ -187,7 +187,7 @@ class Varien_File_Uploader_Image extends Varien_File_Uploader
      */
     public function addReflection($height="10%", $space=0, $color="#FFFFFF", $opacity=60)
     {
-        if( intval($height) == 0 ) {
+        if(intval($height) == 0) {
             return;
         }
 
@@ -204,7 +204,7 @@ class Varien_File_Uploader_Image extends Varien_File_Uploader
      */
     public function addText($string="")
     {
-        if( trim($string) == "" ) {
+        if(trim($string) == "") {
             return;
         }
 

--- a/lib/Varien/Filter/Template/Tokenizer/Variable.php
+++ b/lib/Varien/Filter/Template/Tokenizer/Variable.php
@@ -67,7 +67,7 @@ class Varien_Filter_Template_Tokenizer_Variable extends Varien_Filter_Template_T
             }
         } while ($this->next());
 
-        if($parameterName != '' ) {
+        if($parameterName != '') {
             if($variableSet) {
                     $actions[] = array('type'=>'property',
                                        'name'=>$parameterName);
@@ -101,7 +101,7 @@ class Varien_Filter_Template_Tokenizer_Variable extends Varien_Filter_Template_T
         }
 
         while ($this->next()) {
-            if (!$breakSymbol && ($this->isWhiteSpace() || $this->char() == ',' || $this->char() == ')') ) {
+            if (!$breakSymbol && ($this->isWhiteSpace() || $this->char() == ',' || $this->char() == ')')) {
                 $this->prev();
                 break;
             } else if ($breakSymbol && $this->char() == $breakSymbol) {
@@ -165,7 +165,7 @@ class Varien_Filter_Template_Tokenizer_Variable extends Varien_Filter_Template_T
      */
     public function getNumber() {
         $value = $this->char();
-        while( ($this->isNumeric() || $this->char()=='.') && $this->next() ) {
+        while(($this->isNumeric() || $this->char()=='.') && $this->next()) {
             $value.= $this->char();
         }
 

--- a/lib/Varien/Image.php
+++ b/lib/Varien/Image.php
@@ -50,7 +50,7 @@ class Varien_Image
     {
         $this->_getAdapter($adapter);
         $this->_fileName = $fileName;
-        if( isset($fileName) ) {
+        if(isset($fileName)) {
             $this->open();
         }
     }
@@ -78,7 +78,7 @@ class Varien_Image
     {
         $this->_getAdapter()->checkDependencies();
 
-        if( !file_exists($this->_fileName) ) {
+        if(!file_exists($this->_fileName)) {
             throw new Exception("File '{$this->_fileName}' does not exists.");
         }
 
@@ -198,7 +198,7 @@ class Varien_Image
      */
     public function watermark($watermarkImage, $positionX=0, $positionY=0, $watermarkImageOpacity=30, $repeat=false)
     {
-        if( !file_exists($watermarkImage) ) {
+        if(!file_exists($watermarkImage)) {
             throw new Exception("Required file '{$watermarkImage}' does not exists.");
         }
         $this->_getAdapter()->watermark($watermarkImage, $positionX, $positionY, $watermarkImageOpacity, $repeat);
@@ -305,8 +305,8 @@ class Varien_Image
      */
     protected function _getAdapter($adapter=null)
     {
-        if( !isset($this->_adapter) ) {
-            $this->_adapter = Varien_Image_Adapter::factory( $adapter );
+        if(!isset($this->_adapter)) {
+            $this->_adapter = Varien_Image_Adapter::factory($adapter);
         }
         return $this->_adapter;
     }

--- a/lib/Varien/Image/Adapter.php
+++ b/lib/Varien/Image/Adapter.php
@@ -27,7 +27,7 @@ class Varien_Image_Adapter
 
     public static function factory($adapter)
     {
-        switch( $adapter ) {
+        switch($adapter) {
             case self::ADAPTER_GD:
                 return new Varien_Image_Adapter_Gd();
                 break;

--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -128,23 +128,23 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
 
     public function save($destination=null, $newName=null)
     {
-        $fileName = ( !isset($destination) ) ? $this->_fileName : $destination;
+        $fileName = (!isset($destination)) ? $this->_fileName : $destination;
 
-        if( isset($destination) && isset($newName) ) {
+        if(isset($destination) && isset($newName)) {
             $fileName = $destination . "/" . $newName;
-        } elseif( isset($destination) && !isset($newName) ) {
+        } elseif(isset($destination) && !isset($newName)) {
             $info = pathinfo($destination);
             $fileName = $destination;
             $destination = $info['dirname'];
-        } elseif( !isset($destination) && isset($newName) ) {
+        } elseif(!isset($destination) && isset($newName)) {
             $fileName = $this->_fileSrcPath . "/" . $newName;
         } else {
             $fileName = $this->_fileSrcPath . $this->_fileSrcName;
         }
 
-        $destinationDir = ( isset($destination) ) ? $destination : $this->_fileSrcPath;
+        $destinationDir = (isset($destination)) ? $destination : $this->_fileSrcPath;
 
-        if( !is_writable($destinationDir) ) {
+        if(!is_writable($destinationDir)) {
             try {
                 $io = new Varien_Io_File();
                 $io->mkdir($destination);
@@ -466,9 +466,9 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
             $watermark = $newWatermark;
         }
 
-        if( $this->getWatermarkPosition() == self::POSITION_TILE ) {
+        if($this->getWatermarkPosition() == self::POSITION_TILE) {
             $repeat = true;
-        } elseif( $this->getWatermarkPosition() == self::POSITION_STRETCH ) {
+        } elseif($this->getWatermarkPosition() == self::POSITION_STRETCH) {
 
             $newWatermark = imagecreatetruecolor($this->_imageSrcWidth, $this->_imageSrcHeight);
             imagealphablending($newWatermark, false);
@@ -486,7 +486,7 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
             );
             $watermark = $newWatermark;
 
-        } elseif( $this->getWatermarkPosition() == self::POSITION_CENTER ) {
+        } elseif($this->getWatermarkPosition() == self::POSITION_CENTER) {
             $positionX = ($this->_imageSrcWidth/2 - imagesx($watermark)/2);
             $positionY = ($this->_imageSrcHeight/2 - imagesy($watermark)/2);
             imagecopymerge(
@@ -497,7 +497,7 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
                 imagesx($watermark), imagesy($watermark),
                 $this->getWatermarkImageOpacity()
             );
-        } elseif( $this->getWatermarkPosition() == self::POSITION_TOP_RIGHT ) {
+        } elseif($this->getWatermarkPosition() == self::POSITION_TOP_RIGHT) {
             $positionX = ($this->_imageSrcWidth - imagesx($watermark));
             imagecopymerge(
                 $this->_imageHandler,
@@ -507,7 +507,7 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
                 imagesx($watermark), imagesy($watermark),
                 $this->getWatermarkImageOpacity()
             );
-        } elseif( $this->getWatermarkPosition() == self::POSITION_TOP_LEFT  ) {
+        } elseif($this->getWatermarkPosition() == self::POSITION_TOP_LEFT) {
             imagecopymerge(
                 $this->_imageHandler,
                 $watermark,
@@ -516,7 +516,7 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
                 imagesx($watermark), imagesy($watermark),
                 $this->getWatermarkImageOpacity()
             );
-        } elseif( $this->getWatermarkPosition() == self::POSITION_BOTTOM_RIGHT ) {
+        } elseif($this->getWatermarkPosition() == self::POSITION_BOTTOM_RIGHT) {
             $positionX = ($this->_imageSrcWidth - imagesx($watermark));
             $positionY = ($this->_imageSrcHeight - imagesy($watermark));
             imagecopymerge(
@@ -527,7 +527,7 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
                 imagesx($watermark), imagesy($watermark),
                 $this->getWatermarkImageOpacity()
             );
-        } elseif( $this->getWatermarkPosition() == self::POSITION_BOTTOM_LEFT ) {
+        } elseif($this->getWatermarkPosition() == self::POSITION_BOTTOM_LEFT) {
             $positionY = ($this->_imageSrcHeight - imagesy($watermark));
             imagecopymerge(
                 $this->_imageHandler,
@@ -539,7 +539,7 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
             );
         }
 
-        if( $repeat === false && $merged === false ) {
+        if($repeat === false && $merged === false) {
             imagecopymerge(
                 $this->_imageHandler,
                 $watermark,
@@ -551,8 +551,8 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
         } else {
             $offsetX = $positionX;
             $offsetY = $positionY;
-            while( $offsetY <= ($this->_imageSrcHeight+imagesy($watermark)) ) {
-                while( $offsetX <= ($this->_imageSrcWidth+imagesx($watermark)) ) {
+            while($offsetY <= ($this->_imageSrcHeight+imagesy($watermark))) {
+                while($offsetX <= ($this->_imageSrcWidth+imagesx($watermark))) {
                     imagecopymerge(
                         $this->_imageHandler,
                         $watermark,
@@ -574,7 +574,7 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
 
     public function crop($top=0, $left=0, $right=0, $bottom=0)
     {
-        if( $left == 0 && $top == 0 && $right == 0 && $bottom == 0 ) {
+        if($left == 0 && $top == 0 && $right == 0 && $bottom == 0) {
             return;
         }
 
@@ -601,8 +601,8 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
 
     public function checkDependencies()
     {
-        foreach( $this->_requiredExtensions as $value ) {
-            if( !extension_loaded($value) ) {
+        foreach($this->_requiredExtensions as $value) {
+            if(!extension_loaded($value)) {
                 throw new Exception("Required PHP extension '{$value}' was not loaded.");
             }
         }

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -413,7 +413,7 @@ class Varien_Io_File extends Varien_Io_Abstract
      */
     public function cd($dir)
     {
-        if( is_dir($dir) ) {
+        if(is_dir($dir)) {
             @chdir($this->_iwd);
             $this->_cwd = realpath($dir);
             return true;
@@ -734,9 +734,9 @@ class Varien_Io_File extends Varien_Io_Abstract
     {
         $ignoredDirectories = Array('.', '..');
 
-        if( is_dir($this->_cwd) ) {
+        if(is_dir($this->_cwd)) {
             $dir = $this->_cwd;
-        } elseif( is_dir($this->_iwd) ) {
+        } elseif(is_dir($this->_iwd)) {
             $dir = $this->_iwd;
         } else {
             throw new Exception('Unable to list current working directory.');
@@ -750,11 +750,11 @@ class Varien_Io_File extends Varien_Io_Abstract
 
                 $fullpath = $dir . DIRECTORY_SEPARATOR . $entry;
 
-                if( ($grep == self::GREP_DIRS) && (!is_dir($fullpath)) ) {
+                if(($grep == self::GREP_DIRS) && (!is_dir($fullpath))) {
                     continue;
-                } elseif( ($grep == self::GREP_FILES) && (!is_file($fullpath)) ) {
+                } elseif(($grep == self::GREP_FILES) && (!is_file($fullpath))) {
                     continue;
-                } elseif( in_array($entry, $ignoredDirectories) ) {
+                } elseif(in_array($entry, $ignoredDirectories)) {
                     continue;
                 }
 
@@ -763,20 +763,20 @@ class Varien_Io_File extends Varien_Io_Abstract
                 $list_item['permissions'] = $this->_parsePermissions(fileperms($fullpath));
                 $list_item['owner'] = $this->_getFileOwner($fullpath);
 
-                if( is_file($fullpath) ) {
+                if(is_file($fullpath)) {
                     $pathinfo = pathinfo($fullpath);
                     $list_item['size'] = filesize($fullpath);
                     $list_item['leaf'] = true;
-                    if( isset($pathinfo['extension'])
+                    if(isset($pathinfo['extension'])
                         && in_array(strtolower($pathinfo['extension']), Array('jpg', 'jpeg', 'gif', 'bmp', 'png'))
                         && $list_item['size'] > 0
                     ) {
                         $list_item['is_image'] = true;
                         $list_item['filetype'] = $pathinfo['extension'];
-                    } elseif( $list_item['size'] == 0 ) {
+                    } elseif($list_item['size'] == 0) {
                         $list_item['is_image'] = false;
                         $list_item['filetype'] = 'unknown';
-                    } elseif( isset($pathinfo['extension']) ) {
+                    } elseif(isset($pathinfo['extension'])) {
                         $list_item['is_image'] = false;
                         $list_item['filetype'] = $pathinfo['extension'];
                     } else {
@@ -807,19 +807,19 @@ class Varien_Io_File extends Varien_Io_Abstract
      */
     protected function _parsePermissions($mode)
     {
-        if( $mode & 0x1000 )
+        if($mode & 0x1000)
             $type='p'; /* FIFO pipe */
-        else if( $mode & 0x2000 )
+        else if($mode & 0x2000)
             $type='c'; /* Character special */
-        else if( $mode & 0x4000 )
+        else if($mode & 0x4000)
             $type='d'; /* Directory */
-        else if( $mode & 0x6000 )
+        else if($mode & 0x6000)
             $type='b'; /* Block special */
-        else if( $mode & 0x8000 )
+        else if($mode & 0x8000)
             $type='-'; /* Regular */
-        else if( $mode & 0xA000 )
+        else if($mode & 0xA000)
             $type='l'; /* Symbolic Link */
-        else if( $mode & 0xC000 )
+        else if($mode & 0xC000)
             $type='s'; /* Socket */
         else
             $type='u'; /* UNKNOWN */
@@ -836,11 +836,11 @@ class Varien_Io_File extends Varien_Io_Abstract
         $world['execute'] = ($mode & 00001) ? 'x' : '-';
 
         /* Adjust for SUID, SGID and sticky bit */
-        if( $mode & 0x800 )
+        if($mode & 0x800)
             $owner["execute"] = ($owner['execute']=='x') ? 's' : 'S';
-        if( $mode & 0x400 )
+        if($mode & 0x400)
             $group["execute"] = ($group['execute']=='x') ? 's' : 'S';
-        if( $mode & 0x200 )
+        if($mode & 0x200)
             $world["execute"] = ($world['execute']=='x') ? 't' : 'T';
 
         $s=sprintf('%1s', $type);
@@ -859,7 +859,7 @@ class Varien_Io_File extends Varien_Io_Abstract
      */
     protected function _getFileOwner($filename)
     {
-        if( !function_exists('posix_getpwuid') ) {
+        if(!function_exists('posix_getpwuid')) {
             return 'n/a';
         }
 

--- a/lib/Varien/Io/Ftp.php
+++ b/lib/Varien/Io/Ftp.php
@@ -313,7 +313,7 @@ class Varien_Io_Ftp extends Varien_Io_Abstract
     protected function _tmpFilename($new=false)
     {
         if ($new || !$this->_tmpFilename) {
-            $this->_tmpFilename = tempnam( md5(uniqid(rand(), true)), '' );
+            $this->_tmpFilename = tempnam(md5(uniqid(rand(), true)), '');
         }
         return $this->_tmpFilename;
     }


### PR DESCRIPTION
The subject said it all.

**Note:**
I couldn't fine a rule to change this:

`if(intval($roleId) > 0) {`

into this:

`if (intval($roleId) > 0) {`

(adding the space between "if" and "("), if you know one please let me know