### PR TITLE
Added a forced refresh if the user modifies the minicart while being on the cart page

### DIFF
--- a/skin/frontend/rwd/default/js/minicart.js
+++ b/skin/frontend/rwd/default/js/minicart.js
@@ -91,6 +91,7 @@ Minicart.prototype = {
             }).done(function(result) {
                 cart.hideOverlay();
                 if (result.success) {
+                    cart.refreshIfOnCartPage();
                     cart.updateCartQty(result.qty);
                     cart.updateContentOnRemove(result, el.closest('li'));
                 } else {
@@ -155,6 +156,7 @@ Minicart.prototype = {
         }).done(function(result) {
             cart.hideOverlay();
             if (result.success) {
+                cart.refreshIfOnCartPage();
                 cart.updateCartQty(result.qty);
                 if (quantity !== 0) {
                     cart.updateContentOnUpdate(result);
@@ -176,7 +178,6 @@ Minicart.prototype = {
         el.hide('slow', function() {
             $j(cart.selectors.container).html(result.content);
             cart.showMessage(result);
-
         });
     },
 
@@ -224,5 +225,11 @@ Minicart.prototype = {
 
     showSuccess: function(message) {
         $j(this.selectors.success).text(message).fadeIn('slow');
+    },
+
+    refreshIfOnCartPage: function() {
+        if (document.body.classList.contains("checkout-cart-index")){
+            window.location.reload(true);
+        }
     }
 };


### PR DESCRIPTION
The problem is described in issue #2204.

I've checked the body class for the presence of "checkout-cart-index", it should be quite ok.

I've used `document.body.classList.contains("checkout-cart-index")` functionality that is compatible with more modern browsers (ie10), is it ok with everybody? otherwise we've to use regex like `document.body.className.match(/(\s|^)checkout-cart-index(\s|$)/)`

This PR fixes the problem when removing the product but also when changing its quantity.