### PR TITLE
Fix Phpdoc Typos in Various Files

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Abstract.php
@@ -297,7 +297,7 @@ class  Mage_Adminhtml_Block_Sales_Items_Abstract extends Mage_Adminhtml_Block_Te
     }
 
     /**
-     * Retrieve price formated html content
+     * Retrieve price formatted html content
      *
      * @param float $basePrice
      * @param float $price
@@ -338,7 +338,7 @@ class  Mage_Adminhtml_Block_Sales_Items_Abstract extends Mage_Adminhtml_Block_Te
     }
 
     /**
-     * Retrieve include tax html formated content
+     * Retrieve include tax html formatted content
      *
      * @param Varien_Object $item
      * @return string
@@ -364,7 +364,7 @@ class  Mage_Adminhtml_Block_Sales_Items_Abstract extends Mage_Adminhtml_Block_Te
     }
 
     /**
-     * Retrieve subtotal price include tax html formated content
+     * Retrieve subtotal price include tax html formatted content
      *
      * @param Varien_Object $item
      * @return string

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Address.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Address.php
@@ -206,7 +206,7 @@ class Mage_Adminhtml_Block_Sales_Order_Create_Form_Address
     }
 
     /**
-     * Return customer address formated as one-line string
+     * Return customer address formatted as one-line string
      *
      * @param Mage_Customer_Model_Address $address
      * @return string

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Form.php
@@ -66,7 +66,7 @@ class Mage_Adminhtml_Block_Sales_Order_Invoice_View_Form extends Mage_Adminhtml_
     }
 
     /**
-     * Retrieve formated price
+     * Retrieve formatted price
      *
      * @param float $price
      * @return string

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Items.php
@@ -66,7 +66,7 @@ class Mage_Adminhtml_Block_Sales_Order_Invoice_View_Items extends Mage_Adminhtml
     }
 
     /**
-     * Retrieve formated price
+     * Retrieve formatted price
      *
      * @param float $price
      * @return string

--- a/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Abstract.php
+++ b/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Abstract.php
@@ -28,7 +28,7 @@
 abstract class Mage_Bundle_Model_Sales_Order_Pdf_Items_Abstract extends Mage_Sales_Model_Order_Pdf_Items_Abstract
 {
     /**
-     * Getting all available childs for Invoice, Shipmen or Creditmemo item
+     * Getting all available children for Invoice, Shipmen or Creditmemo item
      *
      * @param Varien_Object $item
      * @return array

--- a/app/code/core/Mage/Catalog/Block/Product/View/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Type/Configurable.php
@@ -220,7 +220,7 @@ class Mage_Catalog_Block_Product_View_Type_Configurable extends Mage_Catalog_Blo
                 }
             }
             /**
-             * Prepare formated values for options choose
+             * Prepare formatted values for options choose
              */
             foreach ($optionPrices as $optionPrice) {
                 foreach ($optionPrices as $additional) {

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Abstract.php
@@ -46,7 +46,7 @@ abstract class Mage_Catalog_Block_Seo_Sitemap_Abstract extends Mage_Core_Block_T
     /**
      * Get item URL
      *
-     * In most cases should be overriden in descendant blocks
+     * In most cases should be overridden in descendant blocks
      *
      * @param Mage_Catalog_Block_Seo_Sitemap_Abstract $item
      * @return string

--- a/app/code/core/Mage/Catalog/Model/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Abstract.php
@@ -30,7 +30,7 @@
 abstract class Mage_Catalog_Model_Abstract extends Mage_Core_Model_Abstract
 {
     /**
-     * Identifuer of default store
+     * Identifier of default store
      * used for loading default data for entity
      */
     const DEFAULT_STORE_ID = 0;
@@ -60,7 +60,7 @@ abstract class Mage_Catalog_Model_Abstract extends Mage_Core_Model_Abstract
     protected $_lockedAttributes = [];
 
     /**
-     * Is model deleteable
+     * Is model deletable
      *
      * @var bool
      */

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Abstract.php
@@ -96,7 +96,7 @@ abstract class Mage_Catalog_Model_Layer_Filter_Abstract extends Varien_Object
     }
 
     /**
-     * Get fiter items count
+     * Get filter items count
      *
      * @return int
      */

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -882,7 +882,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     }
 
     /**
-     * Get formated by currency tier price
+     * Get formatted by currency tier price
      *
      * @param   double $qty
      * @return  array | double
@@ -893,7 +893,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     }
 
     /**
-     * Get formated by currency product price
+     * Get formatted by currency product price
      *
      * @return  array|double
      */
