### PR TITLE
Remove declared properties accessed by magic getter in Paypal Config

### DIFF
--- a/app/code/core/Mage/Paypal/Model/Config.php
+++ b/app/code/core/Mage/Paypal/Model/Config.php
@@ -26,6 +26,33 @@
  * @category   Mage
  * @package    Mage_Paypal
  * @author     Magento Core Team <core@magentocommerce.com>
+ *
+ * @property mixed $allow_ba_signup;
+ * @property mixed $api_cert;
+ * @property mixed $api_password;
+ * @property mixed $api_signature;
+ * @property mixed $api_username;
+ * @property mixed $apiAuthentication;
+ * @property mixed $apiPassword;
+ * @property mixed $apiSignature;
+ * @property mixed $apiUsername;
+ * @property mixed $business_account;
+ * @property mixed $businessAccount;
+ * @property mixed $buttonFlavor;
+ * @property mixed $buttonType;
+ * @property mixed $cctypes;
+ * @property mixed $debug;
+ * @property mixed $lineItemsEnabled;
+ * @property mixed $lineItemsSummary;
+ * @property mixed $paymentAction;
+ * @property mixed $paymentMarkSize;
+ * @property mixed $requireBillingAddress;
+ * @property mixed $sandboxFlag;
+ * @property mixed $solutionType;
+ * @property mixed $transferShippingOptions;
+ * @property mixed $verifyPeer;
+ * @property mixed $visible_on_cart;
+ * @property mixed $visible_on_product;
  */
 class Mage_Paypal_Model_Config
 {

--- a/app/code/core/Mage/Paypal/Model/Config.php
+++ b/app/code/core/Mage/Paypal/Model/Config.php
@@ -600,33 +600,6 @@ class Mage_Paypal_Model_Config
         'zh_XC',
     ];
 
-    public $allow_ba_signup;
-    public $api_cert;
-    public $api_password;
-    public $api_signature;
-    public $api_username;
-    public $apiAuthentication;
-    public $apiPassword;
-    public $apiSignature;
-    public $apiUsername;
-    public $business_account;
-    public $businessAccount;
-    public $buttonFlavor;
-    public $buttonType;
-    public $cctypes;
-    public $debug;
-    public $lineItemsEnabled;
-    public $lineItemsSummary;
-    public $paymentAction;
-    public $paymentMarkSize;
-    public $requireBillingAddress;
-    public $sandboxFlag;
-    public $solutionType;
-    public $transferShippingOptions;
-    public $verifyPeer;
-    public $visible_on_cart;
-    public $visible_on_product;
-
     /**
      * Set method and store id, if specified
      *


### PR DESCRIPTION
### Description (*)

In #2554, properties which were being set dynamically were added as class properties to support PHP 8.2. However in the case of `app/code/core/Mage/Paypal/Model/Config.php`, there is a magic getter (conveniently hidden in the center of the file 👀) which was accessing the properties from the paypal configuration which never gets called if the property is already declared on the class.

### Related Pull Requests

1. See OpenMage/magento-lts#2554

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#2756

### Manual testing scenarios (*)

1. Paypal checkout should now be working as normal.

### Questions or comments

`app/code/core/Mage/Paypal/Model/Config.php` will need to be refactored to get rid of dynamic properties assignment, but as that can take more time and can potentially be breaking, I choose to just undo that change until we decide later.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->