### PR TITLE
Add autocomplete attribute to known password fields.

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1351,6 +1351,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "rfeese",
+      "name": "Roger Feese",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7074181?v=4",
+      "profile": "https://github.com/rfeese",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center"><a href="https://github.com/eneiasramos"><img src="https://avatars.githubusercontent.com/u/2862728?v=4" loading="lazy" width="100" alt=""/><br /><sub><b>Enéias Ramos de Melo</b></sub></a></td>
     <td align="center"><a href="https://github.com/discountscott"><img src="https://avatars.githubusercontent.com/u/5454596?v=4" loading="lazy" width="100" alt=""/><br /><sub><b>Scott Moore</b></sub></a></td>
+    <td align="center"><a href="https://github.com/rfeese"><img src="https://avatars.githubusercontent.com/u/7074181?v=4" loading="lazy" width="100" alt=""/><br /><sub><b>Roger Feese</b></sub></a></td>
   </tr>
 </table>
 

--- a/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
@@ -159,7 +159,8 @@
                                    name="billing[customer_password]"
                                    id="billing:customer_password"
                                    title="<?php echo Mage::helper('core')->quoteEscape($this->__('Password')) ?>"
-                                   class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>" />
+                                   class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>"
+                                   autocomplete="off" />
                             <p class="form-instructions">
                                 <?php echo Mage::helper('customer')->__('The minimum password length is %s', $minPasswordLength) ?>
                             </p>
@@ -168,7 +169,7 @@
                     <div class="field">
                         <label for="billing:confirm_password" class="required"><em>*</em><?php echo $this->__('Confirm Password') ?></label>
                         <div class="input-box">
-                            <input type="password" name="billing[confirm_password]" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm Password')) ?>" id="billing:confirm_password" class="input-text required-entry validate-cpassword" />
+                            <input type="password" name="billing[confirm_password]" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm Password')) ?>" id="billing:confirm_password" class="input-text required-entry validate-cpassword" autocomplete="off" />
                         </div>
                     </div>
                 </li>

--- a/app/design/frontend/base/default/template/checkout/onepage/login.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/login.phtml
@@ -74,7 +74,7 @@
                 <li>
                     <label for="login-password" class="required"><em>*</em><?php echo $this->__('Password') ?></label>
                     <div class="input-box">
-                        <input type="password" class="input-text required-entry" id="login-password" name="login[password]" />
+                        <input type="password" class="input-text required-entry" id="login-password" name="login[password]" autocomplete="off" />
                     </div>
                 </li>
                 <?php echo $this->getChildHtml('form.additional.info'); ?>

--- a/app/design/frontend/base/default/template/customer/form/changepassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/changepassword.phtml
@@ -29,7 +29,7 @@
         <li>
             <label for="current_password" class="required"><em>*</em><?php echo $this->__('Current Password') ?></label>
             <div class="input-box">
-                <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Current Password')) ?>" class="input-text required-entry" name="current_password" id="current_password" />
+                <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Current Password')) ?>" class="input-text required-entry" name="current_password" id="current_password" autocomplete="off" />
             </div>
         </li>
         <li class="fields">
@@ -41,7 +41,8 @@
                            title="<?php echo Mage::helper('core')->quoteEscape($this->__('New Password')) ?>"
                            class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>"
                            name="password"
-                           id="password" />
+                           id="password"
+                           autocomplete="new-password" />
                     <p class="form-instructions">
                         <?php echo Mage::helper('customer')->__('The minimum password length is %s', $minPasswordLength) ?>
                     </p>
@@ -50,7 +51,7 @@
             <div class="field">
                 <label for="confirmation" class="required"><em>*</em><?php echo $this->__('Confirm New Password') ?></label>
                 <div class="input-box">
-                    <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm New Password')) ?>" class="input-text required-entry validate-cpassword" name="confirmation" id="confirmation" />
+                    <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm New Password')) ?>" class="input-text required-entry validate-cpassword" name="confirmation" id="confirmation" autocomplete="new-password" />
                 </div>
             </div>
         </li>

--- a/app/design/frontend/base/default/template/customer/form/edit.phtml
+++ b/app/design/frontend/base/default/template/customer/form/edit.phtml
@@ -54,7 +54,7 @@
                 <div class="input-box">
                     <!-- This is a dummy hidden field to trick firefox from auto filling the password -->
                     <input type="text" class="input-text no-display" name="dummy" id="dummy" />
