### PR TITLE
New event "order_status_changed_before_save", ref #1128

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -2353,6 +2353,11 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
         if (!$this->getId()) {
             $this->setData('protect_code', substr(md5(uniqid(mt_rand(), true) . ':' . microtime(true)), 5, 6));
         }
+
+        if ($this->getStatus() !== $this->getOrigData('status')) {
+            Mage::dispatchEvent('order_status_changed_before_save', ['order' => $this]);
+        }
+
         return $this;
     }
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -237,6 +237,7 @@
 | model_save_commit_after | 1.9.4.5 |
 | on_view_report | 1.9.4.5 |
 | order_cancel_after | 1.9.4.5 |
+ | order_status_changed_before_save | 19.5.0 / 20.1.0 |
 | page_block_html_topmenu_gethtml_after | 1.9.4.5 |
 | page_block_html_topmenu_gethtml_before | 1.9.4.5 |
 | payment_form_block_to_html_before | 1.9.4.5 |


### PR DESCRIPTION
https://github.com/OpenMage/magento-lts/pull/1128 was almost finished but dormant since too much. It wasn't modifiable by other people so I superseeded it here.

This PR adds the order_status_changed_before_save event and also its record in the EVENTS.md file.

### Related Pull Requests
- Closes https://github.com/OpenMage/magento-lts/pull/1128