### PR TITLE
remove scriptaculous/effects.js dependency in js/prototype/validation.js

### DIFF
--- a/js/prototype/validation.js
+++ b/js/prototype/validation.js
@@ -237,7 +237,11 @@ Object.extend(Validation, {
     },
     hideAdvice : function(elm, advice){
         if (advice != null) {
-            new Effect.Fade(advice, {duration : 1, afterFinishInternal : function() {advice.hide();}});
+            if(typeof Effect == 'undefined') {
+                advice.hide();
+            } else {
+                new Effect.Fade(advice, {duration : 1, afterFinishInternal : function() {advice.hide();}});
+            }
         }
     },
     updateCallback : function(elm, status) {


### PR DESCRIPTION
### Description (*)
if scriptaculous/effects.js is not loaded hideAdvice function return an error
make validation.js indipendent from scriptaculous/effects.js so we can remove this library to optimize page load 
PS: like in showAdvice() function

### Manual testing scenarios (*)
1. remove scriptaculous/effects.js 
```
<layout version="0.1.0">
	<default>
		<reference name="head">
			<action method="removeItem">
				<type>js</type>
				<name>scriptaculous/effects.js</name>
			</action>
		</reference>
	</default>
</layout>
```
2. test some form validation, first input wrong data then enter validated data
error advice not disappear and return error:
Uncaught ReferenceError: Effect is not defined

