### PR TITLE
Better exceptions for file upload

### DIFF
--- a/lib/Varien/File/Uploader.php
+++ b/lib/Varien/File/Uploader.php
@@ -32,6 +32,16 @@
 
 class Varien_File_Uploader
 {
+    const UPLOAD_ERRORS = array(
+        UPLOAD_ERR_INI_SIZE => 'The uploaded file exceeds the upload_max_filesize directive in php.ini',
+        UPLOAD_ERR_FORM_SIZE => 'The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form',
+        UPLOAD_ERR_PARTIAL => 'The uploaded file was only partially uploaded',
+        UPLOAD_ERR_NO_FILE => 'No file was uploaded',
+        UPLOAD_ERR_NO_TMP_DIR => 'Missing a temporary folder',
+        UPLOAD_ERR_CANT_WRITE => 'Failed to write file to disk',
+        UPLOAD_ERR_EXTENSION => 'A PHP extension stopped the file upload',
+    );
+
     /**
      * Uploaded file handle (copy of $_FILES[] element)
      *
@@ -150,6 +160,10 @@ class Varien_File_Uploader
     {
         $this->_setUploadFileId($fileId);
         if (empty($this->_file['tmp_name']) || !file_exists($this->_file['tmp_name'])) {
+            $errorCode = $this->_file['error'] ?? 0;
+            if ($errorCode && isset(self::UPLOAD_ERRORS[$errorCode])) {
+                throw new Exception(self::UPLOAD_ERRORS[$errorCode]);
+            }
             $code = empty($this->_file['tmp_name']) ? self::TMP_NAME_EMPTY : 0;
             throw new Exception('File was not uploaded.', $code);
         } else {

--- a/lib/Varien/File/Uploader.php
+++ b/lib/Varien/File/Uploader.php
@@ -40,7 +40,7 @@ class Varien_File_Uploader
         UPLOAD_ERR_NO_TMP_DIR => 'Missing a temporary folder',
         UPLOAD_ERR_CANT_WRITE => 'Failed to write file to disk',
         UPLOAD_ERR_EXTENSION => 'A PHP extension stopped the file upload'
-    ]
+    ];
 
     /**
      * Uploaded file handle (copy of $_FILES[] element)

--- a/lib/Varien/File/Uploader.php
+++ b/lib/Varien/File/Uploader.php
@@ -32,15 +32,15 @@
 
 class Varien_File_Uploader
 {
-    const UPLOAD_ERRORS = array(
+    public const UPLOAD_ERRORS = [
         UPLOAD_ERR_INI_SIZE => 'The uploaded file exceeds the upload_max_filesize directive in php.ini',
         UPLOAD_ERR_FORM_SIZE => 'The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form',
         UPLOAD_ERR_PARTIAL => 'The uploaded file was only partially uploaded',
         UPLOAD_ERR_NO_FILE => 'No file was uploaded',
         UPLOAD_ERR_NO_TMP_DIR => 'Missing a temporary folder',
         UPLOAD_ERR_CANT_WRITE => 'Failed to write file to disk',
-        UPLOAD_ERR_EXTENSION => 'A PHP extension stopped the file upload',
-    );
+        UPLOAD_ERR_EXTENSION => 'A PHP extension stopped the file upload'
+    ]
 
     /**
      * Uploaded file handle (copy of $_FILES[] element)


### PR DESCRIPTION
Since https://github.com/OpenMage/magento-lts/pull/1313 was closed because the author couldn't fix it I've rewrote it and posted it.

This PR adds some exception messages in case of uploading error.

Messages and constant name/values are taken from https://www.php.net/manual/en/features.file-upload.errors.php