### PR TITLE
Ensure count() is not called on a string

### DIFF
--- a/lib/Varien/File/Uploader.php
+++ b/lib/Varien/File/Uploader.php
@@ -502,12 +502,7 @@ class Varien_File_Uploader
             $this->_uploadType = self::MULTIPLE_STYLE;
             $this->_file = $fileId;
         } else {
-            preg_match("/^(.*?)\[(.*?)\]$/", $fileId, $file);
-
-            if (count($file) > 0
-                && (count($file[0]) > 0)
-                && (count($file[1]) > 0)
-            ) {
+            if (preg_match('/^(\w+)\[(\w+)\]$/', $fileId, $file)) {
                 array_shift($file);
                 $this->_uploadType = self::MULTIPLE_STYLE;
 


### PR DESCRIPTION
This PR fixes the PHP 8.1 deprecation warning on `setUploadFileId` by checking the existence of `preg_match` values using `isset()` rather than `count()` which is now deprecated for string types.