### PR TITLE
Allow using a separate db connection for Admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Do not use 20.x.x if you need IE support.
 - removed support for `global/sales/old_fields_map` defined in XML ([#921](https://github.com/OpenMage/magento-lts/pull/921))
 - enabled website level config cache ([#2355](https://github.com/OpenMage/magento-lts/pull/2355))
 - make overrides of Mage_Core_Model_Resource_Db_Abstract::delete respect parent api ([#1257](https://github.com/OpenMage/magento-lts/pull/1257))
+- allow using a separate db connection for Admin ([#2903](https://github.com/OpenMage/magento-lts/pull/2903))
 
 For full list of changes, you can [compare tags](https://github.com/OpenMage/magento-lts/compare/1.9.4.x...20.0).
 

--- a/app/code/core/Mage/Core/Model/Resource.php
+++ b/app/code/core/Mage/Core/Model/Resource.php
@@ -33,9 +33,11 @@ class Mage_Core_Model_Resource
     public const AUTO_UPDATE_NEVER      = -1;
     public const AUTO_UPDATE_ALWAYS     = 1;
 
-    public const DEFAULT_READ_RESOURCE  = 'core_read';
-    public const DEFAULT_WRITE_RESOURCE = 'core_write';
-    public const DEFAULT_SETUP_RESOURCE = 'core_setup';
+    public const DEFAULT_ADMIN_READ_RESOURCE  = 'admin_read';
+    public const DEFAULT_ADMIN_WRITE_RESOURCE = 'admin_write';
+    public const DEFAULT_READ_RESOURCE        = 'core_read';
+    public const DEFAULT_WRITE_RESOURCE       = 'core_write';
+    public const DEFAULT_SETUP_RESOURCE       = 'core_setup';
 
     /**
      * Instances of classes for connection types
@@ -201,10 +203,14 @@ class Mage_Core_Model_Resource
      */
     protected function _getDefaultConnection($requiredConnectionName)
     {
+        $isAdmin = Mage::app()->getStore()->isAdmin();
+        $readResource = $isAdmin ? self::DEFAULT_ADMIN_READ_RESOURCE : self::DEFAULT_READ_RESOURCE;
+        $writeResource = $isAdmin ? self::DEFAULT_ADMIN_WRITE_RESOURCE : self::DEFAULT_WRITE_RESOURCE;
+
         if (strpos($requiredConnectionName, 'read') !== false) {
-            return $this->getConnection(self::DEFAULT_READ_RESOURCE);
+            return $this->getConnection($readResource);
         }
-        return $this->getConnection(self::DEFAULT_WRITE_RESOURCE);
+        return $this->getConnection($writeResource);
     }
 
     /**

--- a/app/etc/config.xml
+++ b/app/etc/config.xml
@@ -67,6 +67,16 @@
                     <use>default_read</use>
                 </connection>
             </core_read>
+            <admin_write>
+                <connection>
+                    <use>default_write</use>
+                </connection>
+            </admin_write>
+            <admin_read>
+                <connection>
+                    <use>default_read</use>
+                </connection>
+            </admin_read>
         </resources>
         <resource>
             <connection>


### PR DESCRIPTION
### Description (*)

This PR adds a new feature that allows optionally using separate database connections (`admin_read` and `admin_write`) for the Admin store. This can be desired for many reasons such as limiting the privileges of the frontend connection's db user. By default, these connections inherit the default ones, so they should work out of the box without any configuration.

### Fixed Issues (if relevant)

1. Fixes OpenMage/magento-lts#2870

### Manual testing scenarios (*)

1. Go to your `local.xml` and add the following configuration inside `config/global/resources` element:
```xml
<admin_setup>
    <connection>
        <host><![CDATA[localhost]]></host>
        <username><![CDATA[root]]></username>
        <password><![CDATA[root]]></password>
        <dbname><![CDATA[openmage]]></dbname>
        <initStatements><![CDATA[SET NAMES utf8]]></initStatements>
        <model><![CDATA[mysql4]]></model>
        <type><![CDATA[pdo_mysql]]></type>
        <pdoType><![CDATA[]]></pdoType>
        <active>1</active>
    </connection>
</admin_setup>
<admin_write>
    <connection>
        <use>admin_setup</use>
    </connection>
</admin_write>
<admin_read>
    <connection>
        <use>admin_setup</use>
    </connection>
</admin_read>
<!-- 
It's important to override core_setup to use the new admin connection 
for setup scripts to run without problems, especially if you limit the privileges
of default connection.
-->
<core_setup>
    <connection>
        <use>admin_setup</use>
    </connection>
</core_setup>
```

Test to make sure the Admin area is now using the new connection. In my case, I made it use the database with sample data installed, whereas the frontend was using a clean database.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->