### PR TITLE
Fixed PHPStan error with Mage_Catalog_Model_Resource_Product_Option_Collection

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Option/Value.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Value.php
@@ -25,6 +25,7 @@
  * @package    Mage_Catalog
  * @author     Magento Core Team <core@magentocommerce.com>
  *
+ * @method Mage_Catalog_Model_Resource_Product_Option_Value_Collection getCollection()
  * @method Mage_Catalog_Model_Resource_Product_Option_Value _getResource()
  * @method Mage_Catalog_Model_Resource_Product_Option_Value getResource()
  * @method int getOptionId()

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Collection.php
@@ -150,8 +150,8 @@ class Mage_Catalog_Model_Resource_Product_Option_Collection extends Mage_Core_Mo
         }
         if (!empty($optionIds)) {
             /** @var Mage_Catalog_Model_Resource_Product_Option_Value_Collection $values */
-            $values = Mage::getModel('catalog/product_option_value')
-                ->getCollection()
+            $values = Mage::getModel('catalog/product_option_value')->getCollection();
+            $values
                 ->addTitleToResult($storeId)
                 ->addPriceToResult($storeId)
                 ->addOptionToFilter($optionIds)

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Collection.php
@@ -149,6 +149,7 @@ class Mage_Catalog_Model_Resource_Product_Option_Collection extends Mage_Core_Mo
             $optionIds[] = $option->getId();
         }
         if (!empty($optionIds)) {
+            /** @var Mage_Catalog_Model_Resource_Product_Option_Value_Collection $values */
             $values = Mage::getModel('catalog/product_option_value')
                 ->getCollection()
                 ->addTitleToResult($storeId)

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Collection.php
@@ -149,9 +149,8 @@ class Mage_Catalog_Model_Resource_Product_Option_Collection extends Mage_Core_Mo
             $optionIds[] = $option->getId();
         }
         if (!empty($optionIds)) {
-            /** @var Mage_Catalog_Model_Resource_Product_Option_Value_Collection $values */
-            $values = Mage::getModel('catalog/product_option_value')->getCollection();
-            $values
+            $values = Mage::getModel('catalog/product_option_value')
+                ->getCollection()
                 ->addTitleToResult($storeId)
                 ->addPriceToResult($storeId)
                 ->addOptionToFilter($optionIds)


### PR DESCRIPTION
Discovered in https://github.com/OpenMage/magento-lts/pull/2562 by @elidrissidev, it shouldn't be caused with that PR but anyway this PR should fix it.

Let's see if all lights are gree.