### PR TITLE
Reindex EAV values only for active storeviews

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
@@ -222,6 +222,12 @@ class Mage_Adminhtml_System_StoreController extends Mage_Adminhtml_Controller_Ac
                         if ($postData['store']['store_id']) {
                             $storeModel->load($postData['store']['store_id']);
                         }
+                        if ($postData['store']['is_active'] == 1 && $storeModel->getIsActive() == 0) {
+                            $indexer = Mage::getModel('index/process');
+                            $indexer
+                                ->load('catalog_product_attribute', 'indexer_code')
+                                ->changeStatus(Mage_Index_Model_Process::STATUS_REQUIRE_REINDEX);
+                        }
                         $storeModel->setData($postData['store']);
                         if ($postData['store']['store_id'] == '') {
                             $storeModel->setId(null);

--- a/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
@@ -222,11 +222,6 @@ class Mage_Adminhtml_System_StoreController extends Mage_Adminhtml_Controller_Ac
                         if ($postData['store']['store_id']) {
                             $storeModel->load($postData['store']['store_id']);
                         }
-                        if ($postData['store']['is_active'] == 1 && $storeModel->getIsActive() == 0) {
-                            Mage::getModel('index/process')
-                                ->load('catalog_product_attribute', 'indexer_code')
-                                ->changeStatus(Mage_Index_Model_Process::STATUS_REQUIRE_REINDEX);
-                        }
                         $storeModel->setData($postData['store']);
                         if ($postData['store']['store_id'] == '') {
                             $storeModel->setId(null);

--- a/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
@@ -223,8 +223,7 @@ class Mage_Adminhtml_System_StoreController extends Mage_Adminhtml_Controller_Ac
                             $storeModel->load($postData['store']['store_id']);
                         }
                         if ($postData['store']['is_active'] == 1 && $storeModel->getIsActive() == 0) {
-                            $indexer = Mage::getModel('index/process');
-                            $indexer
+                            Mage::getModel('index/process')
                                 ->load('catalog_product_attribute', 'indexer_code')
                                 ->changeStatus(Mage_Index_Model_Process::STATUS_REQUIRE_REINDEX);
                         }

--- a/app/code/core/Mage/Catalog/Model/Product/Indexer/Eav.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Indexer/Eav.php
@@ -52,6 +52,9 @@ class Mage_Catalog_Model_Product_Indexer_Eav extends Mage_Index_Model_Indexer_Ab
         ],
         Mage_Catalog_Model_Convert_Adapter_Product::ENTITY => [
             Mage_Index_Model_Event::TYPE_SAVE
+        ],
+        Mage_Core_Model_Store::ENTITY => [
+            Mage_Index_Model_Event::TYPE_SAVE
         ]
     ];
 
@@ -120,6 +123,14 @@ class Mage_Catalog_Model_Product_Indexer_Eav extends Mage_Index_Model_Indexer_Ab
             }
         } elseif ($entity == Mage_Catalog_Model_Convert_Adapter_Product::ENTITY) {
             $event->addNewData('catalog_product_eav_reindex_all', true);
+        } elseif ($entity == Mage_Core_Model_Store::ENTITY) {
+            if ($event->getType() === Mage_Index_Model_Event::TYPE_SAVE) {
+                /** @var Mage_Core_Model_Store $store */
+                $store = $event->getDataObject();
+                if ($store->getOrigData('is_active') != $store->getIsActive() && $store->getIsActive()) {
+                    $event->getProcess()->changeStatus(Mage_Index_Model_Process::STATUS_REQUIRE_REINDEX);
+                }
+            }
         }
     }
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Decimal.php
@@ -72,9 +72,9 @@ class Mage_Catalog_Model_Resource_Product_Indexer_Eav_Decimal extends Mage_Catal
                     . ' AND pds.store_id=cs.store_id',
                 ['value' => $productValueExpression]
             )
-            ->where('pdd.store_id=?', Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID)
-            ->where('cs.store_id!=?', Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID)
-            ->where('pdd.attribute_id IN(?)', $attrIds)
+            ->where('pdd.store_id = ?', Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID)
+            ->where('cs.store_id != ? AND s.is_active=1', Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID)
+            ->where('pdd.attribute_id IN (?)', $attrIds)
             ->where("{$productValueExpression} IS NOT NULL");
 
         $statusCond = $write->quoteInto('=?', Mage_Catalog_Model_Product_Status::STATUS_ENABLED);

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
@@ -108,7 +108,7 @@ class Mage_Catalog_Model_Resource_Product_Indexer_Eav_Source extends Mage_Catalo
                 '1 = 1 AND d.store_id = 0',
                 ['entity_id', 'attribute_id', 'value']
             )
-            ->where('s.store_id != 0');
+            ->where('s.store_id != ? AND s.is_active=1', Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID);
 
         $statusCond = $adapter->quoteInto(' = ?', Mage_Catalog_Model_Product_Status::STATUS_ENABLED);
         $this->_addAttributeToSelect($subSelect, 'status', 'd.entity_id', 's.store_id', $statusCond);

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
@@ -211,7 +211,7 @@ class Mage_Catalog_Model_Resource_Product_Indexer_Eav_Source extends Mage_Catalo
                 'pvd.store_id=?',
                 $adapter->getIfNullSql('pvs.store_id', Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID)
             )
-            ->where('cs.store_id!=?', Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID)
+            ->where('cs.store_id != ? AND cs.is_active=1', Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID)
             ->where('pvd.attribute_id IN(?)', $attrIds);
 
         $statusCond = $adapter->quoteInto('=?', Mage_Catalog_Model_Product_Status::STATUS_ENABLED);


### PR DESCRIPTION
EAV indexers now are indexing all datas also from storeviews that are disabled (manage by configuration field core_store.is_active), creating a lot of records in the `catalog_product_index_eav` and `catalog_product_index_eav_decimal` tables.

This PR modifies the idexers in order to exclude disabled storeviews from the EAV indexing.

### Fixed Issues
1. Fixes https://github.com/OpenMage/magento-lts/issues/2650

### Manual testing scenarios (*)
1. create a multi store view environment
2. create indexable EAV attributes
3. create one or more products with indexable attributes
4. disable one or more store views
5. run `php shell/indexer.php --reindex catalog_product_attribute`
6. check tables `catalog_product_index_eav` and `catalog_product_index_eav_decimal`, you'll see that records related to the disabled storeviews are created (column store_id)
7. apply this PR
8. run `php shell/indexer.php --reindex catalog_product_attribute`
9. check tables `catalog_product_index_eav` and `catalog_product_index_eav_decimal`, you'll see that records related to the disabled storeviews are not created anymore