### PR TITLE
PHP8.1 Fixes passing null to trim() - for non-existing payment methods

### DIFF
--- a/app/code/core/Mage/Payment/Helper/Data.php
+++ b/app/code/core/Mage/Payment/Helper/Data.php
@@ -44,7 +44,7 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
         $key = self::XML_PATH_PAYMENT_METHODS . '/' . $code . '/model';
         $class = Mage::getStoreConfig($key);
         if (is_null($class)) {
-            Mage::logException(new Exception(sprintf('Unkown payment method with code "%s"',  $code)));
+            Mage::logException(new Exception(sprintf('Unkown payment method with code "%s"', $code)));
             return false;
         }
         return Mage::getModel($class);

--- a/app/code/core/Mage/Payment/Helper/Data.php
+++ b/app/code/core/Mage/Payment/Helper/Data.php
@@ -43,6 +43,10 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
     {
         $key = self::XML_PATH_PAYMENT_METHODS . '/' . $code . '/model';
         $class = Mage::getStoreConfig($key);
+        if (is_null($class)) {
+            Mage::logException(new Exception(sprintf('Unkown payment method with code "%s"',  $code)));
+            return false;
+        }
         return Mage::getModel($class);
     }
 


### PR DESCRIPTION
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
```
Deprecated functionality: trim(): Passing null to parameter #1 ($string) of type string is deprecated  in /var/www/html/app/code/core/Mage/Core/Model/Config.php on line 1422

#0 [internal function]: mageCoreErrorHandler(8192, 'trim(): Passing...', '/var/www/html/a...', 1422)
#1 /var/www/html/app/code/core/Mage/Core/Model/Config.php(1422): trim(NULL)
#2 /var/www/html/app/code/core/Mage/Core/Model/Config.php(1444): Mage_Core_Model_Config->getModelClassName(NULL)
#3 /var/www/html/app/Mage.php(532): Mage_Core_Model_Config->getModelInstance(NULL, Array)
#4 /var/www/html/app/code/core/Mage/Payment/Helper/Data.php(46): Mage::getModel(NULL)
#5 /var/www/html/app/code/core/Mage/Payment/Helper/Data.php(162): Mage_Payment_Helper_Data->getMethodInstance('pbridge')
```

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. use sample data
2. go to admin -> sales -> Recurring Profiles
3. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->