### PR TITLE
Deprecate PayPal logo block

### DIFF
--- a/app/code/core/Mage/Paypal/Block/Logo.php
+++ b/app/code/core/Mage/Paypal/Block/Logo.php
@@ -20,6 +20,7 @@
 
 /**
  * PayPal online logo with additional options
+ * @deprecated
  */
 class Mage_Paypal_Block_Logo extends Mage_Core_Block_Template
 {

--- a/app/design/frontend/base/default/layout/paypal.xml
+++ b/app/design/frontend/base/default/layout/paypal.xml
@@ -93,25 +93,14 @@ Available logo types can be assigned with action="setLogoType":
             </block>
         </reference>
         <update handle="SHORTCUT_popup" />
-        <reference name="right">
-            <block type="paypal/logo" name="paypal.partner.right.logo" template="paypal/partner/logo.phtml">
-                <!--action method="setLogoType"><value>wePrefer_150x60</value></action-->
-            </block>
-        </reference>
     </catalog_product_view>
 
     <catalog_category_default>
         <update handle="SHORTCUT_popup" />
-        <reference name="right">
-            <block type="paypal/logo" name="paypal.partner.right.logo" template="paypal/partner/logo.phtml"/>
-        </reference>
     </catalog_category_default>
 
     <catalog_category_layered>
         <update handle="SHORTCUT_popup" />
-        <reference name="right">
-            <block type="paypal/logo" name="paypal.partner.right.logo" template="paypal/partner/logo.phtml"/>
-        </reference>
     </catalog_category_layered>
 
     <catalog_product_compare_index>
@@ -146,12 +135,6 @@ Available logo types can be assigned with action="setLogoType":
     <checkout_onepage_failure>
         <update handle="SHORTCUT_popup" />
     </checkout_onepage_failure>
-
-    <cms_index_index>
-        <reference name="right">
-            <block type="paypal/logo" name="paypal.partner.right.logo" template="paypal/partner/logo.phtml"/>
-        </reference>
-    </cms_index_index>
 
     <default>
         <reference name="topCart.extra_actions">

--- a/app/design/frontend/base/default/template/paypal/partner/logo.phtml
+++ b/app/design/frontend/base/default/template/paypal/partner/logo.phtml
@@ -21,6 +21,7 @@
 <?php
 /**
  * @see Mage_Paypal_Block_Logo
+ * @deprecated
  */
 ?>
 <div class="paypal-logo">

--- a/app/design/frontend/base/default/template/paypal/partner/us_logo.phtml
+++ b/app/design/frontend/base/default/template/paypal/partner/us_logo.phtml
@@ -21,6 +21,7 @@
 <?php
 /**
  * @see Mage_Paypal_Block_Logo
+ * @deprecated
  */
 ?>
 <div class="paypal-logo">

--- a/app/design/frontend/rwd/default/layout/paypal.xml
+++ b/app/design/frontend/rwd/default/layout/paypal.xml
@@ -96,25 +96,14 @@ Available logo types can be assigned with action="setLogoType":
             </block>
         </reference>
         <update handle="SHORTCUT_popup" />
-        <reference name="right">
-            <block type="paypal/logo" name="paypal.partner.right.logo" template="paypal/partner/logo.phtml">
-                <!--action method="setLogoType"><value>wePrefer_150x60</value></action-->
-            </block>
-        </reference>
     </catalog_product_view>
 
     <catalog_category_default>
         <update handle="SHORTCUT_popup" />
-        <reference name="right">
-            <block type="paypal/logo" name="paypal.partner.right.logo" template="paypal/partner/logo.phtml"/>
-        </reference>
     </catalog_category_default>
 
     <catalog_category_layered>
         <update handle="SHORTCUT_popup" />
-        <reference name="right">
-            <block type="paypal/logo" name="paypal.partner.right.logo" template="paypal/partner/logo.phtml"/>
-        </reference>
     </catalog_category_layered>
 
     <catalog_product_compare_index>
@@ -149,12 +138,6 @@ Available logo types can be assigned with action="setLogoType":
     <checkout_onepage_failure>
         <update handle="SHORTCUT_popup" />
     </checkout_onepage_failure>
-
-    <cms_index_index>
-        <reference name="right">
-            <block type="paypal/logo" name="paypal.partner.right.logo" template="paypal/partner/logo.phtml"/>
-        </reference>
-    </cms_index_index>
 
     <default>
         <reference name="topCart.extra_actions">

--- a/app/design/frontend/rwd/default/template/paypal/partner/us_logo.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/partner/us_logo.phtml
@@ -21,6 +21,7 @@
 <?php
 /**
  * @see Mage_Paypal_Block_Logo
+ * @deprecated
  */
 ?>
 <div class="paypal-logo">


### PR DESCRIPTION
This block appears in the sidebar of the defaults themes:

<img width="302" alt="Schermata 2022-08-26 alle 23 18 39" src="https://user-images.githubusercontent.com/909743/186997827-7a730c00-4189-4b85-8ed1-2405c873e372.png">

but nowadays it looks extremely old and I don't think anybody have that big paypal logo there.

A lot of website have a picture with all the supported payment methods, but not a big one only for paypal.

This PR removed all the instances of the block from the XML layouts and deprecates all the related files.