### PR TITLE
Add link to the product page and float default qty for bundle items

### DIFF
--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/selection.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/selection.phtml
@@ -48,7 +48,7 @@ var bundleTemplateRow ='<td>' +
                 '    <input type="hidden" name="<?php echo $this->getFieldName() ?>[{{parentIndex}}][{{index}}][delete]" value="" class="delete">' +
                 '    {{name}}<br />' +
                 '   <div  class="nobr">' +
-                '        <strong><?php echo $this->helper('sales')->__('SKU') ?>:</strong> {{sku}}' +
+                '        <strong><?php echo $this->helper('sales')->__('SKU') ?>:</strong> <a href="<?php echo $this->getUrl('*/catalog_product/edit', ['store' => $this->getRequest()->getParam('store')]) ?>id/{{product_id}}/">{{sku}}</a>' +
                 '    </div>' +
                 '</td>' +
                 <?php if ($this->getCanReadPrice() !== false) : ?>
@@ -122,8 +122,12 @@ Bundle.Selection.prototype = {
 
         var option_type = $(bOption.idLabel + '_' + parentIndex + '_type');
 
-        if(!data){
+        if (!data) {
             var data = {};
+        }
+
+        if (data.selection_qty) {
+            data.selection_qty = parseFloat(data.selection_qty);
         }
 
         if (data.can_read_price != undefined && !data.can_read_price) {


### PR DESCRIPTION
### Description

For bundle products edit page, in "Bundle Items" tab, this PR add a link to the product page (with current store id) and it float the "default qty":

before
![image](https://user-images.githubusercontent.com/31816829/201094229-1335c9e5-72c9-4afe-aa72-9aa2a38fc990.png)

after
![image](https://user-images.githubusercontent.com/31816829/201094281-c49c10c1-2ca0-4d1a-adab-e9e3060deec6.png)

The link is an extract of #1379.

OpenMage 20.0.16 / PHP 8.0.25

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)