### PR TITLE
Only run workflows when relevant files change

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -4,11 +4,11 @@ on:
   # Run on all pushes and on all pull requests.
   # Prevent the build from running when there are only irrelevant changes.
   push:
-    paths-ignore:
-      - '**.md'
+    paths:
+      - '**.php'
   pull_request:
-    paths-ignore:
-      - '**.md'
+    paths:
+      - '**.php'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -4,11 +4,11 @@ on:
   # Run on all pushes and on all pull requests.
   # Prevent the build from running when there are only irrelevant changes.
   push:
-    paths-ignore:
-      - '**.md'
+    paths:
+      - '**.php'
   pull_request:
-    paths-ignore:
-      - '**.md'
+    paths:
+      - '**.php'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/syntax-php.yml
+++ b/.github/workflows/syntax-php.yml
@@ -4,11 +4,13 @@ on:
   # Run on all pushes and on all pull requests.
   # Prevent the build from running when there are only irrelevant changes.
   push:
-    paths-ignore:
-      - '**.md'
+    paths:
+      - '**.php'
+      - '**.phtml'
   pull_request:
-    paths-ignore:
-      - '**.md'
+    paths:
+      - '**.php'
+      - '**.phtml'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/syntax-xml.yml
+++ b/.github/workflows/syntax-xml.yml
@@ -4,11 +4,11 @@ on:
   # Run on all pushes and on all pull requests.
   # Prevent the build from running when there are only irrelevant changes.
   push:
-    paths-ignore:
-      - '**.md'
+    paths:
+      - '**.xml'
   pull_request:
-    paths-ignore:
-      - '**.md'
+    paths:
+      - '**.xml'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 


### PR DESCRIPTION
### Description (*)

Yesterday I noticed that apart from LGTM, workflows run all the time regardless of changed files in the event. So this PR is going to change that to make them trigger only when relevant files have changed.

### Manual testing scenarios (*)

1. Only the relevant workflows should run for this PR as an example.

### Questions or comments

I left out Sonar workflow because I'm not sure about that one.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->