### PR TITLE
 Do not crash when creditmemo does not exist

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
@@ -101,6 +101,10 @@ class Mage_Adminhtml_Sales_Order_CreditmemoController extends Mage_Adminhtml_Con
         $orderId = $this->getRequest()->getParam('order_id');
         if ($creditmemoId) {
             $creditmemo = Mage::getModel('sales/order_creditmemo')->load($creditmemoId);
+            if (!$creditmemo->getId()) {
+                $this->_getSession()->addError($this->__('The credit memo no longer exists.'));
+                return false;
+            }
         } elseif ($orderId) {
             $data   = $this->getRequest()->getParam('creditmemo');
             $order  = Mage::getModel('sales/order')->load($orderId);

--- a/app/locale/en_US/Mage_Adminhtml.csv
+++ b/app/locale/en_US/Mage_Adminhtml.csv
@@ -205,6 +205,7 @@
 "Cannot add tracking number.","Cannot add tracking number."
 "Cannot create an invoice without products.","Cannot create an invoice without products."
 "Cannot create credit memo for the order.","Cannot create credit memo for the order."
+"The credit memo no longer exists.","The credit memo no longer exists."
 "Cannot delete the design change.","Cannot delete the design change."
 "Cannot delete tracking number.","Cannot delete tracking number."
 "Cannot do shipment for the order separately from invoice.","Cannot do shipment for the order separately from invoice."


### PR DESCRIPTION
### Description

Go to Sales / Credit memos, open any credit memo. In the URL, change the credit memo id with an id that does not exist, you will got: `Call to a member function updateBackButtonUrl() on bool`.

OpenMage 20.0.16 / PHP 8.0.25

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)