@@ -2090,7 +2090,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     }
 
     /**
-     * Get cahce tags associated with object id
+     * Get cache tags associated with object id
      *
      * @return array
      */
@@ -2105,7 +2105,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     }
 
     /**
-     * Remove model onject related cache
+     * Remove model object related cache
      *
      * @return Mage_Core_Model_Abstract
      */

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
@@ -185,7 +185,7 @@ abstract class Mage_Catalog_Model_Product_Type_Abstract
     }
 
     /**
-     * Retrieve parent ids array by requered child
+     * Retrieve parent ids array by required child
      *
      * @param int|array $childId
      * @return array
@@ -209,7 +209,7 @@ abstract class Mage_Catalog_Model_Product_Type_Abstract
     }
 
     /**
-     * Compare attribues sorting
+     * Compare attributes sorting
      *
      * @param Mage_Catalog_Model_Entity_Attribute $attribute1
      * @param Mage_Catalog_Model_Entity_Attribute $attribute2
@@ -370,7 +370,7 @@ abstract class Mage_Catalog_Model_Product_Type_Abstract
     }
 
     /**
-     * Process product configuaration
+     * Process product configuration
      *
      * @param Varien_Object $buyRequest
      * @param Mage_Catalog_Model_Product $product
@@ -848,7 +848,7 @@ abstract class Mage_Catalog_Model_Product_Type_Abstract
     }
 
     /**
-     * Allow for updates of children qty's
+     * Allow for updates of children quantities
      * (applicable for complicated product types. As default returns false)
      *
      * @param null $product

--- a/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
@@ -697,7 +697,7 @@ abstract class Mage_Catalog_Model_Resource_Abstract extends Mage_Eav_Model_Entit
      * Retrieve attribute's raw value from DB using its source model if available.
      *
      * @param int $entityId
-     * @param int|string|array $attribute atrribute's ids or codes
+     * @param int|string|array $attribute attribute's ids or codes
      * @param int|Mage_Core_Model_Store $store
      * @return bool|string|array
      */

--- a/app/code/core/Mage/Catalog/Model/Resource/Collection/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Collection/Abstract.php
@@ -20,7 +20,7 @@
 
 /**
  * Catalog EAV collection resource abstract model
- * Implement using diferent stores for retrieve attribute values
+ * Implement using different stores for retrieve attribute values
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Collection/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Collection/Abstract.php
@@ -20,7 +20,7 @@
 
 /**
  * Catalog EAV collection resource abstract model
- * Implement using diferent stores for retrieve attribute values
+ * Implement using different stores for retrieve attribute values
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Checkout/Block/Cart/Totals.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Totals.php
@@ -127,7 +127,7 @@ class Mage_Checkout_Block_Cart_Totals extends Mage_Checkout_Block_Cart_Abstract
     }
 
     /**
-     * Get formated in base currency base grand total value
+     * Get formatted in base currency base grand total value
      *
      * @return string
      */

--- a/app/code/core/Mage/Core/Block/Html/Link.php
+++ b/app/code/core/Mage/Core/Block/Html/Link.php
@@ -33,7 +33,7 @@ class Mage_Core_Block_Html_Link extends Mage_Core_Block_Template
         parent::_construct();
     }
     /**
-     * Prepare link attributes as serialized and formated string
+     * Prepare link attributes as serialized and formatted string
      *
      * @return string
      */

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -247,7 +247,7 @@ abstract class Mage_Core_Helper_Abstract
     }
 
     /**
-     * Wrapper for standart strip_tags() function with extra functionality for html entities
+     * Wrapper for standard strip_tags() function with extra functionality for html entities
      *
      * @param string $data
      * @param string $allowableTags
@@ -401,7 +401,7 @@ abstract class Mage_Core_Helper_Abstract
     }
 
     /**
-     *  base64_dencode() for URLs dencoding
+     *  base64_decode() for URLs decoding
      *
      *  @param    string $url
      *  @return   string

--- a/app/code/core/Mage/Core/Model/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Abstract.php
@@ -110,7 +110,7 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
     /**
      * Set resource names
      *
-     * If collection name is ommited, resource name will be used with _collection appended
+     * If collection name is omitted, resource name will be used with _collection appended
      *
      * @param string $resourceName
      * @param string|null $resourceCollectionName
@@ -244,7 +244,7 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
     }
 
     /**
-     * Get array of objects transfered to default events processing
+     * Get array of objects transferred to default events processing
      *
      * @return array
      */
