### PR TITLE
Remove redundant polyfill code for error reporting constants

### DIFF
--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -121,15 +121,6 @@ function mageCoreErrorHandler($errno, $errstr, $errfile, $errline)
     if ($errno == 0) {
         return false;
     }
-    if (!defined('E_STRICT')) {
-        define('E_STRICT', 2048);
-    }
-    if (!defined('E_RECOVERABLE_ERROR')) {
-        define('E_RECOVERABLE_ERROR', 4096);
-    }
-    if (!defined('E_DEPRECATED')) {
-        define('E_DEPRECATED', 8192);
-    }
 
     // Suppress deprecation warnings on PHP 7.x
     if ($errno == E_DEPRECATED && version_compare(PHP_VERSION, '7.0.0', '>=')) {


### PR DESCRIPTION
### Description (*)
This PR removes redundant polyfill code that defines some error reporting constants which should be available in all of our supported PHP versions anyways. Correct if I'm wrong as I couldn't find specific information about when these constants were introduced.

### Manual testing scenarios (*)
1. Everything should remain the same.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->