### PR TITLE
Ensure null values are not passed to trim()

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
@@ -627,7 +627,7 @@ abstract class Mage_Eav_Model_Entity_Attribute_Abstract extends Mage_Core_Model_
             if ($this->isStatic()) {
                 $this->_dataTable = $this->getEntityType()->getValueTablePrefix();
             } else {
-                $backendTable = trim($this->_getData('backend_table'));
+                $backendTable = trim((string)$this->_getData('backend_table'));
                 if (empty($backendTable)) {
                     $entityTable  = [$this->getEntity()->getEntityTablePrefix(), $this->getBackendType()];
                     $backendTable = $this->getResource()->getTable($entityTable);


### PR DESCRIPTION
As Magento allows eav attributes without a backing table (`backend_table` in the DB), we should ensure that those `null` values are passable into the trim function. I noticed @sreichel used a string typecast in the larger #2586 PR , so I'm going with that same convention. Alternatively a null coalesce could be used here if that is preferred. This fixes the deprecation notice in PHP 8.1.