### PR TITLE
Allow to load order, invoice, shipment and creditmemo by increment id

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
@@ -102,8 +102,11 @@ class Mage_Adminhtml_Sales_Order_CreditmemoController extends Mage_Adminhtml_Con
         if ($creditmemoId) {
             $creditmemo = Mage::getModel('sales/order_creditmemo')->load($creditmemoId);
             if (!$creditmemo->getId()) {
-                $this->_getSession()->addError($this->__('The credit memo no longer exists.'));
-                return false;
+                $creditmemo = Mage::getModel('sales/order_creditmemo')->loadByIncrementId($creditmemoId);
+                if (!$creditmemo->getId()) {
+                    $this->_getSession()->addError($this->__('The credit memo no longer exists.'));
+                    return false;
+                }
             }
         } elseif ($orderId) {
             $data   = $this->getRequest()->getParam('creditmemo');

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
@@ -55,8 +55,11 @@ class Mage_Adminhtml_Sales_Order_InvoiceController extends Mage_Adminhtml_Contro
         if ($invoiceId) {
             $invoice = Mage::getModel('sales/order_invoice')->load($invoiceId);
             if (!$invoice->getId()) {
-                $this->_getSession()->addError($this->__('The invoice no longer exists.'));
-                return false;
+                $invoice = Mage::getModel('sales/order_invoice')->loadByIncrementId($invoiceId);
+                if (!$invoice->getId()) {
+                    $this->_getSession()->addError($this->__('The invoice no longer exists.'));
+                    return false;
+                }
             }
         } elseif ($orderId) {
             $order = Mage::getModel('sales/order')->load($orderId);

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
@@ -54,8 +54,11 @@ class Mage_Adminhtml_Sales_Order_ShipmentController extends Mage_Adminhtml_Contr
         if ($shipmentId) {
             $shipment = Mage::getModel('sales/order_shipment')->load($shipmentId);
             if (!$shipment->getId()) {
-                $this->_getSession()->addError($this->__('The shipment no longer exists.'));
-                return false;
+                $shipment = Mage::getModel('sales/order_shipment')->loadByIncrementId($shipmentId);
+                if (!$shipment->getId()) {
+                    $this->_getSession()->addError($this->__('The shipment no longer exists.'));
+                    return false;
+                }
             }
         } elseif ($orderId) {
             $order      = Mage::getModel('sales/order')->load($orderId);

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/OrderController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/OrderController.php
@@ -69,13 +69,18 @@ class Mage_Adminhtml_Sales_OrderController extends Mage_Adminhtml_Controller_Act
         $order = Mage::getModel('sales/order')->load($id);
 
         if (!$order->getId()) {
-            $this->_getSession()->addError($this->__('This order no longer exists.'));
-            $this->_redirect('*/*/');
-            $this->setFlag('', self::FLAG_NO_DISPATCH, true);
-            return false;
+            $order = Mage::getModel('sales/order')->loadByIncrementId($id);
+            if (!$order->getId()) {
+                $this->_getSession()->addError($this->__('This order no longer exists.'));
+                $this->_redirect('*/*/');
+                $this->setFlag('', self::FLAG_NO_DISPATCH, true);
+                return false;
+            }
         }
+
         Mage::register('sales_order', $order);
         Mage::register('current_order', $order);
+
         return $order;
     }
 

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
@@ -225,6 +225,25 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
     }
 
     /**
+     * Load creditmemo by increment id
+     *
+     * @param string $incrementId
+     * @return $this
+     */
+    public function loadByIncrementId($incrementId)
+    {
+        $ids = $this->getCollection()
+            ->addAttributeToFilter('increment_id', $incrementId)
+            ->getAllIds();
+
+        if (!empty($ids)) {
+            reset($ids);
+            $this->load(current($ids));
+        }
+        return $this;
+    }
+
+    /**
      * Retrieve Creditmemo configuration model
      *
      * @return Mage_Sales_Model_Order_Creditmemo_Config

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
@@ -232,15 +232,7 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
      */
     public function loadByIncrementId($incrementId)
     {
-        $ids = $this->getCollection()
-            ->addAttributeToFilter('increment_id', $incrementId)
-            ->getAllIds();
-
-        if (!empty($ids)) {
-            reset($ids);
-            $this->load(current($ids));
-        }
-        return $this;
+        return $this->load($incrementId, 'increment_id');
     }
 
     /**

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -227,15 +227,7 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
      */
     public function loadByIncrementId($incrementId)
     {
-        $ids = $this->getCollection()
-            ->addAttributeToFilter('increment_id', $incrementId)
-            ->getAllIds();
-
-        if (!empty($ids)) {
-            reset($ids);
-            $this->load(current($ids));
-        }
-        return $this;
+        return $this->load($incrementId, 'increment_id');
     }
 
     /**

--- a/app/code/core/Mage/Sales/Model/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment.php
@@ -134,15 +134,7 @@ class Mage_Sales_Model_Order_Shipment extends Mage_Sales_Model_Abstract
      */
     public function loadByIncrementId($incrementId)
     {
-        $ids = $this->getCollection()
-            ->addAttributeToFilter('increment_id', $incrementId)
-            ->getAllIds();
-
-        if (!empty($ids)) {
-            reset($ids);
-            $this->load(current($ids));
-        }
-        return $this;
+        return $this->load($incrementId, 'increment_id');
     }
 
     /**


### PR DESCRIPTION
### Description

This PR allow to load order, invoice, shipment and creditmemo by increment id from URL.

Go to _Sales / Orders_, or _Sales / Invoices_, or _Sales / Shipments_, or _Sales / Credit memos_.
Open any item.
Your URL looks like: `.../index.php/admin/admin/sales_order/view/order_id/2/...`
Now replace the order_id by the increment_id, for example: `.../index.php/admin/admin/sales_order/view/order_id/100000002/...`

And, it works!

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list