### PR TITLE
Allow to save configuration without fields

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/System/ConfigController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/ConfigController.php
@@ -132,7 +132,7 @@ class Mage_Adminhtml_System_ConfigController extends Mage_Adminhtml_Controller_A
         $session = Mage::getSingleton('adminhtml/session');
         /** @var Mage_Adminhtml_Model_Session $session */
 
-        $groups = $this->getRequest()->getPost('groups');
+        $groups = $this->getRequest()->getPost('groups', []);
 
         if (isset($_FILES['groups']['name']) && is_array($_FILES['groups']['name'])) {
             /**
@@ -180,7 +180,10 @@ class Mage_Adminhtml_System_ConfigController extends Mage_Adminhtml_Controller_A
             Mage::dispatchEvent("admin_system_config_changed_section_{$section}",
                 ['website' => $website, 'store' => $store]
             );
-            $session->addSuccess(Mage::helper('adminhtml')->__('The configuration has been saved.'));
+
+            if (!empty($groups)) {
+                $session->addSuccess(Mage::helper('adminhtml')->__('The configuration has been saved.'));
+            }
         }
         catch (Mage_Core_Exception $e) {
             foreach(explode("\n", $e->getMessage()) as $message) {


### PR DESCRIPTION
### Description

If you have a system / configuration page without any fields, when you press the save button, an error occurred:
```
Warning: foreach() argument must be of type array|object,
  null given in app/code/core/Mage/Adminhtml/Model/Config/Data.php on line 405
```
This PR solve this.

OpenMage 20.0.16 / PHP 8.0.25

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)