### PR TITLE
Fixed javascript error on adminhtml login page caused by #2149

### DIFF
--- a/js/mage/adminhtml/form.js
+++ b/js/mage/adminhtml/form.js
@@ -611,4 +611,6 @@ function setPostcodeOptional(zipElement, country) {
     }
 }
 
-varienGlobalEvents.attachEventHandler("address_country_changed", onAddressCountryChanged);
+if (typeof varienGlobalEvents != 'undefined') {
+    varienGlobalEvents.attachEventHandler("address_country_changed", onAddressCountryChanged);
+}


### PR DESCRIPTION
After #2149 the backend's login page shows a javascript error

<img width="463" alt="Schermata 2022-09-28 alle 21 42 24" src="https://user-images.githubusercontent.com/909743/192884664-90bf236c-90b7-4084-9d51-96cfee00ebbd.png">

With this PR the error is gone