### PR TITLE
Fixes passing null to strlen() inside escapeHtml()

### DIFF
--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -212,7 +212,7 @@ abstract class Mage_Core_Helper_Abstract
             }
         } else {
             // process single item
-            if (strlen($data)) {
+            if (is_string($data) && strlen($data)) {
                 if (is_array($allowedTags) && !empty($allowedTags)) {
                     $allowed = implode('|', $allowedTags);
                     $result = preg_replace('/<([\/\s\r\n]*)(' . $allowed . ')([\/\s\r\n]*)>/si', '##$1$2$3##', $data);


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

> I don't disagree with fixing existing uses of escapeHtml but just for practicality sake this is going to be a big headache for those with lots of extensions so I propose changing the signature of escapeHtml to allow a nullable string (if null is passed it should return an empty string).

We just need to check if we pass as string to `strlen()` inside `escapeHtml()`. Should be enough?

### Related Pull Requests
- https://github.com/OpenMage/magento-lts/pull/2586#issuecomment-1256840473
- https://github.com/OpenMage/magento-lts/pull/2586#issuecomment-1369311108

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->