### PR TITLE
Optimisation for Varien_Object::_addFullNames

### DIFF
--- a/lib/Varien/Object.php
+++ b/lib/Varien/Object.php
@@ -111,12 +111,9 @@ class Varien_Object implements ArrayAccess
 
     protected function _addFullNames()
     {
-        $existedShortKeys = array_intersect($this->_syncFieldsMap, array_keys($this->_data));
-        if (!empty($existedShortKeys)) {
-            foreach ($existedShortKeys as $key) {
-                $fullFieldName = array_search($key, $this->_syncFieldsMap);
-                $this->_data[$fullFieldName] = $this->_data[$key];
-            }
+        $existedShortKeys = array_intersect_key(array_flip($this->_syncFieldsMap), $this->_data);
+        foreach ($existedShortKeys as $key => $fullFieldName) {
+            $this->_data[$fullFieldName] = $this->_data[$key];
         }
     }
 

--- a/lib/Varien/Object.php
+++ b/lib/Varien/Object.php
@@ -111,6 +111,10 @@ class Varien_Object implements ArrayAccess
 
     protected function _addFullNames()
     {
+        if (empty($this->_syncFieldsMap)) {
+            return;
+        }
+
         $existedShortKeys = array_intersect_key(array_flip($this->_syncFieldsMap), $this->_data);
         foreach ($existedShortKeys as $key => $fullFieldName) {
             $this->_data[$fullFieldName] = $this->_data[$key];


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Optimization for Varien_Object::_addFullNames
- less code
- array_intersect_key with array_flip is faster than  array_intersect with array_values
- avoid array_search
- Tested with PHP8.0 Openmage 19.4.20 => 3x faster (Test Object: Mage_CatalogInventory_Model_Stock_Item)

### Related Pull Requests
-

### Fixed Issues (if relevant)
-

### Manual testing scenarios (*)
-


### Questions or comments
- Thanks 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->