### PR TITLE
Fix for #2874

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
@@ -110,7 +110,7 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract extends Mage
      */
     public function addItem($itemId, array $item)
     {
-        if ($this->isConfirmMassAction($itemId) && !isset($item['confirm'])) {
+        if (is_string($itemId) && $this->isConfirmMassAction($itemId) && !isset($item['confirm'])) {
             $item['confirm'] = Mage::helper('core')->__('Are you sure?');
         }
 
@@ -131,7 +131,7 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract extends Mage
      * Retrieve massaction item with id $itemId
      *
      * @param string $itemId
-     * @return Mage_Adminhtml_Block_Widget_Grid_Massaction_Item
+     * @return Mage_Adminhtml_Block_Widget_Grid_Massaction_Item|null
      */
     public function getItem($itemId)
     {


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Fix for passing `null` as first argument in 3rd-party-code.

```
Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract->addItem(NULL, Array)
```

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#2874

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->