### PR TITLE
Require a parent category to add a new sub category

### DIFF
--- a/app/design/adminhtml/default/default/template/catalog/category/tree.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/tree.phtml
@@ -381,20 +381,27 @@ Ext.onReady(function()
     reRenderTree();
 });
 
-function addNew(url, isRoot)
+function addNew(url, isRoot, node)
 {
     if (isRoot) {
+        if (tree.currentNodeId && (node = tree.getNodeById(tree.currentNodeId))) {
+            node.unselect();
+        }
         tree.currentNodeId = tree.root.id;
+    }
+    else if (!tree.currentNodeId || (tree.currentNodeId == tree.root.id)) {
+        alert("<?php echo Mage::helper('core')->jsQuoteEscape($this->__('Please select a parent category before add new one.')) ?>");
+        return;
     }
 
     if (/store\/\d+/.test(url)) {
         url = url.replace(/store\/\d+/, "store/" + tree.storeId);
     }
-    else    {
-        url+= "store/" + tree.storeId + "/";
+    else {
+        url += "store/" + tree.storeId + "/";
     }
 
-    url+= 'parent/'+tree.currentNodeId;
+    url += 'parent/' + tree.currentNodeId + '/';
     updateContent(url);
 }
 

--- a/app/design/adminhtml/default/default/template/catalog/category/tree.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/tree.phtml
@@ -390,7 +390,7 @@ function addNew(url, isRoot, node)
         tree.currentNodeId = tree.root.id;
     }
     else if (!tree.currentNodeId || (tree.currentNodeId == tree.root.id)) {
-        alert("<?php echo Mage::helper('core')->jsQuoteEscape($this->__('Please select a parent category before add new one.')) ?>");
+        alert("<?php echo Mage::helper('core')->jsQuoteEscape($this->__('Please select a parent category before adding a new one.')) ?>");
         return;
     }
 

--- a/app/locale/en_US/Mage_Adminhtml.csv
+++ b/app/locale/en_US/Mage_Adminhtml.csv
@@ -735,6 +735,7 @@
 "Phone:","Phone:"
 "Please Select","Please Select"
 "Please confirm site switching. All data that hasn't been saved will be lost.","Please confirm site switching. All data that hasn't been saved will be lost."
+"Please select a parent category before add new one.","Please select a parent category before add new one."
 "Please enter 6 or more characters.","Please enter 6 or more characters."
 "Please enter a number greater than 0 in this field.","Please enter a number greater than 0 in this field."
 "Please enter a valid $ amount. For example $100.00.","Please enter a valid $ amount. For example $100.00."

--- a/app/locale/en_US/Mage_Adminhtml.csv
+++ b/app/locale/en_US/Mage_Adminhtml.csv
@@ -735,7 +735,7 @@
 "Phone:","Phone:"
 "Please Select","Please Select"
 "Please confirm site switching. All data that hasn't been saved will be lost.","Please confirm site switching. All data that hasn't been saved will be lost."
-"Please select a parent category before add new one.","Please select a parent category before add new one."
+"Please select a parent category before adding a new one.","Please select a parent category before adding a new one."
 "Please enter 6 or more characters.","Please enter 6 or more characters."
 "Please enter a number greater than 0 in this field.","Please enter a number greater than 0 in this field."
 "Please enter a valid $ amount. For example $100.00.","Please enter a valid $ amount. For example $100.00."


### PR DESCRIPTION
### Description

Go to Catalog > Categories.

- click on "Add Subcategory" without selecting a parent, this is now not possible
- select any category and click on "Add Subcategory"
- don't save and click on "Add Root Category", selected category is now unselected

![image](https://user-images.githubusercontent.com/31816829/202291950-8e7c6c5e-bd54-4b5d-8d89-06b651a8357f.png)

This is an improved extract of #1379.

OpenMage 20.0.17 / PHP 8.0.25

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)