### PR TITLE
Added getter for Customer::getPassword(), ref #2586

### DIFF
--- a/app/code/core/Mage/Customer/Model/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Customer.php
@@ -81,7 +81,6 @@
  * @method string getOldEmail()
  * @method $this setOldEmail(string $value)
  *
- * @method string getPassword()
  * @method string getPasswordConfirm()
  * @method string getPasswordConfirmation()
  * @method $this setPasswordConfirmation(string $value)
@@ -470,6 +469,14 @@ class Mage_Customer_Model_Customer extends Mage_Core_Model_Abstract
     {
         $this->getAttributes();
         return $this->_attributes[$attributeCode] ?? null;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPassword(): string
+    {
+        return (string) $this->_getData('password');
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

In `Mage_Customer_Model_Customer` method `setPassword()` exists, but there is no getter.

Added in this PR. Should fix some PHP81 related issues.

### Related Pull Requests
<!-- related pull request placeholder -->

- OpenMage/magento-lts#2586 ... search for `getPassword(` in changed files

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->