### PR TITLE
Fix Order comment REST endpoint route param

### DIFF
--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest.php
@@ -32,7 +32,7 @@ abstract class Mage_Sales_Model_Api2_Order_Comment_Rest extends Mage_Sales_Model
      * Parameters in request used in model (usually specified in route mask)
      */
     public const PARAM_ORDER_ID = 'id';
-    public const PARAM_COMMENT_ID = 'comment_id';
+    public const PARAM_COMMENT_ID = 'id';
     /**#@-*/
 
     /**

--- a/app/code/core/Mage/Sales/etc/api2.xml
+++ b/app/code/core/Mage/Sales/etc/api2.xml
@@ -325,7 +325,7 @@
                 </force_attributes>
                 <routes>
                     <route_entity>
-                        <route>/orders/comments/:comment_id</route>
+                        <route>/orders/comments/:id</route>
                         <action_type>entity</action_type>
                     </route_entity>
                     <route_collection>


### PR DESCRIPTION
### Description (*)
In #2315, I mistakenly left out the param name as `comment_id` instead of `id`, which fails when calling `$this->_getLocation()` because it expects the param name to always be `id`.

### Related Pull Requests
1. See OpenMage/magento-lts#2315
2. See OpenMage/magento-lts#2746

### Manual testing scenarios (*)
1. When adding comment to an Order via the REST API, the request should succeed and the the response should contain a valid `Location` header.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->