### PR TITLE
RWD theme: removed border bottom from h1/h2

### DIFF
--- a/skin/frontend/rwd/default/css/styles-ie8.css
+++ b/skin/frontend/rwd/default/css/styles-ie8.css
@@ -635,7 +635,6 @@ h6, .h6 {
   font-size: 24px;
   font-weight: 600;
   color: #636363;
-  border-bottom: 1px solid #ededed;
   padding-bottom: 3px;
   margin-bottom: 15px;
   text-transform: uppercase;
@@ -5116,7 +5115,6 @@ p.product-name a:hover {
  * ============================================ */
 .cart .page-title {
   margin-bottom: 15px;
-  border-bottom: 1px solid #ededed;
 }
 .cart .page-title:after {
   content: '';

--- a/skin/frontend/rwd/default/css/styles.css
+++ b/skin/frontend/rwd/default/css/styles.css
@@ -635,7 +635,6 @@ h6, .h6 {
   font-size: 24px;
   font-weight: 600;
   color: #636363;
-  border-bottom: 1px solid #ededed;
   padding-bottom: 3px;
   margin-bottom: 15px;
   text-transform: uppercase;
@@ -6203,7 +6202,6 @@ p.product-name a:hover {
  * ============================================ */
 .cart .page-title {
   margin-bottom: 15px;
-  border-bottom: 1px solid #ededed;
 }
 .cart .page-title:after {
   content: '';

--- a/skin/frontend/rwd/default/scss/mixin/_typography.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_typography.scss
@@ -104,7 +104,6 @@
     font-size: 24px;
     font-weight: 600;
     color: $c-text;
-    border-bottom: 1px solid $c-module-border-light;
     padding-bottom: 3px;
     margin-bottom: 15px;
     text-transform: uppercase;

--- a/skin/frontend/rwd/default/scss/module/_checkout-cart.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-cart.scss
@@ -131,7 +131,6 @@
 
 .cart .page-title {
     margin-bottom: 15px;
-    border-bottom: 1px solid $c-module-border-light;
 
     &:after {
         @include clearfix;


### PR DESCRIPTION
I was checkin the RWD theme and I noted that some pages have a `border-bottom` below the page title, like these:

<img width="656" alt="Screenshot 2023-01-11 alle 15 49 04" src="https://user-images.githubusercontent.com/909743/211876679-ffbfbace-8f71-40bc-9e25-b9f4a67f215c.png">

<img width="537" alt="Screenshot 2023-01-11 alle 15 49 53" src="https://user-images.githubusercontent.com/909743/211876756-b3a6e04e-6582-442c-be88-aececca295c7.png">

but most of them don't, like:

<img width="622" alt="Screenshot 2023-01-11 alle 15 49 14" src="https://user-images.githubusercontent.com/909743/211876837-663d8d20-e19e-4329-bbd1-09a1c214add0.png">

<img width="553" alt="Screenshot 2023-01-11 alle 15 49 10" src="https://user-images.githubusercontent.com/909743/211876848-60aaea23-dd39-47e0-9df7-69a965716875.png">

Since I find that there are too many borders and I think that it's ok to have separations between `header`, `content` and `footer` but inside the content we should avoid having too many borders, I made the pages look like this:

<img width="791" alt="Screenshot 2023-01-11 alle 15 55 49" src="https://user-images.githubusercontent.com/909743/211877545-6cff099a-36ea-41ce-bb2b-37d57c9b9f51.png">

<img width="454" alt="Screenshot 2023-01-11 alle 15 55 34" src="https://user-images.githubusercontent.com/909743/211877552-3e94aed9-6447-45dc-aef5-16ede0347c96.png">

removing the border-bottom from `.page-title`. Hope you like the idea.