### PR TITLE
Small improvements to RWD's "toolbar"

### DIFF
--- a/skin/frontend/rwd/default/css/madisonisland-ie8.css
+++ b/skin/frontend/rwd/default/css/madisonisland-ie8.css
@@ -1,21 +1,36 @@
-/**
- * OpenMage
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Academic Free License (AFL 3.0)
- * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
- *
- * @category    design
- * @package     rwd_default
- * @copyright   Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
- * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- */
+/*
+// ----------------------------------------------
+// Usage example:
+// For IE set $mq-support to false.
+// Set the fixed value.
+// Then use mixins to test whether styles should be applied.
+// ----------------------------------------------
+
+$mq-support: false;
+$mq-fixed-value: 1024;
+
+// Renders at fixed value
+@include bp (min-width, 300px) {
+    div { color:#000; }
+}
+
+// Doesn't render without MQ support
+@include bp (min-width, 1200px) {
+    div { color:#FFF; }
+}
+
+// Doesn't render without MQ support
+@include bp (max-width, 300px) {
+    div { color:#444; }
+}
+
+// Renders at fixed value
+@include bp (max-width, 1200px) {
+    div { color:#888; }
+}
+
+// ----------------------------------------------
+*/
 /* ============================================ *
  * Homepage
  * ============================================ */
