### PR TITLE
Remove "was" from error messages

### DIFF
--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -227,10 +227,10 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
             $fileType = $this->_fileType;
         }
         if (empty(self::$_callbacks[$fileType])) {
-            throw new Exception("{$unsupportedText}. Type was: {$fileType}. File was: {$this->_fileName}");
+            throw new Exception("{$unsupportedText}. Type: {$fileType}. File: {$this->_fileName}");
         }
         if (empty(self::$_callbacks[$fileType][$callbackType])) {
-            throw new Exception("Callback not found. Callbacktype was: {$callbackType}. File was: {$this->_fileName}");
+            throw new Exception("Callback not found. Callbacktype: {$callbackType}. File: {$this->_fileName}");
         }
         return self::$_callbacks[$fileType][$callbackType];
     }
@@ -245,17 +245,17 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
                 // fill truecolor png with alpha transparency
                 if ($isAlpha) {
                     if (!imagealphablending($imageResourceTo, false)) {
-                        throw new Exception('Failed to set alpha blending for PNG image. File was: {$this->_fileName}');
+                        throw new Exception('Failed to set alpha blending for PNG image. File: {$this->_fileName}');
                     }
                     $transparentAlphaColor = imagecolorallocatealpha($imageResourceTo, 0, 0, 0, 127);
                     if (false === $transparentAlphaColor) {
-                        throw new Exception('Failed to allocate alpha transparency for PNG image. File was: {$this->_fileName}');
+                        throw new Exception('Failed to allocate alpha transparency for PNG image. File: {$this->_fileName}');
                     }
                     if (!imagefill($imageResourceTo, 0, 0, $transparentAlphaColor)) {
-                        throw new Exception('Failed to fill PNG image with alpha transparency. File was: {$this->_fileName}');
+                        throw new Exception('Failed to fill PNG image with alpha transparency. File: {$this->_fileName}');
                     }
                     if (!imagesavealpha($imageResourceTo, true)) {
-                        throw new Exception('Failed to save alpha transparency into PNG image. File was: {$this->_fileName}');
+                        throw new Exception('Failed to save alpha transparency into PNG image. File: {$this->_fileName}');
                     }
 
                     return $transparentAlphaColor;
@@ -281,7 +281,7 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
         list($r, $g, $b) = $this->_backgroundColor;
         $color = imagecolorallocate($imageResourceTo, $r, $g, $b);
         if (!imagefill($imageResourceTo, 0, 0, $color)) {
-            throw new Exception("Failed to fill image background with color {$r} {$g} {$b}. File was: {$this->_fileName}");
+            throw new Exception("Failed to fill image background with color {$r} {$g} {$b}. File: {$this->_fileName}");
         }
 
         return $color;
@@ -329,7 +329,7 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
     public function resize($frameWidth = null, $frameHeight = null)
     {
         if (empty($frameWidth) && empty($frameHeight)) {
-            throw new Exception('Invalid image dimensions. File was: {$this->_fileName}');
+            throw new Exception('Invalid image dimensions. File: {$this->_fileName}');
         }
 
         // calculate lacking dimension


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->