### PR TITLE
Ignore addresses when country is not authorized

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Address.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Address.php
@@ -31,12 +31,22 @@ class Mage_Adminhtml_Block_Sales_Order_Create_Form_Address extends Mage_Adminhtm
 
     /**
      * Return Customer Address Collection as array
+     * Ignore addresses when the country is not allowed
      *
      * @return array
      */
     public function getAddressCollection()
     {
-        return $this->getCustomer()->getAddresses();
+        $addresses = [];
+        $countries = explode(',', Mage::getStoreConfig('general/country/allow', Mage::getSingleton('adminhtml/session_quote')->getStoreId()));
+
+        foreach ($this->getCustomer()->getAddresses() as $address) {
+            if (in_array($address->getData('country_id'), $countries)) {
+                $addresses[$address->getId()] = $address;
+            }
+        }
+
+        return $addresses;
     }
 
     /**


### PR DESCRIPTION
### Description

This PR hide not allowed countries when you create an order from backend.

![image](https://user-images.githubusercontent.com/31816829/217901357-1994ee95-a5ef-483a-b4d7-6acaef60efe3.png)

### Manual testing scenarios 

* For default configuration allow some countries
* Create a customer and create multiple adresses (one per country)
* For one of your store, update store configuration, allow one country
* Try to create an order from backend with this customer with previous store
* Without the PR: all adresses are visible, and with the PR: only addresses for allowed countries are displayed

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list