### PR TITLE
Reduce getId calls

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -273,8 +273,8 @@ class Mage_CatalogInventory_Model_Observer
         $canRemoveErrorFromQuote = true;
 
         /** @var Mage_Sales_Model_Quote_Item $quoteItem */
-        foreach ($quoteItems as $quoteItem) {
-            if ($quoteItem->getItemId() == $item->getItemId()) {
+        foreach ($quoteItems as $quoteItemId => $quoteItem) {
+            if ($quoteItemId == $item->getItemId()) {
                 continue;
             }
 


### PR DESCRIPTION
### Description

This reduce number of getItemId() calls (found with Blackfire).
Same as #2957 #2677 #2699 #1571.

before (with a big cart with 51 downloadable, simple and bundle products):
![before-getitemid](https://user-images.githubusercontent.com/31816829/216548685-2b8f103f-20eb-40d1-837f-b9ad9d178531.png)

after:
![after-getitemid](https://user-images.githubusercontent.com/31816829/216548712-a2cf261e-2722-475f-a0b7-5dc0bd3ad654.png)

To check the PR, I added `if ($quoteItemId != $quoteItem->getItemId()) exit('boom');`.
Yes this will not change many things, but this + many others...ac

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list