### PR TITLE
Moved null-byte fix from lib/Zend to lib/Magento

### DIFF
--- a/lib/Magento/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Magento/Db/Adapter/Pdo/Mysql.php
@@ -113,7 +113,8 @@ class Magento_Db_Adapter_Pdo_Mysql extends Varien_Db_Adapter_Pdo_Mysql
             $value = $this->_convertFloat($value);
             return $value;
         }
-
+        // Fix for null-byte injection
+        $value = addcslashes($value, "\000\032");
         return parent::_quote($value);
     }
 

--- a/lib/Magento/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Magento/Db/Adapter/Pdo/Mysql.php
@@ -114,7 +114,9 @@ class Magento_Db_Adapter_Pdo_Mysql extends Varien_Db_Adapter_Pdo_Mysql
             return $value;
         }
         // Fix for null-byte injection
-        $value = addcslashes($value, "\000\032");
+        if (is_string($value)) {
+            $value = addcslashes($value, "\000\032");
+        }
         return parent::_quote($value);
     }
 

--- a/lib/Zend/Db/Adapter/Pdo/Abstract.php
+++ b/lib/Zend/Db/Adapter/Pdo/Abstract.php
@@ -292,8 +292,6 @@ abstract class Zend_Db_Adapter_Pdo_Abstract extends Zend_Db_Adapter_Abstract
         if (is_int($value) || is_float($value)) {
             return $value;
         }
-        // Fix for null-byte injection
-        $value = addcslashes($value, "\000\032");
         $this->_connect();
         return $this->_connection->quote($value);
     }

--- a/lib/Zend/Db/Adapter/Pdo/Abstract.php
+++ b/lib/Zend/Db/Adapter/Pdo/Abstract.php
@@ -293,7 +293,7 @@ abstract class Zend_Db_Adapter_Pdo_Abstract extends Zend_Db_Adapter_Abstract
             return $value;
         }
         $this->_connect();
-        return $this->_connection->quote($value);
+        return $this->_connection->quote((string) $value);
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Magento fixed this in lib/Zend, that will be (hopefully) replaced soon. Moved this to lib/Magento, that is called before.

ZF1-future does not have this added for Mysql (yet?). 

Edit: cast to string is also in ZF1F

### Related Pull Requests
<!-- related pull request placeholder -->
1. See OpenMage/magento-lts#1812
2. See OpenMage/magento-lts#2787

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->