### PR TITLE
Reduce getId calls

### DIFF
--- a/lib/Varien/Data/Tree/Node/Collection.php
+++ b/lib/Varien/Data/Tree/Node/Collection.php
@@ -129,8 +129,9 @@ class Varien_Data_Tree_Node_Collection implements ArrayAccess, IteratorAggregate
      */
     public function delete($node)
     {
-        if (isset($this->_nodes[$node->getId()])) {
-            unset($this->_nodes[$node->getId()]);
+        $id = $node->getId();
+        if (isset($this->_nodes[$id])) {
+            unset($this->_nodes[$id]);
         }
         return $this;
     }


### PR DESCRIPTION
### Description

This reduce number of `getId()` calls (found with Blackfire).
Same as #2677 and #2699.

![getid-before](https://user-images.githubusercontent.com/31816829/212860005-3103e467-bda8-420b-8919-664933f9f6b0.png)

Yes this will not change many things, but this + many others...

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list