### PR TITLE
Set the right menu for reviews

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/ReviewController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/ReviewController.php
@@ -59,7 +59,7 @@ class Mage_Adminhtml_Catalog_Product_ReviewController extends Mage_Adminhtml_Con
         }
 
         $this->loadLayout();
-        $this->_setActiveMenu('catalog/review');
+        $this->_setActiveMenu('catalog/reviews_ratings/reviews/all');
 
         $this->_addContent($this->getLayout()->createBlock('adminhtml/review_main'));
 
@@ -80,7 +80,7 @@ class Mage_Adminhtml_Catalog_Product_ReviewController extends Mage_Adminhtml_Con
         }
 
         $this->loadLayout();
-        $this->_setActiveMenu('catalog/review');
+        $this->_setActiveMenu('catalog/reviews_ratings/reviews/pending');
 
         Mage::register('usePendingFilter', true);
         $this->_addContent($this->getLayout()->createBlock('adminhtml/review_main'));
@@ -97,7 +97,7 @@ class Mage_Adminhtml_Catalog_Product_ReviewController extends Mage_Adminhtml_Con
         $this->_title($this->__('Edit Review'));
 
         $this->loadLayout();
-        $this->_setActiveMenu('catalog/review');
+        $this->_setActiveMenu('catalog/reviews_ratings/reviews/all');
 
         $this->_addContent($this->getLayout()->createBlock('adminhtml/review_edit'));
 
@@ -113,7 +113,7 @@ class Mage_Adminhtml_Catalog_Product_ReviewController extends Mage_Adminhtml_Con
         $this->_title($this->__('New Review'));
 
         $this->loadLayout();
-        $this->_setActiveMenu('catalog/review');
+        $this->_setActiveMenu('catalog/reviews_ratings/reviews/all');
 
         $this->getLayout()->getBlock('head')->setCanLoadExtJs(true);
 

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/ReviewController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/ReviewController.php
@@ -97,7 +97,11 @@ class Mage_Adminhtml_Catalog_Product_ReviewController extends Mage_Adminhtml_Con
         $this->_title($this->__('Edit Review'));
 
         $this->loadLayout();
-        $this->_setActiveMenu('catalog/reviews_ratings/reviews/all');
+        if ($this->getRequest()->getParam('ret') === 'pending') {
+            $this->_setActiveMenu('catalog/reviews_ratings/reviews/pending');
+        } else {
+            $this->_setActiveMenu('catalog/reviews_ratings/reviews/all');
+        }
 
         $this->_addContent($this->getLayout()->createBlock('adminhtml/review_edit'));
 

--- a/app/code/core/Mage/Adminhtml/controllers/RatingController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/RatingController.php
@@ -39,7 +39,7 @@ class Mage_Adminhtml_RatingController extends Mage_Adminhtml_Controller_Action
         $this->_initEnityId();
         $this->loadLayout();
 
-        $this->_setActiveMenu('catalog/ratings');
+        $this->_setActiveMenu('catalog/reviews_ratings/ratings');
         $this->_addBreadcrumb(Mage::helper('adminhtml')->__('Manage Ratings'), Mage::helper('adminhtml')->__('Manage Ratings'));
         $this->_addContent($this->getLayout()->createBlock('adminhtml/rating_rating'));
 
@@ -58,7 +58,7 @@ class Mage_Adminhtml_RatingController extends Mage_Adminhtml_Controller_Action
 
         $this->_title($ratingModel->getId() ? $ratingModel->getRatingCode() : $this->__('New Rating'));
 
-        $this->_setActiveMenu('catalog/ratings');
+        $this->_setActiveMenu('catalog/reviews_ratings/ratings');
         $this->_addBreadcrumb(Mage::helper('adminhtml')->__('Manage Ratings'), Mage::helper('adminhtml')->__('Manage Ratings'));
 
         $this->_addContent($this->getLayout()->createBlock('adminhtml/rating_edit'))

--- a/app/code/core/Mage/Review/etc/adminhtml.xml
+++ b/app/code/core/Mage/Review/etc/adminhtml.xml
@@ -31,23 +31,23 @@
                             <children>
                                 <pending translate="title" module="review">
                                     <title>Pending Reviews</title>
-                                    <action>adminhtml/catalog_product_review/pending/</action>
+                                    <action>adminhtml/catalog_product_review/pending</action>
                                 </pending>
                                 <all translate="title" module="review">
                                     <title>All Reviews</title>
-                                    <action>adminhtml/catalog_product_review/</action>
+                                    <action>adminhtml/catalog_product_review/index</action>
                                 </all>
                             </children>
                         </reviews>
                         <ratings translate="title" module="review">
                             <title>Manage Ratings</title>
-                            <action>adminhtml/rating/</action>
+                            <action>adminhtml/rating/index</action>
                         </ratings>
                     </children>
                     <sort_order>50</sort_order>
                 </reviews_ratings>
             </children>
-         </catalog>
+        </catalog>
         <report>
             <children>
                 <review translate="title" module="reports">


### PR DESCRIPTION
### Description

There are many "mistakes" for `_setActiveMenu`. This PR set the right menu for reviews and ratings.

OpenMage 20.0.16 / PHP 8.0.25

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)