### PR TITLE
PHP8.0 Fixes passing null as 1st parameter to mktime()

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Report/Config/Form/Field/YtdStart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Config/Form/Field/YtdStart.php
@@ -33,7 +33,7 @@ class Mage_Adminhtml_Block_Report_Config_Form_Field_YtdStart extends Mage_Adminh
         $_months = [];
         for ($i = 1; $i <= 12; $i++) {
             $_months[$i] = Mage::app()->getLocale()
-                ->date(mktime(null, null, null, $i))
+                ->date(mktime(0, null, null, $i))
                 ->get(Zend_Date::MONTH_NAME);
         }
 


### PR DESCRIPTION
### Fixed Issues (if relevant)

`Deprecated functionality: mktime(): Passing null to parameter #1 ($hour) of type int is deprecated`

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. go to Admin config -> General -> Reports
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->