### PR TITLE
Clear hasDataChanges flag after loading collection items

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Status/History.php
+++ b/app/code/core/Mage/Sales/Model/Order/Status/History.php
@@ -38,7 +38,6 @@
  * @method $this setParentId(int $value)
  * @method string getStatus()
  * @method $this setStatus(string $value)
- * @method $this setStoreId(int $value)
  * @method int getIsVisibleOnFront()
  * @method $this setIsVisibleOnFront(int $value)
  */
@@ -69,7 +68,7 @@ class Mage_Sales_Model_Order_Status_History extends Mage_Sales_Model_Abstract
     }
 
     /**
-     * Set order object and grab some metadata from it
+     * Set order object
      *
      * @param   Mage_Sales_Model_Order $order
      * @return  $this
@@ -77,8 +76,17 @@ class Mage_Sales_Model_Order_Status_History extends Mage_Sales_Model_Abstract
     public function setOrder(Mage_Sales_Model_Order $order)
     {
         $this->_order = $order;
-        $this->setStoreId($order->getStoreId());
         return $this;
+    }
+
+    /**
+     * Get store id
+     *
+     * @throws Mage_Core_Model_Store_Exception
+     */
+    public function getStoreId(): int
+    {
+        return $this->getStore()->getStoreId();
     }
 
     /**

--- a/lib/Varien/Data/Collection/Db.php
+++ b/lib/Varien/Data/Collection/Db.php
@@ -587,6 +587,7 @@ class Varien_Data_Collection_Db extends Varien_Data_Collection
                     $item->setIdFieldName($this->getIdFieldName());
                 }
                 $item->addData($row);
+                $item->setDataChanges(false);
                 $this->addItem($item);
             }
         }


### PR DESCRIPTION
### Description (*)

PR created as a replacement for https://github.com/OpenMage/magento-lts/pull/2042#issuecomment-1406779856

When any collection is loaded, all its items have the `hasDataChanges` flag set to `true` because of the call to `setData()`. This causes unnecessary saves for unchanged items.

I also added a getter method to the status history model to prevent the setter from marking the model as dirty again, similar to what was done in #2066.

### Related Pull Requests

- See #2042
- See #523

### Manual testing scenarios (*)

1. Load any collection and call `hasDataChanges()` on the items, it should be `false`.
2. Load status history collection from Order and call `hasDataChanges()` on the items, it should return `false`.
```php
$order = Mage::getModel('sales/order')->load(123);
foreach ($order->getStatusHistoryCollection() as $history) {
    var_dump($history->hasDataChanges()); // bool(false)
}
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->