### PR TITLE
Make Prototype Validator optional

### DIFF
--- a/js/varien/form.js
+++ b/js/varien/form.js
@@ -28,7 +28,9 @@ VarienForm.prototype = {
         this.cache      = $A();
         this.currLoader = false;
         this.currDataIndex = false;
-        this.validator  = new Validation(this.form);
+        if (typeof Validation === 'function') {
+            this.validator  = new Validation(this.form);
+        }
         this.elementFocus   = this.elementOnFocus.bindAsEventListener(this);
         this.elementBlur    = this.elementOnBlur.bindAsEventListener(this);
         this.childLoader    = this.onChangeChildLoad.bindAsEventListener(this);
@@ -187,7 +189,9 @@ RegionUpdater.prototype = {
         var regionRequired = this.config.regions_required.indexOf(this.countryEl.value) >= 0;
 
         elements.each(function(currentElement) {
-            Validation.reset(currentElement);
+            if (typeof Validation !== 'undefined') {
+                Validation.reset(currentElement);
+            }
             label = $$('label[for="' + currentElement.id + '"]')[0];
             if (label) {
                 wildCard = label.down('em') || label.down('span.required');
@@ -293,7 +297,9 @@ RegionUpdater.prototype = {
                     this.regionTextEl.style.display = '';
                 }
                 this.regionSelectEl.style.display = 'none';
-                Validation.reset(this.regionSelectEl);
+                if (typeof Validation !== 'undefined') {
+                    Validation.reset(this.regionSelectEl);
+                }
             } else if (this.disableAction == 'disable') {
                 if (this.regionTextEl) {
                     this.regionTextEl.disabled = false;
@@ -373,7 +379,9 @@ ZipUpdater.prototype = {
 
         // Ajax-request and normal content load compatibility
         if (this.zipElement != undefined) {
-            Validation.reset(this.zipElement);
+            if (typeof Validation !== 'undefined') {
+                Validation.reset(this.zipElement);
+            }
             this._setPostcodeOptional();
         } else {
             Event.observe(window, "load", this._setPostcodeOptional.bind(this));

--- a/js/varien/js.js
+++ b/js/varien/js.js
@@ -573,11 +573,13 @@ Varien.FileElement.prototype = {
     }
 };
 
-Validation.addAllThese([
-    ['validate-custom', ' ', function(v,elm) {
-        return elm.validate();
-    }]
-]);
+if (typeof Validation !== 'undefined') {
+    Validation.addAllThese([
+        ['validate-custom', ' ', function(v,elm) {
+            return elm.validate();
+        }]
+    ]);
+}
 
 function truncateOptions() {
     $$('.truncated').each(function(element){


### PR DESCRIPTION
### Description (*)
I'm removing `prototype/validation.js` from some of my pages, but some shared JavaScript libs assume it's still there and start to generate errors.

The validator is not necessary on every page, hence it should be possible to remove it without running into errors.

In the slightly longer term, I'd like to see the whole thing removed and instead switch to the new HTML5 validation options, which are plenty: https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation.