### PR TITLE
Add index on salesrule_coupon

### DIFF
--- a/app/code/core/Mage/SalesRule/etc/config.xml
+++ b/app/code/core/Mage/SalesRule/etc/config.xml
@@ -23,7 +23,7 @@
 <config>
     <modules>
         <Mage_SalesRule>
-            <version>1.6.0.3</version>
+            <version>1.6.0.4</version>
         </Mage_SalesRule>
     </modules>
     <global>

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * OpenMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * @category   Mage
+ * @package    Mage_SalesRule
+ * @copyright  Copyright (c) 2023 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Sales_Model_Resource_Setup $installer */
+$installer = $this;
+$installer->startSetup();
+
+// Add index to salesrule_coupon for fast lookup, only first 10 bytes
+$keyList = $installer->getConnection()->getIndexList($installer->getTable('salesrule/coupon'));
+if (!isset($keyList['IDX_SALES_COUPON_CODE'])) {
+    $installer->run('
+        ALTER TABLE '.$installer->getTable('salesrule/coupon').'
+        ADD INDEX `IDX_SALES_COUPON_CODE` (`code` (10));
+    ');
+}
+
+$installer->endSetup();


### PR DESCRIPTION
### Description

We have 220,000 coupons in `salesrule_coupon`.
This PR add an index on `code` column, like #2447.

Here is a before/after with Blackfire:

![coupons-before-after](https://user-images.githubusercontent.com/31816829/212872692-ea50e2a2-3b8e-4619-83bd-296182751b02.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list