### PR TITLE
Fix error on add new contributor

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1332,7 +1332,10 @@
       "login": "cebe",
       "name": "Carsten Brandt",
       "avatar_url": "https://avatars.githubusercontent.com/u/189796?v=4",
-      "profile": "http://cebe.cc/"
+      "profile": "http://cebe.cc/",
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "eneiasramos",


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fix Error on add new contributor

Error:
TypeError: Cannot read property 'map' of undefined


"contributions" is undefined after this [PR/Merge](https://github.com/OpenMage/magento-lts/pull/1814/commits/f68c2939ad905f481ad5f770590daabf557ceab4) 

### Manual testing scenarios (*)
1. Add new Contributor `yarn all-contributors add @YOUR_NAME <types>`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->