### PR TITLE
Make PHPStan run independently from PHPCS

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -73,7 +73,7 @@ jobs:
 
   phpstan:
     name: PHPStan
-    needs: [check, composer, phpcs, php-cs-fixer]
+    needs: [check, composer]
     if: |
       needs.check.outputs.php > 0 ||
       needs.check.outputs.phpstan > 0 ||


### PR DESCRIPTION
In our workflows PHPStan runs only when PHP-CS/PHP-CS-Fixer are finished, but I think it shouldn't be that way, I'd prefer to have PHPStan run independently from PHP-CS so that we may find problems in more than a single "point" at the sametime.