### PR TITLE
Wrap WHERE condition in parens

### DIFF
--- a/app/code/core/Mage/Rule/Model/Condition/Combine.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Combine.php
@@ -52,7 +52,7 @@ class Mage_Rule_Model_Condition_Combine extends Mage_Rule_Model_Condition_Abstra
         $wheres = [];
         foreach ($this->getConditions() as $condition) {
             /** @var Mage_Rule_Model_Condition_Abstract $condition */
-            $wheres[] = $condition->prepareConditionSql();
+            $wheres[] = '(' . $condition->prepareConditionSql() . ')';
         }
 
         if (empty($wheres)) {


### PR DESCRIPTION
When utilizing `getProductFlatSelect()`, we ran into a bug in `Mage_Rule_Model_Condition_Combine::prepareConditionSql()` in which the WHERE clause construction did not properly parenthesize the conditions. As an example:

Pre-fix:
```sql
FIND_IN_SET('123',`cpf`.`quantity`) OR FIND_IN_SET('1801',`cpf`.`quantity`) AND FIND_IN_SET('7',`ccp`.`category_id`)
```

Post-fix:
```sql
(FIND_IN_SET('123',`cpf`.`quantity`) OR FIND_IN_SET('1801',`cpf`.`quantity`)) AND (FIND_IN_SET('7',`ccp`.`category_id`))
```

This PR ensures each where clause addition is properly contained and evaluated.