### PR TITLE
Refactoring: Replace dirname(__FILE__) With Corresponding Constant

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -20,7 +20,7 @@
 
 define('DS', DIRECTORY_SEPARATOR);
 define('PS', PATH_SEPARATOR);
-define('BP', dirname(dirname(__FILE__)));
+define('BP', dirname(__DIR__));
 
 Mage::register('original_include_path', get_include_path());
 
@@ -317,8 +317,8 @@ final class Mage
         }
 
         if ($appRoot === '') {
-            // automagically find application root by dirname of Mage.php
-            $appRoot = dirname(__FILE__);
+            // automagically find application root by __DIR__ constant of Mage.php
+            $appRoot = __DIR__;
         }
 
         $appRoot = realpath($appRoot);

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
@@ -18,7 +18,7 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-$installFile = dirname(__FILE__) . DS . 'upgrade-1.6.0.0-1.6.0.0.1.php';
+$installFile = __DIR__ . DS . 'upgrade-1.6.0.0-1.6.0.0.1.php';
 if (file_exists($installFile)) {
     include $installFile;
 }

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.6.0.0.8-1.6.0.0.9.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.6.0.0.8-1.6.0.0.9.php
@@ -18,7 +18,7 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-$installFile = dirname(__FILE__) . DS . 'upgrade-1.6.0.0.8-1.6.0.0.9.php';
+$installFile = __DIR__ . DS . 'upgrade-1.6.0.0.8-1.6.0.0.9.php';
 if (file_exists($installFile)) {
     include $installFile;
 }

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -18,7 +18,7 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-$installFile = dirname(__FILE__) . DS . 'upgrade-1.6.0.0.1-1.6.0.0.2.php';
+$installFile = __DIR__ . DS . 'upgrade-1.6.0.0.1-1.6.0.0.2.php';
 if (file_exists($installFile)) {
     include $installFile;
 }

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.5.0.0.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.5.0.0.php
@@ -21,7 +21,7 @@
 /** @var Mage_Core_Model_Resource_Setup $installer */
 $installer = $this;
 
-$installFile = dirname(__FILE__) . DS . 'install-1.6.0.0.php';
+$installFile = __DIR__ . DS . 'install-1.6.0.0.php';
 if (file_exists($installFile)) {
     include $installFile;
 

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.6.0.0.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.6.0.0.php
@@ -177,7 +177,7 @@ $table = $installer->getConnection()
     ->setComment('Reports Viewed Product Index Table');
 $installer->getConnection()->createTable($table);
 
-$installFile = dirname(__FILE__) . DS . 'install-1.6.0.0.php';
+$installFile = __DIR__ . DS . 'install-1.6.0.0.php';
 if (file_exists($installFile)) {
     include $installFile;
 }

--- a/cron.php
+++ b/cron.php
@@ -19,7 +19,7 @@
  */
 
 // Change current directory to the directory of current script
-chdir(dirname(__FILE__));
+chdir(__DIR__);
 
 require 'app/bootstrap.php';
 require 'app/Mage.php';
@@ -60,7 +60,7 @@ try {
             }
         } else if (!$isShellDisabled) {
             $fileName = escapeshellarg(basename(__FILE__));
-            $cronPath = escapeshellarg(dirname(__FILE__) . '/cron.sh');
+            $cronPath = escapeshellarg(__DIR__ . '/cron.sh');
 
             shell_exec(escapeshellcmd("/bin/sh $cronPath $fileName -mdefault 1") . " > /dev/null 2>&1 &");
             shell_exec(escapeshellcmd("/bin/sh $cronPath $fileName -malways 1") . " > /dev/null 2>&1 &");

--- a/dev/tests/functional/utils/bootstrap.php
+++ b/dev/tests/functional/utils/bootstrap.php
@@ -19,7 +19,7 @@
  */
 umask(0);
 
-$mtfRoot = dirname(dirname(__FILE__));
+$mtfRoot = dirname(__DIR__);
 $mtfRoot = str_replace('\\', '/', $mtfRoot);
 define('MTF_BP', $mtfRoot);
 define('MTF_TESTS_PATH', MTF_BP . '/tests/app/');

--- a/dev/tests/functional/utils/generate.php
+++ b/dev/tests/functional/utils/generate.php
@@ -17,7 +17,7 @@
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-require_once dirname(__FILE__) . '/' . 'bootstrap.php';
+require_once __DIR__ . '/' . 'bootstrap.php';
 
 $objectManager->create('Magento\Mtf\Util\Generate\Page')->launch();
 $objectManager->create('Magento\Mtf\Util\Generate\Fixture')->launch();

--- a/get.php
+++ b/get.php
@@ -34,7 +34,7 @@ ini_set('display_errors', 0);
 
 $ds = DIRECTORY_SEPARATOR;
 $ps = PATH_SEPARATOR;
-$bp = dirname(__FILE__);
+$bp = __DIR__;
 
 require $bp . '/app/bootstrap.php';
 

--- a/index.php
+++ b/index.php
@@ -74,7 +74,7 @@ if (file_exists($maintenanceFile)) {
         }
     }
     if (!$maintenanceBypass) {
-        include_once dirname(__FILE__) . '/errors/503.php';
+        include_once __DIR__ . '/errors/503.php';
         exit;
     }
 }

