### PR TITLE
Avoid filtering on product status if flat catalog is enabled

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Price.php
@@ -117,15 +117,14 @@ class Mage_Catalog_Model_Resource_Layer_Filter_Price extends Mage_Core_Model_Res
 
         // processing WHERE part
         $wherePart = $select->getPart(Zend_Db_Select::WHERE);
+        $select->reset(Zend_Db_Select::WHERE);
         $excludedWherePart = Mage_Catalog_Model_Resource_Product_Collection::MAIN_TABLE_ALIAS . '.status';
         foreach ($wherePart as $key => $wherePartItem) {
             if (strpos($wherePartItem, $excludedWherePart) !== false) {
-                $wherePart[$key] = new Zend_Db_Expr('1=1');
                 continue;
             }
-            $wherePart[$key] = $this->_replaceTableAlias($wherePartItem);
+            $select->where($this->_replaceTableAlias($wherePartItem));
         }
-        $select->setPart(Zend_Db_Select::WHERE, $wherePart);
         $excludeJoinPart = Mage_Catalog_Model_Resource_Product_Collection::MAIN_TABLE_ALIAS . '.entity_id';
         foreach ($priceIndexJoinConditions as $condition) {
             if (strpos($condition, $excludeJoinPart) !== false) {

--- a/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Price.php
@@ -117,14 +117,15 @@ class Mage_Catalog_Model_Resource_Layer_Filter_Price extends Mage_Core_Model_Res
 
         // processing WHERE part
         $wherePart = $select->getPart(Zend_Db_Select::WHERE);
-        $select->reset(Zend_Db_Select::WHERE);
         $excludedWherePart = Mage_Catalog_Model_Resource_Product_Collection::MAIN_TABLE_ALIAS . '.status';
         foreach ($wherePart as $key => $wherePartItem) {
             if (strpos($wherePartItem, $excludedWherePart) !== false) {
+                $wherePart[$key] = new Zend_Db_Expr('1=1');
                 continue;
             }
-            $select->where($this->_replaceTableAlias($wherePartItem));
+            $wherePart[$key] = $this->_replaceTableAlias($wherePartItem);
         }
+        $select->setPart(Zend_Db_Select::WHERE, $wherePart);
         $excludeJoinPart = Mage_Catalog_Model_Resource_Product_Collection::MAIN_TABLE_ALIAS . '.entity_id';
         foreach ($priceIndexJoinConditions as $condition) {
             if (strpos($condition, $excludeJoinPart) !== false) {

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
@@ -442,8 +442,7 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
     {
         if ($this->isEnabledFlat()) {
             $this->getSelect()
-                ->from([self::MAIN_TABLE_ALIAS => $this->getEntity()->getFlatTableName()], null)
-                ->where('e.status = ?', new Zend_Db_Expr(Mage_Catalog_Model_Product_Status::STATUS_ENABLED));
+                ->from([self::MAIN_TABLE_ALIAS => $this->getEntity()->getFlatTableName()], null);
             $this->addAttributeToSelect(['entity_id', 'type_id', 'attribute_set_id']);
             if ($this->getFlatHelper()->isAddChildData()) {
                 $this->getSelect()


### PR DESCRIPTION
Full explanation is here: https://github.com/OpenMage/magento-lts/issues/2658

The way it was coded was simply wrong, when forcing the `setPart()` the "type of where" gets lost and the system doesn't know if it is a AND or an OR.
This PR rewrites it and avoids the usage of "1=1" which wasn't the best anyway.

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#2658

### Manual testing scenarios (*)

Enable flat catalog, reindex, navigate to a category page, no error should be displayed.