### PR TITLE
Set width:auto for td.massaction

### DIFF
--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -183,7 +183,7 @@ table.actions td                { vertical-align:top; }
 
 /* Grid - Mass Action */
 .massaction { width:100%; height:26px; border:1px solid #d1cfcf; border-bottom:none; background:url(images/massaction_bg.gif) repeat-x 0 100% #ebebeb; font-size:.9em; }
-.massaction td                              { width:50%; border-top:1px solid #fff; padding:1px 8px; vertical-align:middle; }
+.massaction td                              { width:auto; border-top:1px solid #fff; padding:1px 8px; vertical-align:middle; }
 .massaction .entry-edit fieldset .select    { width:auto; /*width:120px;*/ display:inline; }
 .massaction .entry-edit fieldset select.validation-failed { border:1px dashed #eb340a !important; background:#faebe7 !important }
 .massaction .entry-edit fieldset            { margin:0; padding:0; background:none; border:none; }


### PR DESCRIPTION
### Description

In english, there are no problems:

![english](https://user-images.githubusercontent.com/31816829/202396407-aee63d91-2233-46d7-b849-7658cb8f205d.png)

But in french, there is a problem:

![french-before](https://user-images.githubusercontent.com/31816829/202396420-9cf0e18b-5928-4de6-b517-a05dd9d839c0.png)

This PR update `td.massaction` `width` to `auto`.
So, now we have:

![french-after](https://user-images.githubusercontent.com/31816829/202396416-4da8bd0a-3c7a-4166-a112-8bdb302c2bf6.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list