### PR TITLE
Get catalog search result collection from engine

### DIFF
--- a/app/code/core/Mage/CatalogSearch/Model/Layer.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Layer.php
@@ -37,7 +37,7 @@ class Mage_CatalogSearch_Model_Layer extends Mage_Catalog_Model_Layer
         if (isset($this->_productCollections[$this->getCurrentCategory()->getId()])) {
             $collection = $this->_productCollections[$this->getCurrentCategory()->getId()];
         } else {
-            $collection = Mage::getResourceModel('catalogsearch/fulltext_collection');
+            $collection = Mage::helper('catalogsearch')->getEngine()->getResultCollection();
             $this->prepareProductCollection($collection);
             $this->_productCollections[$this->getCurrentCategory()->getId()] = $collection;
         }


### PR DESCRIPTION
### Description (*)

When integrating a custom catalog search engine, there is no way to supply the search result from your own engine when customers search for something because the code was hardcoded to always use the default fulltext collection, which loads the results from the database. This PR will change that so that the collection is retrieved from the search engine, which should already be implementing the `getResultCollection` method.

Example module that implemented this change: [smile-magento-elasticsearch](https://github.com/Smile-SA/smile-magento-elasticsearch/blob/master/src/app/code/community/Smile/ElasticSearch/Model/Catalogsearch/Layer.php#L33-L36).

### Manual testing scenarios (*)

1. There is no straight forward way to test this. You need to create your own engine implementation, then when it's time to display the result, you will know something's wrong :D

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->