### PR TITLE
Fixed phpstan-workflow

### DIFF
--- a/.github/workflows/static-code-analyses.yml
+++ b/.github/workflows/static-code-analyses.yml
@@ -9,7 +9,7 @@ jobs:
     name: PHP Syntax ${{ matrix.php-versions }}
     runs-on: ${{ matrix.operating-system }}
     strategy:
-      max-parallel: 5
+      max-parallel: 2
       matrix:
         operating-system: [ubuntu-latest]
         php-versions: ['7.3', '8.1']
@@ -34,11 +34,10 @@ jobs:
     name: PHP Stan ${{ matrix.directories }} - ${{ matrix.config_files }}
     runs-on: [ubuntu-latest]
     strategy:
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         directories: [
-          '',
-          #'lib/',
+          ''
         ]
         config_files: [
           '.github/phpstan.neon',
@@ -111,7 +110,7 @@ jobs:
     runs-on: [ubuntu-latest]
     needs: php_stan
     strategy:
-      max-parallel: 1
+      max-parallel: 6
       fail-fast: false
       matrix:
         directories: [

--- a/.github/workflows/static-code-analyses.yml
+++ b/.github/workflows/static-code-analyses.yml
@@ -91,14 +91,37 @@ jobs:
       fail-fast: false
       matrix:
         directories: [
-          '',
-          'lib/Mage',
-          'lib/Magento',
-          'lib/Varien',
+          ''
         ]
         config_files: [
-            '.github/phpstan.neon',
             '.github/phpstan_experimental_level.neon',
+        ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest --ignore-platform-reqs
+      - name: ensure existance of ./app/code/local
+        run: mkdir -p app/code/local
+      - name: PHPStan Static Analysis
+        continue-on-error: true
+        run: php vendor/bin/phpstan.phar analyze --error-format=raw -c ${{ matrix.config_files }} ${{ matrix.directories }}
+
+  php_stan_experimental_lib:
+    name: PHP Stan ${{ matrix.directories }} - ${{ matrix.config_files }} - experimental
+    runs-on: [ubuntu-latest]
+    needs: php_stan
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        directories: [
+          'lib/Mage',
+          'lib/Magento',
+          'lib/Varien'
+        ]
+        config_files: [
+          '.github/phpstan.neon',
+          '.github/phpstan_experimental_level.neon',
         ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/static-code-analyses.yml
+++ b/.github/workflows/static-code-analyses.yml
@@ -37,11 +37,11 @@ jobs:
       max-parallel: 2
       matrix:
         directories: [
-            '',
-            #'lib/',
+          '',
+          #'lib/',
         ]
         config_files: [
-            '.github/phpstan.neon',
+          '.github/phpstan.neon',
         ]
     steps:
       - uses: actions/checkout@v3
@@ -91,18 +91,15 @@ jobs:
       fail-fast: false
       matrix:
         directories: [
-          ''
+          '',
+          'lib/Mage',
+          'lib/Magento',
+          'lib/Varien',
         ]
         config_files: [
+            '.github/phpstan.neon',
             '.github/phpstan_experimental_level.neon',
         ]
-        include:
-          - directories: [
-            'lib/Mage',
-            'lib/Magento',
-            'lib/Varien'
-          ]
-            config_files: '.github/phpstan.neon'
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Fixed wrong syntax in last commit.

Old: https://github.com/OpenMage/magento-lts/actions/runs/3034521929/jobs/4883776430

> Run php vendor/bin/phpstan.phar analyze --error-format=raw -c .github/phpstan.neon Array
Path /home/runner/work/magento-lts/magento-lts/Array does not exist
Error: Process completed with exit code 1.

Fixed: https://github.com/sreichel/magento-lts/actions/runs/3040478719/jobs/4896569112

### Related Pull Requests
<!-- related pull request placeholder -->

1. See OpenMage/magento-lts#2589

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->