@@ -363,7 +363,7 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
 
     /**
      * Processing data save after transaction commit.
-     * When method is called we don't have garantee what transaction was really commited
+     * When method is called we don't have guarantee what transaction was really committed
      *
      * @deprecated after 1.4.0.0 - please use afterCommitCallback instead
      * @return $this
@@ -376,7 +376,7 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
     /**
      * Check object state (true - if it is object without id on object just created)
      * This method can help detect if object just created in _afterSave method
-     * problem is what in after save onject has id and we can't detect what object was
+     * problem is what in after save object has id and we can't detect what object was
      * created in this transaction
      *
      * @param bool $flag
@@ -433,7 +433,7 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
     }
 
     /**
-     * Get cahce tags associated with object id
+     * Get cache tags associated with object id
      *
      * @return array|bool
      */
@@ -454,7 +454,7 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
     }
 
     /**
-     * Remove model onject related cache
+     * Remove model object related cache
      *
      * @return $this
      */

--- a/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
@@ -186,7 +186,7 @@ abstract class Mage_Core_Model_Resource_Db_Abstract extends Mage_Core_Model_Reso
 
     /**
      * Set main entity table name and primary key field name
-     * If field name is ommited {table_name}_id will be used
+     * If field name is omitted {table_name}_id will be used
      *
      * @param string $mainTable
      * @param string|null $idFieldName
@@ -477,8 +477,8 @@ abstract class Mage_Core_Model_Resource_Db_Abstract extends Mage_Core_Model_Reso
     }
 
     /**
-     * Forsed save object data
-     * forsed update If duplicate unique key data
+     * Forced save object data
+     * forced update If duplicate unique key data
      *
      * @deprecated
      * @param Mage_Core_Model_Abstract $object
@@ -550,7 +550,7 @@ abstract class Mage_Core_Model_Resource_Db_Abstract extends Mage_Core_Model_Reso
     }
 
     /**
-     * Unserialize serializeable object fields
+     * Un-serialize serializable object fields
      *
      * @param Mage_Core_Model_Abstract $object
      */
@@ -755,7 +755,7 @@ abstract class Mage_Core_Model_Resource_Db_Abstract extends Mage_Core_Model_Reso
     }
 
     /**
-     * Serialize serializeable fields of the object
+     * Serialize serializable fields of the object
      *
      * @param Mage_Core_Model_Abstract $object
      */