-                    <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Current Password')) ?>" class="input-text required-entry" name="current_password" id="current_password" />
+                    <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Current Password')) ?>" class="input-text required-entry" name="current_password" id="current_password" autocomplete="off" />
                 </div>
             </li>
             <li class="control">
@@ -74,7 +74,8 @@
                                title="<?php echo Mage::helper('core')->quoteEscape($this->__('New Password')) ?>"
                                class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>"
                                name="password"
-                               id="password" />
+                               id="password"
+                               autocomplete="new-password" />
                         <p class="form-instructions">
                             <?php echo $this->__('The minimum password length is %s', $minPasswordLength) ?>
                         </p>
@@ -83,7 +84,7 @@
                 <div class="field">
                     <label for="confirmation" class="required"><em>*</em><?php echo $this->__('Confirm New Password') ?></label>
                     <div class="input-box">
-                        <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm New Password')) ?>" class="input-text required-entry validate-cpassword" name="confirmation" id="confirmation" />
+                        <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm New Password')) ?>" class="input-text required-entry validate-cpassword" name="confirmation" id="confirmation" autocomplete="new-password" />
                     </div>
                 </div>
             </li>

--- a/app/design/frontend/base/default/template/customer/form/login.phtml
+++ b/app/design/frontend/base/default/template/customer/form/login.phtml
@@ -56,7 +56,7 @@
                         <li>
                             <label for="pass" class="required"><em>*</em><?php echo $this->__('Password') ?></label>
                             <div class="input-box">
-                                <input type="password" name="login[password]" class="input-text required-entry validate-password min-pass-length-5" id="pass" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Password')) ?>" />
+                                <input type="password" name="login[password]" class="input-text required-entry validate-password min-pass-length-5" id="pass" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Password')) ?>" autocomplete="off" />
                             </div>
                         </li>
                         <?php echo $this->getChildHtml('form.additional.info'); ?>

--- a/app/design/frontend/base/default/template/customer/form/mini.login.phtml
+++ b/app/design/frontend/base/default/template/customer/form/mini.login.phtml
@@ -33,7 +33,7 @@
         <?php echo $this->getBlockHtml('formkey') ?>
         <div class="block-content">
             <label for="mini-login"><?php echo $this->__('Email:') ?></label><input type="text" name="login[username]" id="mini-login" class="input-text" />
-            <label for="mini-password"><?php echo $this->__('Password:') ?></label><input type="password" name="login[password]" id="mini-password" class="input-text" />
+            <label for="mini-password"><?php echo $this->__('Password:') ?></label><input type="password" name="login[password]" id="mini-password" class="input-text" autocomplete="off" />
             <div class="actions">
                 <button type="submit" class="button"><span><span><?php echo $this->__('Login') ?></span></span></button>
             </div>

--- a/app/design/frontend/base/default/template/customer/form/register.phtml
+++ b/app/design/frontend/base/default/template/customer/form/register.phtml
@@ -161,7 +161,8 @@
                                    name="password"
                                    id="password"
                                    title="<?php echo Mage::helper('core')->quoteEscape($this->__('Password')) ?>"
-                                   class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>" />
+                                   class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>"
+                                   autocomplete="off" />
                             <p class="form-instructions">
                                 <?php echo $this->__('The minimum password length is %s', $minPasswordLength) ?>
                             </p>
@@ -170,7 +171,7 @@
                     <div class="field">
                         <label for="confirmation" class="required"><em>*</em><?php echo $this->__('Confirm Password') ?></label>
                         <div class="input-box">
-                            <input type="password" name="confirmation" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm Password')) ?>" id="confirmation" class="input-text required-entry validate-cpassword" />
+                            <input type="password" name="confirmation" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm Password')) ?>" id="confirmation" class="input-text required-entry validate-cpassword" autocomplete="off" />
                         </div>
                     </div>
                 </li>

--- a/app/design/frontend/base/default/template/customer/form/resetforgottenpassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/resetforgottenpassword.phtml
@@ -33,7 +33,8 @@
                         <input type="password"
                                class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength; ?>"
                                name="password"
-                               id="password" />
+                               id="password"
+                               autocomplete="off" />
                         <p class="form-instructions">
                             <?php echo Mage::helper('customer')->__('The minimum password length is %s', $minPasswordLength); ?>
                         </p>
