### PR TITLE
Disable cash on delivery for virtual orders

### DIFF
--- a/app/code/core/Mage/Payment/Model/Method/Cashondelivery.php
+++ b/app/code/core/Mage/Payment/Model/Method/Cashondelivery.php
@@ -56,9 +56,7 @@ class Mage_Payment_Model_Method_Cashondelivery extends Mage_Payment_Model_Method
     /**
      * Not available for quote without delivery
      *
-     * @param Mage_Sales_Model_Quote $quote
-     * @param int|null $checksBitMask
-     * @return bool
+     * {@inheritDoc}
      */
     public function isApplicableToQuote($quote, $checksBitMask)
     {

--- a/app/code/core/Mage/Payment/Model/Method/Cashondelivery.php
+++ b/app/code/core/Mage/Payment/Model/Method/Cashondelivery.php
@@ -52,4 +52,19 @@ class Mage_Payment_Model_Method_Cashondelivery extends Mage_Payment_Model_Method
     {
         return trim($this->getConfigData('instructions'));
     }
+
+    /**
+     * Not available for quote without delivery
+     *
+     * @param Mage_Sales_Model_Quote $quote
+     * @param int|null $checksBitMask
+     * @return bool
+     */
+    public function isApplicableToQuote($quote, $checksBitMask)
+    {
+        if ($quote->getIsVirtual()) {
+            return false;
+        }
+        return parent::isApplicableToQuote($quote, $checksBitMask);
+    }
 }


### PR DESCRIPTION
### Description

How customers can pay their orders when there are no delivery?

### Manual testing scenario

- Enable `Cash on delivery` in System > Configuration > Payment methods.
- Create a virtual product
- Try to create an order with the previous virtual product (from backend or from frontend)
- Check payment method list

![image](https://user-images.githubusercontent.com/31816829/212534692-13fdae34-377a-49ed-abfb-1e3d91ca364c.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list