### PR TITLE
Keep current selection for Related, Up-sells, Cross-sells, Associated grids

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
@@ -406,7 +406,7 @@ class Mage_Adminhtml_Catalog_ProductController extends Mage_Adminhtml_Controller
         $this->_initProduct();
         $this->loadLayout();
         $this->getLayout()->getBlock('catalog.product.edit.tab.related')
-            ->setProductsRelated($this->getRequest()->getPost('products_related', null));
+            ->setProductsRelated($this->getRequest()->getPost('products_related', []));
         $this->renderLayout();
     }
 
@@ -419,7 +419,7 @@ class Mage_Adminhtml_Catalog_ProductController extends Mage_Adminhtml_Controller
         $this->_initProduct();
         $this->loadLayout();
         $this->getLayout()->getBlock('catalog.product.edit.tab.upsell')
-            ->setProductsRelated($this->getRequest()->getPost('products_upsell', null));
+            ->setProductsUpsell($this->getRequest()->getPost('products_upsell', []));
         $this->renderLayout();
     }
 
@@ -432,7 +432,7 @@ class Mage_Adminhtml_Catalog_ProductController extends Mage_Adminhtml_Controller
         $this->_initProduct();
         $this->loadLayout();
         $this->getLayout()->getBlock('catalog.product.edit.tab.crosssell')
-            ->setProductsRelated($this->getRequest()->getPost('products_crosssell', null));
+            ->setProductsCrossSell($this->getRequest()->getPost('products_crosssell', []));
         $this->renderLayout();
     }
 
@@ -445,7 +445,7 @@ class Mage_Adminhtml_Catalog_ProductController extends Mage_Adminhtml_Controller
         $this->_initProduct();
         $this->loadLayout();
         $this->getLayout()->getBlock('catalog.product.edit.tab.super.group')
-            ->setProductsGrouped($this->getRequest()->getPost('products_grouped', null));
+            ->setProductsGrouped($this->getRequest()->getPost('products_grouped', []));
         $this->renderLayout();
     }
 


### PR DESCRIPTION
### Description

Go to Catalog > Products and choose any product.
For Related, Up-sells, Cross-sells, Associated (for grouped products) grids.

- Uncheck all products, then reset filter or filter or sort or change the page, after AJAX all products are unchecked.
- Check some products, then reset filter or filter or sort or change the page, after AJAX selected products are checked.

Try Sales / Order grid, this is the same thing.
This is an extract of #1379.

OpenMage 20.0.17 / PHP 8.0.25

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)