@@ -42,7 +43,7 @@
                 <div class="field">
                     <label for="confirmation" class="required"><em>*</em><?php echo $this->__('Confirm New Password'); ?></label>
                     <div class="input-box">
-                        <input type="password" class="input-text required-entry validate-cpassword" name="confirmation" id="confirmation" />
+                        <input type="password" class="input-text required-entry validate-cpassword" name="confirmation" id="confirmation" autocomplete="off "/>
                     </div>
                 </div>
             </li>

--- a/app/design/frontend/base/default/template/oauth/authorize/form/login-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/form/login-simple.phtml
@@ -52,7 +52,7 @@
                                     <em class="required">*</em>&nbsp;<?php echo $this->__('Password') ?>
                                 </label>
                                 <input type="password" id="login" name="login[password]" class="required-entry input-text"
-                                       value=""/></div>
+                                       value="" autocomplete="off" /></div>
                             <div class="clear"></div>
                             <div class="form-buttons">
                                 <button type="submit" class="form-button"

--- a/app/design/frontend/base/default/template/oauth/authorize/form/login.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/form/login.phtml
@@ -47,7 +47,7 @@ $rejectJs = "document.location.href='{$this->getRejectUrl()}';";
                             <li>
                                 <label for="pass"><?php echo $this->__('Password') ?></label>
                                 <div class="input-box">
-                                    <input type="password" name="login[password]" class="input-text required-entry validate-password min-pass-length-5" id="pass" title="<?php echo $this->__('Password') ?>" />
+                                    <input type="password" name="login[password]" class="input-text required-entry validate-password min-pass-length-5" id="pass" title="<?php echo $this->__('Password') ?>" autocomplete="off" />
                                 </div>
                             </li>
                         </ul>

--- a/app/design/frontend/base/default/template/persistent/checkout/onepage/billing.phtml
+++ b/app/design/frontend/base/default/template/persistent/checkout/onepage/billing.phtml
@@ -157,7 +157,8 @@
                                    name="billing[customer_password]"
                                    id="billing:customer_password"
                                    title="<?php echo $this->quoteEscape($this->__('Password')) ?>"
-                                   class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>" />
+                                   class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>"
+                                   autocomplete="off" />
                             <p class="form-instructions">
                                 <?php echo Mage::helper('customer')->__('The minimum password length is %s', $minPasswordLength) ?>
                             </p>
@@ -166,7 +167,7 @@
                     <div class="field">
                         <label for="billing:confirm_password" class="required"><em>*</em><?php echo $this->__('Confirm Password') ?></label>
                         <div class="input-box">
-                            <input type="password" name="billing[confirm_password]" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm Password')) ?>" id="billing:confirm_password" class="input-text required-entry validate-cpassword" />
+                            <input type="password" name="billing[confirm_password]" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm Password')) ?>" id="billing:confirm_password" class="input-text required-entry validate-cpassword" autocomplete="off" />
                         </div>
                     </div>
                 </li>

--- a/app/design/frontend/base/default/template/persistent/checkout/onepage/login.phtml
+++ b/app/design/frontend/base/default/template/persistent/checkout/onepage/login.phtml
@@ -81,7 +81,7 @@
                 <li>
                     <label for="login-password" class="required"><em>*</em><?php echo $this->__('Password') ?></label>
                     <div class="input-box">
-                        <input type="password" class="input-text required-entry" id="login-password" name="login[password]" />
+                        <input type="password" class="input-text required-entry" id="login-password" name="login[password]" autocomplete="off" />
                     </div>
                 </li>
                 <?php echo $this->getChildHtml('form.additional.info'); ?>

--- a/app/design/frontend/base/default/template/persistent/customer/form/login.phtml
+++ b/app/design/frontend/base/default/template/persistent/customer/form/login.phtml
@@ -55,7 +55,7 @@
                         <li>
                             <label for="pass" class="required"><em>*</em><?php echo $this->__('Password') ?></label>
                             <div class="input-box">
-                                <input type="password" name="login[password]" class="input-text required-entry" id="pass" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Password')) ?>" />
+                                <input type="password" name="login[password]" class="input-text required-entry" id="pass" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Password')) ?>" autocomplete="off" />
                             </div>
                         </li>
                         <?php echo $this->getChildHtml('form.additional.info'); ?>

