### PR TITLE
Fixed incorrect datetime in block, ref #1525

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ Do not use 20.x.x if you need IE support.
 
 - removed IE conditional comments, IE styles, IE scripts and IE eot files [#1073](https://github.com/OpenMage/magento-lts/pull/1073)
 - removed frontend default themes (default, modern, iphone, german, french, blank, blue) [#1600](https://github.com/OpenMage/magento-lts/pull/1600)
-- fixed incorrect datetime in customer block (`$useTimezone` parameter) [#1525](https://github.com/OpenMage/magento-lts/pull/1525)
 - added redis as a valid option for `global/session_save` [#1513](https://github.com/OpenMage/magento-lts/pull/1513)
 - reduce needless saves by avoiding setting `_hasDataChanges` flag [#2066](https://github.com/OpenMage/magento-lts/pull/2066)
 - removed support for `global/sales/old_fields_map` defined in XML [#921](https://github.com/OpenMage/magento-lts/pull/921)

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
@@ -79,13 +79,15 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_View extends Mage_Adminhtml_Block_T
      */
     public function getCreateDate()
     {
-        if (!$this->getCustomer()->getCreatedAt()) {
+        $date = $this->getCustomer()->getCreatedAt();
+        if (!$date) {
             return null;
         }
-        return $this->_getCoreHelper()->formatDate(
-            $this->getCustomer()->getCreatedAt(),
+        return $this->_getCoreHelper()->formatTimezoneDate(
+            $date,
             Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM,
-            true
+            true,
+            false
         );
     }
 
@@ -120,7 +122,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_View extends Mage_Adminhtml_Block_T
     {
         $date = $this->getCustomerLog()->getLoginAtTimestamp();
         if ($date) {
-            return Mage::helper('core')->formatDate($date, Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true);
+            return Mage::helper('core')->formatTimezoneDate($date, Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true, false);
         }
         return Mage::helper('customer')->__('Never');
     }

--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -487,6 +487,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     public function unsetChild($alias)
     {
         if (isset($this->_children[$alias])) {
+            /** @var Mage_Core_Block_Abstract $block */
             $block = $this->_children[$alias];
             $name = $block->getNameInLayout();
             unset($this->_children[$alias]);

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -153,23 +153,40 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Format date using current locale options and time zone.
      *
-     * @param   string|Zend_Date|null $date
+     * @param   string|Zend_Date|null $date   If empty, return current datetime.
      * @param   string              $format   See Mage_Core_Model_Locale::FORMAT_TYPE_* constants
      * @param   bool                $showTime Whether to include time
      * @return  string
      */
     public function formatDate($date = null, $format = Mage_Core_Model_Locale::FORMAT_TYPE_SHORT, $showTime = false)
     {
+        return $this->formatTimezoneDate($date, $format, $showTime);
+    }
+
+    /**
+     * Format date using current locale options and time zone.
+     *
+     * @param   string|Zend_Date|null $date   If empty, return current datetime.
+     * @param   string              $format   See Mage_Core_Model_Locale::FORMAT_TYPE_* constants
+     * @param   bool                $showTime Whether to include time
+     * @param   bool                $useTimezone Convert to local datetime?
+     * @return  string
+     */
+    public function formatTimezoneDate($date = null, $format = Mage_Core_Model_Locale::FORMAT_TYPE_SHORT, $showTime = false, $useTimezone = true)
+    {
         if (!in_array($format, $this->_allowedFormats, true)) {
             return $date;
         }
-        if (!($date instanceof Zend_Date) && $date && !strtotime($date)) {
-            return '';
-        }
-        if (is_null($date)) {
-            $date = Mage::app()->getLocale()->date(Mage::getSingleton('core/date')->gmtTimestamp(), null, null);
+        if (empty($date)) {
+            $date = Mage::app()->getLocale()->date(Mage::getSingleton('core/date')->gmtTimestamp(), null, null, $useTimezone);
+        } elseif (is_int($date)) {
+            $date = Mage::app()->getLocale()->date($date, null, null, $useTimezone);
         } elseif (!$date instanceof Zend_Date) {
-            $date = Mage::app()->getLocale()->date(strtotime($date), null, null);
+            if ($time = strtotime($date)) {
+                $date = Mage::app()->getLocale()->date($time, null, null, $useTimezone);
+            } else {
+                return '';
+            }
         }
 
         if ($showTime) {

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -153,7 +153,7 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Format date using current locale options and time zone.
      *
-     * @param   string|Zend_Date|null $date   If empty, return current datetime.
+     * @param   string|Zend_Date|int|null $date If empty, return current local datetime.
      * @param   string              $format   See Mage_Core_Model_Locale::FORMAT_TYPE_* constants
      * @param   bool                $showTime Whether to include time
      * @return  string

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -172,29 +172,31 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
      * @param   bool                $useTimezone Convert to local datetime?
      * @return  string
      */
-    public function formatTimezoneDate($date = null, $format = Mage_Core_Model_Locale::FORMAT_TYPE_SHORT, $showTime = false, $useTimezone = true)
-    {
+    public function formatTimezoneDate(
+        $date = null,
+        string $format = Mage_Core_Model_Locale::FORMAT_TYPE_SHORT,
+        bool $showTime = false,
+        bool $useTimezone = true
+    ) {
         if (!in_array($format, $this->_allowedFormats, true)) {
             return $date;
         }
+
+        $locale = Mage::app()->getLocale();
+
         if (empty($date)) {
-            $date = Mage::app()->getLocale()->date(Mage::getSingleton('core/date')->gmtTimestamp(), null, null, $useTimezone);
+            $date = $locale->date(Mage::getSingleton('core/date')->gmtTimestamp(), null, null, $useTimezone);
         } elseif (is_int($date)) {
-            $date = Mage::app()->getLocale()->date($date, null, null, $useTimezone);
+            $date = $locale->date($date, null, null, $useTimezone);
         } elseif (!$date instanceof Zend_Date) {
-            if ($time = strtotime($date)) {
-                $date = Mage::app()->getLocale()->date($time, null, null, $useTimezone);
-            } else {
-                return '';
+            $time = strtotime($date);
+            if ($time) {
+                $date = $locale->date($time, null, null, $useTimezone);
             }
+            return '';
         }
 
-        if ($showTime) {
-            $format = Mage::app()->getLocale()->getDateTimeFormat($format);
-        } else {
-            $format = Mage::app()->getLocale()->getDateFormat($format);
-        }
-
+        $format = $showTime ? $locale->getDateTimeFormat($format) : $locale->getDateFormat($format);
         return $date->toString($format);
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

#1525 was added to v20 only, because it was a BC breaking change. This PR solves that issue w/o changing existing methods signature. (code from 1525)

Not sure about this change ... changing ...

```
if (!($date instanceof Zend_Date) && $date && !strtotime($date)) {
    return '';
}
if (is_null($date)) {
    $date = Mage::app()->getLocale()->date(Mage::getSingleton('core/date')->gmtTimestamp(), null, null);
```

### Related Pull Requests
<!-- related pull request placeholder -->

1. See OpenMage/magento-lts#1525

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Closes OpenMage/magento-lts#2850

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. see related PR
2. ...

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->