### PR TITLE
Added confirmation before deleting website/store/storeview

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Edit.php
@@ -60,7 +60,9 @@ class Mage_Adminhtml_Block_System_Store_Edit extends Mage_Adminhtml_Block_Widget
 
         $this->_updateButton('save', 'label', $saveLabel);
         $this->_updateButton('delete', 'label', $deleteLabel);
-        $this->_updateButton('delete', 'onclick', 'setLocation(\''.$deleteUrl.'\');');
+        $this->_updateButton('delete', 'onclick', 'confirmSetLocation(\'' .
+            Mage::helper('core')->jsQuoteEscape(Mage::helper('core')->__('Are you sure?')) .
+            '\', \'' . $deleteUrl . '\');');
 
         if (!Mage::registry('store_data')->isCanDelete()) {
             $this->_removeButton('delete');


### PR DESCRIPTION
In the "manage stores" section of the backend it's possible to click the "deleting website/store/storeview" and delete without any confirmation being asked, which is very dangerous.

This PR adds the confirmation before actually delete website/store/storeview.