### PR TITLE
Update label for `system/csrf/use_form_key` config

### DIFF
--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -45,7 +45,7 @@
                     <show_in_store>1</show_in_store>
                     <fields>
                         <use_form_key translate="label">
-                            <label>Add Secret Key To Url</label>
+                            <label>Enable</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>10</sort_order>

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -45,7 +45,7 @@
                     <show_in_store>1</show_in_store>
                     <fields>
                         <use_form_key translate="label">
-                            <label>Enable</label>
+                            <label>Enabled</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>10</sort_order>


### PR DESCRIPTION
### Description (*)
This PR updates the label for `system/csrf/use_form_key` config, it always confuses me because it says "Add Secret Key to URL" which is not true. I guess the whole xml node was copied from `admin/security/use_form_key` and the label was never updated. This update should not break the translation because "Enabled" already exists.

### Manual testing scenarios (*)

1. Go to System -> Configuration -> System -> CSRF protection


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->