### PR TITLE
Set default width for grid datetime columns, ref #2239

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Backup/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Backup/Grid.php
@@ -78,7 +78,6 @@ class Mage_Adminhtml_Block_Backup_Grid extends Mage_Adminhtml_Block_Widget_Grid
             'header'    => Mage::helper('backup')->__('Time'),
             'index'     => 'date_object',
             'type'      => 'datetime',
-            'width'     => 200
         ]);
 
         $this->addColumn('display_name', [

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Wishlist.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Wishlist.php
@@ -91,7 +91,6 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_View_Wishlist extends Mage_Adminhtm
             'header'    => Mage::helper('customer')->__('Date Added'),
             'index'     => 'added_at',
             'type'      => 'date',
-            'width'     => '140px',
         ]);
 
         $this->addColumn('days', [

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid.php
@@ -111,7 +111,6 @@ class Mage_Adminhtml_Block_Customer_Online_Grid extends Mage_Adminhtml_Block_Wid
         $this->addColumn('session_start_time', [
             'header'    => Mage::helper('customer')->__('Session Start Time'),
             'align'     => 'left',
-            'width'     => '200px',
             'type'      => 'datetime',
             'default'   => Mage::helper('customer')->__('n/a'),
             'index'     =>'first_visit_at'
@@ -120,7 +119,6 @@ class Mage_Adminhtml_Block_Customer_Online_Grid extends Mage_Adminhtml_Block_Wid
         $this->addColumn('last_activity', [
             'header'    => Mage::helper('customer')->__('Last Activity'),
             'align'     => 'left',
-            'width'     => '200px',
             'type'      => 'datetime',
             'default'   => Mage::helper('customer')->__('n/a'),
             'index'     => 'last_visit_at'

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Grid.php
@@ -66,7 +66,6 @@ class Mage_Adminhtml_Block_Notification_Grid extends Mage_Adminhtml_Block_Widget
         $this->addColumn('date_added', [
             'header'    => Mage::helper('adminnotification')->__('Date Added'),
             'index'     => 'date_added',
-            'width'     => '150px',
             'type'      => 'datetime'
         ]);
 

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Grid.php
@@ -85,7 +85,6 @@ class Mage_Adminhtml_Block_Poll_Grid extends Mage_Adminhtml_Block_Widget_Grid
         $this->addColumn('date_posted', [
             'header'    => Mage::helper('poll')->__('Date Posted'),
             'align'     => 'left',
-            'width'     => '120px',
             'type'      => 'datetime',
             'index'     => 'date_posted',
             'format'	=> Mage::app()->getLocale()->getDateFormat()
@@ -94,7 +93,6 @@ class Mage_Adminhtml_Block_Poll_Grid extends Mage_Adminhtml_Block_Widget_Grid
         $this->addColumn('date_closed', [
             'header'    => Mage::helper('poll')->__('Date Closed'),
             'align'     => 'left',
-            'width'     => '120px',
             'type'      => 'datetime',
             'default'   => '--',
             'index'     => 'date_closed',

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Grid.php
@@ -81,7 +81,6 @@ class Mage_Adminhtml_Block_Promo_Catalog_Grid extends Mage_Adminhtml_Block_Widge
         $this->addColumn('from_date', [
             'header'    => Mage::helper('catalogrule')->__('Date Start'),
             'align'     => 'left',
-            'width'     => '120px',
             'type'      => 'date',
             'index'     => 'from_date',
         ]);
@@ -89,7 +88,6 @@ class Mage_Adminhtml_Block_Promo_Catalog_Grid extends Mage_Adminhtml_Block_Widge
         $this->addColumn('to_date', [
             'header'    => Mage::helper('catalogrule')->__('Date Expire'),
             'align'     => 'left',
-            'width'     => '120px',
             'type'      => 'date',
             'default'   => '--',
             'index'     => 'to_date',

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
@@ -72,7 +72,6 @@ class Mage_Adminhtml_Block_Promo_Quote_Edit_Tab_Coupons_Grid extends Mage_Adminh
             'index'  => 'created_at',
             'type'   => 'datetime',
             'align'  => 'center',
-            'width'  => '160'
         ]);
 
         $this->addColumn('used', [

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Grid.php
@@ -89,7 +89,6 @@ class Mage_Adminhtml_Block_Promo_Quote_Grid extends Mage_Adminhtml_Block_Widget_
         $this->addColumn('from_date', [
             'header'    => Mage::helper('salesrule')->__('Date Start'),
             'align'     => 'left',
-            'width'     => '120px',
             'type'      => 'date',
             'index'     => 'from_date',
         ]);
@@ -97,7 +96,6 @@ class Mage_Adminhtml_Block_Promo_Quote_Grid extends Mage_Adminhtml_Block_Widget_
         $this->addColumn('to_date', [
             'header'    => Mage::helper('salesrule')->__('Date Expire'),
             'align'     => 'left',
-            'width'     => '120px',
             'type'      => 'date',
             'default'   => '--',
             'index'     => 'to_date',

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser.php
@@ -137,7 +137,6 @@ class Mage_Adminhtml_Block_Promo_Widget_Chooser extends Mage_Adminhtml_Block_Wid
         $this->addColumn('from_date', [
             'header'    => Mage::helper('salesrule')->__('Date Start'),
             'align'     => 'left',
-            'width'     => '120px',
             'type'      => 'date',
             'index'     => 'from_date',
         ]);
@@ -145,7 +144,6 @@ class Mage_Adminhtml_Block_Promo_Widget_Chooser extends Mage_Adminhtml_Block_Wid
         $this->addColumn('to_date', [
             'header'    => Mage::helper('salesrule')->__('Date Expire'),
             'align'     => 'left',
-            'width'     => '120px',
             'type'      => 'date',
             'default'   => '--',
             'index'     => 'to_date',

--- a/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics/Grid.php
@@ -132,7 +132,6 @@ class Mage_Adminhtml_Block_Report_Refresh_Statistics_Grid extends Mage_Adminhtml
             'header'    => Mage::helper('reports')->__('Updated At'),
             'index'     => 'updated_at',
             'type'      => 'datetime',
-            'width'     => 200,
             'default'   => Mage::helper('reports')->__('undefined'),
             'sortable'  => false
         ]);

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Detail/Grid.php
@@ -81,7 +81,6 @@ class Mage_Adminhtml_Block_Report_Tag_Customer_Detail_Grid extends Mage_Adminhtm
 
         $this->addColumn('created_at', [
             'header'    =>Mage::helper('reports')->__('Submitted On'),
-            'width'     => '140px',
             'type'      => 'datetime',
             'index'     => 'created_at'
         ]);

--- a/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
@@ -81,7 +81,6 @@ class Mage_Adminhtml_Block_Review_Grid extends Mage_Adminhtml_Block_Widget_Grid
             'header'        => Mage::helper('review')->__('Created On'),
             'align'         => 'left',
             'type'          => 'datetime',
-            'width'         => '100px',
             'filter_index'  => 'rt.created_at',
             'index'         => 'review_created_at',
         ]);

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
@@ -80,7 +80,6 @@ class Mage_Adminhtml_Block_Sales_Order_Grid extends Mage_Adminhtml_Block_Widget_
             'header' => Mage::helper('sales')->__('Purchased On'),
             'index' => 'created_at',
             'type' => 'datetime',
-            'width' => '150px',
         ]);
 
         $this->addColumn('billing_name', [

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Grid.php
@@ -120,7 +120,6 @@ class Mage_Adminhtml_Block_Sales_Transactions_Grid extends Mage_Adminhtml_Block_
         $this->addColumn('created_at', [
             'header'    => Mage::helper('sales')->__('Created At'),
             'index'     => 'created_at',
-            'width'     => 1,
             'type'      => 'datetime',
             'align'     => 'center',
             'default'   => $this->__('N/A'),

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid.php
@@ -69,7 +69,6 @@ class Mage_Adminhtml_Block_Sitemap_Grid extends Mage_Adminhtml_Block_Widget_Grid
 
         $this->addColumn('sitemap_time', [
             'header'    => Mage::helper('sitemap')->__('Last Time Generated'),
-            'width'     => '150px',
             'index'     => 'sitemap_time',
             'type'      => 'datetime',
         ]);

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/History.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/History.php
@@ -68,7 +68,6 @@ class Mage_Adminhtml_Block_System_Convert_Profile_Edit_Tab_History extends Mage_
             'header'    => Mage::helper('adminhtml')->__('Performed At'),
             'type'      => 'datetime',
             'index'     => 'performed_at',
-            'width'     => '150px',
         ]);
 
         $this->addColumn('firstname', [

--- a/app/code/core/Mage/Adminhtml/Block/System/Design/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design/Grid.php
@@ -80,7 +80,6 @@ class Mage_Adminhtml_Block_System_Design_Grid extends Mage_Adminhtml_Block_Widge
         $this->addColumn('date_from', [
             'header'    => Mage::helper('catalogrule')->__('Date From'),
             'align'     => 'left',
-            'width'     => '100px',
             'type'      => 'date',
             'index'     => 'date_from',
         ]);
@@ -88,7 +87,6 @@ class Mage_Adminhtml_Block_System_Design_Grid extends Mage_Adminhtml_Block_Widge
         $this->addColumn('date_to', [
             'header'    => Mage::helper('catalogrule')->__('Date To'),
             'align'     => 'left',
-            'width'     => '100px',
             'type'      => 'date',
             'index'     => 'date_to',
         ]);

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -212,6 +212,15 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
     protected $_emptyCellLabel = '';
 
     /**
+     * @var array[][]
+     */
+    protected $defaultColumnSettings = [
+        'datetime' => [
+            'width' => 160
+        ]
+    ];
+
+    /**
      * Mage_Adminhtml_Block_Widget_Grid constructor.
      * @param array $attributes
      */
@@ -325,6 +334,9 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
     public function addColumn($columnId, $column)
     {
         if (is_array($column)) {
+            if (isset($column['type'], $this->defaultColumnSettings[$column['type']])) {
+                $column += $this->defaultColumnSettings[$column['type']];
+            }
             $this->_columns[$columnId] = $this->getLayout()->createBlock('adminhtml/widget_grid_column')
                 ->setData($column)
                 ->setGrid($this);

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -215,9 +215,12 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
      * @var array[][]
      */
     protected $defaultColumnSettings = [
+        'date' => [
+            'width' => 140
+        ],
         'datetime' => [
-            'width' => 160
-        ]
+            'width' => 140
+        ],
     ];
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -219,7 +219,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
             'width' => 140
         ],
         'datetime' => [
-            'width' => 140
+            'width' => 160
         ],
     ];
 

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid.php
@@ -144,7 +144,6 @@ class Mage_Index_Block_Adminhtml_Process_Grid extends Mage_Adminhtml_Block_Widge
         $this->addColumn('ended_at', [
             'header'    => Mage::helper('index')->__('Updated At'),
             'type'      => 'datetime',
-            'width'     => '180',
             'align'     => 'left',
             'index'     => 'ended_at',
             'frame_callback' => [$this, 'decorateDate']

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/Grid.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/Grid.php
@@ -139,7 +139,6 @@ class Mage_Sales_Block_Adminhtml_Billing_Agreement_Grid extends Mage_Adminhtml_B
         $this->addColumn('created_at', [
             'header'            => Mage::helper('sales')->__('Created At'),
             'index'             => 'agreement_created_at',
-            'width'             => 1,
             'type'              => 'datetime',
             'align'             => 'center',
             'default'           => $this->__('N/A'),
@@ -149,7 +148,6 @@ class Mage_Sales_Block_Adminhtml_Billing_Agreement_Grid extends Mage_Adminhtml_B
         $this->addColumn('updated_at', [
             'header'            => Mage::helper('sales')->__('Updated At'),
             'index'             => 'agreement_updated_at',
-            'width'             => 1,
             'type'              => 'datetime',
             'align'             => 'center',
             'default'           => $this->__('N/A'),

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/Grid.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/Grid.php
@@ -91,7 +91,6 @@ class Mage_Sales_Block_Adminhtml_Recurring_Profile_Grid extends Mage_Adminhtml_B
             'index' => 'created_at',
             'type' => 'datetime',
             'html_decorators' => ['nobr'],
-            'width' => 1,
         ]);
 
         $this->addColumn('updated_at', [
@@ -99,7 +98,6 @@ class Mage_Sales_Block_Adminhtml_Recurring_Profile_Grid extends Mage_Adminhtml_B
             'index' => 'updated_at',
             'type' => 'datetime',
             'html_decorators' => ['nobr'],
-            'width' => 1,
         ]);
 
         $methods = [];

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Orders.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Orders.php
@@ -83,7 +83,6 @@ class Mage_Sales_Block_Adminhtml_Recurring_Profile_View_Tab_Orders extends Mage_
             'header' => Mage::helper('sales')->__('Purchased On'),
             'index' => 'created_at',
             'type' => 'datetime',
-            'width' => '100px',
         ]);
 
         $this->addColumn('billing_name', [


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This PR replaces all admin grid `width` attributes for `datetime` columns width a default value to make grids more consistent.

The required width for datetime is allways same, so it does not make sense to set it 140 here, to 200 there ...

This could be extended to set defaults for other grid types too (date, action, currency, store ...)

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#2239

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->