### PR TITLE
Reduce again getId calls

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Tree.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Tree.php
@@ -143,8 +143,7 @@ class Mage_Catalog_Model_Resource_Category_Tree extends Varien_Data_Tree_Dbp
         }
 
         $nodeIds = [];
-        foreach ($this->getNodes() as $node) {
-            $id = $node->getId();
+        foreach ($this->getNodes() as $id => $node) {
             if (!in_array($id, $exclude)) {
                 $nodeIds[] = $id;
             }
@@ -174,8 +173,8 @@ class Mage_Catalog_Model_Resource_Category_Tree extends Varien_Data_Tree_Dbp
                 }
             }
 
-            foreach ($this->getNodes() as $node) {
-                if (!$collection->getItemById($node->getId()) && $node->getParent()) {
+            foreach ($this->getNodes() as $id => $node) {
+                if (!$collection->getItemById($id) && $node->getParent()) {
                     $this->removeNode($node);
                 }
             }


### PR DESCRIPTION
### Description

In #2677, this is a good change, but not complete.
I found (again) with Blackfire that I can do a better work:

before
![b](https://user-images.githubusercontent.com/31816829/200648020-4813f271-f5d3-4c2d-82c6-5adaeec75262.png)

after
![a](https://user-images.githubusercontent.com/31816829/200648014-a2b59297-efcb-4a45-bf2c-01ee1f0b5a11.png)

I think I have changed other things to display again theses `getId`.
To check the PR, I added `if ($id != $node->getId()) exit;`.

OpenMage 20.0.16 / PHP 8.0.25

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)