### PR TITLE
Do not autoload captcha class when disabled

### DIFF
--- a/app/code/core/Mage/Captcha/Block/Captcha.php
+++ b/app/code/core/Mage/Captcha/Block/Captcha.php
@@ -37,7 +37,7 @@ class Mage_Captcha_Block_Captcha extends Mage_Core_Block_Template
      */
     protected function _toHtml()
     {
-        if (Mage::getStoreConfigFlag(Mage::app()->getStore()->isAdmin() ? 'admin/captcha/enable' : 'customer/captcha/enable')) {
+        if (Mage::helper('captcha')->isEnabled()) {
             $blockPath = Mage::helper('captcha')->getCaptcha($this->getFormId())->getBlockName();
             $block = $this->getLayout()->createBlock($blockPath);
             $block->setData($this->getData());

--- a/app/code/core/Mage/Captcha/Block/Captcha.php
+++ b/app/code/core/Mage/Captcha/Block/Captcha.php
@@ -37,9 +37,12 @@ class Mage_Captcha_Block_Captcha extends Mage_Core_Block_Template
      */
     protected function _toHtml()
     {
-        $blockPath = Mage::helper('captcha')->getCaptcha($this->getFormId())->getBlockName();
-        $block = $this->getLayout()->createBlock($blockPath);
-        $block->setData($this->getData());
-        return $block->toHtml();
+        if (Mage::getStoreConfigFlag(Mage::app()->getStore()->isAdmin() ? 'admin/captcha/enable' : 'customer/captcha/enable')) {
+            $blockPath = Mage::helper('captcha')->getCaptcha($this->getFormId())->getBlockName();
+            $block = $this->getLayout()->createBlock($blockPath);
+            $block->setData($this->getData());
+            return $block->toHtml();
+        }
+        return '';
     }
 }

--- a/app/code/core/Mage/Captcha/Block/Captcha/Zend.php
+++ b/app/code/core/Mage/Captcha/Block/Captcha/Zend.php
@@ -68,7 +68,7 @@ class Mage_Captcha_Block_Captcha_Zend extends Mage_Core_Block_Template
      */
     protected function _toHtml()
     {
-        if ($this->getCaptchaModel()->isRequired()) {
+        if (Mage::getStoreConfigFlag(Mage::app()->getStore()->isAdmin() ? 'admin/captcha/enable' : 'customer/captcha/enable') && $this->getCaptchaModel()->isRequired()) {
             $this->getCaptchaModel()->generate();
             return parent::_toHtml();
         }

--- a/app/code/core/Mage/Captcha/Block/Captcha/Zend.php
+++ b/app/code/core/Mage/Captcha/Block/Captcha/Zend.php
@@ -68,7 +68,7 @@ class Mage_Captcha_Block_Captcha_Zend extends Mage_Core_Block_Template
      */
     protected function _toHtml()
     {
-        if (Mage::getStoreConfigFlag(Mage::app()->getStore()->isAdmin() ? 'admin/captcha/enable' : 'customer/captcha/enable') && $this->getCaptchaModel()->isRequired()) {
+        if (Mage::helper('captcha')->isEnabled() && $this->getCaptchaModel()->isRequired()) {
             $this->getCaptchaModel()->generate();
             return parent::_toHtml();
         }

--- a/app/code/core/Mage/Captcha/Helper/Data.php
+++ b/app/code/core/Mage/Captcha/Helper/Data.php
@@ -57,6 +57,16 @@ class Mage_Captcha_Helper_Data extends Mage_Core_Helper_Abstract
     protected $_captcha = [];
 
     /**
+     * @return bool
+     * @since 19.4.19 / 20.0.17
+     */
+    public function isEnabled(): bool
+    {
+        $path = Mage::app()->getStore()->isAdmin() ? 'admin/captcha/enable' : 'customer/captcha/enable';
+        return Mage::getStoreConfigFlag($path);
+    }
+
+    /**
      * Get Captcha
      *
      * @param string $formId


### PR DESCRIPTION
### Description

With Blackfire, I found when captcha is disabled in configuration, a class is autoloaded.
I dislike.

![captcha](https://user-images.githubusercontent.com/31816829/200178094-78b4b219-76e4-48af-94b0-c3aecda97bb3.png)

OpenMage 20.0.16 / PHP 8.0.25

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)