### PR TITLE
Fix creation of dynamic property for Cm_RedisSession

### DIFF
--- a/app/code/community/Cm/RedisSession/Model/Session.php
+++ b/app/code/community/Cm/RedisSession/Model/Session.php
@@ -88,6 +88,7 @@ class Cm_RedisSession_Model_Session extends Mage_Core_Model_Mysql4_Session
     protected $_logLevel;
     protected $_maxConcurrency;
     protected $_breakAfter;
+    protected $_failAfter;
     protected $_useLocking;
     protected $_hasLock;
     protected $_sessionWritten; // avoid infinite loops


### PR DESCRIPTION
### Description

This PR fix `Creation of dynamic property Cm_RedisSession_Model_Session::$_failAfter is deprecated` with PHP 8.2.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list