### PR TITLE
Add template only if necessary (ups with Mage_Usa)

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/System/ConfigController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/ConfigController.php
@@ -113,9 +113,12 @@ class Mage_Adminhtml_System_ConfigController extends Mage_Adminhtml_Controller_A
             $block = $this->getLayout()->createBlock('adminhtml/system_config_edit');
             $this->_addContent($block->initForm());
 
-            $this->_addJs($this->getLayout()
-                ->createBlock('adminhtml/template')
-                ->setTemplate('system/shipping/ups.phtml'));
+            if (($current == 'carriers') && Mage::helper('core')->isModuleEnabled('Mage_Usa')) {
+                $this->_addJs($this->getLayout()
+                     ->createBlock('adminhtml/template')
+                     ->setTemplate('system/shipping/ups.phtml'));
+            }
+
             $this->_addJs($this->getLayout()
                 ->createBlock('adminhtml/template')
                 ->setTemplate('system/config/js.phtml'));


### PR DESCRIPTION
### Description

With Blackfire, I discovered that `ups.phtml` template was loaded for all configuration pages, even if `Mage_Usa` is disabled.

Perhaps a better way is to add a new handle, and add the template with:
```xml
<adminhtml_system_config_edit_section_carriers>
    <reference name...>
</adminhtml_system_config_edit_section_carriers>
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list