### PR TITLE
Fix data.title replace when it's null/undefined

### DIFF
--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option.phtml
@@ -91,10 +91,10 @@ Bundle.Option.prototype = {
     },
 
     add : function(data) {
-        if(!data){
+        if (!data) {
             data = {};
             this.top = $('product_bundle_container_top');
-        } else {
+        } else if (data.title) {
             data.title = data.title.replace('"', "&quot;");
         }
 


### PR DESCRIPTION
### Description

This fix one error (I don't remember when it happen, I found it with Sentry), here is a way to reproduce it manually:
```
09:37:42,200 > a = {};
09:37:53,486 > a.title.replace('"', "&quot;");
09:37:53,558 < Uncaught TypeError: a.title is undefined
09:38:01,969 > a = { title: null };
09:38:05,307 > a.title.replace('"', "&quot;");
09:38:05,380 < Uncaught TypeError: a.title is null
09:38:41,052 > a = { title: undefined };
09:38:43,659 > a.title.replace('"', "&quot;");
09:38:43,731 < Uncaught TypeError: a.title is undefined
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list