### PR TITLE
Install composer dependencies in gitpod

### DIFF
--- a/dev/gitpod/docker-compose.yml
+++ b/dev/gitpod/docker-compose.yml
@@ -45,6 +45,11 @@ services:
       - mysql
       - "apache:${HOST_NAME:-openmage-7f000001.nip.io}"
 
+  composer:
+    image: composer:2.4
+    volumes:
+      - ../..:/app
+
   mysql:
     image: mysql:5.7
     ports:

--- a/dev/gitpod/install.sh
+++ b/dev/gitpod/install.sh
@@ -12,7 +12,7 @@ sleep 4
 echo "Starting services..."
 for i in $(seq 1 20); do
   sleep 1
-  docker exec openmage_mysql_1 mysql -e 'show databases;' 2>/dev/null | grep -qF 'openmage' && break
+  docker exec gitpod-mysql-1 mysql -e 'show databases;' 2>/dev/null | grep -qF 'openmage' && break
 done
 
 HOST_PORT_PART=":${HOST_PORT:-80}"
@@ -21,6 +21,9 @@ BASE_URL=${BASE_URL:-"http://${HOST_NAME:-openmage-7f000001.nip.io}${HOST_PORT_P
 ADMIN_EMAIL="${ADMIN_EMAIL:-admin@example.com}"
 ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
 ADMIN_PASSWORD="${ADMIN_PASSWORD:-veryl0ngpassw0rd}"
+
+echo "Installing Composer dependencies..."
+docker-compose run --rm composer composer install --no-progress --ignore-platform-req=ext-*
 
 echo "Installing OpenMage LTS..."
 docker-compose run --rm cli php install.php \
@@ -46,5 +49,5 @@ docker-compose run --rm cli php install.php \
 
 echo ""
 echo "Setup is complete!"
-echo "Visit ${BASE_URL}admin and login with '$ADMIN_USERNAME' : '$ADMIN_PASSWORD'"
-echo "MySQL server IP: $(docker exec openmage_apache_1 getent hosts mysql | awk '{print $1}')"
+echo "Visit ${BASE_URL}/admin and login with '$ADMIN_USERNAME' : '$ADMIN_PASSWORD'"
+echo "MySQL server IP: $(docker exec gitpod-apache-1 getent hosts mysql | awk '{print $1}')"

--- a/dev/openmage/docker-compose.yml
+++ b/dev/openmage/docker-compose.yml
@@ -43,6 +43,11 @@ services:
       - mysql
       - "apache:${HOST_NAME:-openmage-7f000001.nip.io}"
 
+  composer:
+    image: composer:2.4
+    volumes:
+      - ../..:/app
+
   mysql:
     image: mysql:5.7
     ports:

--- a/dev/openmage/install.sh
+++ b/dev/openmage/install.sh
@@ -47,6 +47,9 @@ for i in $(seq 1 20); do
   $dc exec mysql mysql -e 'show databases;' 2>/dev/null | grep -qF 'openmage' && break
 done
 
+echo "Installing Composer dependencies..."
+$dc run --rm composer composer install --no-progress --ignore-platform-req=ext-*
+
 echo "Installing OpenMage LTS..."
 $dc run --rm cli php install.php \
   --license_agreement_accepted yes \


### PR DESCRIPTION

### Description (*)

This PR adds a new container to the local and gitpod docker-compose files to be able to install composer dependencies in the `install.sh` script. I also fixed a couple of container names in gitpod script, since gitpod uses different names prefixed with `gitpod-`.

Local docker installation not tested.

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#2961

### Manual testing scenarios (*)
1. Creating a new workspace in gitpod should install composer dependencies before trying to install openmage.
2. Composer dependencies should also get installed when running with locally with docker using `dev/openmage/install.sh`.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->