@@ -75,7 +90,7 @@ body .promos > li {
   list-style: none;
   text-align: center;
   position: relative;
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   -moz-user-select: none;
   -ms-user-select: none;
   -webkit-user-select: none;
@@ -159,10 +174,10 @@ body .promos > li {
 .cms-index-index h2.subtitle {
   padding: 6px 0;
   text-align: center;
-  color: #3399cc;
+  color: #3399CC;
   font-weight: 600;
-  border-bottom: 1px solid #cccccc;
-  border-top: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
+  border-top: 1px solid #CCCCCC;
 }
 
 .cms-index-noroute h2.subtitle {

--- a/skin/frontend/rwd/default/css/madisonisland-ie8.css
+++ b/skin/frontend/rwd/default/css/madisonisland-ie8.css
@@ -1,36 +1,21 @@
-/*
-// ----------------------------------------------
-// Usage example:
-// For IE set $mq-support to false.
-// Set the fixed value.
-// Then use mixins to test whether styles should be applied.
-// ----------------------------------------------
-
-$mq-support: false;
-$mq-fixed-value: 1024;
-
-// Renders at fixed value
-@include bp (min-width, 300px) {
-    div { color:#000; }
-}
-
-// Doesn't render without MQ support
-@include bp (min-width, 1200px) {
-    div { color:#FFF; }
-}
-
-// Doesn't render without MQ support
-@include bp (max-width, 300px) {
-    div { color:#444; }
-}
-
-// Renders at fixed value
-@include bp (max-width, 1200px) {
-    div { color:#888; }
-}
-
-// ----------------------------------------------
-*/
+/**
+ * OpenMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE_AFL.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * @category    design
+ * @package     rwd_default
+ * @copyright   Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
+ * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
 /* ============================================ *
  * Homepage
  * ============================================ */

--- a/skin/frontend/rwd/default/css/madisonisland.css
+++ b/skin/frontend/rwd/default/css/madisonisland.css
@@ -1,21 +1,36 @@
-/**
- * OpenMage
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Academic Free License (AFL 3.0)
- * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
- *
- * @category    design
- * @package     rwd_default
- * @copyright   Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
- * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- */
+/*
+// ----------------------------------------------
+// Usage example:
+// For IE set $mq-support to false.
+// Set the fixed value.
+// Then use mixins to test whether styles should be applied.
+// ----------------------------------------------
+
+$mq-support: false;
+$mq-fixed-value: 1024;
+
+// Renders at fixed value
+@include bp (min-width, 300px) {
+    div { color:#000; }
+}
+
+// Doesn't render without MQ support
+@include bp (min-width, 1200px) {
+    div { color:#FFF; }
+}
+
+// Doesn't render without MQ support
+@include bp (max-width, 300px) {
+    div { color:#444; }
+}
+
+// Renders at fixed value
+@include bp (max-width, 1200px) {
+    div { color:#888; }
+}
+
+// ----------------------------------------------
+*/
 /* ============================================ *
  * Homepage
  * ============================================ */
@@ -97,7 +112,7 @@ body .promos > li {
   list-style: none;
   text-align: center;
   position: relative;
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   -moz-user-select: none;
   -ms-user-select: none;
   -webkit-user-select: none;
@@ -183,10 +198,10 @@ body .promos > li {
 .cms-index-index h2.subtitle {
   padding: 6px 0;
   text-align: center;
-  color: #3399cc;
+  color: #3399CC;
   font-weight: 600;
-  border-bottom: 1px solid #cccccc;
-  border-top: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
+  border-top: 1px solid #CCCCCC;
 }
 
 .cms-index-noroute h2.subtitle {
@@ -217,12 +232,12 @@ body .promos > li {
   width: 23% !important;
   margin-right: 2.66667% !important;
   margin-bottom: 10px;
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   padding: 10px;
 }
 
 .catblocks li:hover {
-  border-color: #3399cc;
+  border-color: #3399CC;
 }
 
 @media only screen and (max-width: 770px) {

--- a/skin/frontend/rwd/default/css/madisonisland.css
+++ b/skin/frontend/rwd/default/css/madisonisland.css
@@ -1,36 +1,21 @@
-/*
-// ----------------------------------------------
-// Usage example:
-// For IE set $mq-support to false.
-// Set the fixed value.
-// Then use mixins to test whether styles should be applied.
-// ----------------------------------------------
-
-$mq-support: false;
-$mq-fixed-value: 1024;
-
-// Renders at fixed value
-@include bp (min-width, 300px) {
-    div { color:#000; }
-}
-
-// Doesn't render without MQ support
-@include bp (min-width, 1200px) {
-    div { color:#FFF; }
-}
-
-// Doesn't render without MQ support
-@include bp (max-width, 300px) {
-    div { color:#444; }
-}
-
-// Renders at fixed value
-@include bp (max-width, 1200px) {
-    div { color:#888; }
-}
-
-// ----------------------------------------------
-*/
+/**
+ * OpenMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE_AFL.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * @category    design
+ * @package     rwd_default
+ * @copyright   Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
+ * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
 /* ============================================ *
  * Homepage
  * ============================================ */

--- a/skin/frontend/rwd/default/css/scaffold-forms.css
+++ b/skin/frontend/rwd/default/css/scaffold-forms.css
@@ -1,21 +1,36 @@
-/**
- * OpenMage
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Academic Free License (AFL 3.0)
- * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
- *
- * @category    design
- * @package     rwd_default
- * @copyright   Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
- * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- */
+/*
+// ----------------------------------------------
+// Usage example:
+// For IE set $mq-support to false.
+// Set the fixed value.
+// Then use mixins to test whether styles should be applied.
+// ----------------------------------------------
+
+$mq-support: false;
+$mq-fixed-value: 1024;
+
+// Renders at fixed value
+@include bp (min-width, 300px) {
+    div { color:#000; }
+}
+
+// Doesn't render without MQ support
+@include bp (min-width, 1200px) {
+    div { color:#FFF; }
+}
+
+// Doesn't render without MQ support
+@include bp (max-width, 300px) {
+    div { color:#444; }
+}
+
+// Renders at fixed value
+@include bp (max-width, 1200px) {
+    div { color:#888; }
+}
+
+// ----------------------------------------------
+*/
 /* ============================================ *
  * SCAFFOLD FORM
  * ============================================ */

--- a/skin/frontend/rwd/default/css/scaffold-forms.css
+++ b/skin/frontend/rwd/default/css/scaffold-forms.css
@@ -1,36 +1,21 @@
-/*
-// ----------------------------------------------
-// Usage example:
-// For IE set $mq-support to false.
-// Set the fixed value.
-// Then use mixins to test whether styles should be applied.
-// ----------------------------------------------
-
-$mq-support: false;
-$mq-fixed-value: 1024;
-
-// Renders at fixed value
-@include bp (min-width, 300px) {
-    div { color:#000; }
-}
-
-// Doesn't render without MQ support
-@include bp (min-width, 1200px) {
-    div { color:#FFF; }
-}
-
-// Doesn't render without MQ support
-@include bp (max-width, 300px) {
-    div { color:#444; }
-}
-
-// Renders at fixed value
-@include bp (max-width, 1200px) {
-    div { color:#888; }
-}
-
-// ----------------------------------------------
-*/
+/**
+ * OpenMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE_AFL.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * @category    design
+ * @package     rwd_default
+ * @copyright   Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
+ * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
 /* ============================================ *
  * SCAFFOLD FORM
  * ============================================ */

--- a/skin/frontend/rwd/default/css/styles-ie8.css
+++ b/skin/frontend/rwd/default/css/styles-ie8.css
@@ -1,21 +1,36 @@
-/**
- * OpenMage
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Academic Free License (AFL 3.0)
- * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
- *
- * @category    design
- * @package     rwd_default
- * @copyright   Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
- * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- */
+/*
+// ----------------------------------------------
+// Usage example:
+// For IE set $mq-support to false.
+// Set the fixed value.
+// Then use mixins to test whether styles should be applied.
+// ----------------------------------------------
+
+$mq-support: false;
+$mq-fixed-value: 1024;
+
+// Renders at fixed value
+@include bp (min-width, 300px) {
+    div { color:#000; }
+}
+
+// Doesn't render without MQ support
+@include bp (min-width, 1200px) {
+    div { color:#FFF; }
+}
+
+// Doesn't render without MQ support
+@include bp (max-width, 300px) {
+    div { color:#444; }
+}
+
+// Renders at fixed value
+@include bp (max-width, 1200px) {
+    div { color:#888; }
+}
+
+// ----------------------------------------------
+*/
 /*! normalize.css v2.0.1 | MIT License | git.io/normalize */
 /* ==========================================================================
    HTML5 display definitions
@@ -371,15 +386,15 @@ table {
 *,
 *:before,
 *:after {
-  -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
   box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
 
 html {
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  -webkit-tap-highlight-color: transparent;
   /* Prevent tap highlight on iOS/Android */
   -webkit-text-size-adjust: 100%;
   /* Prevent automatic scaling on iOS */
@@ -463,15 +478,12 @@ input[type="search"] {
 @-ms-viewport {
   width: device-width;
 }
-
 @-o-viewport {
   width: device-width;
 }
-
 @viewport {
   width: device-width;
 }
-
 a, button {
   -ms-touch-action: manipulation;
   touch-action: manipulation;
@@ -490,7 +502,7 @@ textarea {
 }
 
 a {
-  color: #3399cc;
+  color: #3399CC;
   text-decoration: none;
 }
 
@@ -517,7 +529,7 @@ ul {
 h1, .h1 {
   margin: 0;
   margin-bottom: 0.7em;
-  color: #3399cc;
+  color: #3399CC;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
   font-size: 28px;
   font-weight: 400;
@@ -610,16 +622,16 @@ h6, .h6 {
 }
 
 .availability.in-stock {
-  color: #11b400;
+  color: #11B400;
 }
 
 .availability.available-soon,
 .availability.out-of-stock {
-  color: #df280a;
+  color: #DF280A;
 }
 
 .availability-only {
-  color: #df280a;
+  color: #DF280A;
   margin-bottom: 10px;
 }
 
@@ -634,7 +646,7 @@ h6, .h6 {
   font-size: 24px;
   font-weight: 600;
   color: #636363;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
   padding-bottom: 3px;
   margin-bottom: 15px;
   text-transform: uppercase;
@@ -670,7 +682,7 @@ h6, .h6 {
   line-height: 1.4;
   text-rendering: optimizeSpeed;
   text-transform: uppercase;
-  color: #3399cc;
+  color: #3399CC;
   margin-bottom: 0;
   text-transform: uppercase;
   font-weight: 600;
@@ -678,7 +690,7 @@ h6, .h6 {
 .block-title small {
   font-size: 100%;
   font-weight: normal;
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 body:not(.customer-account) .block:first-child .block-title {
@@ -745,7 +757,7 @@ body:not(.customer-account) .block:first-child .block-title {
 .block-account li strong,
 .block-cms-menu li strong {
   font-weight: 400;
-  color: #3399cc;
+  color: #3399CC;
 }
 .block-account li a,
 .block-cms-menu li a {
@@ -753,7 +765,7 @@ body:not(.customer-account) .block:first-child .block-title {
 }
 .block-account li a:hover,
 .block-cms-menu li a:hover {
-  color: #3399cc;
+  color: #3399CC;
 }
 
 /* ============================================ *
@@ -764,7 +776,7 @@ body:not(.customer-account) .block:first-child .block-title {
 .cart-table .button,
 .sidebar .actions .button,
 .button.button-secondary {
-  background: #dddddd;
+  background: #DDDDDD;
   color: #636363;
   padding: 7px 15px;
 }
@@ -800,7 +812,7 @@ body:not(.customer-account) .block:first-child .block-title {
 .cart-table .product-cart-actions .button,
 #co-shipping-method-form .buttons-set .button,
 .footer .button {
-  background: #3399cc;
+  background: #3399CC;
   display: inline-block;
   padding: 7px 15px;
   border: 0;
@@ -878,7 +890,7 @@ a.button:hover {
   text-decoration: underline;
   text-transform: uppercase;
   display: inline-block;
-  color: #3399cc;
+  color: #3399CC;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
 }
 .button2 span:hover,
@@ -922,7 +934,7 @@ a.button:hover {
   clear: both;
   margin: 10px 0 0;
   padding-top: 10px;
-  border-top: 1px solid #ededed;
+  border-top: 1px solid #EDEDED;
   text-align: right;
 }
 .buttons-set p.required {
@@ -990,7 +1002,7 @@ a.button:hover {
 }
 
 .breadcrumbs a:hover {
-  color: #3399cc;
+  color: #3399CC;
 }
 
 .breadcrumbs strong {
@@ -1011,7 +1023,7 @@ a.button:hover {
   display: inline-block;
   width: 20px;
   height: 20px;
-  border: 1px solid #ededed;
+  border: 1px solid #EDEDED;
   text-align: center;
   /* Hide text */
   font: 0/0 a;
@@ -1021,13 +1033,13 @@ a.button:hover {
 }
 .btn-remove:hover,
 .btn-previous:hover {
-  background-color: #3399cc;
-  border-color: #3399cc;
+  background-color: #3399CC;
+  border-color: #3399CC;
 }
 
 .btn-remove:after {
   content: 'X';
-  color: #3399cc;
+  color: #3399CC;
   height: 20px;
   line-height: 20px;
   width: 100%;
@@ -1062,7 +1074,7 @@ a.button:hover {
   display: block;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
-  border-right: 4px solid #3399cc;
+  border-right: 4px solid #3399CC;
   border-left: none;
   position: absolute;
   top: 50%;
@@ -1078,7 +1090,7 @@ a.button:hover {
   display: block;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
-  border-right: 4px solid white;
+  border-right: 4px solid #FFFFFF;
   border-left: none;
 }
 
@@ -1105,8 +1117,8 @@ a.button:hover {
   max-height: 125px;
   margin-bottom: 10px;
   padding: 10px;
-  border: 1px solid #cccccc;
-  background: #f4f4f4;
+  border: 1px solid #CCCCCC;
+  background: #F4F4F4;
 }
 
 /* -------------------------------------------- *
@@ -1262,7 +1274,7 @@ a.button:hover {
  */
 .global-site-notice {
   background: #676157;
-  color: #e6e6e6;
+  color: #E6E6E6;
   font-size: 11px;
 }
 .global-site-notice .notice-inner {
@@ -1284,7 +1296,7 @@ a.button:hover {
  * Promotional Message Banner
  */
 .promo-msg {
-  color: #3399cc;
+  color: #3399CC;
   text-align: center;
   margin: 10px;
   text-transform: uppercase;
@@ -1304,16 +1316,16 @@ a.button:hover {
  * Messages
  */
 .success {
-  color: #11b400;
+  color: #11B400;
 }
 
 .error {
-  color: #df280a;
+  color: #DF280A;
   font-weight: bold;
 }
 
 .notice {
-  color: #e26703;
+  color: #E26703;
   font-weight: bold;
 }
 
@@ -1328,7 +1340,7 @@ a.button:hover {
   position: relative;
   margin-bottom: 5px;
   padding: 7px 10px 7px 20px;
-  background: #f4f4f4;
+  background: #F4F4F4;
   font-size: 15px;
 }
 
@@ -1339,9 +1351,9 @@ a.button:hover {
 }
 
 .messages .error-msg li {
-  color: black;
-  border-left: 5px solid #df280a;
-  background-color: #faebe7;
+  color: #000000;
+  border-left: 5px solid #DF280A;
+  background-color: #FAEBE7;
 }
 
 .messages .error-msg li:before {
@@ -1352,14 +1364,14 @@ a.button:hover {
   display: block;
   border-top: 6px solid transparent;
   border-bottom: 6px solid transparent;
-  border-left: 6px solid #df280a;
+  border-left: 6px solid #DF280A;
   border-right: none;
 }
 
 .messages .notice-msg li {
-  color: black;
-  border-left: 5px solid #e26703;
-  background-color: #f9ebe6;
+  color: #000000;
+  border-left: 5px solid #E26703;
+  background-color: #F9EBE6;
 }
 
 .messages .notice-msg li:before {
@@ -1370,14 +1382,14 @@ a.button:hover {
   display: block;
   border-top: 6px solid transparent;
   border-bottom: 6px solid transparent;
-  border-left: 6px solid #e26703;
+  border-left: 6px solid #E26703;
   border-right: none;
 }
 
 .messages .success-msg li {
-  color: black;
-  border-left: 5px solid #11b400;
-  background-color: #eff5ea;
+  color: #000000;
+  border-left: 5px solid #11B400;
+  background-color: #EFF5EA;
 }
 
 .messages .success-msg li:before {
@@ -1388,7 +1400,7 @@ a.button:hover {
   display: block;
   border-top: 6px solid transparent;
   border-bottom: 6px solid transparent;
-  border-left: 6px solid #11b400;
+  border-left: 6px solid #11B400;
   border-right: none;
 }
 
@@ -1442,8 +1454,8 @@ a.button:hover {
   max-width: 100%;
   margin: 5px 15px 15px;
   padding: 15px;
-  border: 1px solid #cccccc;
-  background: #f4f4f4;
+  border: 1px solid #CCCCCC;
+  background: #F4F4F4;
 }
 
 .payment-methods .form-list:before {
@@ -1454,7 +1466,7 @@ a.button:hover {
   display: block;
   border-right: 10px solid transparent;
   border-left: 10px solid transparent;
-  border-bottom: 10px solid #cccccc;
+  border-bottom: 10px solid #CCCCCC;
   border-top: none;
   top: -11px;
   left: 30px;
@@ -1468,7 +1480,7 @@ a.button:hover {
   display: block;
   border-right: 10px solid transparent;
   border-left: 10px solid transparent;
-  border-bottom: 10px solid #f4f4f4;
+  border-bottom: 10px solid #F4F4F4;
   border-top: none;
   top: -10px;
   left: 30px;
@@ -1509,11 +1521,11 @@ a.button:hover {
 }
 
 .price-notice {
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 .price-box .price {
-  color: #3399cc;
+  color: #3399CC;
   font-size: 16px;
 }
 
@@ -1523,19 +1535,19 @@ a.button:hover {
 }
 
 .price-box .price-label {
-  color: #a0a0a0;
+  color: #A0A0A0;
   white-space: nowrap;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
 }
 
 .price-box .minimal-price-link {
   padding-left: 1em;
-  color: #3399cc;
+  color: #3399CC;
   display: block;
   /* We want this to show on its own line, otherwise the layout looks funky */
 }
 .price-box .minimal-price-link .label {
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 /* -------------------------------------------- *
@@ -1555,12 +1567,12 @@ a.button:hover {
 }
 
 .price-box .old-price .price {
-  color: #a0a0a0;
+  color: #A0A0A0;
   text-decoration: line-through;
 }
 
 .price-box .special-price {
-  color: #3399cc;
+  color: #3399CC;
   padding-left: 1em;
 }
 .price-box .special-price .price-label {
@@ -1660,7 +1672,7 @@ span.weee {
   z-index: 300;
   width: 200px;
   padding: 8px;
-  border: 1px solid #3399cc;
+  border: 1px solid #3399CC;
   background-color: #F6F6F6;
   top: 21px;
   left: -100px;
@@ -1673,7 +1685,7 @@ span.weee {
   display: block;
   border-right: 7px solid transparent;
   border-left: 7px solid transparent;
-  border-bottom: 7px solid #3399cc;
+  border-bottom: 7px solid #3399CC;
   border-top: none;
   left: 97px;
   top: -7px;
@@ -1720,11 +1732,11 @@ span.weee {
 .no-touch .product-img-box .product-image:not(.zoom-available):hover {
   position: relative;
   display: block;
-  border: 1px solid #ededed;
+  border: 1px solid #EDEDED;
 }
 
 .no-touch .product-image:hover {
-  border-color: #3399cc;
+  border-color: #3399CC;
 }
 
 /* -------------------------------------------- *
@@ -1784,7 +1796,7 @@ span.weee {
 }
 
 .std .note {
-  color: #a0a0a0;
+  color: #A0A0A0;
   font-size: 13px;
 }
 
@@ -1800,11 +1812,12 @@ span.weee {
  * Toolbar
  */
 .toolbar {
+  display: flex;
   margin-top: 10px;
   margin-bottom: 15px;
-  border-bottom: 1px solid #cccccc;
-  border-top: 1px solid #cccccc;
-  background: #f4f4f4;
+  border-bottom: 1px solid #CCCCCC;
+  border-top: 1px solid #CCCCCC;
+  background: #F4F4F4;
   padding: 5px 10px 0px 10px;
 }
 .toolbar:after {
@@ -1836,11 +1849,12 @@ span.weee {
 }
 
 .sorter {
+  flex-grow: 1;
   float: left;
+  white-space: nowrap;
   margin-bottom: 5px;
 }
 .sorter label {
-  float: left;
   margin-right: 5px;
 }
 .sorter label:after {
@@ -1848,7 +1862,6 @@ span.weee {
 }
 
 .sorter > .sort-by {
-  float: left;
   margin-right: 5px;
   height: 30px;
 }
@@ -1870,12 +1883,8 @@ span.weee {
   background-position: -46px -567px;
 }
 
-.sorter > .view-mode {
-  float: right;
-}
 .sorter > .view-mode .grid,
 .sorter > .view-mode .list {
-  float: left;
   width: 30px;
   height: 30px;
 }
@@ -1896,8 +1905,8 @@ span.weee {
 }
 
 .pager {
+  white-space: nowrap;
   float: right;
-  overflow: hidden;
 }
 .pager > .count-container {
   float: left;
@@ -1951,14 +1960,14 @@ span.weee {
   width: 25px;
   height: 30px;
   padding: 0;
-  color: #3399cc;
+  color: #3399CC;
   font-family: "Helvetica Neue", Verdana, Arial, sans-serif;
 }
 
 .pages .current,
 .pages .current:hover {
   color: #636363;
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   width: 30px;
   background-color: #FFFFFF;
   cursor: default;
@@ -1974,7 +1983,7 @@ span.weee {
 }
 .pages .next:hover,
 .pages .previous:hover {
-  border: 1px solid #3399cc;
+  border: 1px solid #3399CC;
 }
 
 .pages .next:before {
@@ -1985,7 +1994,7 @@ span.weee {
   display: block;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
-  border-left: 4px solid #3399cc;
+  border-left: 4px solid #3399CC;
   border-right: none;
   top: 50%;
   margin-top: -3px;
@@ -2012,7 +2021,7 @@ span.weee {
   display: block;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
-  border-right: 4px solid #3399cc;
+  border-right: 4px solid #3399CC;
   border-left: none;
   top: 50%;
   margin-top: -3px;
@@ -2054,7 +2063,7 @@ body.customer-account .data-table .summary-collapse:before {
   display: block;
   border-right: 7px solid transparent;
   border-left: 7px solid transparent;
-  border-top: 7px solid #3399cc;
+  border-top: 7px solid #3399CC;
   border-bottom: none;
   position: static;
   display: inline-block;
@@ -2086,7 +2095,7 @@ body.customer-account .data-table .show-details .summary-collapse:before {
   display: block;
   border-right: 7px solid transparent;
   border-left: 7px solid transparent;
-  border-bottom: 7px solid #3399cc;
+  border-bottom: 7px solid #3399CC;
   border-top: none;
   position: static;
   display: inline-block;
@@ -2191,7 +2200,7 @@ form .legend {
   text-transform: uppercase;
   margin-bottom: 15px;
   padding-bottom: 7px;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
 }
 
 /* -------------------------------------------- *
@@ -2237,7 +2246,7 @@ label {
 label.required:after,
 span.required:after {
   content: ' *';
-  color: #df280a;
+  color: #DF280A;
   font-weight: normal;
   font-family: "Helvetica Neue", Verdana, Arial, sans-serif;
   font-size: 12px;
@@ -2252,7 +2261,7 @@ span.required em {
  * Hints
  */
 .input-hint {
-  color: #a0a0a0;
+  color: #A0A0A0;
   font-size: 12px;
 }
 
@@ -2269,7 +2278,7 @@ select + select {
 
 select[multiple] {
   width: 270px;
-  border: 1px solid silver;
+  border: 1px solid #C0C0C0;
   font-size: 15px;
   padding: 5px;
 }
@@ -2278,8 +2287,8 @@ select[multiple] {
  * Textarea
  */
 textarea {
-  -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
   box-sizing: border-box;
   width: 100%;
   max-width: 450px;
@@ -2290,28 +2299,25 @@ textarea {
  * Inputs
  */
 .input-text {
-  -webkit-appearance: none;
   -moz-appearance: none;
-  appearance: none;
-  -webkit-border-radius: 2px;
+  -webkit-appearance: none;
   -moz-border-radius: 2px;
-  -ms-border-radius: 2px;
-  -o-border-radius: 2px;
+  -webkit-border-radius: 2px;
   border-radius: 2px;
-  border: 1px solid silver;
+  border: 1px solid #C0C0C0;
   background: #FFFFFF;
   font-size: 15px;
 }
 .input-text:focus {
-  border: 1px solid #3399cc;
+  border: 1px solid #3399CC;
 }
 
 .input-text.validation-failed {
-  border-color: #df280a;
+  border-color: #DF280A;
 }
 
 .input-text.validation-failed:focus {
-  outline-color: #ef9384;
+  outline-color: #ef9485;
 }
 
 input[type=email],
@@ -2365,11 +2371,11 @@ input[type=text].qty {
  * Placeholder
  */
 ::-webkit-input-placeholder {
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 input:-moz-placeholder {
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 /* -------------------------------------------- *
@@ -2398,7 +2404,7 @@ input:-moz-placeholder {
 p.required,
 .validation-advice {
   margin: 5px 0 0;
-  color: #df280a;
+  color: #DF280A;
   font-size: 13px;
 }
 
@@ -2466,7 +2472,7 @@ p.required,
 #co-shipping-method-form .sp-methods dd label,
 .product-options ul.options-list label {
   color: #636363;
-  background-color: #f4f4f4;
+  background-color: #F4F4F4;
   padding: 5px 10px;
   display: inline-block;
   width: auto;
@@ -2480,7 +2486,7 @@ p.required,
 #checkout-shipping-method-load .sp-methods dd label:hover,
 #co-shipping-method-form .sp-methods dd label:hover,
 .product-options ul.options-list label:hover {
-  background-color: #ececec;
+  background-color: #ededed;
 }
 .form-list .control .no-display + label,
 .sp-methods dt .no-display + label,
@@ -2532,7 +2538,7 @@ form .form-instructions {
   font-style: italic;
   font-family: Georgia, Times, "Times New Roman", serif;
   font-size: 13px;
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 /* ============================================ *
@@ -2556,7 +2562,7 @@ form .form-instructions {
 }
 
 .data-table th {
-  background: #f4f4f4;
+  background: #F4F4F4;
   text-transform: uppercase;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
   line-height: 1.4;
@@ -2565,7 +2571,7 @@ form .form-instructions {
 
 .data-table thead th,
 .data-table tbody td {
-  border-bottom: 1px solid silver;
+  border-bottom: 1px solid #C0C0C0;
 }
 
 .data-table tbody td,
@@ -2574,7 +2580,7 @@ form .form-instructions {
 }
 
 .data-table tfoot tr {
-  background: #f4f4f4;
+  background: #F4F4F4;
 }
 
 .data-table tbody td .item-options {
@@ -2589,7 +2595,7 @@ form .form-instructions {
  * Generic Info Table
  * ============================================ */
 .info-box {
-  border: 1px solid silver;
+  border: 1px solid #C0C0C0;
   padding: 12px 15px;
   margin: 0 0 15px;
 }
@@ -2617,19 +2623,19 @@ form .form-instructions {
  * ============================================ */
 .zebra-table tr:first-child,
 .zebra-table th:first-child {
-  border-top: 1px solid silver;
+  border-top: 1px solid #C0C0C0;
 }
 .zebra-table td,
 .zebra-table th {
-  border-bottom: 1px solid silver;
+  border-bottom: 1px solid #C0C0C0;
   padding: 6px;
   background-color: transparent;
 }
 .zebra-table tr {
-  background-color: #eeeded;
+  background-color: #EEEDED;
 }
 .zebra-table tr:nth-child(odd) {
-  background-color: #f8f7f5;
+  background-color: #F8F7F5;
 }
 
 /* ============================================ *
@@ -2683,7 +2689,7 @@ body {
  * ============================================ */
 .header-language-background {
   padding: 10px;
-  background-color: #3399cc;
+  background-color: #3399CC;
   text-transform: uppercase;
 }
 .header-language-background .header-language-container {
@@ -2719,7 +2725,7 @@ body {
 
 .header-language-background,
 .header-language-background a {
-  color: #e6e6e6;
+  color: #E6E6E6;
 }
 
 /* ============================================ *
@@ -2888,7 +2894,7 @@ a.skip-link {
 #header-nav {
   display: block;
   /* Force visibility */
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
 }
 
 /* ============================================ *
@@ -2914,7 +2920,7 @@ a.skip-link {
   position: relative;
 }
 .nav-primary li.level1 a {
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
 }
 
 .nav-primary .menu-active > ul.level0,
@@ -2951,14 +2957,14 @@ a.skip-link {
 }
 .nav-primary a:hover,
 .nav-primary li:hover > a {
-  color: #3399cc;
+  color: #3399CC;
 }
 .nav-primary .menu-active {
   z-index: 200;
 }
 .nav-primary li.level0 ul {
   background: #FBFBFB;
-  border: solid 1px #cccccc;
+  border: solid 1px #CCCCCC;
   position: absolute;
   left: 0;
   top: 30px;
@@ -2997,7 +3003,7 @@ a.skip-link {
   display: block;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
-  border-left: 4px solid #cccccc;
+  border-left: 4px solid #ccc;
   border-right: none;
   right: 5px;
   top: 50%;
@@ -3114,7 +3120,7 @@ a.skip-link {
 
 #header-account.skip-active {
   background: #FBFBFB;
-  border: solid 1px #cccccc;
+  border: solid 1px #CCCCCC;
   display: block;
   position: absolute;
   z-index: 200;
@@ -3131,7 +3137,7 @@ a.skip-link {
 }
 
 #header-account a:hover {
-  color: #3399cc;
+  color: #3399CC;
 }
 
 /* -------------------------------------------- *
@@ -3150,7 +3156,7 @@ a.skip-link {
 }
 
 #header-account a:hover {
-  color: #3399cc;
+  color: #3399CC;
 }
 
 /* ============================================ *
@@ -3173,7 +3179,7 @@ a.skip-link {
 
 #header-cart.skip-active {
   background: #FBFBFB;
-  border: solid 1px #cccccc;
+  border: solid 1px #CCCCCC;
   display: block;
   position: absolute;
   z-index: 200;
@@ -3187,10 +3193,8 @@ a.skip-link {
  * Skip Cart Notifier
  */
 .skip-cart .count {
-  -webkit-border-radius: 12px;
   -moz-border-radius: 12px;
-  -ms-border-radius: 12px;
-  -o-border-radius: 12px;
+  -webkit-border-radius: 12px;
   border-radius: 12px;
   display: inline-block;
   top: -6px;
@@ -3215,17 +3219,15 @@ a.skip-link {
 }
 
 .skip-cart {
-  color: #3399cc;
+  color: #3399CC;
   text-transform: uppercase;
 }
 .skip-cart:hover {
   text-decoration: none;
 }
 .skip-cart .count {
-  -webkit-border-radius: 0px;
   -moz-border-radius: 0px;
-  -ms-border-radius: 0px;
-  -o-border-radius: 0px;
+  -webkit-border-radius: 0px;
   border-radius: 0px;
   position: static;
   background: none;
@@ -3242,7 +3244,7 @@ a.skip-link {
 
 .skip-cart .count,
 .skip-link.skip-active .count {
-  color: #3399cc;
+  color: #3399CC;
 }
 
 .skip-cart .count.empty {
@@ -3292,7 +3294,7 @@ a.skip-link {
   position: relative;
   min-height: 90px;
   padding: 15px 15px 15px 90px;
-  border-top: 1px solid #cccccc;
+  border-top: 1px solid #CCCCCC;
   font-size: 13px;
   line-height: 1.35;
 }
@@ -3314,14 +3316,14 @@ a.skip-link {
 
 .mini-cart-list .has-options {
   margin-bottom: 0;
-  color: #a0a0a0;
+  color: #A0A0A0;
   font-size: 12px;
 }
 
 /* Too full - additional items will be shown in cart */
 .cart-menu .last-added {
   padding: 10px 15px 15px;
-  border-top: 1px solid #cccccc;
+  border-top: 1px solid #CCCCCC;
   font-size: 13px;
 }
 
@@ -3339,7 +3341,7 @@ a.skip-link {
 .footer {
   clear: both;
   width: 100%;
-  border-top: 1px solid #cccccc;
+  border-top: 1px solid #CCCCCC;
   padding-top: 30px;
   /* -------------------------------------------- *
    * Social icons
@@ -3354,7 +3356,7 @@ a.skip-link {
 }
 .footer .block-title,
 .footer address {
-  color: #3399cc;
+  color: #3399CC;
 }
 .footer .links {
   float: left;
@@ -3371,7 +3373,7 @@ a.skip-link {
   color: #636363;
 }
 .footer .links a:hover {
-  color: #3399cc;
+  color: #3399CC;
 }
 .footer .block-subscribe {
   float: right;
@@ -3443,10 +3445,8 @@ a.skip-link {
 .footer .block-subscribe .input-text {
   width: 100%;
   border-right: 0;
-  -webkit-border-radius: 0;
   -moz-border-radius: 0;
-  -ms-border-radius: 0;
-  -o-border-radius: 0;
+  -webkit-border-radius: 0;
   border-radius: 0;
 }
 .footer .block-subscribe .block-content {
@@ -3485,7 +3485,7 @@ a.skip-link {
   display: none;
 }
 .footer address {
-  border-top: 1px solid #cccccc;
+  border-top: 1px solid #CCCCCC;
   text-align: center;
   width: 100%;
   font-size: 11px;
@@ -3561,7 +3561,7 @@ h3.product-name a:hover,
 h4.product-name a:hover,
 h5.product-name a:hover,
 p.product-name a:hover {
-  color: #3399cc;
+  color: #3399CC;
   text-decoration: none;
 }
 
@@ -3642,7 +3642,7 @@ p.product-name a:hover {
 }
 
 .products-grid .price-box {
-  color: #a0a0a0;
+  color: #A0A0A0;
   font-size: 13px;
   margin: 0 0 5px;
 }
@@ -3827,7 +3827,7 @@ p.product-name a:hover {
 .products-list > li {
   padding-bottom: 20px;
   margin-bottom: 20px;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
 }
 .products-list > li:after {
   content: '';
@@ -3956,7 +3956,7 @@ p.product-name a:hover {
  * Catalog - List
  * ============================================ */
 .category-image {
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   padding: 10px;
 }
 .category-image img {
@@ -3992,9 +3992,9 @@ p.product-name a:hover {
   padding: 7px 10px 7px 24px;
   border-width: 1px;
   border-style: solid;
-  border-color: #cccccc;
+  border-color: #CCCCCC;
   position: relative;
-  background-color: #f4f4f4;
+  background-color: #F4F4F4;
   cursor: pointer;
 }
 .block-layered-nav .block-subtitle--filter:after {
@@ -4005,14 +4005,14 @@ p.product-name a:hover {
   display: block;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
-  border-top: 4px solid #3399cc;
+  border-top: 4px solid #3399CC;
   border-bottom: none;
   left: 10px;
   top: 50%;
   margin-top: -3px;
 }
 .block-layered-nav .block-subtitle--filter:hover {
-  background-color: #ececec;
+  background-color: #ededed;
 }
 
 .block-layered-nav .block-content .toggle-tabs {
@@ -4039,9 +4039,9 @@ p.product-name a:hover {
   padding: 7px 10px 7px 24px;
   border-width: 1px;
   border-style: solid;
-  border-color: #cccccc;
+  border-color: #CCCCCC;
   position: relative;
-  background-color: #f4f4f4;
+  background-color: #F4F4F4;
   display: block;
 }
 .block-layered-nav .block-content > dl > dt:after {
@@ -4052,21 +4052,21 @@ p.product-name a:hover {
   display: block;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
-  border-top: 4px solid #3399cc;
+  border-top: 4px solid #3399CC;
   border-bottom: none;
   left: 10px;
   top: 50%;
   margin-top: -3px;
 }
 .block-layered-nav .block-content > dl > dt:hover {
-  background-color: #ececec;
+  background-color: #ededed;
 }
 .block-layered-nav .block-content > dl > dd {
   padding: 10px;
   margin: 0;
   border-width: 0 1px;
   border-style: solid;
-  border-color: #cccccc;
+  border-color: #CCCCCC;
 }
 .block-layered-nav .block-content > dl > dd:last-child {
   border-width: 0 1px 1px 1px;
@@ -4081,7 +4081,7 @@ p.product-name a:hover {
   display: block;
 }
 .block-layered-nav dl dd ol > li > a .count {
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 .block-layered-nav .block-content > dl > dt {
@@ -4148,7 +4148,7 @@ p.product-name a:hover {
 }
 .product-view .product-shop .product-name .h1,
 .product-view .product-img-box .product-name h1 {
-  color: #3399cc;
+  color: #3399CC;
   margin-bottom: 10px;
   border: 0;
 }
@@ -4202,7 +4202,7 @@ p.product-name a:hover {
 .product-view .product-shop .price-box .regular-price .price,
 .product-view .product-shop .price-box .special-price .price,
 .product-view .product-shop .price-box .full-product-price .price {
-  color: #3399cc;
+  color: #3399CC;
   font-size: 24px;
 }
 .product-view .product-shop .price-box .special-price .price-label {
@@ -4343,7 +4343,7 @@ p.product-name a:hover {
 .product-view .add-to-cart {
   padding-bottom: 3px;
   margin-bottom: 10px;
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
 }
 .product-view .add-to-cart .qty-wrapper,
 .product-view .product-options-bottom .price-box,
@@ -4435,7 +4435,7 @@ p.product-name a:hover {
 .product-view .add-to-links a {
   padding: 2px 7px 2px 0px;
   margin-left: 7px;
-  border-right: 1px solid #cccccc;
+  border-right: 1px solid #CCCCCC;
 }
 .product-view .add-to-links li:first-child a {
   margin-left: 0px;
@@ -4497,8 +4497,8 @@ p.product-name a:hover {
   display: block;
   width: 100%;
   position: relative;
-  border: 1px solid #cccccc;
-  background-color: #f4f4f4;
+  border: 1px solid #CCCCCC;
+  background-color: #F4F4F4;
 }
 .product-collateral .toggle-tabs li {
   float: left;
@@ -4522,8 +4522,8 @@ p.product-name a:hover {
   bottom: -1px;
 }
 .product-collateral .toggle-tabs li.current {
-  border-right: 1px solid #cccccc;
-  border-left: 1px solid #cccccc;
+  border-right: 1px solid #CCCCCC;
+  border-left: 1px solid #CCCCCC;
 }
 .product-collateral .toggle-tabs li.current > span {
   background-color: #FFFFFF;
@@ -4531,7 +4531,7 @@ p.product-name a:hover {
 }
 .product-collateral .toggle-tabs li.current span,
 .product-collateral .toggle-tabs li:hover span {
-  color: #3399cc;
+  color: #3399CC;
 }
 .product-collateral .toggle-tabs li:first-child {
   border-left: none;
@@ -4551,7 +4551,7 @@ p.product-name a:hover {
   width: 100%;
   display: none;
   padding: 15px;
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   border-top: 0;
 }
 .product-collateral > dl > dd.current {
@@ -4574,18 +4574,18 @@ p.product-name a:hover {
 
 #product-attribute-specs-table {
   max-width: 50em;
-  border: 1px solid silver;
+  border: 1px solid #C0C0C0;
 }
 #product-attribute-specs-table th {
-  border-right: 1px solid silver;
-  border-bottom: 1px solid silver;
+  border-right: 1px solid #C0C0C0;
+  border-bottom: 1px solid #C0C0C0;
 }
 
 /* -------------------------------------------- *
  * Catalog - Grouped Product List
  */
 .grouped-items-table-wrapper {
-  border: solid 1px silver;
+  border: solid 1px #C0C0C0;
   width: 100%;
   padding: 10px;
   margin-bottom: 15px;
@@ -4595,7 +4595,7 @@ p.product-name a:hover {
 }
 
 .grouped-items-table .name-wrapper {
-  color: #3399cc;
+  color: #3399CC;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
 }
 .grouped-items-table .qty-wrapper {
@@ -4622,7 +4622,7 @@ p.product-name a:hover {
   width: 100%;
   margin: 10px 0 0;
   padding: 10px 15px 15px;
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   clear: both;
   position: relative;
 }
@@ -4665,7 +4665,7 @@ p.product-name a:hover {
 .product-options dd {
   padding: 0 0 10px 0;
   margin: 0 0 5px;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
 }
 
 .product-options dl.last dd.last {
@@ -4687,11 +4687,10 @@ p.product-name a:hover {
 }
 
 .product-options dd .time-picker {
-  display: -moz-inline-stack;
   display: inline-block;
   vertical-align: middle;
   *vertical-align: auto;
-  zoom: 1;
+  *zoom: 1;
   *display: inline;
   padding: 2px 0;
   vertical-align: middle;
@@ -4740,9 +4739,9 @@ p.product-name a:hover {
 }
 
 .product-options-bottom {
-  background-color: #f4f4f4;
+  background-color: #F4F4F4;
   padding: 15px 20px;
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   border-top: 0;
   margin-bottom: 10px;
 }
@@ -4766,7 +4765,7 @@ p.product-name a:hover {
   text-align: right;
   padding-bottom: 5px;
   margin-bottom: 10px;
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
 }
 
 .product-options-bottom .tier-prices li {
@@ -4892,7 +4891,7 @@ p.product-name a:hover {
 
 .map-popup {
   background: #FFFFFF;
-  border: 5px solid #cccccc;
+  border: 5px solid #CCCCCC;
   margin: 12px 0 0;
   position: absolute;
   text-align: left;
@@ -4932,7 +4931,7 @@ p.product-name a:hover {
   text-align: center;
 }
 .map-popup .map-popup-content {
-  border-top: 1px solid #ededed;
+  border-top: 1px solid #EDEDED;
   padding: 10px;
   margin: 0 10px;
   overflow: hidden;
@@ -5007,7 +5006,7 @@ p.product-name a:hover {
 }
 .map-popup .map-popup-text,
 .map-popup .map-popup-only-text {
-  border-top: 1px solid #ededed;
+  border-top: 1px solid #EDEDED;
 }
 
 /* ============================================ *
@@ -5065,8 +5064,8 @@ p.product-name a:hover {
 .cart-forms .giftcard,
 .cart-forms .shipping {
   padding: 10px;
-  background-color: #f4f4f4;
-  border: 1px solid #cccccc;
+  background-color: #F4F4F4;
+  border: 1px solid #CCCCCC;
 }
 
 .cart-table,
@@ -5115,7 +5114,7 @@ p.product-name a:hover {
  * ============================================ */
 .cart .page-title {
   margin-bottom: 15px;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
 }
 .cart .page-title:after {
   content: '';
@@ -5211,7 +5210,7 @@ p.product-name a:hover {
   padding-left: 15px;
 }
 .cart-table tr {
-  border-bottom: 1px solid silver;
+  border-bottom: 1px solid #C0C0C0;
 }
 .cart-table tfoot tr {
   background: none;
@@ -5271,7 +5270,7 @@ p.product-name a:hover {
   display: block;
   border-top: 6px solid transparent;
   border-bottom: 6px solid transparent;
-  border-right: 6px solid #3399cc;
+  border-right: 6px solid #3399CC;
   border-left: none;
   position: absolute;
   top: 3px;
@@ -5285,7 +5284,7 @@ p.product-name a:hover {
   display: block;
   border-right: 6px solid transparent;
   border-left: 6px solid transparent;
-  border-top: 6px solid #3399cc;
+  border-top: 6px solid #3399CC;
   border-bottom: none;
   right: -15px;
   top: 6px;
@@ -5309,7 +5308,7 @@ p.product-name a:hover {
 }
 .cart-table .product-cart-actions .qty {
   height: 30px;
-  border-color: silver;
+  border-color: #C0C0C0;
   border-radius: 0;
   margin-bottom: 10px;
   text-align: center;
@@ -5334,10 +5333,10 @@ p.product-name a:hover {
   max-width: 100%;
   height: 30px;
   display: block;
-  border: 1px solid silver;
+  border: 1px solid #C0C0C0;
 }
 .shipping select.validation-failed {
-  border-color: #df280a;
+  border-color: #DF280A;
 }
 .shipping .shipping-desc {
   display: none;
@@ -5406,12 +5405,12 @@ p.product-name a:hover {
   margin-left: 0;
 }
 .shipping #co-shipping-method-form .sp-methods dd label {
-  border: 1px solid #cccccc;
-  background-color: #ececec;
+  border: 1px solid #CCCCCC;
+  background-color: #ededed;
   min-width: 220px;
 }
 .shipping #co-shipping-method-form .sp-methods dd label:hover {
-  background-color: #dbdbdb;
+  background-color: gainsboro;
 }
 
 .cart .cart-totals {
@@ -5525,7 +5524,7 @@ p.product-name a:hover {
  * Checkout - Cart Cross sell
  * ============================================ */
 .crosssell h2 {
-  color: #3399cc;
+  color: #3399CC;
 }
 .crosssell .item a.product-image {
   width: auto;
@@ -5569,7 +5568,7 @@ p.product-name a:hover {
  */
 .opc .section .step-title {
   width: 100%;
-  border-top: 1px solid #ececec;
+  border-top: 1px solid #ECECEC;
   position: relative;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -5589,11 +5588,11 @@ p.product-name a:hover {
 
 /* Using .no-touch since touch devices emulate hover, thereby making steps look active that are not */
 .no-touch .opc .section.allow:not(.active) .step-title:hover {
-  background-color: #f4f4f4;
+  background-color: #F4F4F4;
 }
 
 .opc .section.active .step-title {
-  border-bottom: 1px solid #ececec;
+  border-bottom: 1px solid #ECECEC;
 }
 
 .opc .section .step-title a {
@@ -5620,7 +5619,7 @@ p.product-name a:hover {
   text-align: center;
   color: #FFFFFF;
   line-height: 26px;
-  background-color: #3399cc;
+  background-color: #3399CC;
   display: block;
   position: absolute;
   top: 50%;
@@ -5629,16 +5628,16 @@ p.product-name a:hover {
 }
 
 .opc .section.allow .step-title .number {
-  background-color: #99cce5;
+  background-color: #99cce6;
 }
 
 .opc .section.allow .step-title h2 {
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 .opc .section.allow .step-title:hover h2,
 .opc .section.active .step-title h2 {
-  color: #3399cc;
+  color: #3399CC;
 }
 
 .opc .section .step-title h2 {
@@ -5712,27 +5711,24 @@ p.product-name a:hover {
  */
 .opc.opc-firststep-login .section:not(#opc-login) .step-title,
 .opc-block-progress-step-login {
-  -webkit-transition: opacity 300ms linear;
-  -webkit-transition-delay: 0;
-  -moz-transition: opacity 300ms linear 0;
-  -o-transition: opacity 300ms linear 0;
-  transition: opacity 300ms linear 0;
+  -moz-transition: opacity 300ms 0;
+  -o-transition: opacity 300ms 0;
+  -webkit-transition: opacity 300ms 0;
+  transition: opacity 300ms 0;
 }
 
 .opc.opc-firststep-login .section#opc-login .step-title .number {
-  -webkit-transition: width 80ms linear;
-  -webkit-transition-delay: 0;
-  -moz-transition: width 80ms linear 0;
-  -o-transition: width 80ms linear 0;
-  transition: width 80ms linear 0;
+  -moz-transition: width 80ms 0;
+  -o-transition: width 80ms 0;
+  -webkit-transition: width 80ms 0;
+  transition: width 80ms 0;
 }
 
 .opc.opc-firststep-login .section#opc-login .step-title h2 {
-  -webkit-transition: margin-left 80ms linear;
-  -webkit-transition-delay: 0;
-  -moz-transition: margin-left 80ms linear 0;
-  -o-transition: margin-left 80ms linear 0;
-  transition: margin-left 80ms linear 0;
+  -moz-transition: margin-left 80ms 0;
+  -o-transition: margin-left 80ms 0;
+  -webkit-transition: margin-left 80ms 0;
+  transition: margin-left 80ms 0;
 }
 
 /* When a user progresses from the "Checkout Method" to "Billing Information" for the first time, the              */
@@ -5825,7 +5821,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 .block-progress {
   border: 0;
   margin: 0;
-  border-left: 1px solid #cccccc;
+  border-left: 1px solid #CCCCCC;
   padding-left: 20px;
 }
 .block-progress .block-content {
@@ -5846,7 +5842,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   margin-bottom: 6px;
   text-transform: uppercase;
   font-weight: normal;
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 .block-progress dt.complete {
   color: #636363;
@@ -6003,7 +5999,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 .gift-message-form .gift-item {
   padding-bottom: 10px;
   margin-bottom: 10px;
-  border-bottom: solid 1px #ececec;
+  border-bottom: solid 1px #ECECEC;
 }
 .gift-message-form .gift-item:after {
   content: '';
@@ -6065,7 +6061,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 }
 
 .swatch-link {
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   margin: 0 0 3px;
 }
 .swatch-link img {
@@ -6099,7 +6095,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   border: 1px solid #fff;
   margin: 0;
   white-space: nowrap;
-  background: #f4f4f4;
+  background: #F4F4F4;
 }
 
 .configurable-swatch-list {
@@ -6123,7 +6119,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   display: block;
 }
 .configurable-swatch-list .not-available .swatch-link {
-  border-color: #ededed;
+  border-color: #EDEDED;
   position: relative;
 }
 .configurable-swatch-list .not-available .swatch-link.has-image img {
@@ -6155,11 +6151,11 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   line-height: inherit;
 }
 #narrow-by-list dd .swatch-link:hover .swatch-label {
-  border-color: #3399cc;
+  border-color: #3399CC;
 }
 #narrow-by-list dd .swatch-label {
-  background: #f4f4f4;
-  border: 1px solid #cccccc;
+  background: #F4F4F4;
+  border: 1px solid #CCCCCC;
   border-radius: 3px;
   display: block;
   float: left;
@@ -6195,7 +6191,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   margin: 0 0 0 3px;
 }
 .currently .swatch-link:hover {
-  border-color: #cccccc;
+  border-color: #CCCCCC;
   cursor: default;
 }
 
@@ -6203,7 +6199,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 .configurable-swatch-list .hover .swatch-link,
 .configurable-swatch-list .selected .swatch-link,
 .swatch-link:hover {
-  border-color: #3399cc;
+  border-color: #3399CC;
 }
 
 .configurable-swatch-box {
@@ -6214,7 +6210,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 }
 .configurable-swatch-box .validation-advice {
   margin: 0 0 5px;
-  background: #df280a;
+  background: #DF280A;
   padding: 2px 5px !important;
   font-weight: bold;
   color: #fff !important;
@@ -6225,7 +6221,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 
 /* CUSTOM */
 .availability.out-of-stock span {
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 .product-view .product-options .swatch-attr {
@@ -6245,7 +6241,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 .product-view .product-options .swatch-attr .select-label {
   display: inline;
   font-weight: normal;
-  color: #3399cc;
+  color: #3399CC;
   padding-left: 5px;
 }
 .product-view .product-options dd .input-box {
@@ -6291,14 +6287,14 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 }
 .customer-account-login .col2-set .col-2 {
   padding-left: 20px;
-  border-left: 1px solid #ededed;
+  border-left: 1px solid #EDEDED;
 }
 .customer-account-login .col2-set .col-1 {
   padding-right: 0;
 }
 .customer-account-login .col2-set .col-2 {
   padding-left: 60px;
-  border-left: 1px solid #ededed;
+  border-left: 1px solid #EDEDED;
 }
 
 .customer-account-create .scaffold-form label:first-child {
@@ -6309,7 +6305,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   font-style: italic;
   font-family: Georgia, Times, "Times New Roman", serif;
   font-size: 13px;
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 .remember-me-box a.hide {
@@ -6322,7 +6318,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 
 .remember-me-popup {
   display: none;
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   padding: 10px;
   position: relative;
 }
@@ -6473,7 +6469,7 @@ body.customer-account .sidebar .block-reorder ol#cart-sidebar-reorder p.product-
  * ============================================ */
 .dashboard .box-head {
   margin-top: 30px;
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
   padding-bottom: 7px;
 }
 .dashboard .box-head h2 {
@@ -6492,7 +6488,7 @@ body.customer-account .sidebar .block-reorder ol#cart-sidebar-reorder p.product-
 }
 .dashboard .box-account {
   padding-bottom: 40px;
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
   margin-bottom: 45px;
 }
 .dashboard .box-account p,
@@ -6527,7 +6523,7 @@ body.customer-account .sidebar .block-reorder ol#cart-sidebar-reorder p.product-
 }
 .dashboard .box-reviews li {
   padding: 10px 0;
-  border-top: 1px solid #ededed;
+  border-top: 1px solid #EDEDED;
 }
 .dashboard .box-reviews li:first-child {
   border-top: 0;
@@ -6580,7 +6576,7 @@ body.customer-account .sidebar .block-reorder ol#cart-sidebar-reorder p.product-
  * ============================================ */
 .order-info {
   padding-bottom: 10px;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
   width: 100%;
   margin-bottom: 30px;
 }
@@ -6614,7 +6610,7 @@ body.customer-account .sidebar .block-reorder ol#cart-sidebar-reorder p.product-
 }
 .order-info-box + .order-info-box {
   padding-bottom: 40px;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
 }
 .order-info-box .col-1 {
   padding-right: 0;
@@ -6716,7 +6712,7 @@ body.newsletter-manage-index .my-account .fieldset h2 {
   display: none;
 }
 body.newsletter-manage-index .my-account .form-list {
-  border-top: 1px solid #ededed;
+  border-top: 1px solid #EDEDED;
   padding-top: 10px;
 }
 
@@ -6737,7 +6733,7 @@ body.newsletter-manage-index .my-account .form-list {
 .paypal-review-order .info-set {
   margin-bottom: 10px;
   padding-bottom: 10px;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
 }
 .paypal-review-order .buttons-set {
   margin-top: 0px;
@@ -6848,8 +6844,8 @@ div.paypal-logo span > img {
   float: none;
 }
 #customer-reviews .review-heading {
-  border-top: 1px solid #cccccc;
-  border-bottom: 1px solid #cccccc;
+  border-top: 1px solid #CCCCCC;
+  border-bottom: 1px solid #CCCCCC;
   padding: 10px 0 5px;
 }
 #customer-reviews .review-heading:after {
@@ -6878,7 +6874,7 @@ div.paypal-logo span > img {
   display: none;
 }
 #customer-reviews h2 {
-  color: #3399cc;
+  color: #3399CC;
   font-size: 12px;
   text-transform: uppercase;
 }
@@ -6892,14 +6888,14 @@ div.paypal-logo span > img {
   text-transform: uppercase;
 }
 #customer-reviews h3 span {
-  color: #3399cc;
+  color: #3399CC;
 }
 #customer-reviews .fieldset {
   padding-top: 25px;
   width: 470px;
 }
 #customer-reviews .fieldset h4 {
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
   font-size: 12px;
   font-weight: normal;
@@ -6927,13 +6923,13 @@ div.paypal-logo span > img {
   font-weight: normal;
 }
 #customer-reviews .fieldset .form-list textarea {
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   border-radius: 0;
   min-width: 100%;
   -webkit-appearance: none;
 }
 #customer-reviews .fieldset .form-list input {
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   border-radius: 0;
 }
 #customer-reviews .fieldset .form-list input[type="text"] {
@@ -6975,7 +6971,7 @@ div.paypal-logo span > img {
   margin: 15px 0;
 }
 #customer-reviews dl dd .review-meta {
-  color: #3399cc;
+  color: #3399CC;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
   font-size: 10px;
   font-weight: normal;
@@ -6983,7 +6979,7 @@ div.paypal-logo span > img {
 }
 
 .review-summary-table {
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
   margin: 0 0 10px;
 }
 .review-summary-table thead {
@@ -7074,7 +7070,7 @@ div.paypal-logo span > img {
   display: block;
   width: 100%;
   margin: 10px 0;
-  border: 1px solid #ededed;
+  border: 1px solid #EDEDED;
 }
 .slideshow-container .slideshow {
   width: 100%;
@@ -7244,7 +7240,7 @@ div.paypal-logo span > img {
   width: 100%;
 }
 #wishlist-table.clean-table th {
-  border-bottom: 1px solid silver;
+  border-bottom: 1px solid #C0C0C0;
 }
 #wishlist-table.clean-table td {
   padding: 15px;
@@ -7262,7 +7258,7 @@ div.paypal-logo span > img {
   text-transform: uppercase;
 }
 #wishlist-table .product-name a {
-  color: #3399cc;
+  color: #3399CC;
 }
 #wishlist-table .wishlist-sku {
   font-size: 11px;
@@ -7270,7 +7266,7 @@ div.paypal-logo span > img {
   margin: 5px 0;
 }
 #wishlist-table textarea {
-  border: 1px solid silver;
+  border: 1px solid #C0C0C0;
   width: 100%;
   height: 45px;
   font-size: 11px;
@@ -7289,7 +7285,7 @@ div.paypal-logo span > img {
   text-transform: uppercase;
 }
 #wishlist-table textarea:focus {
-  border: 1px solid #3399cc;
+  border: 1px solid #3399CC;
 }
 #wishlist-table .item-manage {
   text-align: right;
@@ -7356,12 +7352,12 @@ div.paypal-logo span > img {
 }
 #wishlist-table .giftregisty-add li {
   cursor: pointer;
-  color: #3399cc;
+  color: #3399CC;
   margin-bottom: 3px;
 }
 #wishlist-table .truncated .details {
   background: none;
-  color: #3399cc;
+  color: #3399CC;
 }
 #wishlist-table td[data-rwd-label]:before {
   font-weight: 600;
@@ -7396,7 +7392,7 @@ div.paypal-logo span > img {
   text-transform: uppercase;
   margin-right: 7px;
   padding-right: 7px;
-  border-right: 1px solid #ededed;
+  border-right: 1px solid #EDEDED;
 }
 
 /* ============================================ *
@@ -7489,7 +7485,7 @@ div.paypal-logo span > img {
   font-weight: bold;
 }
 .header-minicart .product-details .product-name a {
-  color: #3399cc;
+  color: #3399CC;
 }
 .header-minicart .info-wrapper {
   margin-bottom: 0.5em;
@@ -7499,7 +7495,7 @@ div.paypal-logo span > img {
   padding-right: 10px;
 }
 .header-minicart .info-wrapper td {
-  color: #3399cc;
+  color: #3399CC;
   clear: right;
 }
 .header-minicart .info-wrapper .qty-wrapper td {
@@ -7516,13 +7512,13 @@ div.paypal-logo span > img {
 }
 .header-minicart .info-wrapper .quantity-button {
   opacity: 0;
-  -webkit-transition-property: opacity;
   -moz-transition-property: opacity;
   -o-transition-property: opacity;
+  -webkit-transition-property: opacity;
   transition-property: opacity;
-  -webkit-transition-duration: 100ms;
   -moz-transition-duration: 100ms;
   -o-transition-duration: 100ms;
+  -webkit-transition-duration: 100ms;
   transition-duration: 100ms;
 }
 .header-minicart .info-wrapper .quantity-button[disabled] {
@@ -7541,7 +7537,7 @@ div.paypal-logo span > img {
   text-transform: uppercase;
 }
 .header-minicart .subtotal .price {
-  color: #3399cc;
+  color: #3399CC;
 }
 .header-minicart .minicart-actions {
   padding: 10px;
@@ -7599,13 +7595,11 @@ div.paypal-logo span > img {
   z-index: 200;
 }
 .search-autocomplete ul {
-  -webkit-border-radius: 2px;
   -moz-border-radius: 2px;
-  -ms-border-radius: 2px;
-  -o-border-radius: 2px;
+  -webkit-border-radius: 2px;
   border-radius: 2px;
   background-color: #FFFFFF;
-  border: 1px solid #3399cc;
+  border: 1px solid #3399CC;
   left: 0;
   padding-left: 0;
   position: absolute;
@@ -7613,8 +7607,8 @@ div.paypal-logo span > img {
   width: 100%;
 }
 .search-autocomplete ul li {
-  border-bottom: 1px solid #f4f4f4;
-  color: #3399cc;
+  border-bottom: 1px solid #F4F4F4;
+  color: #3399CC;
   cursor: pointer;
   font-size: 12px;
   padding: 4px 6px;
@@ -7624,7 +7618,7 @@ div.paypal-logo span > img {
   color: #2e8ab8;
 }
 .search-autocomplete ul li.selected {
-  background-color: #3399cc;
+  background-color: #3399CC;
   color: white;
 }
 .search-autocomplete ul li .amount {
@@ -7642,7 +7636,7 @@ div.paypal-logo span > img {
   display: block;
   border-right: 7px solid transparent;
   border-left: 7px solid transparent;
-  border-bottom: 7px solid #3399cc;
+  border-bottom: 7px solid #3399CC;
   border-top: none;
   left: 50%;
   top: -7px;
@@ -7652,12 +7646,12 @@ div.paypal-logo span > img {
  * Search - Advanced
  * ============================================ */
 .advanced-search {
-  background: #f4f4f4;
-  border: 1px solid #ededed;
+  background: #F4F4F4;
+  border: 1px solid #EDEDED;
   padding: 30px;
 }
 .advanced-search select.multiselect option {
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
   padding: 2px 5px;
 }
 
@@ -7665,7 +7659,7 @@ div.paypal-logo span > img {
  * Account - Reviews
  * ============================================ */
 .product-review .product-img-box p.label {
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
   font-size: 16px;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
   margin-top: 20px;
@@ -7676,7 +7670,7 @@ div.paypal-logo span > img {
   margin: 15px 0;
 }
 .product-review .product-details h2 {
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
   color: #3399CC;
   font-size: 16px;
   font-weight: 600;
@@ -7696,7 +7690,7 @@ div.paypal-logo span > img {
   text-transform: uppercase;
 }
 .product-review .ratings-description dt {
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
   font-size: 16px;
   font-weight: 400;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
@@ -7741,11 +7735,11 @@ div.paypal-logo span > img {
 }
 .cms-page-view .std h1,
 .cms-no-route .std h1 {
-  color: #3399cc;
+  color: #3399CC;
 }
 .cms-page-view .std h2,
 .cms-no-route .std h2 {
-  color: #3399cc;
+  color: #3399CC;
 }
 .cms-page-view .std li,
 .cms-no-route .std li {
@@ -7809,9 +7803,9 @@ div.paypal-logo span > img {
   padding: 7px 10px 7px 24px;
   border-width: 1px;
   border-style: solid;
-  border-color: #cccccc;
+  border-color: #CCCCCC;
   position: relative;
-  background-color: #f4f4f4;
+  background-color: #F4F4F4;
   display: block;
 }
 #accordion > dl > dt:after {
@@ -7822,21 +7816,21 @@ div.paypal-logo span > img {
   display: block;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
-  border-top: 4px solid #3399cc;
+  border-top: 4px solid #3399CC;
   border-bottom: none;
   left: 10px;
   top: 50%;
   margin-top: -3px;
 }
 #accordion > dl > dt:hover {
-  background-color: #ececec;
+  background-color: #ededed;
 }
 #accordion > dl > dd {
   padding: 10px;
   margin: 0;
   border-width: 0 1px;
   border-style: solid;
-  border-color: #cccccc;
+  border-color: #CCCCCC;
 }
 #accordion > dl > dd:last-child {
   border-width: 0 1px 1px 1px;
@@ -7889,7 +7883,7 @@ div.paypal-logo span > img {
  * Pricing Conditions
  * ============================================ */
 .price-box .minimal-price-link .label {
-  color: #cf5050;
+  color: #CF5050;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
   font-size: 12px;
   text-transform: uppercase;
@@ -7951,8 +7945,8 @@ div.paypal-logo span > img {
 }
 
 .product-tags {
-  background-color: #f4f4f4;
-  border: 1px solid #cccccc;
+  background-color: #F4F4F4;
+  border: 1px solid #CCCCCC;
   float: left;
   margin-bottom: 10px;
   padding: 5px 1% 10px;
@@ -8041,7 +8035,7 @@ div.paypal-logo span > img {
 }
 
 .captcha-img {
-  border: 20px solid #bbbbbb;
+  border: 20px solid #bbb;
 }
 
 .captcha-input-container {
@@ -8246,15 +8240,15 @@ body[class*="checkout-multishipping-"] .checkout-progress > li {
   width: 20%;
   text-align: center;
   padding: 8px 1% 6px;
-  background: #f4f4f4;
+  background: #F4F4F4;
   text-transform: uppercase;
-  border-bottom: 1px solid #cccccc;
-  border-right: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
+  border-right: 1px solid #CCCCCC;
   margin-bottom: 10px;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
 }
 body[class*="checkout-multishipping-"] .checkout-progress > li.active {
-  background-color: #dddddd;
+  background-color: #DDDDDD;
 }
 body[class*="checkout-multishipping-"] .checkout-progress > li.last {
   border-right: 0px;
@@ -8344,8 +8338,8 @@ body[class*="checkout-multishipping-"] #review-buttons-container {
 .checkout-multishipping-overview .col-2 .box-title h4 {
   font-weight: normal;
   width: 100%;
-  background: #f4f4f4;
-  border-bottom: 1px solid #cccccc;
+  background: #F4F4F4;
+  border-bottom: 1px solid #CCCCCC;
   padding: 10px;
   font-size: 14px;
 }
@@ -8356,8 +8350,8 @@ body[class*="checkout-multishipping-"] #review-buttons-container {
 .checkout-multishipping-overview .col-2 > h4 {
   font-weight: normal;
   width: 100%;
-  background: #f4f4f4;
-  border-bottom: 1px solid #cccccc;
+  background: #F4F4F4;
+  border-bottom: 1px solid #CCCCCC;
   padding: 10px;
   font-size: 14px;
 }

--- a/skin/frontend/rwd/default/css/styles-ie8.css
+++ b/skin/frontend/rwd/default/css/styles-ie8.css
@@ -1,36 +1,21 @@
-/*
-// ----------------------------------------------
-// Usage example:
-// For IE set $mq-support to false.
-// Set the fixed value.
-// Then use mixins to test whether styles should be applied.
-// ----------------------------------------------
-
-$mq-support: false;
-$mq-fixed-value: 1024;
-
-// Renders at fixed value
-@include bp (min-width, 300px) {
-    div { color:#000; }
-}
-
-// Doesn't render without MQ support
-@include bp (min-width, 1200px) {
-    div { color:#FFF; }
-}
-
-// Doesn't render without MQ support
-@include bp (max-width, 300px) {
-    div { color:#444; }
-}
-
-// Renders at fixed value
-@include bp (max-width, 1200px) {
-    div { color:#888; }
-}
-
-// ----------------------------------------------
-*/
+/**
+ * OpenMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE_AFL.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * @category    design
+ * @package     rwd_default
+ * @copyright   Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
+ * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
 /*! normalize.css v2.0.1 | MIT License | git.io/normalize */
 /* ==========================================================================
    HTML5 display definitions

--- a/skin/frontend/rwd/default/css/styles.css
+++ b/skin/frontend/rwd/default/css/styles.css
@@ -1,21 +1,36 @@
-/**
- * OpenMage
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Academic Free License (AFL 3.0)
- * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
- *
- * @category    design
- * @package     rwd_default
- * @copyright   Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
- * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- */
+/*
+// ----------------------------------------------
+// Usage example:
+// For IE set $mq-support to false.
+// Set the fixed value.
+// Then use mixins to test whether styles should be applied.
+// ----------------------------------------------
+
+$mq-support: false;
+$mq-fixed-value: 1024;
+
+// Renders at fixed value
+@include bp (min-width, 300px) {
+    div { color:#000; }
+}
+
+// Doesn't render without MQ support
+@include bp (min-width, 1200px) {
+    div { color:#FFF; }
+}
+
+// Doesn't render without MQ support
+@include bp (max-width, 300px) {
+    div { color:#444; }
+}
+
+// Renders at fixed value
+@include bp (max-width, 1200px) {
+    div { color:#888; }
+}
+
+// ----------------------------------------------
+*/
 /*! normalize.css v2.0.1 | MIT License | git.io/normalize */
 /* ==========================================================================
    HTML5 display definitions
@@ -371,15 +386,15 @@ table {
 *,
 *:before,
 *:after {
-  -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
   box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
 
 html {
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  -webkit-tap-highlight-color: transparent;
   /* Prevent tap highlight on iOS/Android */
   -webkit-text-size-adjust: 100%;
   /* Prevent automatic scaling on iOS */
@@ -463,15 +478,12 @@ input[type="search"] {
 @-ms-viewport {
   width: device-width;
 }
-
 @-o-viewport {
   width: device-width;
 }
-
 @viewport {
   width: device-width;
 }
-
 a, button {
   -ms-touch-action: manipulation;
   touch-action: manipulation;
@@ -490,7 +502,7 @@ textarea {
 }
 
 a {
-  color: #3399cc;
+  color: #3399CC;
   text-decoration: none;
 }
 
@@ -517,7 +529,7 @@ ul {
 h1, .h1 {
   margin: 0;
   margin-bottom: 0.7em;
-  color: #3399cc;
+  color: #3399CC;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
   font-size: 28px;
   font-weight: 400;
@@ -610,16 +622,16 @@ h6, .h6 {
 }
 
 .availability.in-stock {
-  color: #11b400;
+  color: #11B400;
 }
 
 .availability.available-soon,
 .availability.out-of-stock {
-  color: #df280a;
+  color: #DF280A;
 }
 
 .availability-only {
-  color: #df280a;
+  color: #DF280A;
   margin-bottom: 10px;
 }
 
@@ -634,7 +646,7 @@ h6, .h6 {
   font-size: 24px;
   font-weight: 600;
   color: #636363;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
   padding-bottom: 3px;
   margin-bottom: 15px;
   text-transform: uppercase;
@@ -670,7 +682,7 @@ h6, .h6 {
   line-height: 1.4;
   text-rendering: optimizeSpeed;
   text-transform: uppercase;
-  color: #3399cc;
+  color: #3399CC;
   margin-bottom: 0;
   text-transform: uppercase;
   font-weight: 600;
@@ -678,7 +690,7 @@ h6, .h6 {
 .block-title small {
   font-size: 100%;
   font-weight: normal;
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 body:not(.customer-account) .block:first-child .block-title {
@@ -760,9 +772,9 @@ body:not(.customer-account) .block:first-child .block-title {
     padding: 7px 10px 7px 24px;
     border-width: 1px;
     border-style: solid;
-    border-color: #cccccc;
+    border-color: #CCCCCC;
     position: relative;
-    background-color: #f4f4f4;
+    background-color: #F4F4F4;
     display: block;
     width: 100%;
     cursor: pointer;
@@ -776,14 +788,14 @@ body:not(.customer-account) .block:first-child .block-title {
     display: block;
     border-top: 4px solid transparent;
     border-bottom: 4px solid transparent;
-    border-left: 4px solid #3399cc;
+    border-left: 4px solid #3399CC;
     border-right: none;
     left: 10px;
     top: 50%;
     margin-top: -3px;
   }
   .sidebar .block:not(.block-layered-nav) .block-title > strong:hover {
-    background-color: #ececec;
+    background-color: #ededed;
   }
   .sidebar .block:not(.block-layered-nav) .block-title.active > strong {
     margin: 0;
@@ -806,9 +818,9 @@ body:not(.customer-account) .block:first-child .block-title {
     padding: 7px 10px 7px 24px;
     border-width: 1px;
     border-style: solid;
-    border-color: #cccccc;
+    border-color: #CCCCCC;
     position: relative;
-    background-color: #f4f4f4;
+    background-color: #F4F4F4;
   }
   .sidebar .block:not(.block-layered-nav) .block-title.active > strong:after {
     content: '';
@@ -818,24 +830,24 @@ body:not(.customer-account) .block:first-child .block-title {
     display: block;
     border-right: 4px solid transparent;
     border-left: 4px solid transparent;
-    border-top: 4px solid #3399cc;
+    border-top: 4px solid #3399CC;
     border-bottom: none;
     left: 10px;
     top: 50%;
     margin-top: -3px;
   }
   .sidebar .block:not(.block-layered-nav) .block-title.active > strong:hover {
-    background-color: #ececec;
+    background-color: #ededed;
   }
   .sidebar .block:not(.block-layered-nav) .block-content {
     padding: 10px;
     margin-top: 0;
     border-width: 0 1px;
     border-style: solid;
-    border-color: #cccccc;
+    border-color: #CCCCCC;
   }
   .sidebar .block:last-of-type {
-    border-bottom: 1px solid #cccccc;
+    border-bottom: 1px solid #CCCCCC;
   }
 }
 /* -------------------------------------------- *
@@ -855,7 +867,7 @@ body:not(.customer-account) .block:first-child .block-title {
 .block-account li strong,
 .block-cms-menu li strong {
   font-weight: 400;
-  color: #3399cc;
+  color: #3399CC;
 }
 .block-account li a,
 .block-cms-menu li a {
@@ -863,7 +875,7 @@ body:not(.customer-account) .block:first-child .block-title {
 }
 .block-account li a:hover,
 .block-cms-menu li a:hover {
-  color: #3399cc;
+  color: #3399CC;
 }
 
 /* ============================================ *
@@ -874,7 +886,7 @@ body:not(.customer-account) .block:first-child .block-title {
 .cart-table .button,
 .sidebar .actions .button,
 .button.button-secondary {
-  background: #dddddd;
+  background: #DDDDDD;
   color: #636363;
   padding: 7px 15px;
 }
@@ -910,7 +922,7 @@ body:not(.customer-account) .block:first-child .block-title {
 .cart-table .product-cart-actions .button,
 #co-shipping-method-form .buttons-set .button,
 .footer .button {
-  background: #3399cc;
+  background: #3399CC;
   display: inline-block;
   padding: 7px 15px;
   border: 0;
@@ -988,7 +1000,7 @@ a.button:hover {
   text-decoration: underline;
   text-transform: uppercase;
   display: inline-block;
-  color: #3399cc;
+  color: #3399CC;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
 }
 .button2 span:hover,
@@ -1078,7 +1090,7 @@ a.button:hover {
   clear: both;
   margin: 10px 0 0;
   padding-top: 10px;
-  border-top: 1px solid #ededed;
+  border-top: 1px solid #EDEDED;
   text-align: right;
 }
 .buttons-set p.required {
@@ -1146,7 +1158,7 @@ a.button:hover {
 }
 
 .breadcrumbs a:hover {
-  color: #3399cc;
+  color: #3399CC;
 }
 
 .breadcrumbs strong {
@@ -1172,7 +1184,7 @@ a.button:hover {
   display: inline-block;
   width: 20px;
   height: 20px;
-  border: 1px solid #ededed;
+  border: 1px solid #EDEDED;
   text-align: center;
   /* Hide text */
   font: 0/0 a;
@@ -1182,13 +1194,13 @@ a.button:hover {
 }
 .btn-remove:hover,
 .btn-previous:hover {
-  background-color: #3399cc;
-  border-color: #3399cc;
+  background-color: #3399CC;
+  border-color: #3399CC;
 }
 
 .btn-remove:after {
   content: 'X';
-  color: #3399cc;
+  color: #3399CC;
   height: 20px;
   line-height: 20px;
   width: 100%;
@@ -1223,7 +1235,7 @@ a.button:hover {
   display: block;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
-  border-right: 4px solid #3399cc;
+  border-right: 4px solid #3399CC;
   border-left: none;
   position: absolute;
   top: 50%;
@@ -1239,7 +1251,7 @@ a.button:hover {
   display: block;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
-  border-right: 4px solid white;
+  border-right: 4px solid #FFFFFF;
   border-left: none;
 }
 
@@ -1266,8 +1278,8 @@ a.button:hover {
   max-height: 125px;
   margin-bottom: 10px;
   padding: 10px;
-  border: 1px solid #cccccc;
-  background: #f4f4f4;
+  border: 1px solid #CCCCCC;
+  background: #F4F4F4;
 }
 
 /* -------------------------------------------- *
@@ -1498,7 +1510,7 @@ a.button:hover {
  */
 .global-site-notice {
   background: #676157;
-  color: #e6e6e6;
+  color: #E6E6E6;
   font-size: 11px;
 }
 .global-site-notice .notice-inner {
@@ -1520,7 +1532,7 @@ a.button:hover {
  * Promotional Message Banner
  */
 .promo-msg {
-  color: #3399cc;
+  color: #3399CC;
   text-align: center;
   margin: 10px;
   text-transform: uppercase;
@@ -1540,16 +1552,16 @@ a.button:hover {
  * Messages
  */
 .success {
-  color: #11b400;
+  color: #11B400;
 }
 
 .error {
-  color: #df280a;
+  color: #DF280A;
   font-weight: bold;
 }
 
 .notice {
-  color: #e26703;
+  color: #E26703;
   font-weight: bold;
 }
 
@@ -1564,7 +1576,7 @@ a.button:hover {
   position: relative;
   margin-bottom: 5px;
   padding: 7px 10px 7px 20px;
-  background: #f4f4f4;
+  background: #F4F4F4;
   font-size: 15px;
 }
 
@@ -1575,9 +1587,9 @@ a.button:hover {
 }
 
 .messages .error-msg li {
-  color: black;
-  border-left: 5px solid #df280a;
-  background-color: #faebe7;
+  color: #000000;
+  border-left: 5px solid #DF280A;
+  background-color: #FAEBE7;
 }
 
 .messages .error-msg li:before {
@@ -1588,14 +1600,14 @@ a.button:hover {
   display: block;
   border-top: 6px solid transparent;
   border-bottom: 6px solid transparent;
-  border-left: 6px solid #df280a;
+  border-left: 6px solid #DF280A;
   border-right: none;
 }
 
 .messages .notice-msg li {
-  color: black;
-  border-left: 5px solid #e26703;
-  background-color: #f9ebe6;
+  color: #000000;
+  border-left: 5px solid #E26703;
+  background-color: #F9EBE6;
 }
 
 .messages .notice-msg li:before {
@@ -1606,14 +1618,14 @@ a.button:hover {
   display: block;
   border-top: 6px solid transparent;
   border-bottom: 6px solid transparent;
-  border-left: 6px solid #e26703;
+  border-left: 6px solid #E26703;
   border-right: none;
 }
 
 .messages .success-msg li {
-  color: black;
-  border-left: 5px solid #11b400;
-  background-color: #eff5ea;
+  color: #000000;
+  border-left: 5px solid #11B400;
+  background-color: #EFF5EA;
 }
 
 .messages .success-msg li:before {
@@ -1624,7 +1636,7 @@ a.button:hover {
   display: block;
   border-top: 6px solid transparent;
   border-bottom: 6px solid transparent;
-  border-left: 6px solid #11b400;
+  border-left: 6px solid #11B400;
   border-right: none;
 }
 
@@ -1679,8 +1691,8 @@ a.button:hover {
   max-width: 100%;
   margin: 5px 15px 15px;
   padding: 15px;
-  border: 1px solid #cccccc;
-  background: #f4f4f4;
+  border: 1px solid #CCCCCC;
+  background: #F4F4F4;
 }
 
 .payment-methods .form-list:before {
@@ -1691,7 +1703,7 @@ a.button:hover {
   display: block;
   border-right: 10px solid transparent;
   border-left: 10px solid transparent;
-  border-bottom: 10px solid #cccccc;
+  border-bottom: 10px solid #CCCCCC;
   border-top: none;
   top: -11px;
   left: 30px;
@@ -1705,7 +1717,7 @@ a.button:hover {
   display: block;
   border-right: 10px solid transparent;
   border-left: 10px solid transparent;
-  border-bottom: 10px solid #f4f4f4;
+  border-bottom: 10px solid #F4F4F4;
   border-top: none;
   top: -10px;
   left: 30px;
@@ -1746,11 +1758,11 @@ a.button:hover {
 }
 
 .price-notice {
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 .price-box .price {
-  color: #3399cc;
+  color: #3399CC;
   font-size: 16px;
 }
 
@@ -1760,19 +1772,19 @@ a.button:hover {
 }
 
 .price-box .price-label {
-  color: #a0a0a0;
+  color: #A0A0A0;
   white-space: nowrap;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
 }
 
 .price-box .minimal-price-link {
   padding-left: 1em;
-  color: #3399cc;
+  color: #3399CC;
   display: block;
   /* We want this to show on its own line, otherwise the layout looks funky */
 }
 .price-box .minimal-price-link .label {
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 /* -------------------------------------------- *
@@ -1792,12 +1804,12 @@ a.button:hover {
 }
 
 .price-box .old-price .price {
-  color: #a0a0a0;
+  color: #A0A0A0;
   text-decoration: line-through;
 }
 
 .price-box .special-price {
-  color: #3399cc;
+  color: #3399CC;
   padding-left: 1em;
 }
 .price-box .special-price .price-label {
@@ -1897,7 +1909,7 @@ span.weee {
   z-index: 300;
   width: 200px;
   padding: 8px;
-  border: 1px solid #3399cc;
+  border: 1px solid #3399CC;
   background-color: #F6F6F6;
   top: 21px;
   left: -100px;
@@ -1910,7 +1922,7 @@ span.weee {
   display: block;
   border-right: 7px solid transparent;
   border-left: 7px solid transparent;
-  border-bottom: 7px solid #3399cc;
+  border-bottom: 7px solid #3399CC;
   border-top: none;
   left: 97px;
   top: -7px;
@@ -1979,16 +1991,16 @@ span.weee {
 .no-touch .product-img-box .product-image:not(.zoom-available):hover {
   position: relative;
   display: block;
-  border: 1px solid #ededed;
+  border: 1px solid #EDEDED;
 }
 
 @media only screen and (max-width: 770px) {
   body .product-img-box .product-image:hover {
-    border-color: #ededed;
+    border-color: #EDEDED;
   }
 }
 .no-touch .product-image:hover {
-  border-color: #3399cc;
+  border-color: #3399CC;
 }
 
 /* -------------------------------------------- *
@@ -2048,7 +2060,7 @@ span.weee {
 }
 
 .std .note {
-  color: #a0a0a0;
+  color: #A0A0A0;
   font-size: 13px;
 }
 
@@ -2064,11 +2076,12 @@ span.weee {
  * Toolbar
  */
 .toolbar {
+  display: flex;
   margin-top: 10px;
   margin-bottom: 15px;
-  border-bottom: 1px solid #cccccc;
-  border-top: 1px solid #cccccc;
-  background: #f4f4f4;
+  border-bottom: 1px solid #CCCCCC;
+  border-top: 1px solid #CCCCCC;
+  background: #F4F4F4;
   padding: 5px 10px 0px 10px;
 }
 .toolbar:after {
@@ -2100,11 +2113,12 @@ span.weee {
 }
 
 .sorter {
+  flex-grow: 1;
   float: left;
+  white-space: nowrap;
   margin-bottom: 5px;
 }
 .sorter label {
-  float: left;
   margin-right: 5px;
 }
 .sorter label:after {
@@ -2112,7 +2126,6 @@ span.weee {
 }
 
 .sorter > .sort-by {
-  float: left;
   margin-right: 5px;
   height: 30px;
 }
@@ -2134,12 +2147,8 @@ span.weee {
   background-position: -46px -567px;
 }
 
-.sorter > .view-mode {
-  float: right;
-}
 .sorter > .view-mode .grid,
 .sorter > .view-mode .list {
-  float: left;
   width: 30px;
   height: 30px;
 }
@@ -2160,8 +2169,8 @@ span.weee {
 }
 
 .pager {
+  white-space: nowrap;
   float: right;
-  overflow: hidden;
 }
 .pager > .count-container {
   float: left;
@@ -2215,14 +2224,14 @@ span.weee {
   width: 25px;
   height: 30px;
   padding: 0;
-  color: #3399cc;
+  color: #3399CC;
   font-family: "Helvetica Neue", Verdana, Arial, sans-serif;
 }
 
 .pages .current,
 .pages .current:hover {
   color: #636363;
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   width: 30px;
   background-color: #FFFFFF;
   cursor: default;
@@ -2238,7 +2247,7 @@ span.weee {
 }
 .pages .next:hover,
 .pages .previous:hover {
-  border: 1px solid #3399cc;
+  border: 1px solid #3399CC;
 }
 
 .pages .next:before {
@@ -2249,7 +2258,7 @@ span.weee {
   display: block;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
-  border-left: 4px solid #3399cc;
+  border-left: 4px solid #3399CC;
   border-right: none;
   top: 50%;
   margin-top: -3px;
@@ -2276,7 +2285,7 @@ span.weee {
   display: block;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
-  border-right: 4px solid #3399cc;
+  border-right: 4px solid #3399CC;
   border-left: none;
   top: 50%;
   margin-top: -3px;
@@ -2313,33 +2322,8 @@ span.weee {
   .col1-layout .pager {
     width: 100%;
   }
-  .col1-layout .pager {
-    float: left;
-    clear: both;
-  }
-  .col1-layout .pager .pages {
-    float: left;
-    margin-left: 0;
-  }
-  .col1-layout .pager .count-container {
-    float: right;
-  }
 }
 @media only screen and (max-width: 979px) {
-  .col2-left-layout .sorter,
-  .col2-left-layout .pager,
-  .col2-right-layout .sorter,
-  .col2-right-layout .pager,
-  .col3-layout .sorter,
-  .col3-layout .pager {
-    width: 100%;
-  }
-  .col2-left-layout .pager,
-  .col2-right-layout .pager,
-  .col3-layout .pager {
-    float: left;
-    clear: both;
-  }
   .col2-left-layout .pager .pages,
   .col2-right-layout .pager .pages,
   .col3-layout .pager .pages {
@@ -2376,7 +2360,7 @@ body.customer-account .data-table .summary-collapse:before {
   display: block;
   border-right: 7px solid transparent;
   border-left: 7px solid transparent;
-  border-top: 7px solid #3399cc;
+  border-top: 7px solid #3399CC;
   border-bottom: none;
   position: static;
   display: inline-block;
@@ -2408,7 +2392,7 @@ body.customer-account .data-table .show-details .summary-collapse:before {
   display: block;
   border-right: 7px solid transparent;
   border-left: 7px solid transparent;
-  border-bottom: 7px solid #3399cc;
+  border-bottom: 7px solid #3399CC;
   border-top: none;
   position: static;
   display: inline-block;
@@ -2513,7 +2497,7 @@ form .legend {
   text-transform: uppercase;
   margin-bottom: 15px;
   padding-bottom: 7px;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
 }
 
 /* -------------------------------------------- *
@@ -2559,7 +2543,7 @@ label {
 label.required:after,
 span.required:after {
   content: ' *';
-  color: #df280a;
+  color: #DF280A;
   font-weight: normal;
   font-family: "Helvetica Neue", Verdana, Arial, sans-serif;
   font-size: 12px;
@@ -2574,7 +2558,7 @@ span.required em {
  * Hints
  */
 .input-hint {
-  color: #a0a0a0;
+  color: #A0A0A0;
   font-size: 12px;
 }
 
@@ -2591,7 +2575,7 @@ select + select {
 
 select[multiple] {
   width: 270px;
-  border: 1px solid silver;
+  border: 1px solid #C0C0C0;
   font-size: 15px;
   padding: 5px;
 }
@@ -2600,8 +2584,8 @@ select[multiple] {
  * Textarea
  */
 textarea {
-  -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
   box-sizing: border-box;
   width: 100%;
   max-width: 450px;
@@ -2612,28 +2596,25 @@ textarea {
  * Inputs
  */
 .input-text {
-  -webkit-appearance: none;
   -moz-appearance: none;
-  appearance: none;
-  -webkit-border-radius: 2px;
+  -webkit-appearance: none;
   -moz-border-radius: 2px;
-  -ms-border-radius: 2px;
-  -o-border-radius: 2px;
+  -webkit-border-radius: 2px;
   border-radius: 2px;
-  border: 1px solid silver;
+  border: 1px solid #C0C0C0;
   background: #FFFFFF;
   font-size: 15px;
 }
 .input-text:focus {
-  border: 1px solid #3399cc;
+  border: 1px solid #3399CC;
 }
 
 .input-text.validation-failed {
-  border-color: #df280a;
+  border-color: #DF280A;
 }
 
 .input-text.validation-failed:focus {
-  outline-color: #ef9384;
+  outline-color: #ef9485;
 }
 
 input[type=email],
@@ -2687,11 +2668,11 @@ input[type=text].qty {
  * Placeholder
  */
 ::-webkit-input-placeholder {
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 input:-moz-placeholder {
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 /* -------------------------------------------- *
@@ -2720,7 +2701,7 @@ input:-moz-placeholder {
 p.required,
 .validation-advice {
   margin: 5px 0 0;
-  color: #df280a;
+  color: #DF280A;
   font-size: 13px;
 }
 
@@ -2788,7 +2769,7 @@ p.required,
 #co-shipping-method-form .sp-methods dd label,
 .product-options ul.options-list label {
   color: #636363;
-  background-color: #f4f4f4;
+  background-color: #F4F4F4;
   padding: 5px 10px;
   display: inline-block;
   width: auto;
@@ -2802,7 +2783,7 @@ p.required,
 #checkout-shipping-method-load .sp-methods dd label:hover,
 #co-shipping-method-form .sp-methods dd label:hover,
 .product-options ul.options-list label:hover {
-  background-color: #ececec;
+  background-color: #ededed;
 }
 .form-list .control .no-display + label,
 .sp-methods dt .no-display + label,
@@ -2854,7 +2835,7 @@ form .form-instructions {
   font-style: italic;
   font-family: Georgia, Times, "Times New Roman", serif;
   font-size: 13px;
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 /* ============================================ *
@@ -2878,7 +2859,7 @@ form .form-instructions {
 }
 
 .data-table th {
-  background: #f4f4f4;
+  background: #F4F4F4;
   text-transform: uppercase;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
   line-height: 1.4;
@@ -2887,7 +2868,7 @@ form .form-instructions {
 
 .data-table thead th,
 .data-table tbody td {
-  border-bottom: 1px solid silver;
+  border-bottom: 1px solid #C0C0C0;
 }
 
 .data-table tbody td,
@@ -2896,7 +2877,7 @@ form .form-instructions {
 }
 
 .data-table tfoot tr {
-  background: #f4f4f4;
+  background: #F4F4F4;
 }
 
 .data-table tbody td .item-options {
@@ -2911,7 +2892,7 @@ form .form-instructions {
  * Generic Info Table
  * ============================================ */
 .info-box {
-  border: 1px solid silver;
+  border: 1px solid #C0C0C0;
   padding: 12px 15px;
   margin: 0 0 15px;
 }
@@ -2939,19 +2920,19 @@ form .form-instructions {
  * ============================================ */
 .zebra-table tr:first-child,
 .zebra-table th:first-child {
-  border-top: 1px solid silver;
+  border-top: 1px solid #C0C0C0;
 }
 .zebra-table td,
 .zebra-table th {
-  border-bottom: 1px solid silver;
+  border-bottom: 1px solid #C0C0C0;
   padding: 6px;
   background-color: transparent;
 }
 .zebra-table tr {
-  background-color: #eeeded;
+  background-color: #EEEDED;
 }
 .zebra-table tr:nth-child(odd) {
-  background-color: #f8f7f5;
+  background-color: #F8F7F5;
 }
 
 /* ============================================ *
@@ -2978,7 +2959,7 @@ form .form-instructions {
   }
   .linearize-table tbody tr {
     position: relative;
-    border-bottom: 1px solid #cccccc;
+    border-bottom: 1px solid #CCCCCC;
   }
   .linearize-table tbody td {
     padding: 0 10px 4px;
@@ -3061,7 +3042,7 @@ form .form-instructions {
   }
   .linearize-table-large tbody tr {
     position: relative;
-    border-bottom: 1px solid #cccccc;
+    border-bottom: 1px solid #CCCCCC;
   }
   .linearize-table-large tbody td {
     padding: 0 10px 4px;
@@ -3173,7 +3154,7 @@ body {
  * ============================================ */
 .header-language-background {
   padding: 10px;
-  background-color: #3399cc;
+  background-color: #3399CC;
   text-transform: uppercase;
 }
 .header-language-background .header-language-container {
@@ -3217,7 +3198,7 @@ body {
 }
 .header-language-background,
 .header-language-background a {
-  color: #e6e6e6;
+  color: #E6E6E6;
 }
 
 @media only screen and (max-width: 770px) {
@@ -3378,7 +3359,7 @@ a.skip-link {
   #header-account li a,
   .nav-primary a.level0 {
     padding: 0 15px 0 25px;
-    border-bottom: 1px solid #cccccc;
+    border-bottom: 1px solid #CCCCCC;
     text-align: left;
     color: #636363;
     text-transform: uppercase;
@@ -3392,7 +3373,7 @@ a.skip-link {
 
   .no-touch #header-account a:hover,
   .no-touch .nav-primary a:hover {
-    background-color: #f4f4f4;
+    background-color: #F4F4F4;
     text-decoration: none;
   }
 }
@@ -3450,7 +3431,7 @@ a.skip-link {
   #header-nav {
     display: block;
     /* Force visibility */
-    border-bottom: 1px solid #ededed;
+    border-bottom: 1px solid #EDEDED;
   }
 }
 /* ============================================ *
@@ -3477,7 +3458,7 @@ a.skip-link {
   position: relative;
 }
 .nav-primary li.level1 a {
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
 }
 
 .nav-primary .menu-active > ul.level0,
@@ -3514,7 +3495,7 @@ a.skip-link {
     display: block;
     border-top: 5px solid transparent;
     border-bottom: 5px solid transparent;
-    border-left: 5px solid #cccccc;
+    border-left: 5px solid #ccc;
     border-right: none;
     top: 50%;
     left: 10px;
@@ -3530,7 +3511,7 @@ a.skip-link {
     display: block;
     border-right: 5px solid transparent;
     border-left: 5px solid transparent;
-    border-top: 5px solid #cccccc;
+    border-top: 5px solid #ccc;
     border-bottom: none;
     top: 50%;
     left: 10px;
@@ -3539,7 +3520,7 @@ a.skip-link {
   }
   .nav-primary li.menu-active > a,
   .nav-primary li.sub-menu-active > a {
-    color: #3399cc;
+    color: #3399CC;
   }
 }
 /* ============================================ *
@@ -3565,14 +3546,14 @@ a.skip-link {
   }
   .nav-primary a:hover,
   .nav-primary li:hover > a {
-    color: #3399cc;
+    color: #3399CC;
   }
   .nav-primary .menu-active {
     z-index: 200;
   }
   .nav-primary li.level0 ul {
     background: #FBFBFB;
-    border: solid 1px #cccccc;
+    border: solid 1px #CCCCCC;
     position: absolute;
     left: 0;
     top: 30px;
@@ -3611,7 +3592,7 @@ a.skip-link {
     display: block;
     border-top: 4px solid transparent;
     border-bottom: 4px solid transparent;
-    border-left: 4px solid #cccccc;
+    border-left: 4px solid #ccc;
     border-right: none;
     right: 5px;
     top: 50%;
@@ -3731,7 +3712,7 @@ a.skip-link {
 
   #header-account.skip-active {
     background: #FBFBFB;
-    border: solid 1px #cccccc;
+    border: solid 1px #CCCCCC;
     display: block;
     position: absolute;
     z-index: 200;
@@ -3748,7 +3729,7 @@ a.skip-link {
   }
 
   #header-account a:hover {
-    color: #3399cc;
+    color: #3399CC;
   }
 }
 /* -------------------------------------------- *
@@ -3767,7 +3748,7 @@ a.skip-link {
 }
 
 #header-account a:hover {
-  color: #3399cc;
+  color: #3399CC;
 }
 
 /* ============================================ *
@@ -3791,7 +3772,7 @@ a.skip-link {
 
   #header-cart.skip-active {
     background: #FBFBFB;
-    border: solid 1px #cccccc;
+    border: solid 1px #CCCCCC;
     display: block;
     position: absolute;
     z-index: 200;
@@ -3805,10 +3786,8 @@ a.skip-link {
  * Skip Cart Notifier
  */
 .skip-cart .count {
-  -webkit-border-radius: 12px;
   -moz-border-radius: 12px;
-  -ms-border-radius: 12px;
-  -o-border-radius: 12px;
+  -webkit-border-radius: 12px;
   border-radius: 12px;
   display: inline-block;
   top: -6px;
@@ -3839,17 +3818,15 @@ a.skip-link {
 }
 @media only screen and (min-width: 771px) {
   .skip-cart {
-    color: #3399cc;
+    color: #3399CC;
     text-transform: uppercase;
   }
   .skip-cart:hover {
     text-decoration: none;
   }
   .skip-cart .count {
-    -webkit-border-radius: 0px;
     -moz-border-radius: 0px;
-    -ms-border-radius: 0px;
-    -o-border-radius: 0px;
+    -webkit-border-radius: 0px;
     border-radius: 0px;
     position: static;
     background: none;
@@ -3866,7 +3843,7 @@ a.skip-link {
 
   .skip-cart .count,
   .skip-link.skip-active .count {
-    color: #3399cc;
+    color: #3399CC;
   }
 }
 .skip-cart .count.empty {
@@ -3916,7 +3893,7 @@ a.skip-link {
   position: relative;
   min-height: 90px;
   padding: 15px 15px 15px 90px;
-  border-top: 1px solid #cccccc;
+  border-top: 1px solid #CCCCCC;
   font-size: 13px;
   line-height: 1.35;
 }
@@ -3938,14 +3915,14 @@ a.skip-link {
 
 .mini-cart-list .has-options {
   margin-bottom: 0;
-  color: #a0a0a0;
+  color: #A0A0A0;
   font-size: 12px;
 }
 
 /* Too full - additional items will be shown in cart */
 .cart-menu .last-added {
   padding: 10px 15px 15px;
-  border-top: 1px solid #cccccc;
+  border-top: 1px solid #CCCCCC;
   font-size: 13px;
 }
 
@@ -3963,7 +3940,7 @@ a.skip-link {
 .footer {
   clear: both;
   width: 100%;
-  border-top: 1px solid #cccccc;
+  border-top: 1px solid #CCCCCC;
   padding-top: 30px;
   /* -------------------------------------------- *
    * Social icons
@@ -3983,7 +3960,7 @@ a.skip-link {
 }
 .footer .block-title,
 .footer address {
-  color: #3399cc;
+  color: #3399CC;
 }
 .footer .links {
   float: left;
@@ -4000,7 +3977,7 @@ a.skip-link {
   color: #636363;
 }
 .footer .links a:hover {
-  color: #3399cc;
+  color: #3399CC;
 }
 .footer .block-subscribe {
   float: right;
@@ -4072,10 +4049,8 @@ a.skip-link {
 .footer .block-subscribe .input-text {
   width: 100%;
   border-right: 0;
-  -webkit-border-radius: 0;
   -moz-border-radius: 0;
-  -ms-border-radius: 0;
-  -o-border-radius: 0;
+  -webkit-border-radius: 0;
   border-radius: 0;
 }
 .footer .block-subscribe .block-content {
@@ -4114,7 +4089,7 @@ a.skip-link {
   display: none;
 }
 .footer address {
-  border-top: 1px solid #cccccc;
+  border-top: 1px solid #CCCCCC;
   text-align: center;
   width: 100%;
   font-size: 11px;
@@ -4213,7 +4188,7 @@ h3.product-name a:hover,
 h4.product-name a:hover,
 h5.product-name a:hover,
 p.product-name a:hover {
-  color: #3399cc;
+  color: #3399CC;
   text-decoration: none;
 }
 
@@ -4294,7 +4269,7 @@ p.product-name a:hover {
 }
 
 .products-grid .price-box {
-  color: #a0a0a0;
+  color: #A0A0A0;
   font-size: 13px;
   margin: 0 0 5px;
 }
@@ -4481,7 +4456,7 @@ p.product-name a:hover {
 .products-list > li {
   padding-bottom: 20px;
   margin-bottom: 20px;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
 }
 .products-list > li:after {
   content: '';
@@ -4626,7 +4601,7 @@ p.product-name a:hover {
  * Catalog - List
  * ============================================ */
 .category-image {
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   padding: 10px;
 }
 .category-image img {
@@ -4662,9 +4637,9 @@ p.product-name a:hover {
   padding: 7px 10px 7px 24px;
   border-width: 1px;
   border-style: solid;
-  border-color: #cccccc;
+  border-color: #CCCCCC;
   position: relative;
-  background-color: #f4f4f4;
+  background-color: #F4F4F4;
   cursor: pointer;
 }
 .block-layered-nav .block-subtitle--filter:after {
@@ -4675,14 +4650,14 @@ p.product-name a:hover {
   display: block;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
-  border-top: 4px solid #3399cc;
+  border-top: 4px solid #3399CC;
   border-bottom: none;
   left: 10px;
   top: 50%;
   margin-top: -3px;
 }
 .block-layered-nav .block-subtitle--filter:hover {
-  background-color: #ececec;
+  background-color: #ededed;
 }
 
 .block-layered-nav .block-content .toggle-tabs {
@@ -4709,9 +4684,9 @@ p.product-name a:hover {
   padding: 7px 10px 7px 24px;
   border-width: 1px;
   border-style: solid;
-  border-color: #cccccc;
+  border-color: #CCCCCC;
   position: relative;
-  background-color: #f4f4f4;
+  background-color: #F4F4F4;
   display: block;
 }
 .block-layered-nav .block-content > dl > dt:after {
@@ -4722,21 +4697,21 @@ p.product-name a:hover {
   display: block;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
-  border-top: 4px solid #3399cc;
+  border-top: 4px solid #3399CC;
   border-bottom: none;
   left: 10px;
   top: 50%;
   margin-top: -3px;
 }
 .block-layered-nav .block-content > dl > dt:hover {
-  background-color: #ececec;
+  background-color: #ededed;
 }
 .block-layered-nav .block-content > dl > dd {
   padding: 10px;
   margin: 0;
   border-width: 0 1px;
   border-style: solid;
-  border-color: #cccccc;
+  border-color: #CCCCCC;
 }
 .block-layered-nav .block-content > dl > dd:last-child {
   border-width: 0 1px 1px 1px;
@@ -4751,7 +4726,7 @@ p.product-name a:hover {
   display: block;
 }
 .block-layered-nav dl dd ol > li > a .count {
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 @media only screen and (min-width: 771px) {
@@ -4780,7 +4755,7 @@ p.product-name a:hover {
     border-bottom-width: 0;
   }
   .block-layered-nav .block-content > dl > dt:hover {
-    color: #3399cc;
+    color: #3399CC;
   }
   .block-layered-nav .block-content > dl > dt:after {
     content: '';
@@ -4790,7 +4765,7 @@ p.product-name a:hover {
     display: block;
     border-top: 4px solid transparent;
     border-bottom: 4px solid transparent;
-    border-left: 4px solid #3399cc;
+    border-left: 4px solid #3399CC;
     border-right: none;
   }
   .block-layered-nav .block-content > dl > dt.last {
@@ -4810,7 +4785,7 @@ p.product-name a:hover {
     display: block;
     border-right: 4px solid transparent;
     border-left: 4px solid transparent;
-    border-top: 4px solid #3399cc;
+    border-top: 4px solid #3399CC;
     border-bottom: none;
     left: 6px;
     top: 50%;
@@ -4821,7 +4796,7 @@ p.product-name a:hover {
   }
 
   .block-layered-nav .block-subtitle--filter {
-    background-color: #3399cc;
+    background-color: #3399CC;
     border: 0;
     margin-bottom: 0;
     display: block;
@@ -4835,7 +4810,7 @@ p.product-name a:hover {
     display: block;
     border-top: 4px solid transparent;
     border-bottom: 4px solid transparent;
-    border-left: 4px solid white;
+    border-left: 4px solid #FFFFFF;
     border-right: none;
     right: 10px;
     top: 50%;
@@ -4853,7 +4828,7 @@ p.product-name a:hover {
     display: block;
     border-right: 4px solid transparent;
     border-left: 4px solid transparent;
-    border-top: 4px solid white;
+    border-top: 4px solid #FFFFFF;
     border-bottom: none;
     right: 10px;
     top: 50%;
@@ -4863,7 +4838,7 @@ p.product-name a:hover {
   #narrow-by-list,
   #narrow-by-list2 {
     padding: 10px;
-    border: 1px solid #cccccc;
+    border: 1px solid #CCCCCC;
     border-top: 0;
   }
 
@@ -4875,12 +4850,12 @@ p.product-name a:hover {
 
   .block-layered-nav dl ol > li > a {
     color: #636363;
-    background-color: #f4f4f4;
+    background-color: #F4F4F4;
     padding: 5px 10px;
   }
   .block-layered-nav dl ol > li > a:hover {
     text-decoration: none;
-    background: #ececec;
+    background: #ededed;
   }
 }
 .block-layered-nav .currently .block-subtitle {
@@ -4940,7 +4915,7 @@ p.product-name a:hover {
 }
 .product-view .product-shop .product-name .h1,
 .product-view .product-img-box .product-name h1 {
-  color: #3399cc;
+  color: #3399CC;
   margin-bottom: 10px;
   border: 0;
 }
@@ -4994,7 +4969,7 @@ p.product-name a:hover {
 .product-view .product-shop .price-box .regular-price .price,
 .product-view .product-shop .price-box .special-price .price,
 .product-view .product-shop .price-box .full-product-price .price {
-  color: #3399cc;
+  color: #3399CC;
   font-size: 24px;
 }
 .product-view .product-shop .price-box .special-price .price-label {
@@ -5175,7 +5150,7 @@ p.product-name a:hover {
 .product-view .add-to-cart {
   padding-bottom: 3px;
   margin-bottom: 10px;
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
 }
 .product-view .add-to-cart .qty-wrapper,
 .product-view .product-options-bottom .price-box,
@@ -5283,7 +5258,7 @@ p.product-name a:hover {
 .product-view .add-to-links a {
   padding: 2px 7px 2px 0px;
   margin-left: 7px;
-  border-right: 1px solid #cccccc;
+  border-right: 1px solid #CCCCCC;
 }
 .product-view .add-to-links li:first-child a {
   margin-left: 0px;
@@ -5353,8 +5328,8 @@ p.product-name a:hover {
     display: block;
     width: 100%;
     position: relative;
-    border: 1px solid #cccccc;
-    background-color: #f4f4f4;
+    border: 1px solid #CCCCCC;
+    background-color: #F4F4F4;
   }
   .product-collateral .toggle-tabs li {
     float: left;
@@ -5378,8 +5353,8 @@ p.product-name a:hover {
     bottom: -1px;
   }
   .product-collateral .toggle-tabs li.current {
-    border-right: 1px solid #cccccc;
-    border-left: 1px solid #cccccc;
+    border-right: 1px solid #CCCCCC;
+    border-left: 1px solid #CCCCCC;
   }
   .product-collateral .toggle-tabs li.current > span {
     background-color: #FFFFFF;
@@ -5387,7 +5362,7 @@ p.product-name a:hover {
   }
   .product-collateral .toggle-tabs li.current span,
   .product-collateral .toggle-tabs li:hover span {
-    color: #3399cc;
+    color: #3399CC;
   }
   .product-collateral .toggle-tabs li:first-child {
     border-left: none;
@@ -5407,7 +5382,7 @@ p.product-name a:hover {
     width: 100%;
     display: none;
     padding: 15px;
-    border: 1px solid #cccccc;
+    border: 1px solid #CCCCCC;
     border-top: 0;
   }
   .product-collateral > dl > dd.current {
@@ -5439,9 +5414,9 @@ p.product-name a:hover {
     padding: 7px 10px 7px 24px;
     border-width: 1px;
     border-style: solid;
-    border-color: #cccccc;
+    border-color: #CCCCCC;
     position: relative;
-    background-color: #f4f4f4;
+    background-color: #F4F4F4;
     display: block;
   }
   .product-collateral > dl > dt:after {
@@ -5452,21 +5427,21 @@ p.product-name a:hover {
     display: block;
     border-right: 4px solid transparent;
     border-left: 4px solid transparent;
-    border-top: 4px solid #3399cc;
+    border-top: 4px solid #3399CC;
     border-bottom: none;
     left: 10px;
     top: 50%;
     margin-top: -3px;
   }
   .product-collateral > dl > dt:hover {
-    background-color: #ececec;
+    background-color: #ededed;
   }
   .product-collateral > dl > dd {
     padding: 10px;
     margin: 0;
     border-width: 0 1px;
     border-style: solid;
-    border-color: #cccccc;
+    border-color: #CCCCCC;
   }
   .product-collateral > dl > dd:last-child {
     border-width: 0 1px 1px 1px;
@@ -5476,7 +5451,7 @@ p.product-name a:hover {
     border-bottom-width: 0;
   }
   .product-collateral > dl > dt:hover {
-    color: #3399cc;
+    color: #3399CC;
   }
   .product-collateral > dl > dt:after {
     content: '';
@@ -5486,7 +5461,7 @@ p.product-name a:hover {
     display: block;
     border-top: 4px solid transparent;
     border-bottom: 4px solid transparent;
-    border-left: 4px solid #3399cc;
+    border-left: 4px solid #3399CC;
     border-right: none;
   }
   .product-collateral > dl > dt.last {
@@ -5506,7 +5481,7 @@ p.product-name a:hover {
     display: block;
     border-right: 4px solid transparent;
     border-left: 4px solid transparent;
-    border-top: 4px solid #3399cc;
+    border-top: 4px solid #3399CC;
     border-bottom: none;
     left: 6px;
     top: 50%;
@@ -5554,18 +5529,18 @@ p.product-name a:hover {
 
 #product-attribute-specs-table {
   max-width: 50em;
-  border: 1px solid silver;
+  border: 1px solid #C0C0C0;
 }
 #product-attribute-specs-table th {
-  border-right: 1px solid silver;
-  border-bottom: 1px solid silver;
+  border-right: 1px solid #C0C0C0;
+  border-bottom: 1px solid #C0C0C0;
 }
 
 /* -------------------------------------------- *
  * Catalog - Grouped Product List
  */
 .grouped-items-table-wrapper {
-  border: solid 1px silver;
+  border: solid 1px #C0C0C0;
   width: 100%;
   padding: 10px;
   margin-bottom: 15px;
@@ -5580,7 +5555,7 @@ p.product-name a:hover {
 }
 
 .grouped-items-table .name-wrapper {
-  color: #3399cc;
+  color: #3399CC;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
 }
 .grouped-items-table .qty-wrapper {
@@ -5607,7 +5582,7 @@ p.product-name a:hover {
   width: 100%;
   margin: 10px 0 0;
   padding: 10px 15px 15px;
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   clear: both;
   position: relative;
 }
@@ -5655,7 +5630,7 @@ p.product-name a:hover {
 .product-options dd {
   padding: 0 0 10px 0;
   margin: 0 0 5px;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
 }
 
 .product-options dl.last dd.last {
@@ -5677,11 +5652,10 @@ p.product-name a:hover {
 }
 
 .product-options dd .time-picker {
-  display: -moz-inline-stack;
   display: inline-block;
   vertical-align: middle;
   *vertical-align: auto;
-  zoom: 1;
+  *zoom: 1;
   *display: inline;
   padding: 2px 0;
   vertical-align: middle;
@@ -5730,9 +5704,9 @@ p.product-name a:hover {
 }
 
 .product-options-bottom {
-  background-color: #f4f4f4;
+  background-color: #F4F4F4;
   padding: 15px 20px;
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   border-top: 0;
   margin-bottom: 10px;
 }
@@ -5760,7 +5734,7 @@ p.product-name a:hover {
     text-align: right;
     padding-bottom: 5px;
     margin-bottom: 10px;
-    border-bottom: 1px solid #cccccc;
+    border-bottom: 1px solid #CCCCCC;
   }
 }
 
@@ -5895,7 +5869,7 @@ p.product-name a:hover {
 
 .map-popup {
   background: #FFFFFF;
-  border: 5px solid #cccccc;
+  border: 5px solid #CCCCCC;
   margin: 12px 0 0;
   position: absolute;
   text-align: left;
@@ -5948,7 +5922,7 @@ p.product-name a:hover {
   text-align: center;
 }
 .map-popup .map-popup-content {
-  border-top: 1px solid #ededed;
+  border-top: 1px solid #EDEDED;
   padding: 10px;
   margin: 0 10px;
   overflow: hidden;
@@ -6052,7 +6026,7 @@ p.product-name a:hover {
 }
 .map-popup .map-popup-text,
 .map-popup .map-popup-only-text {
-  border-top: 1px solid #ededed;
+  border-top: 1px solid #EDEDED;
 }
 
 /* ============================================ *
@@ -6110,8 +6084,8 @@ p.product-name a:hover {
 .cart-forms .giftcard,
 .cart-forms .shipping {
   padding: 10px;
-  background-color: #f4f4f4;
-  border: 1px solid #cccccc;
+  background-color: #F4F4F4;
+  border: 1px solid #CCCCCC;
 }
 
 .cart-table,
@@ -6202,7 +6176,7 @@ p.product-name a:hover {
  * ============================================ */
 .cart .page-title {
   margin-bottom: 15px;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
 }
 .cart .page-title:after {
   content: '';
@@ -6320,7 +6294,7 @@ p.product-name a:hover {
   padding-left: 15px;
 }
 .cart-table tr {
-  border-bottom: 1px solid silver;
+  border-bottom: 1px solid #C0C0C0;
 }
 .cart-table tfoot tr {
   background: none;
@@ -6380,7 +6354,7 @@ p.product-name a:hover {
   display: block;
   border-top: 6px solid transparent;
   border-bottom: 6px solid transparent;
-  border-right: 6px solid #3399cc;
+  border-right: 6px solid #3399CC;
   border-left: none;
   position: absolute;
   top: 3px;
@@ -6394,7 +6368,7 @@ p.product-name a:hover {
   display: block;
   border-right: 6px solid transparent;
   border-left: 6px solid transparent;
-  border-top: 6px solid #3399cc;
+  border-top: 6px solid #3399CC;
   border-bottom: none;
   right: -15px;
   top: 6px;
@@ -6418,7 +6392,7 @@ p.product-name a:hover {
 }
 .cart-table .product-cart-actions .qty {
   height: 30px;
-  border-color: silver;
+  border-color: #C0C0C0;
   border-radius: 0;
   margin-bottom: 10px;
   text-align: center;
@@ -6599,10 +6573,10 @@ p.product-name a:hover {
   max-width: 100%;
   height: 30px;
   display: block;
-  border: 1px solid silver;
+  border: 1px solid #C0C0C0;
 }
 .shipping select.validation-failed {
-  border-color: #df280a;
+  border-color: #DF280A;
 }
 .shipping .shipping-desc {
   display: none;
@@ -6671,12 +6645,12 @@ p.product-name a:hover {
   margin-left: 0;
 }
 .shipping #co-shipping-method-form .sp-methods dd label {
-  border: 1px solid #cccccc;
-  background-color: #ececec;
+  border: 1px solid #CCCCCC;
+  background-color: #ededed;
   min-width: 220px;
 }
 .shipping #co-shipping-method-form .sp-methods dd label:hover {
-  background-color: #dbdbdb;
+  background-color: gainsboro;
 }
 
 @media only screen and (max-width: 770px) {
@@ -6813,7 +6787,7 @@ p.product-name a:hover {
  * Checkout - Cart Cross sell
  * ============================================ */
 .crosssell h2 {
-  color: #3399cc;
+  color: #3399CC;
 }
 .crosssell .item a.product-image {
   width: auto;
@@ -6894,7 +6868,7 @@ p.product-name a:hover {
  */
 .opc .section .step-title {
   width: 100%;
-  border-top: 1px solid #ececec;
+  border-top: 1px solid #ECECEC;
   position: relative;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -6914,11 +6888,11 @@ p.product-name a:hover {
 
 /* Using .no-touch since touch devices emulate hover, thereby making steps look active that are not */
 .no-touch .opc .section.allow:not(.active) .step-title:hover {
-  background-color: #f4f4f4;
+  background-color: #F4F4F4;
 }
 
 .opc .section.active .step-title {
-  border-bottom: 1px solid #ececec;
+  border-bottom: 1px solid #ECECEC;
 }
 
 .opc .section .step-title a {
@@ -6945,7 +6919,7 @@ p.product-name a:hover {
   text-align: center;
   color: #FFFFFF;
   line-height: 26px;
-  background-color: #3399cc;
+  background-color: #3399CC;
   display: block;
   position: absolute;
   top: 50%;
@@ -6954,16 +6928,16 @@ p.product-name a:hover {
 }
 
 .opc .section.allow .step-title .number {
-  background-color: #99cce5;
+  background-color: #99cce6;
 }
 
 .opc .section.allow .step-title h2 {
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 .opc .section.allow .step-title:hover h2,
 .opc .section.active .step-title h2 {
-  color: #3399cc;
+  color: #3399CC;
 }
 
 .opc .section .step-title h2 {
@@ -7054,27 +7028,24 @@ p.product-name a:hover {
  */
 .opc.opc-firststep-login .section:not(#opc-login) .step-title,
 .opc-block-progress-step-login {
-  -webkit-transition: opacity 300ms linear;
-  -webkit-transition-delay: 0;
-  -moz-transition: opacity 300ms linear 0;
-  -o-transition: opacity 300ms linear 0;
-  transition: opacity 300ms linear 0;
+  -moz-transition: opacity 300ms 0;
+  -o-transition: opacity 300ms 0;
+  -webkit-transition: opacity 300ms 0;
+  transition: opacity 300ms 0;
 }
 
 .opc.opc-firststep-login .section#opc-login .step-title .number {
-  -webkit-transition: width 80ms linear;
-  -webkit-transition-delay: 0;
-  -moz-transition: width 80ms linear 0;
-  -o-transition: width 80ms linear 0;
-  transition: width 80ms linear 0;
+  -moz-transition: width 80ms 0;
+  -o-transition: width 80ms 0;
+  -webkit-transition: width 80ms 0;
+  transition: width 80ms 0;
 }
 
 .opc.opc-firststep-login .section#opc-login .step-title h2 {
-  -webkit-transition: margin-left 80ms linear;
-  -webkit-transition-delay: 0;
-  -moz-transition: margin-left 80ms linear 0;
-  -o-transition: margin-left 80ms linear 0;
-  transition: margin-left 80ms linear 0;
+  -moz-transition: margin-left 80ms 0;
+  -o-transition: margin-left 80ms 0;
+  -webkit-transition: margin-left 80ms 0;
+  transition: margin-left 80ms 0;
 }
 
 /* When a user progresses from the "Checkout Method" to "Billing Information" for the first time, the              */
@@ -7175,7 +7146,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 .block-progress {
   border: 0;
   margin: 0;
-  border-left: 1px solid #cccccc;
+  border-left: 1px solid #CCCCCC;
   padding-left: 20px;
 }
 .block-progress .block-content {
@@ -7196,7 +7167,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   margin-bottom: 6px;
   text-transform: uppercase;
   font-weight: normal;
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 .block-progress dt.complete {
   color: #636363;
@@ -7381,7 +7352,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 .gift-message-form .gift-item {
   padding-bottom: 10px;
   margin-bottom: 10px;
-  border-bottom: solid 1px #ececec;
+  border-bottom: solid 1px #ECECEC;
 }
 .gift-message-form .gift-item:after {
   content: '';
@@ -7458,7 +7429,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 }
 
 .swatch-link {
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   margin: 0 0 3px;
 }
 .swatch-link img {
@@ -7492,7 +7463,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   border: 1px solid #fff;
   margin: 0;
   white-space: nowrap;
-  background: #f4f4f4;
+  background: #F4F4F4;
 }
 
 .configurable-swatch-list {
@@ -7516,7 +7487,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   display: block;
 }
 .configurable-swatch-list .not-available .swatch-link {
-  border-color: #ededed;
+  border-color: #EDEDED;
   position: relative;
 }
 .configurable-swatch-list .not-available .swatch-link.has-image img {
@@ -7548,11 +7519,11 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   line-height: inherit;
 }
 #narrow-by-list dd .swatch-link:hover .swatch-label {
-  border-color: #3399cc;
+  border-color: #3399CC;
 }
 #narrow-by-list dd .swatch-label {
-  background: #f4f4f4;
-  border: 1px solid #cccccc;
+  background: #F4F4F4;
+  border: 1px solid #CCCCCC;
   border-radius: 3px;
   display: block;
   float: left;
@@ -7593,7 +7564,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   margin: 0 0 0 3px;
 }
 .currently .swatch-link:hover {
-  border-color: #cccccc;
+  border-color: #CCCCCC;
   cursor: default;
 }
 
@@ -7601,7 +7572,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 .configurable-swatch-list .hover .swatch-link,
 .configurable-swatch-list .selected .swatch-link,
 .swatch-link:hover {
-  border-color: #3399cc;
+  border-color: #3399CC;
 }
 
 .configurable-swatch-box {
@@ -7612,7 +7583,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 }
 .configurable-swatch-box .validation-advice {
   margin: 0 0 5px;
-  background: #df280a;
+  background: #DF280A;
   padding: 2px 5px !important;
   font-weight: bold;
   color: #fff !important;
@@ -7623,7 +7594,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 
 /* CUSTOM */
 .availability.out-of-stock span {
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 .product-view .product-options .swatch-attr {
@@ -7643,7 +7614,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 .product-view .product-options .swatch-attr .select-label {
   display: inline;
   font-weight: normal;
-  color: #3399cc;
+  color: #3399CC;
   padding-left: 5px;
 }
 .product-view .product-options dd .input-box {
@@ -7690,7 +7661,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   }
   .customer-account-login .col2-set .col-2 {
     padding-left: 20px;
-    border-left: 1px solid #ededed;
+    border-left: 1px solid #EDEDED;
   }
 }
 @media only screen and (min-width: 770px) {
@@ -7699,7 +7670,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   }
   .customer-account-login .col2-set .col-2 {
     padding-left: 60px;
-    border-left: 1px solid #ededed;
+    border-left: 1px solid #EDEDED;
   }
 }
 @media only screen and (max-width: 479px) {
@@ -7708,7 +7679,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   }
   .customer-account-login .col2-set .col-2 {
     padding-top: 30px;
-    border-top: 1px solid #ededed;
+    border-top: 1px solid #EDEDED;
   }
 }
 @media only screen and (max-width: 770px) {
@@ -7725,7 +7696,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   font-style: italic;
   font-family: Georgia, Times, "Times New Roman", serif;
   font-size: 13px;
-  color: #a0a0a0;
+  color: #A0A0A0;
 }
 
 .remember-me-box a.hide {
@@ -7738,7 +7709,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 
 .remember-me-popup {
   display: none;
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   padding: 10px;
   position: relative;
 }
@@ -7901,7 +7872,7 @@ body.customer-account .sidebar .block-reorder ol#cart-sidebar-reorder p.product-
  * ============================================ */
 .dashboard .box-head {
   margin-top: 30px;
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
   padding-bottom: 7px;
 }
 .dashboard .box-head h2 {
@@ -7920,7 +7891,7 @@ body.customer-account .sidebar .block-reorder ol#cart-sidebar-reorder p.product-
 }
 .dashboard .box-account {
   padding-bottom: 40px;
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
   margin-bottom: 45px;
 }
 .dashboard .box-account p,
@@ -7955,7 +7926,7 @@ body.customer-account .sidebar .block-reorder ol#cart-sidebar-reorder p.product-
 }
 .dashboard .box-reviews li {
   padding: 10px 0;
-  border-top: 1px solid #ededed;
+  border-top: 1px solid #EDEDED;
 }
 .dashboard .box-reviews li:first-child {
   border-top: 0;
@@ -8025,7 +7996,7 @@ body.customer-account .sidebar .block-reorder ol#cart-sidebar-reorder p.product-
  * ============================================ */
 .order-info {
   padding-bottom: 10px;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
   width: 100%;
   margin-bottom: 30px;
 }
@@ -8059,7 +8030,7 @@ body.customer-account .sidebar .block-reorder ol#cart-sidebar-reorder p.product-
 }
 .order-info-box + .order-info-box {
   padding-bottom: 40px;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
 }
 .order-info-box .col-1 {
   padding-right: 0;
@@ -8147,7 +8118,7 @@ ol#cart-sidebar-reorder p.product-name {
     margin-right: 10px;
   }
   #my-orders-table tr.bundle {
-    border-color: #ededed;
+    border-color: #EDEDED;
   }
   #my-orders-table tr.bundle.child td[data-rwd-label] {
     padding-left: 60px;
@@ -8306,7 +8277,7 @@ ol#cart-sidebar-reorder p.product-name {
   .order-info-box .col-1,
   .order-info-box .col-2 {
     width: 100%;
-    border-bottom: 1px solid #ededed;
+    border-bottom: 1px solid #EDEDED;
     padding: 15px 0;
   }
   .order-info-box + .order-info-box {
@@ -8329,7 +8300,7 @@ body.newsletter-manage-index .my-account .fieldset h2 {
   display: none;
 }
 body.newsletter-manage-index .my-account .form-list {
-  border-top: 1px solid #ededed;
+  border-top: 1px solid #EDEDED;
   padding-top: 10px;
 }
 
@@ -8366,10 +8337,11 @@ body.newsletter-manage-index .my-account .form-list {
     padding: 0px;
   }
 }
+
 .paypal-review-order .info-set {
   margin-bottom: 10px;
   padding-bottom: 10px;
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
 }
 .paypal-review-order .buttons-set {
   margin-top: 0px;
@@ -8494,8 +8466,8 @@ div.paypal-logo span > img {
   float: none;
 }
 #customer-reviews .review-heading {
-  border-top: 1px solid #cccccc;
-  border-bottom: 1px solid #cccccc;
+  border-top: 1px solid #CCCCCC;
+  border-bottom: 1px solid #CCCCCC;
   padding: 10px 0 5px;
 }
 #customer-reviews .review-heading:after {
@@ -8524,7 +8496,7 @@ div.paypal-logo span > img {
   display: none;
 }
 #customer-reviews h2 {
-  color: #3399cc;
+  color: #3399CC;
   font-size: 12px;
   text-transform: uppercase;
 }
@@ -8538,14 +8510,14 @@ div.paypal-logo span > img {
   text-transform: uppercase;
 }
 #customer-reviews h3 span {
-  color: #3399cc;
+  color: #3399CC;
 }
 #customer-reviews .fieldset {
   padding-top: 25px;
   width: 470px;
 }
 #customer-reviews .fieldset h4 {
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
   font-size: 12px;
   font-weight: normal;
@@ -8573,13 +8545,13 @@ div.paypal-logo span > img {
   font-weight: normal;
 }
 #customer-reviews .fieldset .form-list textarea {
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   border-radius: 0;
   min-width: 100%;
   -webkit-appearance: none;
 }
 #customer-reviews .fieldset .form-list input {
-  border: 1px solid #cccccc;
+  border: 1px solid #CCCCCC;
   border-radius: 0;
 }
 #customer-reviews .fieldset .form-list input[type="text"] {
@@ -8621,7 +8593,7 @@ div.paypal-logo span > img {
   margin: 15px 0;
 }
 #customer-reviews dl dd .review-meta {
-  color: #3399cc;
+  color: #3399CC;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
   font-size: 10px;
   font-weight: normal;
@@ -8629,7 +8601,7 @@ div.paypal-logo span > img {
 }
 
 .review-summary-table {
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
   margin: 0 0 10px;
 }
 .review-summary-table thead {
@@ -8795,7 +8767,7 @@ div.paypal-logo span > img {
   display: block;
   width: 100%;
   margin: 10px 0;
-  border: 1px solid #ededed;
+  border: 1px solid #EDEDED;
 }
 .slideshow-container .slideshow {
   width: 100%;
@@ -8965,7 +8937,7 @@ div.paypal-logo span > img {
   width: 100%;
 }
 #wishlist-table.clean-table th {
-  border-bottom: 1px solid silver;
+  border-bottom: 1px solid #C0C0C0;
 }
 #wishlist-table.clean-table td {
   padding: 15px;
@@ -8983,7 +8955,7 @@ div.paypal-logo span > img {
   text-transform: uppercase;
 }
 #wishlist-table .product-name a {
-  color: #3399cc;
+  color: #3399CC;
 }
 #wishlist-table .wishlist-sku {
   font-size: 11px;
@@ -8991,7 +8963,7 @@ div.paypal-logo span > img {
   margin: 5px 0;
 }
 #wishlist-table textarea {
-  border: 1px solid silver;
+  border: 1px solid #C0C0C0;
   width: 100%;
   height: 45px;
   font-size: 11px;
@@ -9010,7 +8982,7 @@ div.paypal-logo span > img {
   text-transform: uppercase;
 }
 #wishlist-table textarea:focus {
-  border: 1px solid #3399cc;
+  border: 1px solid #3399CC;
 }
 #wishlist-table .item-manage {
   text-align: right;
@@ -9077,12 +9049,12 @@ div.paypal-logo span > img {
 }
 #wishlist-table .giftregisty-add li {
   cursor: pointer;
-  color: #3399cc;
+  color: #3399CC;
   margin-bottom: 3px;
 }
 #wishlist-table .truncated .details {
   background: none;
-  color: #3399cc;
+  color: #3399CC;
 }
 #wishlist-table td[data-rwd-label]:before {
   font-weight: 600;
@@ -9241,7 +9213,7 @@ div.paypal-logo span > img {
   text-transform: uppercase;
   margin-right: 7px;
   padding-right: 7px;
-  border-right: 1px solid #ededed;
+  border-right: 1px solid #EDEDED;
 }
 
 /* ============================================ *
@@ -9339,7 +9311,7 @@ div.paypal-logo span > img {
   font-weight: bold;
 }
 .header-minicart .product-details .product-name a {
-  color: #3399cc;
+  color: #3399CC;
 }
 .header-minicart .info-wrapper {
   margin-bottom: 0.5em;
@@ -9349,7 +9321,7 @@ div.paypal-logo span > img {
   padding-right: 10px;
 }
 .header-minicart .info-wrapper td {
-  color: #3399cc;
+  color: #3399CC;
   clear: right;
 }
 .header-minicart .info-wrapper .qty-wrapper td {
@@ -9366,13 +9338,13 @@ div.paypal-logo span > img {
 }
 .header-minicart .info-wrapper .quantity-button {
   opacity: 0;
-  -webkit-transition-property: opacity;
   -moz-transition-property: opacity;
   -o-transition-property: opacity;
+  -webkit-transition-property: opacity;
   transition-property: opacity;
-  -webkit-transition-duration: 100ms;
   -moz-transition-duration: 100ms;
   -o-transition-duration: 100ms;
+  -webkit-transition-duration: 100ms;
   transition-duration: 100ms;
 }
 .header-minicart .info-wrapper .quantity-button[disabled] {
@@ -9391,7 +9363,7 @@ div.paypal-logo span > img {
   text-transform: uppercase;
 }
 .header-minicart .subtotal .price {
-  color: #3399cc;
+  color: #3399CC;
 }
 .header-minicart .minicart-actions {
   padding: 10px;
@@ -9519,13 +9491,11 @@ div.paypal-logo span > img {
   z-index: 200;
 }
 .search-autocomplete ul {
-  -webkit-border-radius: 2px;
   -moz-border-radius: 2px;
-  -ms-border-radius: 2px;
-  -o-border-radius: 2px;
+  -webkit-border-radius: 2px;
   border-radius: 2px;
   background-color: #FFFFFF;
-  border: 1px solid #3399cc;
+  border: 1px solid #3399CC;
   left: 0;
   padding-left: 0;
   position: absolute;
@@ -9533,8 +9503,8 @@ div.paypal-logo span > img {
   width: 100%;
 }
 .search-autocomplete ul li {
-  border-bottom: 1px solid #f4f4f4;
-  color: #3399cc;
+  border-bottom: 1px solid #F4F4F4;
+  color: #3399CC;
   cursor: pointer;
   font-size: 12px;
   padding: 4px 6px;
@@ -9544,7 +9514,7 @@ div.paypal-logo span > img {
   color: #2e8ab8;
 }
 .search-autocomplete ul li.selected {
-  background-color: #3399cc;
+  background-color: #3399CC;
   color: white;
 }
 .search-autocomplete ul li .amount {
@@ -9562,7 +9532,7 @@ div.paypal-logo span > img {
   display: block;
   border-right: 7px solid transparent;
   border-left: 7px solid transparent;
-  border-bottom: 7px solid #3399cc;
+  border-bottom: 7px solid #3399CC;
   border-top: none;
   left: 50%;
   top: -7px;
@@ -9572,12 +9542,12 @@ div.paypal-logo span > img {
  * Search - Advanced
  * ============================================ */
 .advanced-search {
-  background: #f4f4f4;
-  border: 1px solid #ededed;
+  background: #F4F4F4;
+  border: 1px solid #EDEDED;
   padding: 30px;
 }
 .advanced-search select.multiselect option {
-  border-bottom: 1px solid #ededed;
+  border-bottom: 1px solid #EDEDED;
   padding: 2px 5px;
 }
 
@@ -9590,7 +9560,7 @@ div.paypal-logo span > img {
  * Account - Reviews
  * ============================================ */
 .product-review .product-img-box p.label {
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
   font-size: 16px;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
   margin-top: 20px;
@@ -9601,7 +9571,7 @@ div.paypal-logo span > img {
   margin: 15px 0;
 }
 .product-review .product-details h2 {
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
   color: #3399CC;
   font-size: 16px;
   font-weight: 600;
@@ -9621,7 +9591,7 @@ div.paypal-logo span > img {
   text-transform: uppercase;
 }
 .product-review .ratings-description dt {
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
   font-size: 16px;
   font-weight: 400;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
@@ -9678,11 +9648,11 @@ div.paypal-logo span > img {
 }
 .cms-page-view .std h1,
 .cms-no-route .std h1 {
-  color: #3399cc;
+  color: #3399CC;
 }
 .cms-page-view .std h2,
 .cms-no-route .std h2 {
-  color: #3399cc;
+  color: #3399CC;
 }
 .cms-page-view .std li,
 .cms-no-route .std li {
@@ -9746,9 +9716,9 @@ div.paypal-logo span > img {
   padding: 7px 10px 7px 24px;
   border-width: 1px;
   border-style: solid;
-  border-color: #cccccc;
+  border-color: #CCCCCC;
   position: relative;
-  background-color: #f4f4f4;
+  background-color: #F4F4F4;
   display: block;
 }
 #accordion > dl > dt:after {
@@ -9759,21 +9729,21 @@ div.paypal-logo span > img {
   display: block;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
-  border-top: 4px solid #3399cc;
+  border-top: 4px solid #3399CC;
   border-bottom: none;
   left: 10px;
   top: 50%;
   margin-top: -3px;
 }
 #accordion > dl > dt:hover {
-  background-color: #ececec;
+  background-color: #ededed;
 }
 #accordion > dl > dd {
   padding: 10px;
   margin: 0;
   border-width: 0 1px;
   border-style: solid;
-  border-color: #cccccc;
+  border-color: #CCCCCC;
 }
 #accordion > dl > dd:last-child {
   border-width: 0 1px 1px 1px;
@@ -9831,7 +9801,7 @@ div.paypal-logo span > img {
  * Pricing Conditions
  * ============================================ */
 .price-box .minimal-price-link .label {
-  color: #cf5050;
+  color: #CF5050;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
   font-size: 12px;
   text-transform: uppercase;
@@ -9928,8 +9898,8 @@ div.paypal-logo span > img {
 }
 
 .product-tags {
-  background-color: #f4f4f4;
-  border: 1px solid #cccccc;
+  background-color: #F4F4F4;
+  border: 1px solid #CCCCCC;
   float: left;
   margin-bottom: 10px;
   padding: 5px 1% 10px;
@@ -10024,7 +9994,7 @@ div.paypal-logo span > img {
 }
 
 .captcha-img {
-  border: 20px solid #bbbbbb;
+  border: 20px solid #bbb;
 }
 
 .captcha-input-container {
@@ -10375,15 +10345,15 @@ body[class*="checkout-multishipping-"] .checkout-progress > li {
   width: 20%;
   text-align: center;
   padding: 8px 1% 6px;
-  background: #f4f4f4;
+  background: #F4F4F4;
   text-transform: uppercase;
-  border-bottom: 1px solid #cccccc;
-  border-right: 1px solid #cccccc;
+  border-bottom: 1px solid #CCCCCC;
+  border-right: 1px solid #CCCCCC;
   margin-bottom: 10px;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
 }
 body[class*="checkout-multishipping-"] .checkout-progress > li.active {
-  background-color: #dddddd;
+  background-color: #DDDDDD;
 }
 body[class*="checkout-multishipping-"] .checkout-progress > li.last {
   border-right: 0px;
@@ -10473,8 +10443,8 @@ body[class*="checkout-multishipping-"] #review-buttons-container {
 .checkout-multishipping-overview .col-2 .box-title h4 {
   font-weight: normal;
   width: 100%;
-  background: #f4f4f4;
-  border-bottom: 1px solid #cccccc;
+  background: #F4F4F4;
+  border-bottom: 1px solid #CCCCCC;
   padding: 10px;
   font-size: 14px;
 }
@@ -10485,8 +10455,8 @@ body[class*="checkout-multishipping-"] #review-buttons-container {
 .checkout-multishipping-overview .col-2 > h4 {
   font-weight: normal;
   width: 100%;
-  background: #f4f4f4;
-  border-bottom: 1px solid #cccccc;
+  background: #F4F4F4;
+  border-bottom: 1px solid #CCCCCC;
   padding: 10px;
   font-size: 14px;
 }
@@ -10503,10 +10473,6 @@ body[class*="checkout-multishipping-"] #review-buttons-container {
 .checkout-multishipping-billing .sp-methods dt {
   float: left;
   width: 100%;
-}
-
-.checkout-multishipping-payment-customerbalance input.checkbox {
-  margin-left: 15px;
 }
 
 #multiship-addresses-table > tbody > tr > td.a-center.last > a {

--- a/skin/frontend/rwd/default/css/styles.css
+++ b/skin/frontend/rwd/default/css/styles.css
@@ -1,36 +1,21 @@
-/*
-// ----------------------------------------------
-// Usage example:
-// For IE set $mq-support to false.
-// Set the fixed value.
-// Then use mixins to test whether styles should be applied.
-// ----------------------------------------------
-
-$mq-support: false;
-$mq-fixed-value: 1024;
-
-// Renders at fixed value
-@include bp (min-width, 300px) {
-    div { color:#000; }
-}
-
-// Doesn't render without MQ support
-@include bp (min-width, 1200px) {
-    div { color:#FFF; }
-}
-
-// Doesn't render without MQ support
-@include bp (max-width, 300px) {
-    div { color:#444; }
-}
-
-// Renders at fixed value
-@include bp (max-width, 1200px) {
-    div { color:#888; }
-}
-
-// ----------------------------------------------
-*/
+/**
+ * OpenMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE_AFL.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * @category    design
+ * @package     rwd_default
+ * @copyright   Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
+ * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
 /*! normalize.css v2.0.1 | MIT License | git.io/normalize */
 /* ==========================================================================
    HTML5 display definitions

--- a/skin/frontend/rwd/default/scss/core/_common.scss
+++ b/skin/frontend/rwd/default/scss/core/_common.scss
@@ -1513,6 +1513,7 @@ span.weee {
  */
 
 .toolbar {
+    display: flex;
     margin-top: $box-spacing;
     margin-bottom: 15px;
     border-bottom: 1px solid $c-module-border;
@@ -1551,11 +1552,12 @@ span.weee {
 $toolbar-icon-padding-offset: 8px;
 
 .sorter {
+    flex-grow: 1;
     float: left;
+    white-space: nowrap;
     margin-bottom: 5px;
 
     label {
-        float: left;
         margin-right: 5px;
 
         &:after {
@@ -1565,7 +1567,6 @@ $toolbar-icon-padding-offset: 8px;
 }
 
 .sorter > .sort-by {
-    float: left;
     margin-right: 5px;
     height: 30px;
 
@@ -1590,11 +1591,8 @@ $toolbar-icon-padding-offset: 8px;
 }
 
 .sorter > .view-mode {
-    float: right;
-
     .grid,
     .list {
-        float: left;
         width: 30px;
         height: 30px;
         @extend .icon-sprite;
@@ -1618,8 +1616,8 @@ $toolbar-icon-padding-offset: 8px;
 }
 
 .pager {
+    white-space: nowrap;
     float: right;
-    overflow: hidden;
 
     & > .count-container {
         float: left;
@@ -1758,20 +1756,6 @@ $toolbar-icon-padding-offset: 8px;
         .pager {
             width: 100%;
         }
-
-        .pager {
-            float: left;
-            clear: both;
-
-            .pages {
-                float: left;
-                margin-left: 0;
-            }
-
-            .count-container {
-                float: right;
-            }
-        }
     }
 }
 
@@ -1780,15 +1764,8 @@ $toolbar-icon-padding-offset: 8px;
     .col2-left-layout,
     .col2-right-layout,
     .col3-layout {
-        .sorter,
-        .pager {
-            width: 100%;
-        }
 
         .pager {
-            float: left;
-            clear: both;
-
             .pages {
                 float: left;
                 margin-left: 0;

--- a/skin/frontend/rwd/default/scss/email-non-inline.scss
+++ b/skin/frontend/rwd/default/scss/email-non-inline.scss
@@ -27,7 +27,7 @@
 @import "framework";
 
 /* Font Styles */
-@import url(https://fonts.googleapis.com/css?family=Raleway:400,500,700);
+@import url("https://fonts.googleapis.com/css?family=Raleway:400,500,700");
 
 /* Media Queries */
 /* Setting the Web Font inside a media query so that Outlook doesn't try to render the web font */


### PR DESCRIPTION
At some resolutions the toolbar is shown with the pager on a new row:

<img width="806" alt="Schermata 2022-09-30 alle 14 53 42" src="https://user-images.githubusercontent.com/909743/193285282-1ccd9c2a-f2f3-4a12-b4eb-ae4c93a1b90f.png">

So I decided to do a bit of a cleanup of that part of the CSS, starting to use flexbox and removing everything that I could and that was not necessary anymore, the result is this (on a modern browser)

<img width="1262" alt="Schermata 2022-09-30 alle 14 09 44" src="https://user-images.githubusercontent.com/909743/193285549-440367bc-8391-451d-a65a-d34fa3909162.png">

and I still checked that IE8 works:

<img width="1451" alt="Schermata 2022-09-30 alle 14 09 32" src="https://user-images.githubusercontent.com/909743/193285763-ee226604-965e-4e3b-b6c6-95b0e5b3f0a8.png">

To compile the CSS I used "compass compile" which, as far as I know, should be the right way to do it. This is the reason why there are quite some differences in the generated CSS.