### PR TITLE
Removed border-top from .block-title class (rwd theme)

### DIFF
--- a/skin/frontend/rwd/default/css/styles-ie8.css
+++ b/skin/frontend/rwd/default/css/styles-ie8.css
@@ -656,7 +656,6 @@ h6, .h6 {
   position: relative;
   padding: 10px 0 0;
   margin-bottom: 5px;
-  border-top: 1px solid #cccccc;
 }
 .block-title h2,
 .block-title h3,

--- a/skin/frontend/rwd/default/css/styles.css
+++ b/skin/frontend/rwd/default/css/styles.css
@@ -656,7 +656,6 @@ h6, .h6 {
   position: relative;
   padding: 10px 0 0;
   margin-bottom: 5px;
-  border-top: 1px solid #cccccc;
 }
 .block-title h2,
 .block-title h3,

--- a/skin/frontend/rwd/default/scss/core/_common.scss
+++ b/skin/frontend/rwd/default/scss/core/_common.scss
@@ -151,7 +151,6 @@ h6, .h6 { @include h6; }
     position: relative;
     padding: 10px 0 0;
     margin-bottom: 5px;
-    border-top: 1px solid $c-module-border;
 
     h2,
     h3,


### PR DESCRIPTION
In the rwd theme there's a border-top added to the block-title class, which shows like this:

<img width="1279" alt="Schermata 2022-08-28 alle 17 30 28" src="https://user-images.githubusercontent.com/909743/187084655-a46a7a35-871f-4718-9b5c-d8bb70a4bcbb.png">

I see why it was added years ago, but now I think it looks nicer and cleaner without that border:

<img width="1243" alt="Schermata 2022-08-28 alle 17 30 00" src="https://user-images.githubusercontent.com/909743/187084686-4f726765-9061-4b6d-a84d-357614dfdcb5.png">

It is also better on mobile in my opinion.