### PR TITLE
Require Mage_Backup and Mage_PageCache on v19's release builder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,10 @@ jobs:
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
         restore-keys: ${{ runner.os }}-composer-
 
+    - name: Require Mage_Backup on v19
+      if: startsWith(github.event.release.tag_name, 'v19')
+      run: composer require --no-install --prefer-dist --no-progress --ignore-platform-req=ext-* openmage/module-mage-backup
+
     - name: Composer install
       run: composer install --prefer-dist --no-progress --ignore-platform-req=ext-* --no-dev
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
       if: startsWith(github.event.release.tag_name, 'v19')
       run: composer require --no-install --prefer-dist --no-progress --ignore-platform-req=ext-* openmage/module-mage-backup
 
+    - name: Require Mage_PageCache on v19
+      if: startsWith(github.event.release.tag_name, 'v19')
+      run: composer require --no-install --prefer-dist --no-progress --ignore-platform-req=ext-* openmage/module-mage-pagecache
+
     - name: Composer install
       run: composer install --prefer-dist --no-progress --ignore-platform-req=ext-* --no-dev
 


### PR DESCRIPTION
Since https://github.com/OpenMage/magento-lts/pull/2811 Mage_Backup should be in the release builder, only for v19