### PR TITLE
Removed info about Magento versions merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,9 +262,7 @@ for more information.
 ## Versioning
 
 Though Magento does __not__ follow [Semantic Versioning](http://semver.org/) we aim to provide a workable system for
-dependency definition. Each Magento `1.<minor>.<revision>` release will get its own branch (named `1.<minor>.<revision>.x`)
-that will be independently maintained with upstream patches and community bug fixes for as long as it makes sense
-to do so (based on available resources). For example, Magento version `1.9.4.5` was merged into the `1.9.4.x` branch.
+dependency definition.
 
 ## Public Communication
 


### PR DESCRIPTION
Magento 1 doesn't exist anymore since years so I think it doesn't really make sense to have this information in our README anymore (it was perfect at the time when it was introduced).

Probably this section of the README should be expanded but we're in the process of deciding and it may take a while.