### PR TITLE
Set constant sort order for tax rates

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid.php
@@ -29,7 +29,7 @@ class Mage_Adminhtml_Block_Tax_Rate_Grid extends Mage_Adminhtml_Block_Widget_Gri
     public function __construct()
     {
         parent::__construct();
-        $this->setDefaultSort('region_name');
+        $this->setDefaultSort('code');
         $this->setDefaultDir('asc');
         $this->setId('tax_rate_grid');
         $this->setSaveParametersInSession(true);


### PR DESCRIPTION
### Description

Not sure if it's good or not, but without this PR, when we go to Sales / Tax / Manage Tax Rates, the sort order is "random".
When we go to the page:

![image](https://user-images.githubusercontent.com/31816829/202399545-394946e7-d825-4ba4-86d8-7d36a1238c2a.png)

After refresh the page:

![image](https://user-images.githubusercontent.com/31816829/202399624-9abe38c1-c214-4ea5-9651-2dd047439aef.png)

Yes, this problem is still present when we sort by state/region.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list