### PR TITLE
Removed PHP 5.3 compatibility code from Mage_Adminhtml_Model_System_Config_Backend_Locale_Timezone

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale/Timezone.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale/Timezone.php
@@ -27,21 +27,9 @@
  */
 class Mage_Adminhtml_Model_System_Config_Backend_Locale_Timezone extends Mage_Core_Model_Config_Data
 {
-    /**
-     * Const for PHP 5.3+ compatibility
-     * This value copied from DateTimeZone::ALL_WITH_BC in PHP 5.3+
-     *
-     * @constant ALL_WITH_BC
-     */
-    const ALL_WITH_BC = 4095;
-
     protected function _beforeSave()
     {
-        $allWithBc = self::ALL_WITH_BC;
-        if (defined('DateTimeZone::ALL_WITH_BC')) {
-            $allWithBc = DateTimeZone::ALL_WITH_BC;
-        }
-
+        $allWithBc = DateTimeZone::ALL_WITH_BC;
         if (!in_array($this->getValue(), DateTimeZone::listIdentifiers($allWithBc))) {
             Mage::throwException(Mage::helper('adminhtml')->__('Invalid timezone'));
         }


### PR DESCRIPTION
The code is triggered when you save the configuration from backend, ""system -> configuration -> general -> general -> locale options"