### PR TITLE
Remove status filter from Product Collection in CatalogSearch Layer

### DIFF
--- a/app/code/core/Mage/CatalogSearch/Model/Layer.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Layer.php
@@ -60,10 +60,7 @@ class Mage_CatalogSearch_Model_Layer extends Mage_Catalog_Model_Layer
             ->addPriceData()
             ->addTaxPercents()
             ->addStoreFilter()
-            ->addUrlRewrite()
-            ->addAttributeToFilter('status', [
-                'in' => Mage::getSingleton('catalog/product_status')->getVisibleStatusIds()
-            ]);
+            ->addUrlRewrite();
         Mage::getSingleton('catalog/product_visibility')->addVisibleInSearchFilterToCollection($collection);
 
         return $this;


### PR DESCRIPTION
### Description (*)

A followup to #2662 which removed the `status` filter from Product Collection in Catalog Layer to fix the issue discussed in https://github.com/OpenMage/magento-lts/pull/2603#issuecomment-1451514520.

This issue could be fixed by #2660, but this change is just to keep the consistency between Catalog and CatalogSearch Layers.

### Related Pull Requests

- See #2662
- See #2603


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->