### PR TITLE
Generalized currency formatting method formatPriceTxt() for use in or…

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -2012,13 +2012,14 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
     }
 
     /**
-     * Retrieve text formatted price value including order rate
+     * Retrieve currency formatted string.
      *
-     * @param   float $price
-     * @return  string
+     * @param float|string $price Numeric value or field name, e.g. "grand_total".
+     * @return string
      */
     public function formatPriceTxt($price)
     {
+        $price = (float) (is_numeric($price) ? $price : $this->_getData($price));
         return $this->getOrderCurrency()->formatTxt($price);
     }
 


### PR DESCRIPTION
…der email templates.

### Description (*)
It is now possible to print currency formatting number in email templates.

### Related Pull Requests
See PR #1946. 

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#1946

### Manual testing scenarios (*)
```php
$text = Mage::getSingleton('core/email_template_filter')
    ->setVariables(['order' => Mage::getModel('sales/order')->setGrandTotal(153)])
    ->filter("Formatted grand_total: {{var order.formatPriceTxt('grand_total')}} Formatted numeric value: {{var order.formatPriceTxt(1.23)}}");
```

$text is 
```
"Formatted grand_total: MYR153.00 Formatted numeric value: MYR1.23"
```

