### PR TITLE
Remove minOccurs attr from WSDL message part

### DIFF
--- a/app/code/core/Mage/Sales/etc/wsdl.xml
+++ b/app/code/core/Mage/Sales/etc/wsdl.xml
@@ -844,7 +844,7 @@
         <part name="carrier" type="xsd:string" />
         <part name="title" type="xsd:string" />
         <part name="trackNumber" type="xsd:string" />
-        <part name="weight" type="xsd:double" minOccurs="0" />
+        <part name="weight" type="xsd:double" />
     </message>
     <message name="salesOrderShipmentAddTrackResponse">
         <part name="result" type="xsd:int" />


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

As mentioned in https://github.com/OpenMage/magento-lts/pull/1377#issuecomment-1431312619, the WSDL message `<part>` may not contain a `minOccurs` and it throws an error when calling the endpoint.

### Related Pull Requests

- See https://github.com/OpenMage/magento-lts/pull/1377

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->