### PR TITLE
EAV Config Cache followup: select non-existent attribute exception

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -438,6 +438,10 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
             } else {
                 $attrInstance = Mage::getSingleton('eav/config')
                     ->getAttribute($this->getEntity()->getType(), $attribute);
+                // failure to resolve an attribute from the eav config implies it does not exist
+                if (empty($attrInstance)) {
+                    return $this;
+                }
             }
             if (empty($attrInstance)) {
                 throw Mage::exception(


### PR DESCRIPTION
This PR fixes an exception that is trigger when a collection selects a non-existent attribute because `getAttribute()` no longer returns an empty model for non-existent attributes.

### Related Pull Requests
#2993

### Manual testing scenarios (*)
```php
$productCollections = Mage::getResourceModel("catalog/product_collection");
$productCollections->addAttributeToSelect("test_does_not_exist");
```