### PR TITLE
Fix passing null and array to string conversion error

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -410,7 +410,8 @@ final class Mage
      */
     public static function getStoreConfigFlag($path, $store = null)
     {
-        $flag = strtolower(self::getStoreConfig($path, $store));
+        $flag = self::getStoreConfig($path, $store);
+        $flag = is_string($flag) ? strtolower($flag) : $flag;
         if (!empty($flag) && $flag !== 'false') {
             return true;
         } else {


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Fixes a bug when passing not a full config path to `Mage::getStoreConfigFlag()`. Also fixes php8.1 passing `null` to `strtolower()`.


### Related Pull Requests
<!-- related pull request placeholder -->

- https://github.com/OpenMage/magento-lts/pull/2586/files#diff-4163393d22b627674a0b85fae62f751335e2c126e28fcb260a2b35708ad6589dL415-R415

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

```
// $test = Mage::getStoreConfigFlag('dev/css/merge_css_files');
$test = Mage::getStoreConfigFlag('dev/css');
var_dump($test);
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->