### PR TITLE
Fix bug in admin interface where Bundle Option Is Required setting is not loaded.

### DIFF
--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option.phtml
@@ -114,7 +114,7 @@ Bundle.Option.prototype = {
         }
 
         //set selected is_require
-        if (data.required) {
+        if (typeof data.required !== 'undefined') {
             $A($(this.idLabel + '_'+data.index+'_required').options).each(function(option){
                 if (option.value==data.required) option.selected = true;
             });


### PR DESCRIPTION

<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->



<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This fixes a bug in the admin area when editing Bundle Items Options on a Bundle type product. When "Is Required" on an Option is set to No, the select element on the screen is not initialized with the selected value from the database because of an oversight in the check for existence of a variable with value zero (in the case of Is Required = "No").

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. In Admin interface, Create or Edit a Bundle type product.
2. On the "Bundle Items" tab, Create / Edit an existing Option.
3. Change the Option "Is Required" setting to "No".
4. Save and Continue Edit or Save and return to Edit the product.
5. Notice that the "Is Required" setting reverts back to "Yes" (the first option).

This happens because the javascript that initializes the "Is Required" select element only runs if the value is "Yes" (1) due to the code checking the value of the variable -- "No" (0) evaluates to false.

Note that the Is Required setting *is* saved correctly based on what *currently* shows in the Admin screen (Is Required will be set to Yes unless you change it before saving), and appears to be handled correctly in the customer view.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

I think that the intention of the code was to check for the existence of the variable, so I modified the check to look for whether the variable was defined using typeof.

I suspect this type of problem could show up in other places, but have not attempted to find other instances of this yet.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->