### PR TITLE
Fixed undefined array key warning in Mage_Catalog_Model_Resource_Category_Flat

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
@@ -839,7 +839,9 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
         ];
         foreach ($attributesType as $type) {
             foreach ($this->_getAttributeTypeValues($type, $entityIds, $store_id) as $row) {
-                $values[$row['entity_id']][$attributes[$row['attribute_id']]['attribute_code']] = $row['value'];
+                if (isset($attributes[$row['attribute_id']])) {
+                    $values[$row['entity_id']][$attributes[$row['attribute_id']]['attribute_code']] = $row['value'];
+                }
             }
         }
         return $values;


### PR DESCRIPTION
Everything is explained in https://github.com/OpenMage/magento-lts/issues/3046

### Fixed Issues (if relevant)
1. Fixes https://github.com/OpenMage/magento-lts/issues/3046
