### PR TITLE
Update review_entity_summary when unapprove the latest comment

### DIFF
--- a/app/code/core/Mage/Rating/Model/Resource/Rating.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating.php
@@ -278,6 +278,16 @@ class Mage_Rating_Model_Resource_Rating extends Mage_Core_Model_Resource_Db_Abst
             }
         }
 
+        if (empty($result[0])) {
+            // when you unapprove the latest comment and save
+            //  store_id = 0 is missing and not updated in review_entity_summary
+            $clone = clone $object;
+            $clone->setCount(0);
+            $clone->setSum(0);
+            $clone->setStoreId(0);
+            $result[0] = $clone;
+        }
+
         return array_values($result);
     }
 
@@ -289,10 +299,9 @@ class Mage_Rating_Model_Resource_Rating extends Mage_Core_Model_Resource_Db_Abst
      */
     protected function _getEntitySummaryData($object)
     {
-        $adapter    = $this->_getReadAdapter();
-
-        $sumColumn      = new Zend_Db_Expr("SUM(rating_vote.{$adapter->quoteIdentifier('percent')})");
-        $countColumn    = new Zend_Db_Expr("COUNT(*)");
+        $adapter     = $this->_getReadAdapter();
+        $sumColumn   = new Zend_Db_Expr("SUM(rating_vote.{$adapter->quoteIdentifier('percent')})");
+        $countColumn = new Zend_Db_Expr("COUNT(*)");
 
         $select = $adapter->select()
             ->from(
@@ -300,7 +309,8 @@ class Mage_Rating_Model_Resource_Rating extends Mage_Core_Model_Resource_Db_Abst
                 [
                     'entity_pk_value' => 'rating_vote.entity_pk_value',
                     'sum'             => $sumColumn,
-                'count'           => $countColumn]
+                    'count'           => $countColumn
+                ]
             )
             ->join(
                 ['review' => $this->getTable('review/review')],

--- a/app/code/core/Mage/Review/Model/Resource/Review.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review.php
@@ -308,13 +308,14 @@ class Mage_Review_Model_Resource_Review extends Mage_Core_Model_Resource_Db_Abst
      */
     public function aggregate($object)
     {
-        $readAdapter    = $this->_getReadAdapter();
-        $writeAdapter   = $this->_getWriteAdapter();
+        $readAdapter  = $this->_getReadAdapter();
+        $writeAdapter = $this->_getWriteAdapter();
+        $ratingModel  = Mage::getModel('rating/rating');
+
         if (!$object->getEntityPkValue() && $object->getId()) {
             $object->load($object->getReviewId());
         }
 
-        $ratingModel    = Mage::getModel('rating/rating');
         $ratingSummaries = $ratingModel->getEntitySummary($object->getEntityPkValue(), false);
 
         foreach ($ratingSummaries as $ratingSummaryObject) {


### PR DESCRIPTION
### Description

On any product with only one approved comment, if you unapprove it from backend, summary is not updated for store 0.

OpenMage 20.0.16 / PHP 8.0.25

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list