### PR TITLE
conditionaly insert/remove translator inline on frontend

### DIFF
--- a/app/code/core/Mage/Core/Helper/Js.php
+++ b/app/code/core/Mage/Core/Helper/Js.php
@@ -68,6 +68,10 @@ class Mage_Core_Helper_Js extends Mage_Core_Helper_Abstract
      */
     public function getTranslatorScript()
     {
+        if (!Mage::helper('core')->isDevAllowed() || !Mage::getStoreConfigFlag('dev/translate_inline/active')) { 
+            return;
+        }
+
         $script = 'var Translator = new Translate('.$this->getTranslateJson().');';
         return $this->getScript($script);
     }

--- a/app/design/frontend/base/default/layout/page.xml
+++ b/app/design/frontend/base/default/layout/page.xml
@@ -40,7 +40,7 @@ Default layout, loads most of the pages
                 <action method="addJs"><script>varien/js.js</script></action>
                 <action method="addJs"><script>varien/form.js</script></action>
                 <action method="addJs"><script>varien/menu.js</script></action>
-                <action method="addJs"><script>mage/translate.js</script></action>
+                <action method="addJs" ifconfig="dev/translate_inline/active"><script>mage/translate.js</script></action>
                 <action method="addJs"><script>mage/cookies.js</script></action>
 
                 <block type="page/js_cookie" name="js_cookies" template="page/js/cookie.phtml"/>
@@ -116,7 +116,7 @@ Default layout, loads most of the pages
 
             <block type="page/html_head" name="head" as="head">
                 <action method="addJs"><script>prototype/prototype.js</script></action>
-                <action method="addJs"><script>mage/translate.js</script></action>
+                <action method="addJs" ifconfig="dev/translate_inline/active"><script>mage/translate.js</script></action>
                 <action method="addJs"><script>lib/ccard.js</script></action>
                 <action method="addJs"><script>prototype/validation.js</script></action>
                 <action method="addJs"><script>varien/js.js</script></action>


### PR DESCRIPTION
add condition to inline translator scripts
include only if translation config is enabled and and dev ip is allowed

remove Translator data on frontend like "var Translator = new Translate..."
and the inclusion of the script mage/translate.js

