### PR TITLE
Update README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ __Please be aware that although OpenMage is compatible that one or more extensio
 
 ### Manual Install
 
-Download the latest [release archive](https://github.com/OpenMage/magento-lts/releases) and extract it over your existing install.
+Download the latest [release archive](https://github.com/OpenMage/magento-lts/releases) and extract it over your existing install. **Important:** you must download the ZIP file from a tagged version on the releases page, otherwise there will be missing dependencies.
 
 ### Composer
 
@@ -106,7 +106,7 @@ composer require "openmage/magento-lts":"^20.0.0"
 
 <small>Note: be sure to select `y` if composer asks you to trust `magento-hackathon/magento-composer-installer` or `cweagans/composer-patches`.</small>
 
-To get the latest changes use:
+To install the latest development version (may be unstable):
 
 ```bash
 # OpenMage v19

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ composer require "aydin-hassan/magento-core-composer-installer":">=1.0.0 <2.1.0"
 composer require "aydin-hassan/magento-core-composer-installer":"*"
 ```
 
-<small>Note: be sure to select `y` if composer asks you to trust `aydin-hassan/magento-core-composer-installer` or `cweagans/composer-patches`.</small>
+<small>Note: be sure to select `y` if composer asks you to trust `aydin-hassan/magento-core-composer-installer`.</small>
 
 Step 4: Require `magento-lts`:
 
@@ -104,7 +104,7 @@ composer require "openmage/magento-lts":"^19.4.0"
 composer require "openmage/magento-lts":"^20.0.0"
 ```
 
-<small>Note: be sure to select `y` if composer asks you to trust `magento-hackathon/magento-composer-installer`.</small>
+<small>Note: be sure to select `y` if composer asks you to trust `magento-hackathon/magento-composer-installer` or `cweagans/composer-patches`.</small>
 
 To get the latest changes use:
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ level of backwards compatibility to the official releases.
 - [Requirements](#requirements)
   - [Optional](#optional)
 - [Installation](#installation)
+  - [Manual Install](#manual-install)
   - [Composer](#composer)
   - [Git](#git)
 - [Secure your installation](#secure-your-installation)
@@ -61,21 +62,59 @@ __Please be aware that although OpenMage is compatible that one or more extensio
 
 ## Installation
 
+### Manual Install
+
+Download the latest [release archive](https://github.com/OpenMage/magento-lts/releases) and extract it over your existing install.
+
 ### Composer
 
-Download the latest archive and extract it, clone the repo, or add a composer dependency to your existing project like so:
+Step 1: Create a new composer project:
 
 ```bash
-composer require "openmage/magento-lts":"^19.5.0"
+composer init
 ```
+
+Step 2: Configure required install options. You can see all options [here](https://github.com/AydinHassan/magento-core-composer-installer#configuration).
+
+```bash
+composer config --json extra.enable-patching true
+composer config extra.magento-core-package-type magento-source
+composer config extra.magento-root-dir htdocs
+```
+
+Step 3: Require `magento-core-composer-installer`:
+
+``` bash
+# PHP 7
+composer require "aydin-hassan/magento-core-composer-installer":">=1.0.0 <2.1.0"
+
+# PHP 8
+composer require "aydin-hassan/magento-core-composer-installer":"*"
+```
+
+<small>Note: be sure to select `y` if composer asks you to trust `aydin-hassan/magento-core-composer-installer` or `cweagans/composer-patches`.</small>
+
+Step 4: Require `magento-lts`:
+
+```bash
+# OpenMage v19
+composer require "openmage/magento-lts":"^19.4.0"
+
+# OpenMage v20
+composer require "openmage/magento-lts":"^20.0.0"
+```
+
+<small>Note: be sure to select `y` if composer asks you to trust `magento-hackathon/magento-composer-installer`.</small>
 
 To get the latest changes use:
 
 ```bash
-composer require "openmage/magento-lts":"dev-main"
-```
+# OpenMage v19
+composer require "openmage/magento-lts":"1.9.4.x-dev"
 
-<small>Note: `dev-main` is just an alias for current `1.9.4.x` branch and may change</small>
+# OpenMage v20
+composer require "openmage/magento-lts":"20.0.x-dev"
+```
 
 ### Git
 

--- a/README.md
+++ b/README.md
@@ -74,12 +74,17 @@ Step 1: Create a new composer project:
 composer init
 ```
 
-Step 2: Configure required install options. You can see all options [here](https://github.com/AydinHassan/magento-core-composer-installer#configuration).
+Step 2: Configure composer. **The below options are required.** You can see all options [here](https://github.com/AydinHassan/magento-core-composer-installer#configuration).
 
 ```bash
+# Allow composer to apply patches to dependencies of magento-lts
 composer config --json extra.enable-patching true
+
+# Configure Magento core composer installer to use magento-lts as the Magento source package
 composer config extra.magento-core-package-type magento-source
-composer config extra.magento-root-dir htdocs
+
+# Configure the root directory that magento-lts will be installed to, such as "pub", "htdocs", or "www"
+composer config extra.magento-root-dir pub
 ```
 
 Step 3: Require `magento-core-composer-installer`:

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ Step 3: Require `magento-core-composer-installer`:
 
 ``` bash
 # PHP 7
-composer require "aydin-hassan/magento-core-composer-installer":">=1.0.0 <2.1.0"
+composer require "aydin-hassan/magento-core-composer-installer":"~2.0.0"
 
 # PHP 8
-composer require "aydin-hassan/magento-core-composer-installer":"*"
+composer require "aydin-hassan/magento-core-composer-installer":"^2.1.0"
 ```
 
 <small>Note: be sure to select `y` if composer asks you to trust `aydin-hassan/magento-core-composer-installer`.</small>


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
IMO, the install instructions are both unclear and inaccurate. I expanded on the section to explain exactly how to install via composer. I also added in notes about allowing patches which is critical to avoid security vulns.

View formatted README here: https://github.com/justinbeaty/magento-lts/tree/topic-readme-install#installation

### Related Pull Requests
https://github.com/OpenMage/OpenMage.github.io/pull/118


### Manual testing scenarios (*)
* Try to install via composer the old way, it doesn't work
* Try to install via composer the new way, it should work.

### Questions or comments
1. I changed `"openmage/magento-lts":"^19.5.0"` to `"openmage/magento-lts":"^19.4.0"` because 19.5.x doesn't exist. Plus, `^19.4.0` allows `19.5.x` when it will exist.
2. Packagist is outdated. It tries to install `19.4.18`.
3. Is it just me, or does the branch alias not work? `composer require "openmage/magento-lts":"dev-main"` doesn't work for me. I believe there's special consideration when a branch has a numerical name. ([Ref](https://github.com/composer/composer/pull/3480))


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->