### PR TITLE
Prevent from editing a non-editable Order

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/EditController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/EditController.php
@@ -44,15 +44,19 @@ class Mage_Adminhtml_Sales_Order_EditController extends Mage_Adminhtml_Sales_Ord
         $orderId = $this->getRequest()->getParam('order_id');
         $order = Mage::getModel('sales/order')->load($orderId);
 
+        if (!$order->getId()) {
+            $this->_redirect('*/sales_order/');
+            return;
+        }
+
         try {
-            if ($order->getId()) {
-                $this->_getSession()->setUseOldShippingMethod(true);
-                $this->_getOrderCreateModel()->initFromOrder($order);
-                $this->_redirect('*/*');
+            if (!$order->canEdit()) {
+                Mage::throwException(Mage::helper('sales')->__('This order cannot be edited.'));
             }
-            else {
-                $this->_redirect('*/sales_order/');
-            }
+
+            $this->_getSession()->setUseOldShippingMethod(true);
+            $this->_getOrderCreateModel()->initFromOrder($order);
+            $this->_redirect('*/*');
         } catch (Mage_Core_Exception $e) {
             Mage::getSingleton('adminhtml/session')->addError($e->getMessage());
             $this->_redirect('*/sales_order/view', ['order_id' => $orderId]);

--- a/app/locale/en_US/Mage_Sales.csv
+++ b/app/locale/en_US/Mage_Sales.csv
@@ -780,6 +780,7 @@
 "There is no update for the payment.","There is no update for the payment."
 "This message will be shown in shopping cart when subtotal after discount less than minimum amount.","This message will be shown in shopping cart when subtotal after discount less than minimum amount."
 "This operation requires an existing transaction object.","This operation requires an existing transaction object."
+"This order cannot be edited.","This order cannot be edited."
 "This order contains (%s) items and therefore cannot be edited through the admin interface at this time, if you wish to continue editing the (%s) items will be removed, the order will be canceled and a new order will be placed.","This order contains (%s) items and therefore cannot be edited through the admin interface at this time, if you wish to continue editing the (%s) items will be removed, the order will be canceled and a new order will be placed."
 "This order no longer exists.","This order no longer exists."
 "This product does not have any configurable options","This product does not have any configurable options"


### PR DESCRIPTION
### Description (*)

This PR will add a check before editing an Order to see if it's editable. This prevents from editing an Order that got already canceled before you refreshed the page.

### Fixed Issues (if relevant)

1. Fixes OpenMage/magento-lts#2232

### Manual testing scenarios (*)

1. Create a new order and once redirected to the order view page, open that same page on another browser tab.
2. Cancel the order on the first tab, and then try to edit it from the second tab without refreshing the page.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->