### PR TITLE
Update hardcoded credit card message in checkout

### DIFF
--- a/app/design/frontend/base/default/template/checkout/onepage/review/totals.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review/totals.phtml
@@ -30,7 +30,7 @@
     <?php if ($this->needDisplayBaseGrandtotal()):?>
     <tr>
         <td class="a-right" colspan="<?php echo $_colspan; ?>">
-            <small><?php echo $this->helper('sales')->__('Your credit card will be charged for') ?></small>
+            <small><?php echo $this->helper('sales')->__('Grand Total to be Charged') ?></small>
         </td>
         <td class="a-right">
             <small><?php echo $this->displayBaseGrandtotal() ?></small>

--- a/app/design/frontend/default/iphone/template/checkout/onepage/review/totals.phtml
+++ b/app/design/frontend/default/iphone/template/checkout/onepage/review/totals.phtml
@@ -30,7 +30,7 @@
     <?php if ($this->needDisplayBaseGrandtotal()):?>
     <tr>
         <td class="a-right" colspan="<?php echo $_colspan; ?>">
-            <small><?php echo $this->helper('sales')->__('Your credit card will be charged for') ?></small>
+            <small><?php echo $this->helper('sales')->__('Grand Total to be Charged') ?></small>
         </td>
         <td class="a-right">
             <small><?php echo $this->displayBaseGrandtotal() ?></small>


### PR DESCRIPTION
### Description (*)

This PR will update the hardcoded message in checkout when the quote currency is different from the base one. The old message always says "Your credit card will be charged for" regardless of the payment method. I updated it with the same message from the order view in frontend that says "Grand Total to be Charged", which should be translated in language packs.

### Fixed Issues (if relevant)

1. Fixes OpenMage/magento-lts#1953

### Manual testing scenarios (*)

1. Have at least 2 allowed currencies in a store.
2. Set your currency to something different from the base currency (`currency/options/base`).
3. Go through the checkout and you should see the new message in "Review" step.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->