### PR TITLE
Do not crash when shipment does not exist

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
@@ -53,6 +53,10 @@ class Mage_Adminhtml_Sales_Order_ShipmentController extends Mage_Adminhtml_Contr
         $orderId = $this->getRequest()->getParam('order_id');
         if ($shipmentId) {
             $shipment = Mage::getModel('sales/order_shipment')->load($shipmentId);
+            if (!$shipment->getId()) {
+                $this->_getSession()->addError($this->__('The shipment no longer exists.'));
+                return false;
+            }
         } elseif ($orderId) {
             $order      = Mage::getModel('sales/order')->load($orderId);
 

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
@@ -137,7 +137,7 @@ class Mage_Adminhtml_Sales_Order_ShipmentController extends Mage_Adminhtml_Contr
             $this->_setActiveMenu('sales/order')
                 ->renderLayout();
         } else {
-            $this->_forward('noRoute');
+            $this->_redirect('*/*/');
         }
     }
 

--- a/app/locale/en_US/Mage_Adminhtml.csv
+++ b/app/locale/en_US/Mage_Adminhtml.csv
@@ -207,6 +207,7 @@
 "Cannot create credit memo for the order.","Cannot create credit memo for the order."
 "Cannot delete the design change.","Cannot delete the design change."
 "Cannot delete tracking number.","Cannot delete tracking number."
+"The shipment no longer exists.","The shipment no longer exists."
 "Cannot do shipment for the order separately from invoice.","Cannot do shipment for the order separately from invoice."
 "Cannot do shipment for the order.","Cannot do shipment for the order."
 "Cannot initialize shipment for adding tracking number.","Cannot initialize shipment for adding tracking number."


### PR DESCRIPTION
### Description

Go to Sales / Shipment, open any shipment. In the URL, change the shipment id with an id that does not exist, you will got: `no date part in '' found`.

OpenMage 20.0.16 / PHP 8.0.25

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)