### PR TITLE
Remove unmatched error from phpstan baseline

### DIFF
--- a/phpstan.dist.baseline.neon
+++ b/phpstan.dist.baseline.neon
@@ -6711,11 +6711,6 @@ parameters:
 			path: app/code/core/Mage/Shipping/Model/Tracking/Result.php
 
 		-
-			message: "#^Call to an undefined method Zend_Db_Adapter_Abstract\\:\\:getCheckSql\\(\\)\\.$#"
-			count: 1
-			path: app/code/core/Mage/Sitemap/Model/Resource/Catalog/Abstract.php
-
-		-
 			message: "#^Method Mage_Tag_Model_Resource_Tag_Collection\\:\\:addPopularity\\(\\) invoked with 2 parameters, 0\\-1 required\\.$#"
 			count: 1
 			path: app/code/core/Mage/Tag/Block/Customer/Tags.php


### PR DESCRIPTION
### Description (*)

Only removed the error manually to stop workflow from failing. Can't regenerate the baseline at this time.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->