### PR TITLE
Use correct code for Greece VAT validation

### DIFF
--- a/app/code/core/Mage/Customer/Helper/Data.php
+++ b/app/code/core/Mage/Customer/Helper/Data.php
@@ -572,13 +572,16 @@ class Mage_Customer_Helper_Data extends Mage_Core_Helper_Abstract
             return $gatewayResponse;
         }
 
+        $countryCodeForVatNumber = $this->_getCountryCodeForVatNumber($countryCode);
+        $requesterCountryCodeForVatNumber = $this->_getCountryCodeForVatNumber($requesterCountryCode);
+
         try {
             $soapClient = $this->_createVatNumberValidationSoapClient();
 
             $requestParams = [];
-            $requestParams['countryCode'] = $countryCode;
+            $requestParams['countryCode'] = $countryCodeForVatNumber;
             $requestParams['vatNumber'] = str_replace([' ', '-'], ['', ''], $vatNumber);
-            $requestParams['requesterCountryCode'] = $requesterCountryCode;
+            $requestParams['requesterCountryCode'] = $requesterCountryCodeForVatNumber;
             $requestParams['requesterVatNumber'] = str_replace([' ', '-'], ['', ''], $requesterVatNumber);
 
             // Send request to service
@@ -737,5 +740,19 @@ class Mage_Customer_Helper_Data extends Mage_Core_Helper_Abstract
     protected function _createVatNumberValidationSoapClient($trace = false)
     {
         return new SoapClient(self::VAT_VALIDATION_WSDL_URL, ['trace' => $trace]);
+    }
+
+    /**
+     * Returns the country code used in VAT number which can be different from the ISO-2 country code.
+     *
+     * @param string $countryCode
+     * @return string
+     */
+    protected function _getCountryCodeForVatNumber(string $countryCode): string
+    {
+        // Greece uses a different code for VAT validation than its ISO-2 country code.
+        // See: https://en.wikipedia.org/wiki/VAT_identification_number#European_Union_VAT_identification_numbers
+
+        return $countryCode === 'GR' ? 'EL' : $countryCode;
     }
 }


### PR DESCRIPTION

### Description (*)

Greece uses a different code for VAT validation number (EL) than its ISO-2 country code (GR). This PR backports the fix in magento2 to allow overriding the country code before performing the VAT validation request.

### Related Pull Requests

- See magento/magento2#20548

### Fixed Issues (if relevant)

1. Fixes OpenMage/magento-lts#2828

### Manual testing scenarios (*)
1. Create a customer with Greece country in its address, then try validating the VAT number either from the frontend or admin.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->