### PR TITLE
Enabled PHP 8.2 in composer.json, updated README with software compatibility info

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,13 @@ level of backwards compatibility to the official releases.
 
 ## Requirements
 
-- PHP 7.3+ (PHP 8.0 is supported, PHP 8.1 is work in progress)
+- PHP 7.3+ (PHP 8.0 is supported, PHP 8.1 supported but some warnings may be shown/logged, PHP 8.2 is usable but still being tested)
 - MySQL 5.6+ (8.0+ recommended) or MariaDB
+- optional: Redis 5.x, 6.x and 7.0.x are supported
 
 
 - PHP extension `intl` <small>since 1.9.4.19 & 20.0.17</small>
 - Command `patch` 2.7+ (or `gpatch` on MacOS/HomeBrew) <small>since 1.9.5.0 & 20.1.0</small>
-
-__Please be aware that although OpenMage is compatible that one or more extensions may not be.__
-
-### Optional
-
-- Redis 5+ (6.x recommended, latest verified compatible 6.0.7 with 20.x)
 
 ## Installation
 
@@ -173,7 +168,7 @@ Most important changes will be listed here, all other changes since `19.4.0` can
 
 ### Between Magento 1.9.4.5 and OpenMage 19.x
 
-- bug fixes and PHP 7.x, 8.0 and 8.1 compatibility
+- bug fixes and PHP 7.x, 8.0, 8.1 and 8.2 compatibility
 - added config cache for system.xml ([#1916](https://github.com/OpenMage/magento-lts/pull/1916))
 - search for "NULL" in backend grids ([#1203](https://github.com/OpenMage/magento-lts/pull/1203))
 - removed `lib/flex` containing unused ActionScript "file uploader" files ([#2271](https://github.com/OpenMage/magento-lts/pull/2271))
@@ -303,11 +298,11 @@ grep -rn 'urn:Magento' --include \*.xml
   ddev launch
   ```
 
-## Development with PHP 8.1
+## Development with PHP 8.1+
 
 Deprecation errors are supressed by default.
 
-If you want to work on PHP 8.1 support, set environment variable `DEV_PHP_STRICT` to `1`, to show all errors.  
+If you want to work on PHP 8.1+ support, set environment variable `DEV_PHP_STRICT` to `1`, to show all errors.  
 
 ## PhpStorm Factory Helper
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "type": "magento-source",
     "require": {
-        "php": ">=7.3 <8.2",
+        "php": ">=7.3 <=8.2",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "125d669c318bb7c9ff8b70053cecbe80",
+    "content-hash": "cd382901fe8a279600c88dc4a11cb003",
     "packages": [
         {
             "name": "colinmollenhour/cache-backend-redis",
@@ -5813,7 +5813,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3 <8.2",
+        "php": ">=7.3 <=8.2",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",


### PR DESCRIPTION
I'm testing OM with PHP8.2 and it works for me as good as 8.1, we should at least let people install OM via composer with 8.2.

This PR enables that and updates the README