--- a/app/design/frontend/base/default/template/persistent/customer/form/register.phtml
+++ b/app/design/frontend/base/default/template/persistent/customer/form/register.phtml
@@ -158,7 +158,8 @@
                                    name="password"
                                    id="password"
                                    title="<?php echo $this->quoteEscape($this->__('Password')) ?>"
-                                   class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>" />
+                                   class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>"
+                                   autocomplete="off" />
                             <p class="form-instructions">
                                 <?php echo Mage::helper('customer')->__('The minimum password length is %s', $minPasswordLength) ?>
                             </p>
@@ -167,7 +168,7 @@
                     <div class="field">
                         <label for="confirmation" class="required"><em>*</em><?php echo $this->__('Confirm Password') ?></label>
                         <div class="input-box">
-                            <input type="password" name="confirmation" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm Password')) ?>" id="confirmation" class="input-text required-entry validate-cpassword" />
+                            <input type="password" name="confirmation" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm Password')) ?>" id="confirmation" class="input-text required-entry validate-cpassword" autocomplete="off" />
                         </div>
                     </div>
                 </li>

--- a/app/design/frontend/default/iphone/template/customer/form/login.phtml
+++ b/app/design/frontend/default/iphone/template/customer/form/login.phtml
@@ -49,7 +49,7 @@
                         <li>
                             <label for="pass" class="required"><em>*</em><?php echo $this->__('Password') ?></label>
                             <div class="input-box">
-                                <input type="password" name="login[password]" class="input-text required-entry validate-password min-pass-length-5" id="pass" title="<?php echo $this->__('Password') ?>" />
+                                <input type="password" name="login[password]" class="input-text required-entry validate-password min-pass-length-5" id="pass" title="<?php echo $this->__('Password') ?>" autocomplete="off" />
                             </div>
                         </li>
                         <li class="note">

--- a/app/design/frontend/default/iphone/template/persistent/checkout/onepage/login.phtml
+++ b/app/design/frontend/default/iphone/template/persistent/checkout/onepage/login.phtml
@@ -46,7 +46,7 @@
                 <li>
                     <label for="login-password" class="required"><em>*</em><?php echo $this->__('Password') ?></label>
                     <div class="input-box">
-                        <input type="password" class="input-text required-entry" id="login-password" name="login[password]" />
+                        <input type="password" class="input-text required-entry" id="login-password" name="login[password]" autocomplete="off" />
                     </div>
                 </li>
                 <?php echo $this->getChildHtml('form.additional.info'); ?>

--- a/app/design/frontend/default/iphone/template/persistent/customer/form/login.phtml
+++ b/app/design/frontend/default/iphone/template/persistent/customer/form/login.phtml
@@ -48,7 +48,7 @@
                         <li>
                             <label for="pass" class="required"><em>*</em><?php echo $this->__('Password') ?></label>
                             <div class="input-box">
-                                <input type="password" name="login[password]" class="input-text required-entry validate-password min-pass-length-5" id="pass" title="<?php echo $this->__('Password') ?>" />
+                                <input type="password" name="login[password]" class="input-text required-entry validate-password min-pass-length-5" id="pass" title="<?php echo $this->__('Password') ?>" autocomplete="off" />
                             </div>
                         </li>
                         <li class="note">

--- a/app/design/frontend/rwd/default/template/customer/form/changepassword.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/changepassword.phtml
@@ -30,7 +30,7 @@
         <li>
             <label for="current_password" class="required"><em>*</em><?php echo $this->__('Current Password') ?></label>
             <div class="input-box">
-                <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Current Password')) ?>" class="input-text required-entry" name="current_password" id="current_password" />
+                <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Current Password')) ?>" class="input-text required-entry" name="current_password" id="current_password" autocomplete="off" />
             </div>
         </li>
         <li class="fields">
@@ -42,7 +42,8 @@
                            title="<?php echo Mage::helper('core')->quoteEscape($this->__('New Password')) ?>"
                            class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>"
                            name="password"
-                           id="password" />
+                           id="password"
+                           autocomplete="new-password" />
                     <p class="form-instructions">
                         <?php echo Mage::helper('customer')->__('The minimum password length is %s', $minPasswordLength) ?>
                     </p>
@@ -51,7 +52,7 @@
             <div class="field">
                 <label for="confirmation" class="required"><em>*</em><?php echo $this->__('Confirm New Password') ?></label>
                 <div class="input-box">
