### PR TITLE
Simplify PHP version error message in index.php, install.php, api.php…

### DIFF
--- a/api.php
+++ b/api.php
@@ -19,8 +19,9 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-if (version_compare(phpversion(), '7.3.0', '<') === true) {
-    echo 'It looks like you have an invalid PHP version. OpenMage supports PHP 7.3.0 or newer';
+$minVersion = '7.3.0';
+if (version_compare(phpversion(), $minVersion, '<') === true) {
+    echo "It looks like you have an invalid PHP version. OpenMage supports PHP $minVersion or newer";
     exit;
 }
 

--- a/get.php
+++ b/get.php
@@ -18,15 +18,14 @@
  * @copyright  Copyright (c) 2016-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-if (version_compare(phpversion(), '7.3.0', '<') === true) {
-    echo  '<div style="font:12px/1.35em arial, helvetica, sans-serif;"><div style="margin:0 0 25px 0; '
-        . 'border-bottom:1px solid #ccc;"><h3 style="margin:0; font-size:1.7em; font-weight:normal; '
-        . 'text-transform:none; text-align:left; color:#2f2f2f;">Whoops, it looks like you have an invalid PHP version.'
 
-        . '</h3></div><p>OpenMage supports PHP 7.3.0 or newer. <a href="https://www.openmage.org/magento-lts/install.html" '
-        . 'target="">Find out</a> how to install</a> OpenMage using PHP-CGI as a work-around.</p></div>';
+$minVersion = '7.3.0';
+if (version_compare(phpversion(), $minVersion, '<') === true) {
+    echo "<h3>Whoops, it looks like you have an invalid PHP version.</h3>";
+    echo "<p>OpenMage supports PHP $minVersion or newer. <a href=\"https://www.openmage.org/magento-lts/install.html\">Find out how to install</a> OpenMage using PHP-CGI as a work-around.</p>";
     exit;
 }
+
 $start = microtime(true);
 /**
  * Error reporting

--- a/index.php
+++ b/index.php
@@ -19,13 +19,10 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-if (version_compare(phpversion(), '7.3.0', '<') === true) {
-    echo  '<div style="font:12px/1.35em arial, helvetica, sans-serif;">
-<div style="margin:0 0 25px 0; border-bottom:1px solid #ccc;">
-<h3 style="margin:0; font-size:1.7em; font-weight:normal; text-transform:none; text-align:left; color:#2f2f2f;">
-Whoops, it looks like you have an invalid PHP version.</h3></div><p>OpenMage supports PHP 7.3.0 or newer.
-<a href="https://www.openmage.org/magento-lts/install.html" target="">Find out</a> how to install</a>
- OpenMage using PHP-CGI as a work-around.</p></div>';
+$minVersion = '7.3.0';
+if (version_compare(phpversion(), $minVersion, '<') === true) {
+    echo "<h3>Whoops, it looks like you have an invalid PHP version.</h3>";
+    echo "<p>OpenMage supports PHP $minVersion or newer. <a href=\"https://www.openmage.org/magento-lts/install.html\">Find out how to install</a> OpenMage using PHP-CGI as a work-around.</p>";
     exit;
 }
 

--- a/install.php
+++ b/install.php
@@ -113,9 +113,13 @@
  *
  */
 
-if (version_compare(phpversion(), '7.3.0', '<') === true) {
-    die('ERROR: Whoops, it looks like you have an invalid PHP version. OpenMage supports PHP 7.3.0 or newer.');
+$minVersion = '7.3.0';
+if (version_compare(phpversion(), $minVersion, '<') === true) {
+    echo "<h3>Whoops, it looks like you have an invalid PHP version.</h3>";
+    echo "<p>OpenMage supports PHP $minVersion or newer. <a href=\"https://www.openmage.org/magento-lts/install.html\">Find out how to install</a> OpenMage using PHP-CGI as a work-around.</p>";
+    exit;
 }
+
 set_include_path(__DIR__ . PATH_SEPARATOR . get_include_path());
 require 'app/bootstrap.php';
 require 'app/Mage.php';


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The hardcoded HTML in some root files has always bothered me. First, it contains broken html: (two closing `</a>`)

```
<a href="https://www.openmage.org/magento-lts/install.html" target="">Find out</a> how to install</a>
```

But also, we really don't need those inline styles. It looks fine considering nobody should see it.

![image](https://user-images.githubusercontent.com/51970393/213583336-16a5f4ea-b516-43f9-ac4d-099da6cba23d.png)


I also created the `$minVersion` variable so we don't have to change it twice in each file.

### Manual testing scenarios (*)
1. Change `$minVersion` to `9.0.0` or similar to see the error message.

### Questions or comments
Can we move `$minVersion` to some file that gets included so we don't have to duplicate it?

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->