### PR TITLE
EAV Config Cache revert return empty attribute model

### DIFF
--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -209,7 +209,7 @@ class Mage_Eav_Model_Config
     protected function _loadEntityAttributes($entityType, $storeId)
     {
         // preload attributes in array form to avoid instantiating models for every attribute even if it is never accessed
-        $entityAttributes = $entityType->newAttributeCollection(null, false)
+        $entityAttributes = $entityType->newAttributeCollection()
             ->addStoreLabel($storeId)
             ->getData();
 

--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -209,7 +209,7 @@ class Mage_Eav_Model_Config
     protected function _loadEntityAttributes($entityType, $storeId)
     {
         // preload attributes in array form to avoid instantiating models for every attribute even if it is never accessed
-        $entityAttributes = $entityType->getAttributeCollection(null, false)
+        $entityAttributes = $entityType->newAttributeCollection(null, false)
             ->addStoreLabel($storeId)
             ->getData();
 
@@ -221,7 +221,7 @@ class Mage_Eav_Model_Config
             $attributeId = $entityAttributeData['attribute_id'];
             $attributeCode = $entityAttributeData['attribute_code'];
 
-            // workaround for getAttributeCollection()->getData() returning all columns as string
+            // workaround for newAttributeCollection()->getData() returning all columns as string
             foreach (self::NUMERIC_ATTRIBUTE_COLUMNS as $key) {
                 if (!isset($entityAttributeData[$key])) {
                     continue;

--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -209,7 +209,7 @@ class Mage_Eav_Model_Config
     protected function _loadEntityAttributes($entityType, $storeId)
     {
         // preload attributes in array form to avoid instantiating models for every attribute even if it is never accessed
-        $entityAttributes = $entityType->getAttributeCollection()
+        $entityAttributes = $entityType->getAttributeCollection(null, false)
             ->addStoreLabel($storeId)
             ->getData();
 

--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -484,6 +484,11 @@ class Mage_Eav_Model_Config
             $attribute = $this->_getDefaultAttributeIfExists($entityType, $code, $storeId);
         }
 
+        // maintain old behavior and return an empty model to avoid breaking compatibility
+        if (!$attribute) {
+            $attribute = $this->_hydrateAttribute(["entity_type_id" => $entityType->getId()]);
+        }
+
         return $attribute;
     }
 

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -438,6 +438,10 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
             } else {
                 $attrInstance = Mage::getSingleton('eav/config')
                     ->getAttribute($this->getEntity()->getType(), $attribute);
+                // failure to resolve an attribute from the eav config implies it does not exist
+                if (empty($attrInstance)) {
+                    return $this;
+                }
             }
             if (empty($attrInstance)) {
                 throw Mage::exception(

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -439,7 +439,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
                 $attrInstance = Mage::getSingleton('eav/config')
                     ->getAttribute($this->getEntity()->getType(), $attribute);
                 // failure to resolve an attribute from the eav config implies it does not exist
-                if (empty($attrInstance)) {
+                if (empty($attrInstance) || !$attrInstance->getId()) {
                     return $this;
                 }
             }

--- a/app/code/core/Mage/Eav/Model/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Type.php
@@ -99,24 +99,33 @@ class Mage_Eav_Model_Entity_Type extends Mage_Core_Model_Abstract
     /**
      * Retrieve entity type attributes collection
      *
-     * @param   int $setId
-     * @return  Mage_Eav_Model_Resource_Entity_Attribute_Collection
+     * @param int|null $setId
+     * @param bool $useCache reuse local cache for collection
+     * @return Mage_Eav_Model_Resource_Entity_Attribute_Collection
      */
-    public function getAttributeCollection($setId = null)
+    public function getAttributeCollection(int $setId = null, bool $useCache = true)
     {
-        if ($setId === null) {
-            if ($this->_attributes === null) {
-                $this->_attributes = $this->_getAttributeCollection()
-                    ->setEntityTypeFilter($this);
+        if ($useCache) {
+            if ($setId === null && $this->_attributes !== null) {
+                return $this->_attributes;
+            } elseif (isset($this->_attributesBySet[$setId])) {
+                return $this->_attributesBySet[$setId];
             }
-            $collection = $this->_attributes;
-        } else {
-            if (!isset($this->_attributesBySet[$setId])) {
-                $this->_attributesBySet[$setId] = $this->_getAttributeCollection()
-                    ->setEntityTypeFilter($this)
-                    ->setAttributeSetFilter($setId);
+        }
+
+        $collection = $this->_getAttributeCollection()
+            ->setEntityTypeFilter($this);
+
+        if ($setId !== null) {
+            $collection->setAttributeSetFilter($setId);
+        }
+
+        if ($useCache) {
+            if ($setId === null) {
+                $this->_attributes = $collection;
+            } else {
+                $this->_attributesBySet[$setId] = $collection;
             }
-            $collection = $this->_attributesBySet[$setId];
         }
 
         return $collection;

--- a/app/code/core/Mage/Eav/Model/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Type.php
@@ -100,32 +100,40 @@ class Mage_Eav_Model_Entity_Type extends Mage_Core_Model_Abstract
      * Retrieve entity type attributes collection
      *
      * @param int|null $setId
-     * @param bool $useCache reuse local cache for collection
      * @return Mage_Eav_Model_Resource_Entity_Attribute_Collection
      */
-    public function getAttributeCollection($setId = null, $useCache = true)
+    public function getAttributeCollection($setId = null)
     {
-        if ($useCache) {
-            if ($setId === null && $this->_attributes !== null) {
-                return $this->_attributes;
-            } elseif (isset($this->_attributesBySet[$setId])) {
-                return $this->_attributesBySet[$setId];
-            }
+        if ($setId === null && $this->_attributes !== null) {
+            return $this->_attributes;
+        } elseif (isset($this->_attributesBySet[$setId])) {
+            return $this->_attributesBySet[$setId];
         }
 
+        $collection = $this->newAttributeCollection($setId);
+
+        if ($setId === null) {
+            $this->_attributes = $collection;
+        } else {
+            $this->_attributesBySet[$setId] = $collection;
+        }
+
+        return $collection;
+    }
+
+    /**
+     * Create entity type attributes collection
+     *
+     * @param int|null $setId
+     * @return Mage_Eav_Model_Resource_Entity_Attribute_Collection
+     */
+    public function newAttributeCollection($setId = null)
+    {
         $collection = $this->_getAttributeCollection()
             ->setEntityTypeFilter($this);
 
         if ($setId !== null) {
             $collection->setAttributeSetFilter($setId);
-        }
-
-        if ($useCache) {
-            if ($setId === null) {
-                $this->_attributes = $collection;
-            } else {
-                $this->_attributesBySet[$setId] = $collection;
-            }
         }
 
         return $collection;

--- a/app/code/core/Mage/Eav/Model/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Type.php
@@ -103,7 +103,7 @@ class Mage_Eav_Model_Entity_Type extends Mage_Core_Model_Abstract
      * @param bool $useCache reuse local cache for collection
      * @return Mage_Eav_Model_Resource_Entity_Attribute_Collection
      */
-    public function getAttributeCollection(int $setId = null, bool $useCache = true)
+    public function getAttributeCollection($setId = null, $useCache = true)
     {
         if ($useCache) {
             if ($setId === null && $this->_attributes !== null) {

--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -61,11 +61,11 @@ class Mage_GoogleAnalytics_Block_Ga extends Mage_Core_Block_Template
     /**
      * Get a specific page name (may be customized via layout)
      *
-     * @return string|null
+     * @return string
      */
     public function getPageName()
     {
-        return $this->_getData('page_name');
+        return $this->_getData('page_name') ?? '';
     }
 
     /**


### PR DESCRIPTION
Changes made in #2993 changed the behaviour of `getAttribute` to return `false` instead of an empty model. While this might be a more desirable return type it breaks some behavior that relies on it. This PR reverts that change and returns a fresh empty model when `getAttribute("non_existent_code")` is called.

### Related Pull Requests
#2993

### Fixed Issues (if relevant)
1. #3057
2. #3055 (underlying cause listed in #3057)
