### PR TITLE
Fix exception logged when no Category image is uploaded

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Image.php
@@ -60,7 +60,7 @@ class Mage_Catalog_Model_Category_Attribute_Backend_Image extends Mage_Eav_Model
             $object->setData($this->getAttribute()->getName(), $result['file']);
             $this->getAttribute()->getEntity()->saveAttribute($object, $this->getAttribute()->getName());
         } catch (Exception $e) {
-            if ($e->getCode() != Mage_Core_Model_File_Uploader::TMP_NAME_EMPTY) {
+            if ($e->getCode() != UPLOAD_ERR_NO_FILE) {
                 Mage::logException($e);
             }
         }

--- a/lib/Varien/File/Uploader.php
+++ b/lib/Varien/File/Uploader.php
@@ -146,7 +146,11 @@ class Varien_File_Uploader
 
     public const SINGLE_STYLE = 0;
     public const MULTIPLE_STYLE = 1;
-    public const TMP_NAME_EMPTY = 666;
+
+    /**
+     * @deprecated Use UPLOAD_ERR_NO_FILE instead
+     */
+    public const TMP_NAME_EMPTY = UPLOAD_ERR_NO_FILE;
 
     /**
      * Resulting of uploaded file
@@ -161,11 +165,9 @@ class Varien_File_Uploader
         $this->_setUploadFileId($fileId);
         if (empty($this->_file['tmp_name']) || !file_exists($this->_file['tmp_name'])) {
             $errorCode = $this->_file['error'] ?? 0;
-            $code = empty($this->_file['tmp_name']) ? self::TMP_NAME_EMPTY : 0;
-            if ($errorCode && isset(self::UPLOAD_ERRORS[$errorCode])) {
-                throw new Exception(self::UPLOAD_ERRORS[$errorCode], $code);
+            if (isset(self::UPLOAD_ERRORS[$errorCode])) {
+                throw new Exception(self::UPLOAD_ERRORS[$errorCode], $errorCode);
             }
-            throw new Exception('File was not uploaded.', $code);
         } else {
             $this->_fileExists = true;
         }
@@ -509,7 +511,7 @@ class Varien_File_Uploader
     private function _setUploadFileId($fileId)
     {
         if (empty($_FILES)) {
-            throw new Exception('$_FILES array is empty', self::TMP_NAME_EMPTY);
+            throw new Exception('$_FILES array is empty', UPLOAD_ERR_NO_FILE);
         }
 
         if (is_array($fileId)) {

--- a/lib/Varien/File/Uploader.php
+++ b/lib/Varien/File/Uploader.php
@@ -161,10 +161,10 @@ class Varien_File_Uploader
         $this->_setUploadFileId($fileId);
         if (empty($this->_file['tmp_name']) || !file_exists($this->_file['tmp_name'])) {
             $errorCode = $this->_file['error'] ?? 0;
-            if ($errorCode && isset(self::UPLOAD_ERRORS[$errorCode])) {
-                throw new Exception(self::UPLOAD_ERRORS[$errorCode]);
-            }
             $code = empty($this->_file['tmp_name']) ? self::TMP_NAME_EMPTY : 0;
+            if ($errorCode && isset(self::UPLOAD_ERRORS[$errorCode])) {
+                throw new Exception(self::UPLOAD_ERRORS[$errorCode], $code);
+            }
             throw new Exception('File was not uploaded.', $code);
         } else {
             $this->_fileExists = true;


### PR DESCRIPTION
### Description (*)
As @luigifab pointed out in https://github.com/OpenMage/magento-lts/discussions/3025#discussioncomment-5196210, updating a Category without an image keeps logging an exception "No file was uploaded" in `exception.log`.

This error is normally being ignored by checking `$e->getCode()` because the Category image is optional, but the new error handling introduced in #2902 isn't passing the error code with the `Exception` object making the exception be logged.

### Related Pull Requests

- See #2902

### Manual testing scenarios (*)
1. Make sure logs are enabled.
2. Go to Catalog -> Categories and try to save any category, then check `exception.log` file.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->