-                    <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm New Password')) ?>" class="input-text required-entry validate-cpassword" name="confirmation" id="confirmation" />
+                    <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm New Password')) ?>" class="input-text required-entry validate-cpassword" name="confirmation" id="confirmation" autocomplete="new-password" />
                 </div>
             </div>
         </li>

--- a/app/design/frontend/rwd/default/template/customer/form/edit.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/edit.phtml
@@ -55,7 +55,7 @@
                 <div class="input-box">
                     <!-- This is a dummy hidden field to trick firefox from auto filling the password -->
                     <input type="text" class="input-text no-display" name="dummy" id="dummy" />
-                    <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Current Password')) ?>" class="input-text required-entry" name="current_password" id="current_password" />
+                    <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Current Password')) ?>" class="input-text required-entry" name="current_password" id="current_password" autocomplete="off" />
                 </div>
             </li>
             <li class="control">
@@ -75,7 +75,8 @@
                                title="<?php echo Mage::helper('core')->quoteEscape($this->__('New Password')) ?>"
                                class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>"
                                name="password"
-                               id="password" />
+                               id="password"
+                               autocomplete="new-password" />
                         <p class="form-instructions">
                             <?php echo $this->__('The minimum password length is %s', $minPasswordLength) ?>
                         </p>
@@ -84,7 +85,7 @@
                 <div class="field">
                     <label for="confirmation" class="required"><em>*</em><?php echo $this->__('Confirm New Password') ?></label>
                     <div class="input-box">
-                        <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm New Password')) ?>" class="input-text required-entry validate-cpassword" name="confirmation" id="confirmation" />
+                        <input type="password" title="<?php echo Mage::helper('core')->quoteEscape($this->__('Confirm New Password')) ?>" class="input-text required-entry validate-cpassword" name="confirmation" id="confirmation" autocomplete="new-password" />
                     </div>
                 </div>
             </li>

--- a/app/design/frontend/rwd/default/template/customer/form/mini.login.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/mini.login.phtml
@@ -33,7 +33,7 @@
         <?php echo $this->getBlockHtml('formkey') ?>
         <div class="block-content">
             <label for="mini-login"><?php echo $this->__('Email:') ?></label><input type="email" autocapitalize="off" autocorrect="off" spellcheck="false" name="login[username]" id="mini-login" class="input-text" />
-            <label for="mini-password"><?php echo $this->__('Password:') ?></label><input type="password" name="login[password]" id="mini-password" class="input-text" />
+            <label for="mini-password"><?php echo $this->__('Password:') ?></label><input type="password" name="login[password]" id="mini-password" class="input-text" autocomplete="off" />
             <div class="actions">
                 <button type="submit" class="button"><span><span><?php echo $this->__('Login') ?></span></span></button>
             </div>

--- a/app/design/frontend/rwd/default/template/customer/form/resetforgottenpassword.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/resetforgottenpassword.phtml
@@ -34,7 +34,8 @@
                         <input type="password"
                                class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength; ?>"
                                name="password"
-                               id="password" />
+                               id="password"
+                               autocomplete="new-password" />
                         <p class="form-instructions">
                             <?php echo Mage::helper('customer')->__('The minimum password length is %s', $minPasswordLength); ?>
                         </p>
@@ -43,7 +44,7 @@
                 <div class="field">
                     <label for="confirmation" class="required"><em>*</em><?php echo $this->__('Confirm New Password'); ?></label>
                     <div class="input-box">
-                        <input type="password" class="input-text required-entry validate-cpassword" name="confirmation" id="confirmation" />
+                        <input type="password" class="input-text required-entry validate-cpassword" name="confirmation" id="confirmation" autocomplete="new-password" />
                     </div>
                 </div>
             </li>

--- a/app/design/frontend/rwd/default/template/oauth/authorize/form/login-simple.phtml
+++ b/app/design/frontend/rwd/default/template/oauth/authorize/form/login-simple.phtml
@@ -52,7 +52,7 @@
                                     <em class="required">*</em>&nbsp;<?php echo $this->__('Password') ?>
                                 </label>
                                 <input type="password" id="login" name="login[password]" class="required-entry input-text"
-                                       value=""/></div>
+                                       value="" autocomplete="off" /></div>
                             <div class="clear"></div>
                             <div class="form-buttons">
                                 <button type="submit" class="form-button"

