### PR TITLE
Check if remote storage is enabled before saving local file

### DIFF
--- a/app/code/core/Mage/Core/Model/File/Storage.php
+++ b/app/code/core/Mage/Core/Model/File/Storage.php
@@ -105,9 +105,6 @@ class Mage_Core_Model_File_Storage extends Mage_Core_Model_Abstract
             case self::STORAGE_MEDIA_DATABASE:
                 $connection = $params['connection'] ?? null;
                 $model = Mage::getModel('core/file_storage_database', ['connection' => $connection]);
-                // Always initialize database storage to ensure the table exists
-                // see: https://github.com/OpenMage/magento-lts/pull/2627
-                $params['init'] = true;
                 break;
             default:
                 return false;

--- a/app/code/core/Mage/Core/Model/File/Storage.php
+++ b/app/code/core/Mage/Core/Model/File/Storage.php
@@ -105,6 +105,9 @@ class Mage_Core_Model_File_Storage extends Mage_Core_Model_Abstract
             case self::STORAGE_MEDIA_DATABASE:
                 $connection = $params['connection'] ?? null;
                 $model = Mage::getModel('core/file_storage_database', ['connection' => $connection]);
+                // Always initialize database storage to ensure the table exists
+                // see: https://github.com/OpenMage/magento-lts/pull/2627
+                $params['init'] = true;
                 break;
             default:
                 return false;

--- a/get.php
+++ b/get.php
@@ -141,6 +141,11 @@ if (substr_count($relativeFilename, '/') > 10) {
     sendNotFoundPage();
 }
 
+// Nothing to do if DB storage is disabled
+if (!Mage::helper('core/file_storage_database')->checkDbUsage()) {
+    sendNotFoundPage();
+}
+
 $localStorage = Mage::getModel('core/file_storage_file');
 $remoteStorage = Mage::getModel('core/file_storage_database');
 try {


### PR DESCRIPTION

### Description (*)
This PR will add a simple check if remote DB storage for media is enabled before trying to write the file locally (using `get.php`). This will prevent unnecessary exceptions from being logged that say `core_file_storage` doesn't exist, since it's often created at runtime.

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#2614

### Manual testing scenarios (*)
1. Have logging enabled and try to access a non-existent media file. e.g: `http://<magento_host>/media/catalog/notfound.jpg`. You will see an exception logged before this patch, but not after.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->