### PR TITLE
Add a search bar for orders, invoices, shipments and credit memos

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo.php
@@ -34,4 +34,13 @@ class Mage_Adminhtml_Block_Sales_Creditmemo extends Mage_Adminhtml_Block_Widget_
         parent::__construct();
         $this->_removeButton('add');
     }
+
+    public function getButtonsHtml($area = null)
+    {
+        return '<form action="'.$this->getUrl('*/*/view').'" method="get" class="tinysearch">' .
+            ' <input type="text" name="creditmemo_id" class="input-text" required="required" placeholder="creditmemo_id / increment_id" />' .
+            ' <button type="submit" class="scalable go"><span><span>'.$this->__('View').'</span></span></button>' .
+            '</form> ' .
+            parent::getButtonsHtml($area);
+    }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Invoice.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Invoice.php
@@ -39,4 +39,13 @@ class Mage_Adminhtml_Block_Sales_Invoice extends Mage_Adminhtml_Block_Widget_Gri
     {
         return $this->getChildHtml('payment_info');
     }
+
+    public function getButtonsHtml($area = null)
+    {
+        return '<form action="'.$this->getUrl('*/*/view').'" method="get" class="tinysearch">' .
+            ' <input type="text" name="invoice_id" class="input-text" required="required" placeholder="invoice_id / increment_id" />' .
+            ' <button type="submit" class="scalable go"><span><span>'.$this->__('View').'</span></span></button>' .
+            '</form> ' .
+            parent::getButtonsHtml($area);
+    }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order.php
@@ -42,4 +42,13 @@ class Mage_Adminhtml_Block_Sales_Order extends Mage_Adminhtml_Block_Widget_Grid_
     {
         return $this->getUrl('*/sales_order_create/start');
     }
+
+    public function getButtonsHtml($area = null)
+    {
+        return '<form action="'.$this->getUrl('*/*/view').'" method="get" class="tinysearch">' .
+            ' <input type="text" name="order_id" class="input-text" required="required" placeholder="order_id / increment_id" />' .
+            ' <button type="submit" class="scalable go"><span><span>'.$this->__('View').'</span></span></button>' .
+            '</form> ' .
+            parent::getButtonsHtml($area);
+    }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Shipment.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Shipment.php
@@ -34,4 +34,13 @@ class Mage_Adminhtml_Block_Sales_Shipment extends Mage_Adminhtml_Block_Widget_Gr
         parent::__construct();
         $this->_removeButton('add');
     }
+
+    public function getButtonsHtml($area = null)
+    {
+        return '<form action="'.$this->getUrl('*/*/view').'" method="get" class="tinysearch">' .
+            ' <input type="text" name="shipment_id" class="input-text" required="required" placeholder="shipment_id / increment_id" />' .
+            ' <button type="submit" class="scalable go"><span><span>'.$this->__('View').'</span></span></button>' .
+            '</form> ' .
+            parent::getButtonsHtml($area);
+    }
 }

--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -180,6 +180,9 @@ table.actions td                { vertical-align:top; }
 .grid tr.headings th a.sort-arrow-desc span.sort-title { background-image:url(images/grid_sort_desc.gif); }
 .grid tr.headings th a.sort-arrow-asc span.sort-title { background-image:url(images/grid_sort_asc.gif); }
 
+/* Grid - Tiny search bar */
+.content-header .tinysearch input { margin-bottom: -1px; padding: 3px 2px 2px; }
+.content-header .tinysearch button { margin-left: -4px; }
 
 /* Grid - Mass Action */
 .massaction { width:100%; height:26px; border:1px solid #d1cfcf; border-bottom:none; background:url(images/massaction_bg.gif) repeat-x 0 100% #ebebeb; font-size:.9em; }


### PR DESCRIPTION
### Description

This PR add a new search bar!

Yes you can continue to copy/paste the increment_id in the filter of the grid, press enter or click on the search button, and then click on the row. Or you can now simply copy/paste the increment_id or the order_id in the search bar, and press enter or click on the view button.

Go to _Sales / Orders_, or _Sales / Invoices_, or _Sales / Shipments_, or _Sales / Credit memos_:

![image](https://user-images.githubusercontent.com/31816829/202408597-45b0b967-9c3d-40a3-97b9-911b71334819.png)

For increment_id, it require #2725.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list