### PR TITLE
Fix parameter type for preg_match

### DIFF
--- a/app/design/adminhtml/default/default/template/widget/tabs.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabs.phtml
@@ -15,7 +15,7 @@
  * @category    design
  * @package     default_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
- * @copyright   Copyright (c) 2021 The OpenMage Contributors (https://www.openmage.org)
+ * @copyright   Copyright (c) 2021-2023 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
@@ -24,22 +24,23 @@
  * @var Mage_Adminhtml_Block_Widget_Tabs $this
  */
 ?>
-<?php if($this->getTitle()): ?>
+
+<?php if ($this->getTitle()): ?>
     <h3><?php echo $this->getTitle() ?></h3>
 <?php endif ?>
-<?php if(!empty($tabs)): ?>
+<?php if (!empty($tabs)): ?>
 <ul id="<?php echo $this->getId() ?>" class="tabs">
 <?php foreach ($tabs as $_tab): ?>
-<?php if (!$this->canShowTab($_tab)): continue;  endif; ?>
-    <li <?php if($this->getTabIsHidden($_tab)): ?> style="display:none"<?php endif ?>>
-        <a href="<?php echo $this->getTabUrl($_tab) ?>" id="<?php echo $this->getTabId($_tab) ?>" name="<?php echo $this->getTabId($_tab, false) ?>" title="<?php echo Mage::helper('core')->quoteEscape($this->getTabTitle($_tab)) ?>" class="tab-item-link <?php echo $this->getTabClass($_tab) ?><?php if (preg_match('/\s?ajax\s?/', $_tab->getClass())) {?> notloaded<?php }?>">
-            <span><span class="changed" title="<?php echo Mage::helper('core')->quoteEscape($this->__('The information in this tab has been changed.')) ?>"></span><span class="error" title="<?php echo Mage::helper('core')->quoteEscape($this->__('This tab contains invalid data. Please solve the problem before saving.')) ?>"></span><?php echo $this->getTabLabel($_tab); ?></span>
+    <?php if (!$this->canShowTab($_tab)) continue; ?>
+    <li<?php if ($this->getTabIsHidden($_tab)): ?> style="display:none"<?php endif ?>>
+        <a href="<?php echo $this->getTabUrl($_tab) ?>" id="<?php echo $this->getTabId($_tab) ?>" title="<?php echo Mage::helper('core')->quoteEscape($this->getTabTitle($_tab)) ?>" class="tab-item-link <?php echo $class = $this->getTabClass($_tab) ?><?php if (!empty($class) && preg_match('/\s?ajax\s?/', $class)): ?> notloaded<?php endif ?>">
+            <span><span class="changed" title="<?php echo Mage::helper('core')->quoteEscape($this->__('The information in this tab has been changed.')) ?>"></span><span class="error" title="<?php echo Mage::helper('core')->quoteEscape($this->__('This tab contains invalid data. Please solve the problem before saving.')) ?>"></span><?php echo $this->getTabLabel($_tab) ?></span>
         </a>
         <div id="<?php echo $this->getTabId($_tab) ?>_content" style="display:none;"><?php echo $this->getTabContent($_tab) ?></div>
     </li>
 <?php endforeach ?>
 </ul>
 <script type="text/javascript">
-    <?php echo $this->getJsObjectName() ?> = new varienTabs('<?php echo $this->getId() ?>', '<?php echo $this->getDestElementId() ?>', '<?php echo $this->getActiveTabId() ?>', <?php echo $this->getAllShadowTabs()?>);
+    <?php echo $this->getJsObjectName() ?> = new varienTabs('<?php echo $this->getId() ?>', '<?php echo $this->getDestElementId() ?>', '<?php echo $this->getActiveTabId() ?>', <?php echo $this->getAllShadowTabs() ?>);
 </script>
 <?php endif ?>

--- a/app/design/adminhtml/default/default/template/widget/tabshoriz.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabshoriz.phtml
@@ -15,7 +15,7 @@
  * @category    design
  * @package     default_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
- * @copyright   Copyright (c) 2021 The OpenMage Contributors (https://www.openmage.org)
+ * @copyright   Copyright (c) 2021-2023 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
@@ -24,22 +24,20 @@
  * @var Mage_Adminhtml_Block_Widget_Tabs $this
  */
 ?>
-<!-- <?php if($this->getTitle()): ?>
-    <h3><?php echo $this->getTitle() ?></h3>
-<?php endif ?> -->
-<?php if(!empty($tabs)): ?>
+
+<?php if (!empty($tabs)): ?>
 <ul id="<?php echo $this->getId() ?>" class="tabs-horiz">
 <?php foreach ($tabs as $_tab): ?>
+    <?php if (!$this->canShowTab($_tab)) continue; ?>
     <li>
-        <a href="<?php echo $this->getTabUrl($_tab)?>" id="<?php echo $this->getTabId($_tab) ?>" title="<?php echo $this->getTabTitle($_tab) ?>" class="tab-item-link <?php echo $this->getTabClass($_tab) ?><?php if (preg_match('/\s?ajax\s?/', $this->getTabClass($_tab))) {?> notloaded<?php }?>">
+        <a href="<?php echo $this->getTabUrl($_tab) ?>" id="<?php echo $this->getTabId($_tab) ?>" title="<?php echo Mage::helper('core')->quoteEscape($this->getTabTitle($_tab)) ?>" class="tab-item-link <?php echo $class = $this->getTabClass($_tab) ?><?php if (!empty($class) && preg_match('/\s?ajax\s?/', $class)): ?> notloaded<?php endif ?>">
             <span><span class="changed" title="<?php echo Mage::helper('core')->quoteEscape($this->__('The information in this tab has been changed.')) ?>"></span><span class="error" title="<?php echo Mage::helper('core')->quoteEscape($this->__('This tab contains invalid data. Please solve the problem before saving.')) ?>"></span><?php echo $this->getTabLabel($_tab) ?></span>
         </a>
-        <div id="<?php echo $this->getTabId($_tab) ?>_content" style="display:none"><?php echo $this->getTabContent($_tab) ?></div>
+        <div id="<?php echo $this->getTabId($_tab) ?>_content" style="display:none;"><?php echo $this->getTabContent($_tab) ?></div>
     </li>
 <?php endforeach ?>
 </ul>
 <script type="text/javascript">
-
-    <?php echo $this->getId() ?>JsTabs = new varienTabs('<?php echo $this->getId() ?>', '<?php echo $this->getDestElementId() ?>', '<?php echo $this->getActiveTabId() ?>', <?php echo $this->getAllShadowTabs()?>);
+    <?php echo $this->getJsObjectName() ?> = new varienTabs('<?php echo $this->getId() ?>', '<?php echo $this->getDestElementId() ?>', '<?php echo $this->getActiveTabId() ?>', <?php echo $this->getAllShadowTabs() ?>);
 </script>
 <?php endif ?>


### PR DESCRIPTION
### Description

This fix: `Deprecated functionality: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated  in app/design/adminhtml/default/default/template/widget/tabs.phtml on line 35`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list