### PR TITLE
[PHP 8.1] Fix passing null to preg_split limit param

### DIFF
--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -396,7 +396,7 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
         $allowedIps = Mage::getStoreConfig(self::XML_PATH_DEV_ALLOW_IPS, $storeId);
         $remoteAddr = Mage::helper('core/http')->getRemoteAddr();
         if (!empty($allowedIps) && !empty($remoteAddr)) {
-            $allowedIps = preg_split('#\s*,\s*#', $allowedIps, null, PREG_SPLIT_NO_EMPTY);
+            $allowedIps = preg_split('#\s*,\s*#', $allowedIps, -1, PREG_SPLIT_NO_EMPTY);
             if (array_search($remoteAddr, $allowedIps) === false
                 && array_search(Mage::helper('core/http')->getHttpHost(), $allowedIps) === false) {
                 $allow = false;

--- a/app/code/core/Mage/Core/Helper/String.php
+++ b/app/code/core/Mage/Core/Helper/String.php
@@ -183,7 +183,7 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
             }
         } // split smartly, keeping words
         else {
-            $split = preg_split('/(' . $wordSeparatorRegex . '+)/siu', $str, null, PREG_SPLIT_DELIM_CAPTURE);
+            $split = preg_split('/(' . $wordSeparatorRegex . '+)/siu', $str, -1, PREG_SPLIT_DELIM_CAPTURE);
             $i        = 0;
             $space    = '';
             $spaceLen = 0;
@@ -253,7 +253,7 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
     public function splitWords($str, $uniqueOnly = false, $maxWordLength = 0, $wordSeparatorRegexp = '\s')
     {
         $result = [];
-        $split = preg_split('#' . $wordSeparatorRegexp . '#siu', $str, null, PREG_SPLIT_NO_EMPTY);
+        $split = preg_split('#' . $wordSeparatorRegexp . '#siu', $str, -1, PREG_SPLIT_NO_EMPTY);
         foreach ($split as $word) {
             if ($uniqueOnly) {
                 $result[$word] = $word;

--- a/app/code/core/Mage/Cron/Model/Schedule.php
+++ b/app/code/core/Mage/Cron/Model/Schedule.php
@@ -66,7 +66,7 @@ class Mage_Cron_Model_Schedule extends Mage_Core_Model_Abstract
      */
     public function setCronExpr($expr)
     {
-        $e = preg_split('#\s+#', $expr, null, PREG_SPLIT_NO_EMPTY);
+        $e = preg_split('#\s+#', $expr, -1, PREG_SPLIT_NO_EMPTY);
         if (count($e) < 5 || count($e) > 6) {
             throw Mage::exception('Mage_Cron', 'Invalid cron expression: '.$expr);
         }

--- a/app/code/core/Mage/Rule/Model/Condition/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Abstract.php
@@ -338,7 +338,7 @@ abstract class Mage_Rule_Model_Condition_Abstract extends Varien_Object implemen
         if (!$this->hasValueParsed()) {
             $value = $this->getData('value');
             if ($this->isArrayOperatorType() && is_string($value)) {
-                $value = preg_split('#\s*[,;]\s*#', $value, null, PREG_SPLIT_NO_EMPTY);
+                $value = preg_split('#\s*[,;]\s*#', $value, -1, PREG_SPLIT_NO_EMPTY);
             }
             $this->setValueParsed($value);
         }

--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -721,7 +721,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
      */
     protected function _splitMultiQuery($sql)
     {
-        $parts = preg_split('#(;|\'|"|\\\\|//|--|\n|/\*|\*/)#', $sql, null,
+        $parts = preg_split('#(;|\'|"|\\\\|//|--|\n|/\*|\*/)#', $sql, -1,
             PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE
         );
 

--- a/lib/Varien/Event/Observer/Cron.php
+++ b/lib/Varien/Event/Observer/Cron.php
@@ -41,7 +41,7 @@ class Varien_Event_Observer_Cron extends Varien_Event_Observer
      */
     public function isValidFor(Varien_Event $event)
     {
-        $e = preg_split('#\s+#', $this->getCronExpr(), null, PREG_SPLIT_NO_EMPTY);
+        $e = preg_split('#\s+#', $this->getCronExpr(), -1, PREG_SPLIT_NO_EMPTY);
         if (count($e) !== 5) {
             return false;
         }


### PR DESCRIPTION
### Description (*)
This PR fixes the deprecation error in PHP 8.1 when passing `null` to `preg_split`'s limit parameter, it should default to -1 if not being used.

### Related Pull Requests
This PR was extracted from #2586 for ease of review and merging.

### Manual testing scenarios (*)
1. You should no longer see any deprecation errors related to `preg_split` usages.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->