### PR TITLE
Fix for mcrypt_compat 2.0.4

### DIFF
--- a/lib/Varien/Crypt/Mcrypt.php
+++ b/lib/Varien/Crypt/Mcrypt.php
@@ -126,7 +126,8 @@ class Varien_Crypt_Mcrypt extends Varien_Crypt_Abstract
 
     protected function _reset()
     {
-        mcrypt_generic_deinit($this->getHandler());
-        mcrypt_module_close($this->getHandler());
+        $handler = $this->getHandler();
+        mcrypt_generic_deinit($handler);
+        mcrypt_module_close($handler);
     }
 }


### PR DESCRIPTION
### Description

This fix the following notice with PHP 8.0.27 and [mcrypt_compat 2.0.4](https://github.com/phpseclib/mcrypt_compat).
I'm not sure if it's good or not.

```
Notice: Only variables should be passed by reference  in lib/Varien/Crypt/Mcrypt.php on line 129

#0 lib/Varien/Crypt/Mcrypt.php(129): mageCoreErrorHandler()
#1 lib/Varien/Crypt/Mcrypt.php(48): Varien_Crypt_Mcrypt->_reset()
#2 [internal function]: Varien_Crypt_Mcrypt->destruct()
#3 {main}
  thrown in lib/Varien/Crypt/Mcrypt.php on line 129
  catched by Mage::printException() via mageCoreErrorHandler()
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list