### PR TITLE
Remove try catch throw

### DIFF
--- a/app/code/core/Mage/Newsletter/Model/Subscriber.php
+++ b/app/code/core/Mage/Newsletter/Model/Subscriber.php
@@ -359,20 +359,16 @@ class Mage_Newsletter_Model_Subscriber extends Mage_Core_Model_Abstract
 
         $this->setIsStatusChanged(true);
 
-        try {
-            $this->save();
-            if ($isConfirmNeed === true
-                && $isOwnSubscribes === false
-            ) {
-                $this->sendConfirmationRequestEmail();
-            } else {
-                $this->sendConfirmationSuccessEmail();
-            }
-
-            return $this->getStatus();
-        } catch (Exception $e) {
-            throw new Exception($e->getMessage());
+        $this->save();
+        if ($isConfirmNeed === true
+            && $isOwnSubscribes === false
+        ) {
+            $this->sendConfirmationRequestEmail();
+        } else {
+            $this->sendConfirmationSuccessEmail();
         }
+
+        return $this->getStatus();
     }
 
     /**


### PR DESCRIPTION
### Description

This remove the `try { } catch ($e) { throw $e }`.

OpenMage 20.0.16 / PHP 8.0.25

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)