--- a/app/design/frontend/rwd/default/template/persistent/checkout/onepage/billing.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/checkout/onepage/billing.phtml
@@ -160,7 +160,8 @@
                                    name="billing[customer_password]"
                                    id="billing:customer_password"
                                    title="<?php echo $this->quoteEscape($this->__('Password')) ?>"
-                                   class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>" />
+                                   class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>"
+                                   autocomplete="new-password" />
                             <p class="form-instructions">
                                 <?php echo Mage::helper('customer')->__('The minimum password length is %s', $minPasswordLength) ?>
                             </p>
@@ -169,7 +170,7 @@
                     <div class="field">
                         <label for="billing:confirm_password" class="required"><em>*</em><?php echo $this->__('Confirm Password') ?></label>
                         <div class="input-box">
-                            <input type="password" name="billing[confirm_password]" title="<?php echo $this->quoteEscape($this->__('Confirm Password')) ?>" id="billing:confirm_password" class="input-text required-entry validate-cpassword" />
+                            <input type="password" name="billing[confirm_password]" title="<?php echo $this->quoteEscape($this->__('Confirm Password')) ?>" id="billing:confirm_password" class="input-text required-entry validate-cpassword" autocomplete="new-password" />
                         </div>
                     </div>
                 </li>

--- a/app/design/frontend/rwd/default/template/persistent/checkout/onepage/login.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/checkout/onepage/login.phtml
@@ -99,7 +99,7 @@
                 <li>
                     <label for="login-password" class="required"><em>*</em><?php echo $this->__('Password') ?></label>
                     <div class="input-box">
-                        <input type="password" class="input-text required-entry" id="login-password" name="login[password]" />
+                        <input type="password" class="input-text required-entry" id="login-password" name="login[password]" autocomplete="off" />
                     </div>
                 </li>
                 <li>

--- a/app/design/frontend/rwd/default/template/persistent/customer/form/login.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/customer/form/login.phtml
@@ -72,7 +72,7 @@
                         <li>
                             <label for="pass" class="required"><em>*</em><?php echo $this->__('Password') ?></label>
                             <div class="input-box">
-                                <input type="password" name="login[password]" class="input-text required-entry" id="pass" title="<?php echo $this->quoteEscape($this->__('Password')) ?>" />
+                                <input type="password" name="login[password]" class="input-text required-entry" id="pass" title="<?php echo $this->quoteEscape($this->__('Password')) ?>" autocomplete="off" />
                             </div>
                         </li>
                         <?php echo $this->getChildHtml('form.additional.info'); ?>

--- a/app/design/frontend/rwd/default/template/persistent/customer/form/register.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/customer/form/register.phtml
@@ -147,7 +147,8 @@
                                    name="password"
                                    id="password"
                                    title="<?php echo $this->quoteEscape($this->__('Password')) ?>"
-                                   class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>" />
+                                   class="input-text required-entry validate-password min-pass-length-<?php echo $minPasswordLength ?>"
+                                   autocomplete="new-password" />
                             <p class="form-instructions">
                                 <?php echo Mage::helper('customer')->__('The minimum password length is %s', $minPasswordLength) ?>
                             </p>
@@ -156,7 +157,7 @@
                     <div class="field">
                         <label for="confirmation" class="required"><em>*</em><?php echo $this->__('Confirm Password') ?></label>
                         <div class="input-box">
-                            <input type="password" name="confirmation" title="<?php echo $this->quoteEscape($this->__('Confirm Password')) ?>" id="confirmation" class="input-text required-entry validate-cpassword" />
+                            <input type="password" name="confirmation" title="<?php echo $this->quoteEscape($this->__('Confirm Password')) ?>" id="confirmation" class="input-text required-entry validate-cpassword" autocomplete="new-password" />
                         </div>
                     </div>
                 </li>


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Add "autocomplete" attribute to password fields on customer-facing forms. This is not really a security issue in my opinion, but this change is intended to help meet PCI attestation requirements. Some vulnerability scanners are known to flag this as an issue. For example: https://www.tenable.com/plugins/nessus/42057

I attempted to use the most appropriate value for the attribute (off or new-password). These changes should not have any noticeable impact on users.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Access a customer login screen.
2. Verify that the password field has an "autocomplete" attribute.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->