### PR TITLE
Added counter for input fields with maximum-length attribute

### DIFF
--- a/app/design/adminhtml/default/default/layout/admin.xml
+++ b/app/design/adminhtml/default/default/layout/admin.xml
@@ -21,6 +21,14 @@
 -->
 
 <layout>
+    <adminhtml_input_counter_handle>
+        <reference name="head">
+            <action method="addJs">
+                <script>mage/adminhtml/input-counter.js</script>
+            </action>
+        </reference>
+    </adminhtml_input_counter_handle>
+
     <!-- admin acl users edit page -->
     <adminhtml_permissions_user_edit>
         <reference name="left">
@@ -87,4 +95,16 @@
             <block type="adminhtml/cache_additional" name="cache.additional" template="system/cache/additional.phtml"></block>
         </reference>
     </adminhtml_cache_index>
+
+    <adminhtml_catalog_product_attribute_edit>
+        <update handle="adminhtml_input_counter_handle"/>
+    </adminhtml_catalog_product_attribute_edit>
+
+    <adminhtml_catalog_product_edit>
+        <update handle="adminhtml_input_counter_handle"/>
+    </adminhtml_catalog_product_edit>
+
+    <adminhtml_system_config_edit>
+        <update handle="adminhtml_input_counter_handle"/>
+    </adminhtml_system_config_edit>
 </layout>

--- a/js/mage/adminhtml/input-counter.js
+++ b/js/mage/adminhtml/input-counter.js
@@ -1,7 +1,7 @@
 // https://stackoverflow.com/a/44436408/5703627
 document.observe('dom:loaded', function() {
     Element.addMethods({
-        // setup once, memoize the counter element and maxLen
+        // setup once, memorize the counter element and maxLen
         prepare_for_countdown: function(element) {
             var elm = $(element);
             // even if you call it multiple times, it only works once

--- a/js/mage/adminhtml/input-counter.js
+++ b/js/mage/adminhtml/input-counter.js
@@ -21,10 +21,11 @@ document.observe('dom:loaded', function() {
             var maxLen = elm.retrieve('maxLen');
             var count  = maxLen - curLen;
             var counter = elm.retrieve('counter');
-            if (curLen >= maxLen) {
-                counter.update(' (' + count + ')').setStyle({'color': 'red'});
+            counter.update(' (' + curLen + '/' + maxLen + ')');
+            if (curLen > maxLen) {
+                counter.setStyle({'color': 'red'});
             } else {
-                counter.update(' (+' + count + ')').setStyle({'color': 'green'});
+                counter.setStyle({'color': 'inherit'});
             }
             return elm;
         }

--- a/js/mage/adminhtml/input-counter.js
+++ b/js/mage/adminhtml/input-counter.js
@@ -1,0 +1,40 @@
+// https://stackoverflow.com/a/44436408/5703627
+document.observe('dom:loaded', function() {
+    Element.addMethods({
+        // setup once, memoize the counter element and maxLen
+        prepare_for_countdown: function(element) {
+            var elm = $(element);
+            // even if you call it multiple times, it only works once
+            if(!elm.retrieve('counter')) {
+                var counter = new Element('span');
+                elm.next('.note').insert(counter);
+                elm.store('counter', counter);
+                var maxLen = elm.className.match(/maximum-length-(\d+)/)[1];
+                elm.store('maxLen', maxLen);
+            }
+            return elm; // so you can chain
+        },
+        // display the value, run once at load and on each observed keyup
+        countdown: function(element) {
+            var elm = $(element);
+            var curLen = elm.getValue().length;
+            var maxLen = elm.retrieve('maxLen');
+            var count  = maxLen - curLen;
+            var counter = elm.retrieve('counter');
+            if (curLen >= maxLen) {
+                counter.update(' (' + count + ')').setStyle({'color': 'red'});
+            } else {
+                counter.update(' (+' + count + ')').setStyle({'color': 'green'});
+            }
+            return elm;
+        }
+    });
+
+    // run setup and call countdown once outside of listener to initialize
+    $$('.validate-length').invoke('prepare_for_countdown').invoke('countdown');
+
+    // deferred listener, only responds to keyups that issue from a matching element
+    document.on('keyup', '.validate-length', function(evt, elm) {
+        elm.countdown();
+    });
+});


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Adds js-snippet to ...

- admin product edit page
- admin product attributes edit page
- admin config section

... to show how many chars are left for valid input.

__Note:__ requires `validate-length` and `maximum-length-XXX` attribute

![counter](https://user-images.githubusercontent.com/5022236/212648788-645cf899-4c90-48b9-9cec-006d9882e0fb.PNG)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->