### PR TITLE
Added docs for multistore error pages

### DIFF
--- a/docs/ERROR_PAGE.md
+++ b/docs/ERROR_PAGE.md
@@ -1,0 +1,43 @@
+## For Multistore setups
+
+If you want to setup multiple stores with a different layout and localized content for each store, this is done by passing the `$_GET['skin']` parameter to the intended processor In the example below, we are using a `503` type error template file, which requires localized content.
+
+The constructor of the `Error_Processor` class accepts a `skin` GET parameter to change layout:
+
+```php
+if (isset($_GET['skin'])) {
+    $this->_setSkin($_GET['skin']);
+}
+```
+
+This can also be added a rewrite rule in the `.htaccess` file that will append a `skin` parameter to the URL.
+
+### $_GET['skin'] parameter
+
+To use the `skin` parameter:
+
+1. Check if the `maintenance.flag` exists
+1. Note the host address, that refers to the `HTTP_HOST`, or any other variable such as ENV variables
+1. Check if the `skin` parameter exists
+1. Set the parameter by using the rewrite rules below.
+
+This is what it looks like as a rewrite rule:
+
+```
+RewriteCond `%{DOCUMENT_ROOT}/maintenance.flag -f
+RewriteCond `%{HTTP_HOST} ^sub.example.com$`
+RewriteCond `%{QUERY_STRING} !(^|&)skin=sub(&|$)` [NC]
+RewriteRule `^ %{REQUEST_URI}?skin=sub` [L]
+```
+
+Copy the following files:
+
+*  `errors/default/503.phtml` to `errors/sub/503.phtml`
+*  `errors/default/css/styles.css` to `errors/sub/styles.css`
+
+Edit these files to provide localized content in the `503.phtml` file and custom styling in the `styles.css` file.
+
+Ensure your paths point to your `errors` directory. The directory name must match the URL parameter indicated in the RewriteRule. In the example above, the `sub` directory is used, which is specified as a parameter in the RewriteRule (`skin=sub`)
+
+### ToDo: nginx
+The nginx setting should be added for multistore setups.


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Added docs how to setup error pages for multistore environment.

This was never mentioned in M1 docs and may be usefull for some.

Its been copy&pasted from https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-subcommands-maint.html#multi-store-setups and adjusted for M1/OM.

Copy&Paste seems to be okay in this case ... my code, my issue :)

- https://github.com/magento/devdocs/issues/3393
- https://magento.stackexchange.com/a/186868/46249

Edit:

@Flyingmana re-open wiki-pages? We cant put any information into README and wiki seems better then docs in root ...

### Related Pull Requests
<!-- related pull request placeholder -->

1. OpenMage/magento-lts#2407

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [X] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->