--- a/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
@@ -103,7 +103,7 @@ abstract class Mage_Core_Model_Resource_Helper_Abstract
 
     /**
      * Escapes value, that participates in LIKE, with '\' symbol.
-     * Note: this func cannot be used on its own, because different RDMBS may use different default escape symbols,
+     * Note: this func cannot be used on its own, because different RDBMS may use different default escape symbols,
      * so you should either use addLikeEscape() to produce LIKE construction, or add escape symbol on your own.
      *
      * By default escapes '_', '%' and '\' symbols. If some masking symbols must not be escaped, then you can set

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Abstract.php
@@ -539,7 +539,7 @@ abstract class Mage_Eav_Model_Attribute_Data_Abstract
     abstract public function restoreValue($value);
 
     /**
-     * Return formated attribute value from entity model
+     * Return formatted attribute value from entity model
      *
      * @param string $format
      * @return string|array

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Date.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Date.php
@@ -120,7 +120,7 @@ class Mage_Eav_Model_Attribute_Data_Date extends Mage_Eav_Model_Attribute_Data_A
     }
 
     /**
-     * Return formated attribute value from entity model
+     * Return formatted attribute value from entity model
      *
      * @param string $format
      * @return string|array

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/File.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/File.php
@@ -258,7 +258,7 @@ class Mage_Eav_Model_Attribute_Data_File extends Mage_Eav_Model_Attribute_Data_A
     }
 
     /**
-     * Return formated attribute value from entity model
+     * Return formatted attribute value from entity model
      *
      * @param string $format
      * @return string|array

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Multiline.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Multiline.php
@@ -118,7 +118,7 @@ class Mage_Eav_Model_Attribute_Data_Multiline extends Mage_Eav_Model_Attribute_D
     }
 
     /**
-     * Return formated attribute value from entity model
+     * Return formatted attribute value from entity model
      *
      * @param string $format
      * @return string|array

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Multiselect.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Multiselect.php
@@ -56,7 +56,7 @@ class Mage_Eav_Model_Attribute_Data_Multiselect extends Mage_Eav_Model_Attribute
     }
 
     /**
-     * Return formated attribute value from entity model
+     * Return formatted attribute value from entity model
      *
      * @param string $format
      * @return string|array

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Select.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Select.php
@@ -108,7 +108,7 @@ class Mage_Eav_Model_Attribute_Data_Select extends Mage_Eav_Model_Attribute_Data
     }
 
     /**
-     * Return formated attribute value from entity model
+     * Return formatted attribute value from entity model
      *
      * @param string $format
      * @return string|array

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
@@ -115,7 +115,7 @@ class Mage_Eav_Model_Attribute_Data_Text extends Mage_Eav_Model_Attribute_Data_A
     }
 
     /**
-     * Return formated attribute value from entity model
+     * Return formatted attribute value from entity model
      *
      * @param string $format
      * @return string|array

--- a/app/code/core/Mage/Eav/Model/Form.php
+++ b/app/code/core/Mage/Eav/Model/Form.php
@@ -439,7 +439,7 @@ abstract class Mage_Eav_Model_Form
     }
 
     /**
-     * Return array of entity formated values
+     * Return array of entity formatted values
      *
      * @param string $format
      * @return array

--- a/app/code/core/Mage/GiftMessage/Helper/Message.php
+++ b/app/code/core/Mage/GiftMessage/Helper/Message.php
@@ -184,7 +184,7 @@ class Mage_GiftMessage_Helper_Message extends Mage_Core_Helper_Data
     }
 
     /**
-     * Retrieve escaped and preformated gift message text for specified entity
+     * Retrieve escaped and preformatted gift message text for specified entity
      *
      * @param Varien_Object $entity
      * @return string|null

--- a/app/code/core/Mage/Index/Model/Indexer.php
+++ b/app/code/core/Mage/Index/Model/Indexer.php
@@ -183,7 +183,7 @@ class Mage_Index_Model_Indexer
     }
 
     /**
-     * Check if onject actions are locked
+     * Check if object actions are locked
      *
      * @deprecated after 1.6.1.0
      * @return bool

--- a/app/code/core/Mage/Index/Model/Indexer/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Indexer/Abstract.php
@@ -145,7 +145,7 @@ abstract class Mage_Index_Model_Indexer_Abstract extends Mage_Core_Model_Abstrac
     }
 
     /**
-     * Try dynamicly detect and call event hanler from resource model.
+     * Try dynamically detect and call event handler from resource model.
      * Handler name will be generated from event entity and type code
      *
      * @param   Mage_Index_Model_Event $event

--- a/app/code/core/Mage/Payment/Model/Method/Abstract.php
+++ b/app/code/core/Mage/Payment/Model/Method/Abstract.php
@@ -376,7 +376,7 @@ abstract class Mage_Payment_Model_Method_Abstract extends Varien_Object
     }
 
     /**
-     * Retrieve payment iformation model object
+     * Retrieve payment information model object
      *
      * @return Mage_Payment_Model_Info
      */

