### PR TITLE
Fix bug in admin interface where Bundle Option Select User Defined Qty setting is not loaded.

### DIFF
--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/selection.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/selection.phtml
@@ -154,13 +154,13 @@ Bundle.Selection.prototype = {
 
         Element.insert(tbody[0], {'bottom':this.template.evaluate(data)});
 
-        if (data.selection_price_type) {
+        if (typeof data.selection_price_type !== 'undefined') {
             $A($(this.idLabel + '_'+data.index+'_price_type').options).each(function(option){
                 if (option.value==data.selection_price_type) option.selected = true;
             });
         }
 
-        if (data.selection_price_type) {
+        if (typeof data.selection_price_type !== 'undefined') {
             $A($(this.idLabel + '_'+data.index+'_can_change_qty').options).each(function(option){
                 if (option.value==data.selection_can_change_qty) option.selected = true;
             });


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
After #3014, I found another similar issue on the Bundle Options admin screen. 
This fixes a bug in the admin area when editing Bundle Items Options on a Bundle type product. When bundle option selection price type is "Fixed" or zero (0), "User Defined Qty" is not initialized with the selected value from the database because of an oversight in the check for existence of a variable with value zero (in the case of selection_price_type = "Fixed").

### Related Pull Requests
<!-- related pull request placeholder -->
#3014 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. In Admin interface, Create or Edit a Bundle type product.
2. On the "Bundle Items" tab, Create / Edit an existing Option.
3. Add a Selection if one does not already exist.
4. Change the "User Defined Qty" on a Selection to "No".
5. Save and Continue or Save and return to Edit the product.
6. Notice that "User Defined Qty" is not loaded with the value "No".

This happens because the javascript does not update the select element due to the "selection_price_type" evaluating to zero. Note that selection_price_type field may be hidden as it appears to be related to the overall product pricing settings.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

In doing more research, I found a similar problem fixed in a slightly different way: #2441 . I am not sure if you have any preference on the syntax.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->