### PR TITLE
Replace deprecated gmstrftime with gmdate

### DIFF
--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer.php
@@ -364,7 +364,6 @@ class Mage_ImportExport_Model_Import_Entity_Customer extends Mage_ImportExport_M
     {
         /** @var Mage_Customer_Model_Customer $resource */
         $resource       = Mage::getModel('customer/customer');
-        $strftimeFormat = Varien_Date::convertZendToStrftime(Varien_Date::DATETIME_INTERNAL_FORMAT, true, true);
         $table = $resource->getResource()->getEntityTable();
         /** @var Mage_ImportExport_Model_Resource_Helper_Mysql4 $helper */
         $helper         = Mage::getResourceHelper('importexport');
@@ -392,7 +391,7 @@ class Mage_ImportExport_Model_Import_Entity_Customer extends Mage_ImportExport_M
                         'store_id'   => empty($rowData[self::COL_STORE])
                                         ? 0 : $this->_storeCodeToId[$rowData[self::COL_STORE]],
                         'created_at' => empty($rowData['created_at'])
-                                        ? $now : gmstrftime($strftimeFormat, strtotime($rowData['created_at'])),
+                                        ? $now : gmdate(Varien_Date::DATETIME_PHP_FORMAT, strtotime($rowData['created_at'])),
                         'updated_at' => $now
                     ];
 
@@ -424,7 +423,7 @@ class Mage_ImportExport_Model_Import_Entity_Customer extends Mage_ImportExport_M
                             if ($attrParams['type'] === 'select') {
                                 $value = $attrParams['options'][strtolower($value)];
                             } elseif ($attrParams['type'] === 'datetime') {
-                                $value = gmstrftime($strftimeFormat, strtotime($value));
+                                $value = gmdate(Varien_Date::DATETIME_PHP_FORMAT, strtotime($value));
                             } elseif ($attrParams['type'] === 'multiselect') {
                                 $value = (array)$attrParams['options'][strtolower($value)];
                                 $attribute->getBackend()->beforeSave($resource->setData($attrCode, $value));

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer/Address.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer/Address.php
@@ -156,7 +156,6 @@ class Mage_ImportExport_Model_Import_Entity_Customer_Address extends Mage_Import
         $customer       = Mage::getModel('customer/customer');
         /** @var Mage_Customer_Model_Address $resource */
         $resource       = Mage::getModel('customer/address');
-        $strftimeFormat = Varien_Date::convertZendToStrftime(Varien_Date::DATETIME_INTERNAL_FORMAT, true, true);
         $table          = $resource->getResource()->getEntityTable();
         /** @var Mage_ImportExport_Model_Resource_Helper_Mysql4 $helper */
         $helper         = Mage::getResourceHelper('importexport');
@@ -201,7 +200,7 @@ class Mage_ImportExport_Model_Import_Entity_Customer_Address extends Mage_Import
                         if ($attrParams['type'] === 'select') {
                             $value = $attrParams['options'][strtolower($rowData[$attrAlias])];
                         } elseif ($attrParams['type'] === 'datetime') {
-                            $value = gmstrftime($strftimeFormat, strtotime($rowData[$attrAlias]));
+                            $value = gmdate(Varien_Date::DATETIME_PHP_FORMAT, strtotime($rowData[$attrAlias]));
                         } elseif ($attrParams['type'] === 'multiselect') {
                             $value = $attrParams['options'][strtolower($rowData[$attrAlias])];
                             $multiSelect[$attrParams['id']][] = $value;

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
@@ -1516,6 +1516,7 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
     /**
      * Retrieve pattern for time formatting
      *
+     * @deprecated
      * @return string
      */
     protected function _getStrftimeFormat()
@@ -1569,7 +1570,7 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
             $storeIds = [0];
 
             if ($attribute->getBackendType() === 'datetime' && strtotime($attrValue)) {
-                $attrValue = gmstrftime($this->_getStrftimeFormat(), strtotime($attrValue));
+                $attrValue = gmdate(Varien_Date::DATETIME_PHP_FORMAT, strtotime($attrValue));
             } elseif ($attribute->getAttributeCode() === 'url_key') {
                 if (empty($attrValue)) {
                     $attrValue = $product->formatUrlKey($product->getName());


### PR DESCRIPTION

### Description (*)

Replaces [`gmstrftime`](https://www.php.net/manual/en/function.gmstrftime.php) which is deprecated starting from PHP 8.1 with [`gmdate`](https://www.php.net/manual/en/function.gmdate.php).

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#2030

### Manual testing scenarios (*)

```php
<?php

date_default_timezone_set('Europe/Amsterdam'); // GMT+1

echo date('Y-m-d H:i:s', mktime(0, 0, 0, 1, 1, 1998)) . PHP_EOL;
// > 1998-01-01 00:00:00 (from Europe/Amsterdam timezone)
echo gmdate('Y-m-d H:i:s', mktime(0, 0, 0, 1, 1, 1998)) . PHP_EOL;
// > 1997-12-31 23:00:00 (from UTC timezone)
echo gmstrftime("%Y-%m-%d %H:%M:%S", mktime(0, 0, 0, 1, 1, 1998)) . PHP_EOL;
// > 1997-12-31 23:00:00 (from UTC timezone)
```


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->