### PR TITLE
Added getter/setter for getCouponCode()

### DIFF
--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -59,8 +59,6 @@
  * @method $this setCheckoutMethod(string $value)
  * @method string getConvertedAt()
  * @method $this setConvertedAt(string $value)
- * @method string getCouponCode()
- * @method $this setCouponCode(string $value)
  * @method string getCreatedAt()
  * @method $this setCreatedAt(string $value)
  * @method string getCustomerDob()
@@ -2088,5 +2086,22 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
             return $this;
         }
         return parent::save();
+    }
+
+    /**
+     * @return string
+     */
+    public function getCouponCode(): string
+    {
+        return (string)$this->_getData('coupon_code');
+    }
+
+    /**
+     * @param string $couponCode
+     * @return $this
+     */
+    public function setCouponCode(string $couponCode) #static with php74
+    {
+        return $this->setData('coupon_code', $couponCode);
     }
 }

--- a/app/design/frontend/base/default/template/checkout/cart/coupon.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/coupon.phtml
@@ -18,6 +18,8 @@
  * @copyright   Copyright (c) 2021 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Checkout_Block_Cart_Coupon $this */
 ?>
 <form id="discount-coupon-form" action="<?php echo $this->getFormActionUrl() ?>" method="post">
     <div class="discount">

--- a/app/design/frontend/rwd/default/template/checkout/cart/coupon.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/coupon.phtml
@@ -18,6 +18,8 @@
  * @copyright   Copyright (c) 2021 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Checkout_Block_Cart_Coupon $this */
 ?>
 <form id="discount-coupon-form" action="<?php echo $this->getFormActionUrl() ?>" method="post">
     <div class="discount">


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
@elidrissidev https://github.com/OpenMage/magento-lts/pull/2586#issuecomment-1256919234

> escapeHtml phpdoc doesn't say it accepts nullable data, after all it doesn't make sense to escape null.
> 
> Respecting the PHPdocs will make it easier in the future to add strict type hinting to methods instead of making everything nullable.
> 
> What do you say?


> Yes, it does make no sense to escape null, but currently it is done.
> 
> I'd prefer the method, that takes most effort. Adding getter/setter methods ...

Added first getter/setter for test ... should make some changes  to templates obsolete.

### Related Pull Requests
<!-- related pull request placeholder -->
1. See OpenMage/magento-lts#2586 ... search for `$this->getCouponCode()`

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->