### PR TITLE
Ensure store-scoped values selected before default

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
@@ -116,7 +116,8 @@ abstract class Mage_Catalog_Model_Resource_Abstract extends Mage_Eav_Model_Entit
         $select = $this->_getReadAdapter()->select()
             ->from(['attr_table' => $table], [])
             ->where("attr_table.{$this->getEntityIdField()} = ?", $object->getId())
-            ->where('attr_table.store_id IN (?)', $storeIds);
+            ->where('attr_table.store_id IN (?)', $storeIds)
+            ->order('attr_table.store_id ASC');
         if ($setId) {
             $select->join(
                 ['set_table' => $this->getTable('eav/entity_attribute')],

--- a/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
@@ -116,8 +116,10 @@ abstract class Mage_Catalog_Model_Resource_Abstract extends Mage_Eav_Model_Entit
         $select = $this->_getReadAdapter()->select()
             ->from(['attr_table' => $table], [])
             ->where("attr_table.{$this->getEntityIdField()} = ?", $object->getId())
-            ->where('attr_table.store_id IN (?)', $storeIds)
-            ->order('attr_table.store_id ASC');
+            ->where('attr_table.store_id IN (?)', $storeIds);
+        if (count($storeIds) > 1) {
+            $select->order('attr_table.store_id ASC');
+        }
         if ($setId) {
             $select->join(
                 ['set_table' => $this->getTable('eav/entity_attribute')],


### PR DESCRIPTION
We've encountered a bug in which a user created a category under a store scope with some values filled in (description, title, etc.). They then switched to the default scope, modifying other separate fields, and then switched back to the store scope to find the data they had inputted is gone. This occurred because the `_getLoadAttributesSelect()` query fetched the default values _first_ upon going back to the store-scoped category page.

To reproduce:

1. The category is created on a store scope with some values added/selected. 
2. Switch to default store scope view, adding value to category shop by attribute, saving the category.
3. Switch back to the store scope and some values are gone (description, page title, etc etc.).

This PR ensures store_id is sorted `ASC` to ensure the store-scoped values are also fetched properly.