--- a/app/code/core/Mage/Paypal/Controller/Express/Abstract.php
+++ b/app/code/core/Mage/Paypal/Controller/Express/Abstract.php
@@ -142,7 +142,7 @@ abstract class Mage_Paypal_Controller_Express_Abstract extends Mage_Core_Control
     {
         try {
             $this->_initToken(false);
-            // TODO verify if this logic of order cancelation is deprecated
+            // TODO verify if this logic of order cancellation is deprecated
             // if there is an order - cancel it
             $orderId = $this->_getCheckoutSession()->getLastOrderId();
             $order = ($orderId) ? Mage::getModel('sales/order')->load($orderId) : false;

--- a/app/code/core/Mage/Paypal/Model/Api/Abstract.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Abstract.php
@@ -305,7 +305,7 @@ abstract class Mage_Paypal_Model_Api_Abstract extends Varien_Object
     }
 
     /**
-     * Always take into accoun
+     * Always take into account
      */
     public function getFraudManagementFiltersEnabled()
     {

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
@@ -91,7 +91,7 @@ abstract class Mage_Reports_Model_Resource_Report_Abstract extends Mage_Core_Mod
     }
 
     /**
-     * Trancate table
+     * Truncate table
      *
      * @param string $table
      * @return Mage_Reports_Model_Resource_Report_Abstract

--- a/app/code/core/Mage/Rule/Model/Condition/Product/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Product/Abstract.php
@@ -504,7 +504,7 @@ abstract class Mage_Rule_Model_Condition_Product_Abstract extends Mage_Rule_Mode
     }
 
     /**
-     * Validate product attrbute value for condition
+     * Validate product attribute value for condition
      *
      * @param Varien_Object $object
      * @return bool

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Items.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Items.php
@@ -59,7 +59,7 @@ class Mage_Adminhtml_Block_Sales_Recurring_Profile_View_Items extends Mage_Admin
     }
 
     /**
-     * Retrieve formated price
+     * Retrieve formatted price
      *
      * @param   float $value
      * @return  string

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -1984,7 +1984,7 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
     }
 
     /**
-     * Get formated price value including order currency rate to order website currency
+     * Get formatted price value including order currency rate to order website currency
      *
      * @param   float $price
      * @param   bool  $addBrackets
@@ -2007,7 +2007,7 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
     }
 
     /**
-     * Retrieve text formated price value includeing order rate
+     * Retrieve text formatted price value including order rate
      *
      * @param   float $price
      * @return  string
@@ -2264,7 +2264,7 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
     }
 
     /**
-     * Get formated order created date in store timezone
+     * Get formatted order created date in store timezone
      *
      * @param   string $format date format type (short|medium|long|full)
      * @return  string

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Abstract.php
@@ -115,7 +115,7 @@ abstract class Mage_Sales_Model_Quote_Address_Total_Abstract
     }
 
     /**
-     * Set address shich can be used inside totals calculation
+     * Set address which can be used inside totals calculation
      *
      * @param   Mage_Sales_Model_Quote_Address $address
      * @return  Mage_Sales_Model_Quote_Address_Total_Abstract
@@ -238,7 +238,7 @@ abstract class Mage_Sales_Model_Quote_Address_Total_Abstract
     }
 
     /**
-     * Whether the item row total may be compouded with others
+     * Whether the item row total may be compounded with others
      *
      * @param Mage_Sales_Model_Quote_Item_Abstract $item
      * @return bool

--- a/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
@@ -26,7 +26,7 @@
  *  - original_price - product price before any calculations
  *  - calculation_price - prices for item totals calculation
  *  - custom_price - new price that can be declared by user and recalculated during calculation process
- *  - original_custom_price - original defined value of custom price without any convertion
+ *  - original_custom_price - original defined value of custom price without any conversion
  *
  * @category   Mage
  * @package    Mage_Sales
@@ -279,7 +279,7 @@ abstract class Mage_Sales_Model_Quote_Item_Abstract extends Mage_Core_Model_Abst
     }
 
     /**
-     * Get chil items
+     * Get child items
      *
      * @return $this[]
      */
@@ -722,7 +722,7 @@ abstract class Mage_Sales_Model_Quote_Item_Abstract extends Mage_Core_Model_Abst
     }
 
     /**
-     * Checking can we ship product separatelly (each child separately)
+     * Checking can we ship product separately (each child separately)
      * or each parent product item can be shipped only like one item
      *
      * @return bool

--- a/app/code/core/Mage/Wishlist/Block/Abstract.php
+++ b/app/code/core/Mage/Wishlist/Block/Abstract.php
@@ -242,7 +242,7 @@ abstract class Mage_Wishlist_Block_Abstract extends Mage_Catalog_Block_Product_A
     }
 
     /**
-     * Retrieve formated Date
+     * Retrieve formatted Date
      *
      * @param string $date
      * @return string


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Fixed a bunch of typos all over the core but in PHPDoc comment blocks only. During that I noticed some methods with those typos as well but that is a topic for a follow-up PR. 