### PR TITLE
Add confirm dialog to critical massactions

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Backup/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Backup/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * Adminhtml backups grid block
  *
@@ -56,7 +58,7 @@ class Mage_Adminhtml_Block_Backup_Grid extends Mage_Adminhtml_Block_Widget_Grid
         $this->setMassactionIdField('id');
         $this->getMassactionBlock()->setFormFieldName('ids');
 
-        $this->getMassactionBlock()->addItem('delete', [
+        $this->getMassactionBlock()->addItem(MassAction::DELETE, [
              'label' => Mage::helper('adminhtml')->__('Delete'),
              'url'  => $this->getUrl('*/*/massDelete'),
              'confirm' => Mage::helper('backup')->__('Are you sure you want to delete the selected backup(s)?')

--- a/app/code/core/Mage/Adminhtml/Block/Cache/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cache/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * @category   Mage
  * @package    Mage_Adminhtml
@@ -63,7 +65,7 @@ class Mage_Adminhtml_Block_Cache_Grid extends Mage_Adminhtml_Block_Widget_Grid
     }
 
     /**
-     * Prepare grid columns
+     * @inheritDoc
      */
     protected function _prepareColumns()
     {
@@ -136,6 +138,8 @@ class Mage_Adminhtml_Block_Cache_Grid extends Mage_Adminhtml_Block_Widget_Grid
 
     /**
      * Add mass-actions to grid
+     *
+     * @return $this
      */
     protected function _prepareMassaction()
     {
@@ -144,15 +148,15 @@ class Mage_Adminhtml_Block_Cache_Grid extends Mage_Adminhtml_Block_Widget_Grid
 
         $modeOptions = Mage::getModel('index/process')->getModesOptions();
 
-        $this->getMassactionBlock()->addItem('enable', [
-            'label'         => Mage::helper('index')->__('Enable'),
-            'url'           => $this->getUrl('*/*/massEnable'),
+        $this->getMassactionBlock()->addItem(MassAction::ENABLE, [
+            'label'    => Mage::helper('index')->__('Enable'),
+            'url'      => $this->getUrl('*/*/massEnable'),
         ]);
-        $this->getMassactionBlock()->addItem('disable', [
+        $this->getMassactionBlock()->addItem(MassAction::DISABLE, [
             'label'    => Mage::helper('index')->__('Disable'),
             'url'      => $this->getUrl('*/*/massDisable'),
         ]);
-        $this->getMassactionBlock()->addItem('refresh', [
+        $this->getMassactionBlock()->addItem(MassAction::REFRESH, [
             'label'    => Mage::helper('index')->__('Refresh'),
             'url'      => $this->getUrl('*/*/massRefresh'),
             'selected' => true,

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * Adminhtml customer grid block
  *
@@ -310,16 +312,15 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
         $this->setMassactionIdField('entity_id');
         $this->getMassactionBlock()->setFormFieldName('product');
 
-        $this->getMassactionBlock()->addItem('delete', [
+        $this->getMassactionBlock()->addItem(MassAction::DELETE, [
              'label' => Mage::helper('catalog')->__('Delete'),
-             'url'  => $this->getUrl('*/*/massDelete'),
-             'confirm' => Mage::helper('catalog')->__('Are you sure?')
+             'url'  => $this->getUrl('*/*/massDelete')
         ]);
 
         $statuses = Mage::getSingleton('catalog/product_status')->getOptionArray();
 
         array_unshift($statuses, ['label' => '', 'value' => '']);
-        $this->getMassactionBlock()->addItem('status', [
+        $this->getMassactionBlock()->addItem(MassAction::STATUS, [
              'label' => Mage::helper('catalog')->__('Change status'),
              'url'  => $this->getUrl('*/*/massStatus', ['_current' => true]),
              'additional' => [
@@ -334,7 +335,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
         ]);
 
         if (Mage::getSingleton('admin/session')->isAllowed('catalog/update_attributes')) {
-            $this->getMassactionBlock()->addItem('attributes', [
+            $this->getMassactionBlock()->addItem(MassAction::ATTRIBUTES, [
                 'label' => Mage::helper('catalog')->__('Update Attributes'),
                 'url'   => $this->getUrl('*/catalog_product_action_attribute/edit', ['_current' => true])
             ]);

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * @category    Mage
  * @category   Mage
@@ -152,10 +154,9 @@ class Mage_Adminhtml_Block_Catalog_Search_Grid extends Mage_Adminhtml_Block_Widg
         $this->setMassactionIdField('query_id');
         $this->getMassactionBlock()->setFormFieldName('search');
 
-        $this->getMassactionBlock()->addItem('delete', [
+        $this->getMassactionBlock()->addItem(MassAction::DELETE, [
              'label'    => Mage::helper('catalog')->__('Delete'),
-             'url'      => $this->getUrl('*/*/massDelete'),
-             'confirm'  => Mage::helper('catalog')->__('Are you sure?')
+             'url'      => $this->getUrl('*/*/massDelete')
         ]);
 
         return parent::_prepareMassaction();

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * Adminhtml customer grid block
  *
@@ -178,18 +180,17 @@ class Mage_Adminhtml_Block_Customer_Grid extends Mage_Adminhtml_Block_Widget_Gri
         $this->setMassactionIdField('entity_id');
         $this->getMassactionBlock()->setFormFieldName('customer');
 
-        $this->getMassactionBlock()->addItem('delete', [
+        $this->getMassactionBlock()->addItem(MassAction::DELETE, [
              'label'    => Mage::helper('customer')->__('Delete'),
-             'url'      => $this->getUrl('*/*/massDelete'),
-             'confirm'  => Mage::helper('customer')->__('Are you sure?')
+             'url'      => $this->getUrl('*/*/massDelete')
         ]);
 
-        $this->getMassactionBlock()->addItem('newsletter_subscribe', [
+        $this->getMassactionBlock()->addItem(MassAction::NEWSLETTER_SUBSCRIBE, [
              'label'    => Mage::helper('customer')->__('Subscribe to Newsletter'),
              'url'      => $this->getUrl('*/*/massSubscribe')
         ]);
 
-        $this->getMassactionBlock()->addItem('newsletter_unsubscribe', [
+        $this->getMassactionBlock()->addItem(MassAction::NEWSLETTER_UNSUBSCRIBE, [
              'label'    => Mage::helper('customer')->__('Unsubscribe from Newsletter'),
              'url'      => $this->getUrl('*/*/massUnsubscribe')
         ]);
@@ -199,7 +200,7 @@ class Mage_Adminhtml_Block_Customer_Grid extends Mage_Adminhtml_Block_Widget_Gri
         $groups = $helper->getGroups()->toOptionArray();
 
         array_unshift($groups, ['label' => '', 'value' => '']);
-        $this->getMassactionBlock()->addItem('assign_group', [
+        $this->getMassactionBlock()->addItem(MassAction::ASSIGN_GROUP, [
              'label'        => Mage::helper('customer')->__('Assign a Customer Group'),
              'url'          => $this->getUrl('*/*/massAssignGroup'),
              'additional'   => [

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * Adminhtml newsletter subscribers grid block
  *
@@ -201,12 +203,12 @@ class Mage_Adminhtml_Block_Newsletter_Subscriber_Grid extends Mage_Adminhtml_Blo
         $this->getMassactionBlock()->setFormFieldName('subscriber');
         $this->getMassactionBlock()->setUseSelectAll(false);
 
-        $this->getMassactionBlock()->addItem('unsubscribe', [
+        $this->getMassactionBlock()->addItem(MassAction::UNSUBSCRIBE, [
              'label'        => Mage::helper('newsletter')->__('Unsubscribe'),
              'url'          => $this->getUrl('*/*/massUnsubscribe')
         ]);
 
-        $this->getMassactionBlock()->addItem('delete', [
+        $this->getMassactionBlock()->addItem(MassAction::DELETE, [
              'label'        => Mage::helper('newsletter')->__('Delete'),
              'url'          => $this->getUrl('*/*/massDelete')
         ]);

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * Adminhtml AdminNotification inbox grid
  *
@@ -95,15 +97,14 @@ class Mage_Adminhtml_Block_Notification_Grid extends Mage_Adminhtml_Block_Widget
         $this->setMassactionIdField('notification_id');
         $this->getMassactionBlock()->setFormFieldName('notification');
 
-        $this->getMassactionBlock()->addItem('mark_as_read', [
+        $this->getMassactionBlock()->addItem(MassAction::MARK_AS_READ, [
              'label'    => Mage::helper('adminnotification')->__('Mark as Read'),
              'url'      => $this->getUrl('*/*/massMarkAsRead', ['_current' => true]),
         ]);
 
-        $this->getMassactionBlock()->addItem('remove', [
+        $this->getMassactionBlock()->addItem(MassAction::REMOVE, [
              'label'    => Mage::helper('adminnotification')->__('Remove'),
-             'url'      => $this->getUrl('*/*/massRemove'),
-             'confirm'  => Mage::helper('adminnotification')->__('Are you sure?')
+             'url'      => $this->getUrl('*/*/massRemove')
         ]);
 
         return $this;

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * Coupon codes grid
  *
@@ -38,7 +40,7 @@ class Mage_Adminhtml_Block_Promo_Quote_Edit_Tab_Coupons_Grid extends Mage_Adminh
     /**
      * Prepare collection for grid
      *
-     * @return Mage_Adminhtml_Block_Widget_Grid
+     * @inheritDoc
      */
     protected function _prepareCollection()
     {
@@ -114,10 +116,10 @@ class Mage_Adminhtml_Block_Promo_Quote_Edit_Tab_Coupons_Grid extends Mage_Adminh
         $this->getMassactionBlock()->setUseAjax(true);
         $this->getMassactionBlock()->setHideFormElement(true);
 
-        $this->getMassactionBlock()->addItem('delete', [
-             'label' => Mage::helper('adminhtml')->__('Delete'),
-             'url'  => $this->getUrl('*/*/couponsMassDelete', ['_current' => true]),
-             'confirm' => Mage::helper('salesrule')->__('Are you sure you want to delete the selected coupon(s)?'),
+        $this->getMassactionBlock()->addItem(MassAction::DELETE, [
+             'label'    => Mage::helper('adminhtml')->__('Delete'),
+             'url'      => $this->getUrl('*/*/couponsMassDelete', ['_current' => true]),
+             'confirm'  => Mage::helper('salesrule')->__('Are you sure you want to delete the selected coupon(s)?'),
              'complete' => 'refreshCouponCodesGrid'
         ]);
 

--- a/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * Adminhtml sales report grid block
  *
@@ -36,6 +38,11 @@ class Mage_Adminhtml_Block_Report_Refresh_Statistics_Grid extends Mage_Adminhtml
         $this->setUseAjax(false);
     }
 
+    /**
+     * @param string $reportCode
+     * @return string
+     * @throws Zend_Date_Exception
+     */
     protected function _getUpdatedAt($reportCode)
     {
         $flag = Mage::getModel('reports/flag')->setReportFlagCode($reportCode)->loadSelf();
@@ -48,6 +55,9 @@ class Mage_Adminhtml_Block_Report_Refresh_Statistics_Grid extends Mage_Adminhtml
             : '';
     }
 
+    /**
+     * @inheritDoc
+     */
     protected function _prepareCollection()
     {
         $collection = new Varien_Data_Collection();
@@ -114,6 +124,9 @@ class Mage_Adminhtml_Block_Report_Refresh_Statistics_Grid extends Mage_Adminhtml
         return parent::_prepareCollection();
     }
 
+    /**
+     * @inheritDoc
+     */
     protected function _prepareColumns()
     {
         $this->addColumn('report', [
@@ -142,18 +155,21 @@ class Mage_Adminhtml_Block_Report_Refresh_Statistics_Grid extends Mage_Adminhtml
         return parent::_prepareColumns();
     }
 
+    /**
+     * @return $this
+     */
     protected function _prepareMassaction()
     {
         $this->setMassactionIdField('id');
         $this->getMassactionBlock()->setFormFieldName('code');
 
-        $this->getMassactionBlock()->addItem('refresh_lifetime', [
+        $this->getMassactionBlock()->addItem(MassAction::REFRESH_LIFETIME, [
             'label'    => Mage::helper('reports')->__('Refresh Lifetime Statistics'),
             'url'      => $this->getUrl('*/*/refreshLifetime'),
             'confirm'  => Mage::helper('reports')->__('Are you sure you want to refresh lifetime statistics? There can be performance impact during this operation.')
         ]);
 
-        $this->getMassactionBlock()->addItem('refresh_recent', [
+        $this->getMassactionBlock()->addItem(MassAction::REFRESH_RECENT, [
             'label'    => Mage::helper('reports')->__('Refresh Statistics for the Last Day'),
             'url'      => $this->getUrl('*/*/refreshRecent'),
             'confirm'  => Mage::helper('reports')->__('Are you sure?'),

--- a/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * Adminhtml reviews grid
  *
@@ -35,6 +37,10 @@ class Mage_Adminhtml_Block_Review_Grid extends Mage_Adminhtml_Block_Widget_Grid
         $this->setDefaultSort('created_at');
     }
 
+    /**
+     * @inheritDoc
+     * @throws Exception
+     */
     protected function _prepareCollection()
     {
         $model = Mage::getModel('review/review');
@@ -68,6 +74,10 @@ class Mage_Adminhtml_Block_Review_Grid extends Mage_Adminhtml_Block_Widget_Grid
         return parent::_prepareCollection();
     }
 
+    /**
+     * @inheritDoc
+     * @throws Mage_Core_Model_Store_Exception
+     */
     protected function _prepareColumns()
     {
         $this->addColumn('review_id', [
@@ -200,7 +210,7 @@ class Mage_Adminhtml_Block_Review_Grid extends Mage_Adminhtml_Block_Widget_Grid
     }
 
     /**
-     * @return void
+     * @inheritDoc
      */
     protected function _prepareMassaction()
     {
@@ -210,7 +220,7 @@ class Mage_Adminhtml_Block_Review_Grid extends Mage_Adminhtml_Block_Widget_Grid
         $this->getMassactionBlock()->setFormFieldName('reviews');
         $this->getMassactionBlock()->setUseSelectAll(false);
 
-        $this->getMassactionBlock()->addItem('delete', [
+        $this->getMassactionBlock()->addItem(MassAction::DELETE, [
             'label' => Mage::helper('review')->__('Delete'),
             'url'  => $this->getUrl(
                 '*/*/massDelete',
@@ -221,7 +231,7 @@ class Mage_Adminhtml_Block_Review_Grid extends Mage_Adminhtml_Block_Widget_Grid
 
         $statuses = Mage::helper('review')->getReviewStatusesOptionArray();
         array_unshift($statuses, ['label' => '', 'value' => '']);
-        $this->getMassactionBlock()->addItem('update_status', [
+        $this->getMassactionBlock()->addItem(MassAction::UPDATE_STATUS, [
             'label'         => Mage::helper('review')->__('Update Status'),
             'url'           => $this->getUrl(
                 '*/*/massUpdateStatus',
@@ -237,6 +247,7 @@ class Mage_Adminhtml_Block_Review_Grid extends Mage_Adminhtml_Block_Widget_Grid
                 ]
             ]
         ]);
+        return parent::_prepareMassaction();
     }
 
     public function getRowUrl($row)
@@ -249,6 +260,9 @@ class Mage_Adminhtml_Block_Review_Grid extends Mage_Adminhtml_Block_Widget_Grid
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getGridUrl()
     {
         if ($this->getProductId() || $this->getCustomerId()) {
@@ -259,8 +273,7 @@ class Mage_Adminhtml_Block_Review_Grid extends Mage_Adminhtml_Block_Widget_Grid
                     'customerId' => $this->getCustomerId(),
                 ]
             );
-        } else {
-            return $this->getCurrentUrl();
         }
+        return $this->getCurrentUrl();
     }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * Adminhtml sales orders grid
  *
@@ -143,7 +145,7 @@ class Mage_Adminhtml_Block_Sales_Creditmemo_Grid extends Mage_Adminhtml_Block_Wi
         $this->getMassactionBlock()->setFormFieldName('creditmemo_ids');
         $this->getMassactionBlock()->setUseSelectAll(false);
 
-        $this->getMassactionBlock()->addItem('pdfcreditmemos_order', [
+        $this->getMassactionBlock()->addItem(MassAction::PDF_CREDITMEMOS_ORDER, [
              'label' => Mage::helper('sales')->__('PDF Credit Memos'),
              'url'  => $this->getUrl('*/sales_creditmemo/pdfcreditmemos'),
         ]);

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Invoice/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Invoice/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * Adminhtml sales orders grid
  *
@@ -145,7 +147,7 @@ class Mage_Adminhtml_Block_Sales_Invoice_Grid extends Mage_Adminhtml_Block_Widge
         $this->getMassactionBlock()->setFormFieldName('invoice_ids');
         $this->getMassactionBlock()->setUseSelectAll(false);
 
-        $this->getMassactionBlock()->addItem('pdfinvoices_order', [
+        $this->getMassactionBlock()->addItem(MassAction::PDF_INVOICE_ORDER, [
              'label' => Mage::helper('sales')->__('PDF Invoices'),
              'url'  => $this->getUrl('*/sales_invoice/pdfinvoices'),
         ]);

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * Adminhtml sales orders grid
  *
@@ -163,47 +165,47 @@ class Mage_Adminhtml_Block_Sales_Order_Grid extends Mage_Adminhtml_Block_Widget_
         $this->getMassactionBlock()->setUseSelectAll(false);
 
         if (Mage::getSingleton('admin/session')->isAllowed('sales/order/actions/cancel')) {
-            $this->getMassactionBlock()->addItem('cancel_order', [
+            $this->getMassactionBlock()->addItem(MassAction::CANCEL_ORDER, [
                  'label' => Mage::helper('sales')->__('Cancel'),
                  'url'  => $this->getUrl('*/sales_order/massCancel'),
             ]);
         }
 
         if (Mage::getSingleton('admin/session')->isAllowed('sales/order/actions/hold')) {
-            $this->getMassactionBlock()->addItem('hold_order', [
+            $this->getMassactionBlock()->addItem(MassAction::HOLD_ORDER, [
                  'label' => Mage::helper('sales')->__('Hold'),
                  'url'  => $this->getUrl('*/sales_order/massHold'),
             ]);
         }
 
         if (Mage::getSingleton('admin/session')->isAllowed('sales/order/actions/unhold')) {
-            $this->getMassactionBlock()->addItem('unhold_order', [
+            $this->getMassactionBlock()->addItem(MassAction::UNHOLD_ORDER, [
                  'label' => Mage::helper('sales')->__('Unhold'),
                  'url'  => $this->getUrl('*/sales_order/massUnhold'),
             ]);
         }
 
-        $this->getMassactionBlock()->addItem('pdfinvoices_order', [
+        $this->getMassactionBlock()->addItem(MassAction::PDF_INVOICE_ORDER, [
              'label' => Mage::helper('sales')->__('Print Invoices'),
              'url'  => $this->getUrl('*/sales_order/pdfinvoices'),
         ]);
 
-        $this->getMassactionBlock()->addItem('pdfshipments_order', [
+        $this->getMassactionBlock()->addItem(MassAction::PDF_SHIPMENTS_ORDER, [
              'label' => Mage::helper('sales')->__('Print Packingslips'),
              'url'  => $this->getUrl('*/sales_order/pdfshipments'),
         ]);
 
-        $this->getMassactionBlock()->addItem('pdfcreditmemos_order', [
+        $this->getMassactionBlock()->addItem(MassAction::PDF_CREDITMEMOS_ORDER, [
              'label' => Mage::helper('sales')->__('Print Credit Memos'),
              'url'  => $this->getUrl('*/sales_order/pdfcreditmemos'),
         ]);
 
-        $this->getMassactionBlock()->addItem('pdfdocs_order', [
+        $this->getMassactionBlock()->addItem(MassAction::PDF_DOCS_ORDER, [
              'label' => Mage::helper('sales')->__('Print All'),
              'url'  => $this->getUrl('*/sales_order/pdfdocs'),
         ]);
 
-        $this->getMassactionBlock()->addItem('print_shipping_label', [
+        $this->getMassactionBlock()->addItem(MassAction::PRINT_SHIPMENT_LABEL, [
              'label' => Mage::helper('sales')->__('Print Shipping Labels'),
              'url'  => $this->getUrl('*/sales_order_shipment/massPrintShippingLabel'),
         ]);

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Shipment/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Shipment/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * Adminhtml sales orders grid
  *
@@ -156,12 +158,12 @@ class Mage_Adminhtml_Block_Sales_Shipment_Grid extends Mage_Adminhtml_Block_Widg
         $this->getMassactionBlock()->setFormFieldName('shipment_ids');
         $this->getMassactionBlock()->setUseSelectAll(false);
 
-        $this->getMassactionBlock()->addItem('pdfshipments_order', [
+        $this->getMassactionBlock()->addItem(MassAction::PDF_SHIPMENTS_ORDER, [
              'label' => Mage::helper('sales')->__('PDF Packingslips'),
              'url'  => $this->getUrl('*/sales_shipment/pdfshipments'),
         ]);
 
-        $this->getMassactionBlock()->addItem('print_shipping_label', [
+        $this->getMassactionBlock()->addItem(MassAction::PRINT_SHIPMENT_LABEL, [
              'label' => Mage::helper('sales')->__('Print Shipping Labels'),
              'url'  => $this->getUrl('*/sales_order_shipment/massPrintShippingLabel'),
         ]);

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Pending.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Pending.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * Adminhtml pending tags grid
  *
@@ -137,10 +139,9 @@ class Mage_Adminhtml_Block_Tag_Grid_Pending extends Mage_Adminhtml_Block_Widget_
         $this->setMassactionIdField('tag_id');
         $this->getMassactionBlock()->setFormFieldName('tag');
 
-        $this->getMassactionBlock()->addItem('delete', [
+        $this->getMassactionBlock()->addItem(MassAction::DELETE, [
              'label' => Mage::helper('tag')->__('Delete'),
-             'url'  => $this->getUrl('*/*/massDelete', ['ret' => 'pending']),
-             'confirm' => Mage::helper('tag')->__('Are you sure?')
+             'url'  => $this->getUrl('*/*/massDelete', ['ret' => 'pending'])
         ]);
 
         /** @var Mage_Tag_Helper_Data $helper */
@@ -149,7 +150,7 @@ class Mage_Adminhtml_Block_Tag_Grid_Pending extends Mage_Adminhtml_Block_Widget_
 
         array_unshift($statuses, ['label' => '', 'value' => '']);
 
-        $this->getMassactionBlock()->addItem('status', [
+        $this->getMassactionBlock()->addItem(MassAction::STATUS, [
              'label' => Mage::helper('tag')->__('Change status'),
              'url'  => $this->getUrl('*/*/massStatus', ['_current' => true, 'ret' => 'pending']),
              'additional' => [

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * Adminhtml all tags grid
  *
@@ -126,10 +128,9 @@ class Mage_Adminhtml_Block_Tag_Tag_Grid extends Mage_Adminhtml_Block_Widget_Grid
         $this->setMassactionIdField('tag_id');
         $this->getMassactionBlock()->setFormFieldName('tag');
 
-        $this->getMassactionBlock()->addItem('delete', [
+        $this->getMassactionBlock()->addItem(MassAction::DELETE, [
              'label'    => Mage::helper('tag')->__('Delete'),
-             'url'      => $this->getUrl('*/*/massDelete'),
-             'confirm'  => Mage::helper('tag')->__('Are you sure?')
+             'url'      => $this->getUrl('*/*/massDelete')
         ]);
 
         /** @var Mage_Tag_Helper_Data $helper */
@@ -138,7 +139,7 @@ class Mage_Adminhtml_Block_Tag_Tag_Grid extends Mage_Adminhtml_Block_Widget_Grid
 
         array_unshift($statuses, ['label' => '', 'value' => '']);
 
-        $this->getMassactionBlock()->addItem('status', [
+        $this->getMassactionBlock()->addItem(MassAction::STATUS, [
             'label' => Mage::helper('tag')->__('Change status'),
             'url'  => $this->getUrl('*/*/massStatus', ['_current' => true]),
             'additional' => [

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
@@ -34,7 +34,10 @@ use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
  */
 abstract class Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract extends Mage_Adminhtml_Block_Widget
 {
-    // current massactions
+    /**#@+
+     * Current massactions
+     * @var string
+     */
     public const ASSIGN_GROUP              = 'assign_group';
     public const ATTRIBUTES                = 'attributes';
     public const CANCEL_ORDER              = 'cancel_order';
@@ -60,6 +63,7 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract extends Mage
     public const UNHOLD_ORDER              = 'unhold_order';
     public const UNSUBSCRIBE               = 'unsubscribe';
     public const UPDATE_STATUS             = 'update_status';
+    /**#@-*/
 
     /**
      * @var string[]

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * Grid widget massaction block
  *
@@ -32,6 +34,44 @@
  */
 abstract class Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract extends Mage_Adminhtml_Block_Widget
 {
+    // current massactions
+    public const ASSIGN_GROUP              = 'assign_group';
+    public const ATTRIBUTES                = 'attributes';
+    public const CANCEL_ORDER              = 'cancel_order';
+    public const CHANGE_MODE               = 'change_mode';
+    public const ENABLE                    = 'enable';
+    public const DELETE                    = 'delete';
+    public const DISABLE                   = 'disable';
+    public const HOLD_ORDER                = 'hold_order';
+    public const MARK_AS_READ              = 'mark_as_read';
+    public const NEWSLETTER_SUBSCRIBE      = 'newsletter_subscribe';
+    public const NEWSLETTER_UNSUBSCRIBE    = 'newsletter_unsubscribe';
+    public const PDF_CREDITMEMOS_ORDER     = 'pdfcreditmemos_order';
+    public const PDF_DOCS_ORDER            = 'pdfdocs_order';
+    public const PDF_INVOICE_ORDER         = 'pdfinvoices_order';
+    public const PDF_SHIPMENTS_ORDER       = 'pdfshipments_order';
+    public const PRINT_SHIPMENT_LABEL      = 'print_shipping_label';
+    public const REFRESH                   = 'refresh';
+    public const REFRESH_LIFETIME          = 'refresh_lifetime';
+    public const REFRESH_RECENT            = 'refresh_recent';
+    public const REINDEX                   = 'reindex';
+    public const REMOVE                    = 'remove';
+    public const STATUS                    = 'status';
+    public const UNHOLD_ORDER              = 'unhold_order';
+    public const UNSUBSCRIBE               = 'unsubscribe';
+    public const UPDATE_STATUS             = 'update_status';
+
+    /**
+     * @var string[]
+     */
+    protected static $needsConfirm = [
+        self::CANCEL_ORDER,
+        self::HOLD_ORDER,
+        self::UNHOLD_ORDER,
+        self::DELETE,
+        self::REMOVE
+    ];
+
     /**
      * Massaction items
      *
@@ -66,6 +106,10 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract extends Mage
      */
     public function addItem($itemId, array $item)
     {
+        if ($this->isConfirmMassAction($itemId) && !isset($item['confirm'])) {
+            $item['confirm'] = Mage::helper('core')->__('Are you sure?');
+        }
+
         $this->_items[$itemId] =  $this->getLayout()->createBlock('adminhtml/widget_grid_massaction_item')
             ->setData($item)
             ->setMassaction($this)
@@ -215,6 +259,9 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract extends Mage
         return $this->getButtonHtml($this->__('Submit'), $this->getJsObjectName() . ".apply()");
     }
 
+    /**
+     * @return string
+     */
     public function getJavaScript()
     {
         return " var {$this->getJsObjectName()} = new varienGridMassaction('{$this->getHtmlId()}', "
@@ -227,6 +274,9 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract extends Mage
                 . "{$this->getJsObjectName()}.errorText = '{$this->getErrorText()}';";
     }
 
+    /**
+     * @return string
+     */
     public function getGridIdsJson()
     {
         if (!$this->getUseSelectAll()) {
@@ -241,6 +291,9 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract extends Mage
         return '';
     }
 
+    /**
+     * @return string
+     */
     public function getHtmlId()
     {
         return $this->getParentBlock()->getHtmlId() . '_massaction';
@@ -303,5 +356,14 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract extends Mage
         }
 
         return $groupedItems;
+    }
+
+    /**
+     * @param string $itemId
+     * @return bool
+     */
+    protected function isConfirmMassAction(string $itemId): bool
+    {
+        return in_array($itemId, static::$needsConfirm);
     }
 }

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid.php
@@ -19,6 +19,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
+
 /**
  * @category   Mage
  * @package    Mage_Index
@@ -268,7 +270,7 @@ class Mage_Index_Block_Adminhtml_Process_Grid extends Mage_Adminhtml_Block_Widge
 
         $modeOptions = Mage::getModel('index/process')->getModesOptions();
 
-        $this->getMassactionBlock()->addItem('change_mode', [
+        $this->getMassactionBlock()->addItem(MassAction::CHANGE_MODE, [
             'label'         => Mage::helper('index')->__('Change Index Mode'),
             'url'           => $this->getUrl('*/*/massChangeMode'),
             'additional'    => [
@@ -282,7 +284,7 @@ class Mage_Index_Block_Adminhtml_Process_Grid extends Mage_Adminhtml_Block_Widge
             ]
         ]);
 
-        $this->getMassactionBlock()->addItem('reindex', [
+        $this->getMassactionBlock()->addItem(MassAction::REINDEX, [
             'label'    => Mage::helper('index')->__('Reindex Data'),
             'url'      => $this->getUrl('*/*/massReindex'),
             'selected' => true,

--- a/phpstan.dist.baseline.neon
+++ b/phpstan.dist.baseline.neon
@@ -926,11 +926,6 @@ parameters:
 			path: app/code/core/Mage/Adminhtml/Block/Review/Grid.php
 
 		-
-			message: "#^Return type \\(void\\) of method Mage_Adminhtml_Block_Review_Grid\\:\\:_prepareMassaction\\(\\) should be compatible with return type \\(\\$this\\(Mage_Adminhtml_Block_Widget_Grid\\)\\) of method Mage_Adminhtml_Block_Widget_Grid\\:\\:_prepareMassaction\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Adminhtml/Block/Review/Grid.php
-
-		-
 			message: "#^Return type \\(int\\) of method Mage_Adminhtml_Block_Review_Grid_Filter_Type\\:\\:getCondition\\(\\) should be compatible with return type \\(array\\|null\\) of method Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Select\\:\\:getCondition\\(\\)$#"
 			count: 1
 			path: app/code/core/Mage/Adminhtml/Block/Review/Grid/Filter/Type.php


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Added confirm dialog to some massactions.

I did not change it for every massaction, but added a default check by massaction id/name.

```
    protected static $needsConfirm = [
        self::CANCEL_ORDER,
        self::HOLD_ORDER,
        self::UNHOLD_ORDER,
        self::DELETE,
        self::REMOVE
    ];
```

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#2323

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->