### PR TITLE
Add label, date and datetime picker to system.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Most important changes will be listed here, all other changes since `19.4.0` can
 - bug fixes and PHP 7.x, 8.0, 8.1 and 8.2 compatibility
 - added config cache for system.xml ([#1916](https://github.com/OpenMage/magento-lts/pull/1916))
 - added frontend_type color ([#2945](https://github.com/OpenMage/magento-lts/pull/2945))
+- added `label`, `date` and `datetime` picker field types to system.xml [#2739](https://github.com/OpenMage/magento-lts/pull/2739)
 - search for "NULL" in backend grids ([#1203](https://github.com/OpenMage/magento-lts/pull/1203))
 - removed `lib/flex` containing unused ActionScript "file uploader" files ([#2271](https://github.com/OpenMage/magento-lts/pull/2271))
 - Mage_Catalog_Model_Resource_Abstract::getAttributeRawValue() now returns `'0'` instead of `false` if the value stored in the database is `0` ([#572](https://github.com/OpenMage/magento-lts/pull/572))

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/AbstractDate.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/AbstractDate.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * @category   Mage
+ * @package    Mage_Adminhtml
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
+ * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * @category   Mage
+ * @package    Mage_Adminhtml
+ */
+abstract class Mage_Adminhtml_Block_System_Config_Form_Field_AbstractDate extends Mage_Adminhtml_Block_System_Config_Form_Field
+{
+    /**
+     * @return Varien_Data_Form_Element_Abstract
+     */
+    abstract protected function getDateClass(): Varien_Data_Form_Element_Abstract;
+
+    /**
+     * @param string $format
+     * @return string
+     */
+    abstract protected function getDateFormat(string $format): string;
+
+    /**
+     * @return bool Show date with time
+     */
+    abstract protected function isShowTime(): bool;
+
+    /**
+     * @param Varien_Data_Form_Element_Abstract $element
+     * @return string
+     */
+    protected function _getElementHtml(Varien_Data_Form_Element_Abstract $element)
+    {
+        /** @var Mage_Core_Model_Config_Element $field */
+        $field = $element->getFieldConfig();
+
+        $type = $element->getType();
+        if ($type !== 'date' && $type !== 'datetime' && $type !== 'text') {
+            Mage::throwException(
+                Mage::helper('adminhtml')->__(
+                    'Invalid frontend type for field "%s". Onyl "text", "date" and "datetime" are allowed.',
+                    $field->descend('label')
+                )
+            );
+        }
+
+        $format = Mage_Core_Helper_Date::getDateFormatFromString($field->format->__toString());
+        $format = $this->getDateFormat($format);
+
+        if (empty($field->editable)) {
+            return $this->getLocale()
+                ->date((int)$element->getValue())
+                ->toString($format);
+        }
+
+        $date = $this->getDateClass();
+        $date->setData([
+            'name'    => $element->getName(),
+            'html_id' => $element->getId(),
+            'image'   => $this->getSkinUrl('images/grid-cal.gif'),
+            'time'    => $this->isShowTime()
+        ]);
+        $date->setFormat($format);
+        $date->setValue($element->getValue());
+        $date->setForm($element->getForm());
+
+        return $date->getElementHtml();
+    }
+
+    /**
+     * @return Mage_Core_Model_Locale
+     */
+    public function getLocale()
+    {
+        return Mage::app()->getLocale();
+    }
+}

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/AbstractDate.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/AbstractDate.php
@@ -17,8 +17,7 @@ declare(strict_types=1);
  *
  * @category   Mage
  * @package    Mage_Adminhtml
- * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
- * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @copyright  Copyright (c) 2023 The OpenMage Contributors (https://www.openmage.org)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/AbstractDate.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/AbstractDate.php
@@ -5,15 +5,9 @@ declare(strict_types=1);
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Date.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * @category   Mage
+ * @package    Mage_Adminhtml
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
+ * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Adminhtml system config date field renderer
+ *
+ * @category   Mage
+ * @package    Mage_Adminhtml
+ */
+class Mage_Adminhtml_Block_System_Config_Form_Field_Date extends Mage_Adminhtml_Block_System_Config_Form_Field_AbstractDate
+{
+    /**
+     * @return Varien_Data_Form_Element_Date
+     */
+    protected function getDateClass(): Varien_Data_Form_Element_Date
+    {
+        return new Varien_Data_Form_Element_Date();
+    }
+
+    /**
+     * @param string $format
+     * @return string
+     */
+    protected function getDateFormat(string $format): string
+    {
+        return $this->getLocale()->getDateFormat($format);
+    }
+
+    /**
+     * @return false
+     */
+    protected function isShowTime(): bool
+    {
+        return false;
+    }
+}

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Date.php
@@ -5,15 +5,9 @@ declare(strict_types=1);
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Date.php
@@ -11,8 +11,7 @@ declare(strict_types=1);
  *
  * @category   Mage
  * @package    Mage_Adminhtml
- * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
- * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @copyright  Copyright (c) 2023 The OpenMage Contributors (https://www.openmage.org)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Datetime.php
@@ -19,11 +19,30 @@
  * @category   Mage
  * @package    Mage_Adminhtml
  */
-class Mage_Adminhtml_Block_System_Config_Form_Field_Datetime extends Mage_Adminhtml_Block_System_Config_Form_Field
+class Mage_Adminhtml_Block_System_Config_Form_Field_Datetime extends Mage_Adminhtml_Block_System_Config_Form_Field_AbstractDate
 {
-    protected function _getElementHtml(Varien_Data_Form_Element_Abstract $element)
+    /**
+     * @return Varien_Data_Form_Element_Datetime
+     */
+    protected function getDateClass(): Varien_Data_Form_Element_Datetime
     {
-        $format = Mage::app()->getLocale()->getDateTimeFormat(Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM);
-        return Mage::app()->getLocale()->date((int) $element->getValue())->toString($format);
+        return new Varien_Data_Form_Element_Datetime();
+    }
+
+    /**
+     * @param string $format
+     * @return string
+     */
+    protected function getDateFormat(string $format): string
+    {
+        return $this->getLocale()->getDateTimeFormat($format);
+    }
+
+    /**
+     * @return true
+     */
+    protected function isShowTime(): bool
+    {
+        return true;
     }
 }

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Label.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Label.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * @category   Mage
+ * @package    Mage_Adminhtml
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
+ * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Adminhtml system config label field renderer
+ *
+ * @category   Mage
+ * @package    Mage_Adminhtml
+ * @author     Magento Core Team <core@magentocommerce.com>
+ */
+class Mage_Adminhtml_Block_System_Config_Form_Field_Label extends Mage_Adminhtml_Block_System_Config_Form_Field
+{
+    /**
+     * @param Varien_Data_Form_Element_Abstract $element
+     * @return string
+     */
+    protected function _getElementHtml(Varien_Data_Form_Element_Abstract $element)
+    {
+        $field = $element->getFieldConfig();
+
+        $type = $element->getType();
+        if ($type !== 'label' && $type !== 'text') {
+            Mage::throwException(
+                Mage::helper('adminhtml')->__(
+                    'Invalid frontend type for field "%s". Onyl "text" and "label" are allowed.',
+                    $field->descend('label')
+                )
+            );
+        }
+
+        $label = new Varien_Data_Form_Element_Label();
+        $label->setValue($field->descend('value'));
+        $label->setBold(!empty($field->descend('bold')));
+
+        return $label->getElementHtml();
+    }
+}

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Label.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Label.php
@@ -5,15 +5,9 @@ declare(strict_types=1);
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Label.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Label.php
@@ -11,8 +11,7 @@ declare(strict_types=1);
  *
  * @category   Mage
  * @package    Mage_Adminhtml
- * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
- * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @copyright  Copyright (c) 2023 The OpenMage Contributors (https://www.openmage.org)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/AbstractDate.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/AbstractDate.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * @category   Mage
+ * @package    Mage_Adminhtml
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
+ * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * @category   Mage
+ * @package    Mage_Adminhtml
+ */
+abstract class Mage_Adminhtml_Model_System_Config_Backend_AbstractDate extends Mage_Core_Model_Config_Data
+{
+    /**
+     * @param string $format
+     * @return string
+     */
+    abstract protected function getDateFormat(string $format): string;
+
+    /**
+     * @return $this
+     */
+    protected function _afterLoad()
+    {
+        $value = (string)$this->getValue();
+        if ($value !== '') {
+            $this->setValue($this->getLocale()->date($value)->toString(Varien_Date::DATETIME_INTERNAL_FORMAT));
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    protected function _beforeSave()
+    {
+        $value = (string)$this->getValue();
+        if ($value !== '') {
+            $this->setValue($this->filterDateTime($value));
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $date
+     * @return string
+     */
+    protected function filterDateTime(string $date): string
+    {
+        /** @var Mage_Core_Model_Config_Element $field */
+        $field = $this->getFieldConfig();
+
+        $format = Mage_Core_Helper_Date::getDateFormatFromString($field->format->__toString());
+        $format = $this->getDateFormat($format);
+
+        $filterInput = new Zend_Filter_LocalizedToNormalized([
+            'date_format' => $format
+        ]);
+
+        $date = $filterInput->filter($date);
+
+        // convert to utc
+        return $this->getLocale()->utcDate(null, $date, true)->toString(Varien_Date::DATETIME_INTERNAL_FORMAT);
+    }
+
+    /**
+     * @return Mage_Core_Model_Locale
+     */
+    public function getLocale()
+    {
+        return Mage::app()->getLocale();
+    }
+}

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/AbstractDate.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/AbstractDate.php
@@ -5,15 +5,9 @@ declare(strict_types=1);
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/AbstractDate.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/AbstractDate.php
@@ -11,8 +11,7 @@ declare(strict_types=1);
  *
  * @category   Mage
  * @package    Mage_Adminhtml
- * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
- * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @copyright  Copyright (c) 2023 The OpenMage Contributors (https://www.openmage.org)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Date.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Date.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * @category   Mage
+ * @package    Mage_Adminhtml
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
+ * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Date config field backend model
+ *
+ * @category   Mage
+ * @package    Mage_Adminhtml
+ */
+class Mage_Adminhtml_Model_System_Config_Backend_Date extends Mage_Adminhtml_Model_System_Config_Backend_AbstractDate
+{
+    /**
+     * @param string $format
+     * @return string
+     */
+    protected function getDateFormat(string $format): string
+    {
+        return $this->getLocale()->getDateFormat($format);
+    }
+}

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Date.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Date.php
@@ -5,15 +5,9 @@ declare(strict_types=1);
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Date.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Date.php
@@ -11,8 +11,7 @@ declare(strict_types=1);
  *
  * @category   Mage
  * @package    Mage_Adminhtml
- * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
- * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @copyright  Copyright (c) 2023 The OpenMage Contributors (https://www.openmage.org)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Datetime.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * @category   Mage
+ * @package    Mage_Adminhtml
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
+ * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Datetime config field backend model
+ *
+ * @category   Mage
+ * @package    Mage_Adminhtml
+ */
+class Mage_Adminhtml_Model_System_Config_Backend_Datetime extends Mage_Adminhtml_Model_System_Config_Backend_AbstractDate
+{
+    /**
+     * @param string $format
+     * @return string
+     */
+    protected function getDateFormat(string $format): string
+    {
+        return $this->getLocale()->getDateTimeFormat($format);
+    }
+}

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Datetime.php
@@ -5,15 +5,9 @@ declare(strict_types=1);
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Datetime.php
@@ -11,8 +11,7 @@ declare(strict_types=1);
  *
  * @category   Mage
  * @package    Mage_Adminhtml
- * @copyright  Copyright (c) 2006-2020 Magento, Inc. (http://www.magento.com)
- * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @copyright  Copyright (c) 2023 The OpenMage Contributors (https://www.openmage.org)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Core/Helper/Date.php
+++ b/app/code/core/Mage/Core/Helper/Date.php
@@ -11,8 +11,7 @@ declare(strict_types=1);
  *
  * @category   Mage
  * @package    Mage_Core
- * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
- * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @copyright  Copyright (c) 2023 The OpenMage Contributors (https://www.openmage.org)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Core/Helper/Date.php
+++ b/app/code/core/Mage/Core/Helper/Date.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * @category   Mage
+ * @package    Mage_Core
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
+ * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Core Cookie helper
+ *
+ * @category   Mage
+ * @package    Mage_Core
+ */
+class Mage_Core_Helper_Date extends Mage_Core_Helper_Abstract
+{
+    /**
+     * @param string $format
+     * @return string
+     */
+    public static function getDateFormatFromString(string $format): string
+    {
+        if ($format && defined('Mage_Core_Model_Locale::' . $format)) {
+            return constant('Mage_Core_Model_Locale::' . $format);
+        }
+        return Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM;
+    }
+}

--- a/app/code/core/Mage/Core/Helper/Date.php
+++ b/app/code/core/Mage/Core/Helper/Date.php
@@ -5,15 +5,9 @@ declare(strict_types=1);
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/lib/Varien/Data/Form/Element/Date.php
+++ b/lib/Varien/Data/Form/Element/Date.php
@@ -154,7 +154,7 @@ class Varien_Data_Form_Element_Date extends Varien_Data_Form_Element_Abstract
         $this->addClass('input-text');
 
         $html = sprintf(
-            '<input name="%s" id="%s" value="%s" %s style="width:110px !important;" />'
+            '<input name="%s" id="%s" value="%s" %s style="width:140px !important;" />'
             . ' <img src="%s" alt="" class="v-middle" id="%s_trig" title="%s" style="%s" />',
             $this->getName(),
             $this->getHtmlId(),


### PR DESCRIPTION
### Description

Some new fields for system.xml, example:

![image](https://user-images.githubusercontent.com/31816829/202457141-ab4132ee-7ff8-456a-99e8-c976e89aeda6.png)

XML of the screen shot:
```xml
<head>
	<label>Crash test</label>
	<frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
	<sort_order>1001</sort_order>
	<show_in_default>1</show_in_default>
	<show_in_website>1</show_in_website>
	<show_in_store>1</show_in_store>
</head>
<label_1>
	<label>label</label>
	<value>Pouet</value>
	<frontend_model>adminhtml/system_config_form_field_label</frontend_model>
	<sort_order>1002</sort_order>
	<show_in_default>1</show_in_default>
	<show_in_website>1</show_in_website>
	<show_in_store>1</show_in_store>
</label_1>
<labelbold_2>
	<label>label bold</label>
	<value>Pouet Pouet</value>
	<bold>1</bold>
	<frontend_type>label</frontend_type><!-- optionnal and useless -->
	<frontend_model>adminhtml/system_config_form_field_label</frontend_model>
	<sort_order>1003</sort_order>
	<show_in_default>1</show_in_default>
	<show_in_website>1</show_in_website>
	<show_in_store>1</show_in_store>
</labelbold_2>
<datetime_1>
	<label>datetime (original)</label>
	<frontend_model>adminhtml/system_config_form_field_datetime</frontend_model>
	<sort_order>1004</sort_order>
	<show_in_default>1</show_in_default>
	<show_in_website>1</show_in_website>
	<show_in_store>1</show_in_store>
</datetime_1>
<datetime_2>
	<label>datetime with format</label>
	<frontend_type>datetime</frontend_type><!-- optionnal and useless -->
	<frontend_model>adminhtml/system_config_form_field_datetime</frontend_model>
	<format>FORMAT_TYPE_SHORT</format>
	<sort_order>1005</sort_order>
	<show_in_default>1</show_in_default>
	<show_in_website>1</show_in_website>
	<show_in_store>1</show_in_store>
</datetime_2>
<date_3>
	<label>date</label>
	<frontend_model>adminhtml/system_config_form_field_date</frontend_model>
	<sort_order>1006</sort_order>
	<show_in_default>1</show_in_default>
	<show_in_website>1</show_in_website>
	<show_in_store>1</show_in_store>
</date_3>
<date_4>
	<label>date with format</label>
	<frontend_type>date</frontend_type><!-- optionnal and useless -->
	<frontend_model>adminhtml/system_config_form_field_date</frontend_model>
	<format>FORMAT_TYPE_SHORT</format>
	<sort_order>1007</sort_order>
	<show_in_default>1</show_in_default>
	<show_in_website>1</show_in_website>
	<show_in_store>1</show_in_store>
</date_4>
<datetime_5>
	<label>editable datetime</label>
	<frontend_model>adminhtml/system_config_form_field_datetime</frontend_model>
	<backend_model>adminhtml/system_config_backend_datetime</backend_model>
	<editable>1</editable>
	<sort_order>1008</sort_order>
	<show_in_default>1</show_in_default>
	<show_in_website>1</show_in_website>
	<show_in_store>1</show_in_store>
</datetime_5>
<datetime_6>
	<label>editable datetime with format</label>
	<frontend_type>datetime</frontend_type><!-- optionnal and useless -->
	<frontend_model>adminhtml/system_config_form_field_datetime</frontend_model>
	<backend_model>adminhtml/system_config_backend_datetime</backend_model>
	<format>FORMAT_TYPE_SHORT</format>
	<editable>1</editable>
	<sort_order>1009</sort_order>
	<show_in_default>1</show_in_default>
	<show_in_website>1</show_in_website>
	<show_in_store>1</show_in_store>
</datetime_6>
<date_7>
	<label>editable date</label>
	<frontend_model>adminhtml/system_config_form_field_date</frontend_model>
	<backend_model>adminhtml/system_config_backend_date</backend_model>
	<editable>1</editable>
	<sort_order>1010</sort_order>
	<show_in_default>1</show_in_default>
	<show_in_website>1</show_in_website>
	<show_in_store>1</show_in_store>
</date_7>
<date_8>
	<label>editable date with format</label>
	<frontend_type>date</frontend_type><!-- optionnal and useless -->
	<frontend_model>adminhtml/system_config_form_field_date</frontend_model>
	<backend_model>adminhtml/system_config_backend_date</backend_model>
	<format>FORMAT_TYPE_SHORT</format>
	<editable>1</editable>
	<sort_order>1011</sort_order>
	<show_in_default>1</show_in_default>
	<show_in_website>1</show_in_website>
	<show_in_store>1</show_in_store>
</date_8>
```
There are some bugs with the JS calendar, sometimes it doesn't understand the format, so it's better to use the short format. But this is also another problem.

Date and datetime are stored in UTC time in `core_config_data`. If you check with Adminer, use `SET @@session.time_zone='+00:00';` (https://dba.stackexchange.com/q/20217/242650).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list