### PR TITLE
Fix esi parsing with turpentine

### DIFF
--- a/app/design/frontend/base/default/template/customer/address.phtml
+++ b/app/design/frontend/base/default/template/customer/address.phtml
@@ -80,10 +80,12 @@
     <button type="button" onclick="window.location='<?php echo $this->getUrl('customer/address/form') ?>';" class="button"><span><span><?php echo $this->__('New Address') ?></span></span></button>
 </div>
 <script type="text/javascript">
+//<![CDATA[
     function deleteAddress(addressId) {
-        if(confirm('<?php echo Mage::helper('core')->jsQuoteEscape($this->__('Are you sure you want to delete this address?')) ?>')) {
-            window.location='<?php echo $this->getUrl("customer/address/delete") ?>address/'+addressId;
+        if (confirm('<?php echo Mage::helper('core')->jsQuoteEscape($this->__('Are you sure you want to delete this address?')) ?>')) {
+            window.location="<?php echo $this->getUrl('customer/address/delete') ?>address/"+addressId;
         }
         return false;
     }
+//]]>
 </script>

--- a/app/design/frontend/base/default/template/customer/address/book.phtml
+++ b/app/design/frontend/base/default/template/customer/address/book.phtml
@@ -91,8 +91,8 @@
 <script type="text/javascript">
 //<![CDATA[
     function deleteAddress(addressId) {
-        if(confirm('<?php echo Mage::helper('core')->jsQuoteEscape($this->__('Are you sure you want to delete this address?')) ?>')) {
-            window.location='<?php echo $this->getDeleteUrl() ?>id/'+addressId;
+        if (confirm('<?php echo Mage::helper('core')->jsQuoteEscape($this->__('Are you sure you want to delete this address?')) ?>')) {
+            window.location="<?php echo $this->getDeleteUrl() ?>id/"+addressId;
         }
         return false;
     }


### PR DESCRIPTION
### Description

With Nexcess Magento Turpentine for Varnish, sometimes there is a strange bug with ESI processing (ESI is not processed).

Example: `window.location='https://.../fr/customer/address/delete/form_key/<esi:include src='http://.../fr/turpentine/esi/getFormKey/ttl/86400/method/esi/scope/global/access/private/' />/id/'+addressId;`

The solution is to invert ' and ".

OpenMage 20.0.16 / PHP 8.0.25

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)