### PR TITLE
Fix position sort with flat tables when no category filter is applied

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
@@ -1524,9 +1524,6 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
                 $this->getSelect()->order($this->_getAttributeFieldName($attribute) . ' ' . $dir);
                 return $this;
             }
-            if ($this->isEnabledFlat()) {
-                $this->getSelect()->order("cat_index_position {$dir}");
-            }
             // optimize if using cat index
             $filters = $this->_productLimitationFilters;
             if (isset($filters['category_id']) || isset($filters['visibility'])) {


### PR DESCRIPTION
### Description (*)

This PR will fix the issue when you sort the Product collection by position with flat tables ON, and you either didn't set the Category filter, or the Category doesn't exist (`getId()` returns `null`). The issue was what seems to be a redundant `ORDER BY` clause being added with `cat_index_position` (alias of `catalog_category_product_index.position`), which is only `JOIN`ed if the Category exists. There is already an `ORDER BY` clause being added below the removed code, _with_ the condition of Category filter being present, so this shouldn't cause any change of behavior.

### Fixed Issues (if relevant)

1. Fixes OpenMage/magento-lts#2511

### Manual testing scenarios (*)

```php
// Make sure you're not on Admin store, as flat tables is only used for frontend
Mage::app()->setCurrentStore(1);

Mage::getResourceModel('catalog/product_collection')
  // Either give it a non-existent category or omit the filter
  ->addCategoryFilter(Mage::getModel('catalog/category')->load(1234))
  ->addAttributeToSort('position')
  ->load();
```

This snipped will throw the below error before this patch:
```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'cat_index_position' in 'order clause', query was: SELECT `e`.`entity_id`, `e`.`type_id`, `e`.`attribute_set_id` FROM `catalog_product_flat_1` AS `e` WHERE (e.status = 1) ORDER BY `cat_index_position` ASC, `e`.`entity_id` ASC"
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->