### PR TITLE
Fixed "if newsletter module disabled, customer backend would blank without notice"

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tabs.php
@@ -73,13 +73,15 @@ class Mage_Adminhtml_Block_Customer_Edit_Tabs extends Mage_Adminhtml_Block_Widge
                 'url'       => $this->getUrl('*/*/wishlist', ['_current' => true]),
             ]);
 
-            /** @var Mage_Adminhtml_Block_Customer_Edit_Tab_Newsletter $block */
-            $block = $this->getLayout()->createBlock('adminhtml/customer_edit_tab_newsletter');
-            if (Mage::getSingleton('admin/session')->isAllowed('newsletter/subscriber')) {
-                $this->addTab('newsletter', [
-                    'label'     => Mage::helper('customer')->__('Newsletter'),
-                    'content'   => $block->initForm()->toHtml()
-                ]);
+            if (Mage::helper('core')->isModuleOutputEnabled('Mage_Newsletter')) {
+                /** @var Mage_Adminhtml_Block_Customer_Edit_Tab_Newsletter $block */
+                $block = $this->getLayout()->createBlock('adminhtml/customer_edit_tab_newsletter');
+                if (Mage::getSingleton('admin/session')->isAllowed('newsletter/subscriber')) {
+                    $this->addTab('newsletter', [
+                        'label'     => Mage::helper('customer')->__('Newsletter'),
+                        'content'   => $block->initForm()->toHtml()
+                    ]);
+                }
             }
 
             if (Mage::getSingleton('admin/session')->isAllowed('catalog/reviews_ratings')) {

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Giftmessage.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Giftmessage.php
@@ -50,10 +50,14 @@ class Mage_Adminhtml_Block_Sales_Order_View_Giftmessage extends Mage_Adminhtml_B
      */
     protected function _beforeToHtml()
     {
-        if ($this->getParentBlock() && ($order = $this->getOrder())) {
-            $this->setEntity($order);
+        if (Mage::helper('core')->isModuleOutputEnabled('Mage_Giftmessage')) {
+            if ($this->getParentBlock() && ($order = $this->getOrder())) {
+                $this->setEntity($order);
+            }
+            return parent::_beforeToHtml();
+        } else {
+            return parent::_beforeToHtml();
         }
-        return parent::_beforeToHtml();
     }
 
     /**
@@ -63,15 +67,16 @@ class Mage_Adminhtml_Block_Sales_Order_View_Giftmessage extends Mage_Adminhtml_B
      */
     protected function _prepareLayout()
     {
-        $this->setChild(
-            'save_button',
-            $this->getLayout()->createBlock('adminhtml/widget_button')
-                ->setData([
-                    'label'   => Mage::helper('giftmessage')->__('Save Gift Message'),
-                    'class'   => 'save'
-                ])
-        );
-
+        if (Mage::helper('core')->isModuleOutputEnabled('Mage_Giftmessage')) {
+            $this->setChild(
+                'save_button',
+                $this->getLayout()->createBlock('adminhtml/widget_button')
+                    ->setData([
+                        'label'   => Mage::helper('giftmessage')->__('Save Gift Message'),
+                        'class'   => 'save'
+                    ])
+            );
+        }
         return $this;
     }
 

--- a/app/etc/modules/Mage_Captcha.xml
+++ b/app/etc/modules/Mage_Captcha.xml
@@ -21,9 +21,7 @@
             <codePool>core</codePool>
             <depends>
                 <Mage_Adminhtml/>
-                <Mage_Customer/>
-                <Mage_Sendfriend/>
-                <Mage_Wishlist/>
+                <Mage_Customer/> 
             </depends>
         </Mage_Captcha>
     </modules>

--- a/lib/Varien/Data/Form/Abstract.php
+++ b/lib/Varien/Data/Form/Abstract.php
@@ -132,7 +132,13 @@ class Varien_Data_Form_Abstract extends Varien_Object
         } else {
             $className = 'Varien_Data_Form_Element_' . ucfirst(strtolower($type));
         }
-        $element = new $className($config);
+
+        if (class_exists($className)) {
+            $element = new $className($config);
+        } else {
+            $className = 'Varien_Data_Form_Element_Note';
+            $element = new $className($config);
+        }
         $element->setId($elementId);
         $this->addElement($element, $after);
         return $element;


### PR DESCRIPTION
removeable for the wishlist/giftmessage/sendtofriend/newsletter modules 