### PR TITLE
Fixed "Credit Memo not created when refund issued by merchant"

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Payment.php
@@ -806,7 +806,7 @@ class Mage_Sales_Model_Order_Payment extends Mage_Payment_Model_Info
             $amount = $amountRefundLeft;
         }
 
-        if ($amount != $baseGrandTotal) {
+        if (bccomp($amount, $baseGrandTotal, 2) != 0) {
             $transaction = new Varien_Object(['txn_id' => $this->getTransactionId()]);
             Mage::dispatchEvent('sales_html_txn_id', ['transaction' => $transaction, 'payment' => $this]);
             $transactionId = $transaction->getHtmlTxnId() ? $transaction->getHtmlTxnId() : $transaction->getTxnId();

--- a/app/code/core/Mage/Sales/Model/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Payment.php
@@ -806,7 +806,7 @@ class Mage_Sales_Model_Order_Payment extends Mage_Payment_Model_Info
             $amount = $amountRefundLeft;
         }
 
-        if (bccomp($amount, $baseGrandTotal, 2) != 0) {
+        if (Mage::helper('core')->getExactDivision($amount, $baseGrandTotal) != 0) {
             $transaction = new Varien_Object(['txn_id' => $this->getTransactionId()]);
             Mage::dispatchEvent('sales_html_txn_id', ['transaction' => $transaction, 'payment' => $this]);
             $transactionId = $transaction->getHtmlTxnId() ? $transaction->getHtmlTxnId() : $transaction->getTxnId();


### PR DESCRIPTION
### Description

Sometimes, the total of the order and the total of the refund is a little different, +/- 0.001, so when an admin create a refund from PayPal website (or another payment method), we have:

```
IPN "Refunded". Refund issued by merchant. Registered notification about refunded amount of -61.79 €. 
Transaction ID: "xxxx". Credit Memo has not been created. Please create offline Credit Memo.
```

For this example the order total is 61.79:
![image](https://user-images.githubusercontent.com/31816829/202419707-aee24e24-cdbb-42d0-bf74-c455a09d59bc.png)

<del>This PR require **php-bcmath**. perhaps we can replace `bccomp` with another php code to not require on `bcmath`.</del>

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
