### PR TITLE
Add back notification popup severity icons URL

### DIFF
--- a/app/code/core/Mage/AdminNotification/etc/config.xml
+++ b/app/code/core/Mage/AdminNotification/etc/config.xml
@@ -86,6 +86,7 @@
         <system>
             <adminnotification>
                 <feed_url>www.openmage.org/Web_Notifications/notifications_v1.rss</feed_url>
+                <severity_icons_url>widgets.magentocommerce.com/%s/%s.gif</severity_icons_url>
                 <use_https>1</use_https>
                 <frequency>1</frequency>
                 <last_update>0</last_update>


### PR DESCRIPTION
### Description (*)

This PR will add back a config that stored a URL used for notifications popup icons (weird I know!) that was removed in a previous cleanup PR. We could've copied and used them locally from `skin/`, but I'm not sure if that's permissible since they exist in a remote server.

### Related Pull Requests

#2069

### Manual testing scenarios (*)

1. Have an unread notification.
2. Logout and then login again, you should see the notification popup missing the icon.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->