### PR TITLE
Convert Exception to Throwable in Mage_Core_Block_Template.

### DIFF
--- a/app/code/core/Mage/Core/Block/Template.php
+++ b/app/code/core/Mage/Core/Block/Template.php
@@ -259,9 +259,12 @@ HTML;
                 $thisClass = get_class($this);
                 Mage::log('Not valid template file:' . $fileName . ' class: ' . $thisClass, Zend_Log::CRIT, null, true);
             }
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             ob_get_clean();
-            throw $e;
+            if (Mage::getIsDeveloperMode()) {
+                throw $e;
+            }
+            Mage::logException($e);
         }
 
         if ($hints) {


### PR DESCRIPTION
### Description (*)
This will save some hours for developers, which need to see exceptions. Without this change, a whole class of errors are not caught. See discussion #2606.

### Related Pull Requests
PR #1442 is not going to be merged anytime soon, so why not fix this file first.