--- a/install.php
+++ b/install.php
@@ -115,7 +115,7 @@
 if (version_compare(phpversion(), '7.3.0', '<')===true) {
     die('ERROR: Whoops, it looks like you have an invalid PHP version. OpenMage supports PHP 7.3.0 or newer.');
 }
-set_include_path(dirname(__FILE__) . PATH_SEPARATOR . get_include_path());
+set_include_path(__DIR__ . PATH_SEPARATOR . get_include_path());
 require 'app/bootstrap.php';
 require 'app/Mage.php';
 

--- a/js/index.php
+++ b/js/index.php
@@ -68,7 +68,7 @@ $lastModified = 0;
 foreach ($files as $f) {
     $fileRealPath = realpath($f);
     // check file path (security)
-    if (strpos($fileRealPath, realpath(dirname(__FILE__))) !== 0) {
+    if (strpos($fileRealPath, realpath(__DIR__)) !== 0) {
         continue;
     }
 

--- a/lib/Varien/Debug.php
+++ b/lib/Varien/Debug.php
@@ -46,7 +46,7 @@ class Varien_Debug
             if (defined('BP')) {
                 self::$_filePath = BP;
             } else {
-                self::$_filePath = dirname(dirname(__FILE__));
+                self::$_filePath = dirname(__DIR__);
             }
         }
         return self::$_filePath;

--- a/shell/abstract.php
+++ b/shell/abstract.php
@@ -96,7 +96,7 @@ abstract class Mage_Shell_Abstract
     protected function _getRootPath()
     {
         if (is_null($this->_rootPath)) {
-            $this->_rootPath = dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR;
+            $this->_rootPath = dirname(__DIR__) . DIRECTORY_SEPARATOR;
         }
         return $this->_rootPath;
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
`dirname(__FILE__)` returns the directory of the current file. Since PHP 5.3.0 the constant `__DIR__` exists and is equivalent to the function call (see [Magic constants](https://www.php.net/manual/en/language.constants.magic.php)). At the same time it's easier to grasp at first glance. Our current minimum supported PHP version is 7.3.0. 
The PR replaces all `dirname(__FILE__)` calls with __DIR__ except those in *lib/Zend* and *lib/phpseclib* which are in the process of being removed from the codebase to become externally maintained dependencies. 

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
In two instances `dirname(dirname(__FILE__))` is replaced with `dirname(__DIR__)`. Another variant here would be `dirname(__FILE__),2)` (directory name above the current one). I've chosen the first option but have no disposition which one better to use. Maybe some of you have an opinion regarding e.g. ease of understanding? 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
