### PR TITLE
Replace strftime with date

### DIFF
--- a/app/code/core/Mage/CatalogIndex/Model/Indexer.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer.php
@@ -717,7 +717,7 @@ class Mage_CatalogIndex_Model_Indexer extends Mage_Core_Model_Abstract
                                 if (isset($values[$code]['from']) && isset($values[$code]['to'])) {
                                     if ($values[$code]['from']) {
                                         if (!is_numeric($values[$code]['from'])) {
-                                            $_date = date("Y-m-d H:i:s", strtotime($values[$code]['from']));
+                                            $_date = date(Varien_Db_Adapter_Pdo_Mysql::TIMESTAMP_FORMAT, strtotime($values[$code]['from']));
                                             $values[$code]['from'] = $_date;
                                         }
 
@@ -726,7 +726,7 @@ class Mage_CatalogIndex_Model_Indexer extends Mage_Core_Model_Abstract
 
                                     if ($values[$code]['to']) {
                                         if (!is_numeric($values[$code]['to'])) {
-                                            $values[$code]['to'] = date("Y-m-d H:i:s", strtotime($values[$code]['to']));
+                                            $values[$code]['to'] = date(Varien_Db_Adapter_Pdo_Mysql::TIMESTAMP_FORMAT, strtotime($values[$code]['to']));
                                         }
                                         $filter[$code]->where("value <= ?", $values[$code]['to']);
                                     }

--- a/app/code/core/Mage/Cron/Model/Observer.php
+++ b/app/code/core/Mage/Cron/Model/Observer.php
@@ -183,7 +183,7 @@ class Mage_Cron_Model_Observer
                 ->setStatus(Mage_Cron_Model_Schedule::STATUS_PENDING);
 
             for ($time = $now; $time < $timeAhead; $time += 60) {
-                $ts = strftime('%Y-%m-%d %H:%M:00', $time);
+                $ts = date('Y-m-d H:i:00', $time);
                 if (!empty($exists[$jobCode . '/' . $ts])) {
                     // already scheduled
                     continue;
@@ -319,14 +319,14 @@ class Mage_Cron_Model_Observer
             }
 
             $schedule
-                ->setExecutedAt(strftime('%Y-%m-%d %H:%M:%S', time()))
+                ->setExecutedAt(date(Varien_Db_Adapter_Pdo_Mysql::TIMESTAMP_FORMAT))
                 ->save();
 
             call_user_func_array($callback, $arguments);
 
             $schedule
                 ->setStatus(Mage_Cron_Model_Schedule::STATUS_SUCCESS)
-                ->setFinishedAt(strftime('%Y-%m-%d %H:%M:%S', time()));
+                ->setFinishedAt(date(Varien_Db_Adapter_Pdo_Mysql::TIMESTAMP_FORMAT));
         } catch (Exception $e) {
             $schedule->setStatus($errorStatus)
                 ->setMessages($e->__toString());
@@ -347,7 +347,7 @@ class Mage_Cron_Model_Observer
         /** @var Mage_Cron_Model_Schedule $schedule */
         $schedule = Mage::getModel('cron/schedule')->load($jobCode, 'job_code');
         if ($schedule->getId() === null) {
-            $ts = strftime('%Y-%m-%d %H:%M:00', time());
+            $ts = date('Y-m-d H:i:00');
             $schedule->setJobCode($jobCode)
                 ->setCreatedAt($ts)
                 ->setScheduledAt($ts);

--- a/app/code/core/Mage/Cron/Model/Schedule.php
+++ b/app/code/core/Mage/Cron/Model/Schedule.php
@@ -107,8 +107,8 @@ class Mage_Cron_Model_Schedule extends Mage_Core_Model_Abstract
             && $this->matchCronExpression($e[4], $d['wday']);
 
         if ($match) {
-            $this->setCreatedAt(strftime('%Y-%m-%d %H:%M:%S', time()));
-            $this->setScheduledAt(strftime('%Y-%m-%d %H:%M', (int)$time));
+            $this->setCreatedAt(date(Varien_Db_Adapter_Pdo_Mysql::TIMESTAMP_FORMAT));
+            $this->setScheduledAt(date('Y-m-d H:i:00', (int)$time));
         }
         return $match;
     }

--- a/app/code/core/Mage/Log/Model/Aggregation.php
+++ b/app/code/core/Mage/Log/Model/Aggregation.php
@@ -167,7 +167,7 @@ class Mage_Log_Model_Aggregation extends Mage_Core_Model_Abstract
     {
         $out = $in;
         if (is_numeric($in)) {
-            $out = date("Y-m-d H:i:s", $in);
+            $out = date(Varien_Date::DATETIME_PHP_FORMAT, $in);
         }
         return $out;
     }

--- a/lib/Varien/Db/Adapter/Mysqli.php
+++ b/lib/Varien/Db/Adapter/Mysqli.php
@@ -115,7 +115,7 @@ class Varien_Db_Adapter_Mysqli extends Zend_Db_Adapter_Mysqli
         if ($date instanceof Zend_Date) {
             return $date->toString(self::ISO_DATE_FORMAT);
         }
-        return strftime('%Y-%m-%d', strtotime($date));
+        return date(Varien_Db_Adapter_Pdo_Mysql::DATE_FORMAT, strtotime($date));
     }
 
     public function convertDateTime($datetime)
@@ -123,7 +123,7 @@ class Varien_Db_Adapter_Mysqli extends Zend_Db_Adapter_Mysqli
         if ($datetime instanceof Zend_Date) {
             return $datetime->toString(self::ISO_DATETIME_FORMAT);
         }
-        return strftime('%Y-%m-%d %H:%M:%S', strtotime($datetime));
+        return date(Varien_Db_Adapter_Pdo_Mysql::TIMESTAMP_FORMAT, strtotime($datetime));
     }
 
     // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps


### PR DESCRIPTION
### Description

This PR replace `strftime` because it is [deprecated since PHP 8.1](https://php.watch/versions/8.1/strftime-gmstrftime-deprecated). Ref #1812.

Hope it's good 🤞🏽.
Partially tested with PHP 7.2, 7.3, 7.4, 8.0, 8.1, 8.2 with OpenMage 20.0.18.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list