### PR TITLE
Fix Use Base Class Instead of Child Class when Referencing Constants

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid.php
@@ -101,8 +101,8 @@ class Mage_Adminhtml_Block_Newsletter_Template_Grid extends Mage_Adminhtml_Block
                 'index' => 'template_type',
                 'type' => 'options',
                 'options' => [
-                    Mage_Newsletter_Model_Template::TYPE_HTML   => 'html',
-                    Mage_Newsletter_Model_Template::TYPE_TEXT   => 'text'
+                    Mage_Core_Model_Template::TYPE_HTML => 'html',
+                    Mage_Core_Model_Template::TYPE_TEXT => 'text'
                 ],
             ]
         );

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Filter/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Filter/Type.php
@@ -29,9 +29,9 @@
 class Mage_Adminhtml_Block_System_Email_Template_Grid_Filter_Type extends Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Select
 {
     protected static $_types = [
-        null                                        =>  null,
-        Mage_Newsletter_Model_Template::TYPE_HTML   => 'HTML',
-        Mage_Newsletter_Model_Template::TYPE_TEXT   => 'Text',
+        null                                =>  null,
+        Mage_Core_Model_Template::TYPE_HTML => 'HTML',
+        Mage_Core_Model_Template::TYPE_TEXT => 'Text',
     ];
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Type.php
@@ -29,9 +29,10 @@
 class Mage_Adminhtml_Block_System_Email_Template_Grid_Renderer_Type extends Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract
 {
     protected static $_types = [
-        Mage_Newsletter_Model_Template::TYPE_HTML    => 'HTML',
-        Mage_Newsletter_Model_Template::TYPE_TEXT    => 'Text',
+        Mage_Core_Model_Template::TYPE_HTML => 'HTML',
+        Mage_Core_Model_Template::TYPE_TEXT => 'Text',
     ];
+
     public function render(Varien_Object $row)
     {
         $str = self::$_types[$row->getTemplateType()] ?? Mage::helper('adminhtml')->__('Unknown');

--- a/app/code/core/Mage/Adminhtml/controllers/Newsletter/TemplateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Newsletter/TemplateController.php
@@ -176,10 +176,10 @@ class Mage_Adminhtml_Newsletter_TemplateController extends Mage_Adminhtml_Contro
                 ->setModifiedAt(Mage::getSingleton('core/date')->gmtDate());
 
             if (!$template->getId()) {
-                $template->setTemplateType(Mage_Newsletter_Model_Template::TYPE_HTML);
+                $template->setTemplateType(Mage_Core_Model_Template::TYPE_HTML);
             }
             if ($this->getRequest()->getParam('_change_type_flag')) {
-                $template->setTemplateType(Mage_Newsletter_Model_Template::TYPE_TEXT);
+                $template->setTemplateType(Mage_Core_Model_Template::TYPE_TEXT);
                 $template->setTemplateStyles('');
             }
             if ($this->getRequest()->getParam('_save_as_flag')) {


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
There are two class constants being referenced by using a child class instead of using the base class, in which the constants are defined. Those constants aren't overriden. Therefore I don't think this usage of the child class is deliberate.
In itself this small mistake wouldn't bother me, but I encountered a scenario where those references cause problems. The constants aren't used withing `Mage_Newsletter` but e.g. in a block that is part of the email template grid in the admin area. In case one deactivates/removes `Mage_Newsletter` the code referencing `Mage_Newsletter_Model_Template` will fail. 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->