### PR TITLE
Fix unlink no such file or directory

### DIFF
--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -377,6 +377,7 @@ class Varien_Io_File extends Varien_Io_Abstract
      */
     public static function rmdirRecursive($dir, $recursive = true)
     {
+        $result = true;
         if ($recursive) {
             if (is_dir($dir)) {
                 foreach (scandir($dir) as $item) {
@@ -386,7 +387,7 @@ class Varien_Io_File extends Varien_Io_Abstract
                     self::rmdirRecursive($dir . "/" . $item, $recursive);
                 }
                 $result = @rmdir($dir);
-            } else {
+            } elseif (file_exists($dir)) {
                 $result = @unlink($dir);
             }
         } else {


### PR DESCRIPTION
### Description

Sometimes, when a folder is removed, an error occurred.

![bug-unlink-deleteFolder](https://user-images.githubusercontent.com/31816829/200168925-74e44bdf-2915-4c1a-90d5-f498bc5117d2.png)


OpenMage 20.0.16 / PHP 8.0.25

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)