### PR TITLE
PHP 7.4 is now the minimum required version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.3']
+        php-versions: ['7.4']
     steps:
     - name: Checkout repository
       uses: actions/checkout@master

--- a/.github/workflows/syntax-php.yml
+++ b/.github/workflows/syntax-php.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.3', '8.1', '8.2']
+        php: ['7.4', '8.1', '8.2']
 
     name: PHP Syntax ${{ matrix.php }}
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ level of backwards compatibility to the official releases.
 
 ## Requirements
 
-- PHP 7.3+ (PHP 8.0 is supported, PHP 8.1 supported but some warnings may be shown/logged, PHP 8.2 is usable but still being tested)
+- PHP 7.4+ (PHP 8.0 is supported, PHP 8.1 supported but some warnings may be shown/logged, PHP 8.2 is usable but still being tested)
 - MySQL 5.6+ (8.0+ recommended) or MariaDB
 - optional: Redis 5.x, 6.x and 7.0.x are supported
 
@@ -213,6 +213,8 @@ Do not use 20.x.x if you need IE support.
 For full list of changes, you can [compare tags](https://github.com/OpenMage/magento-lts/compare/1.9.4.x...20.0).
 
 ### Since OpenMage 19.5.0 / 20.1.0
+
+PHP 7.4 is now the minimum required version.
 
 Most of the 3rd party libraries/modules that were bundled in our repository were removed and migrated to composer dependencies.
 This allows for better maintenance and upgradability.

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "type": "magento-source",
     "require": {
-        "php": ">=7.3 <=8.2",
+        "php": ">=7.4 <=8.2",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",
@@ -116,7 +116,7 @@
             "cweagans/composer-patches": true
         },
         "platform": {
-            "php": "7.3"
+            "php": "7.4"
         },
         "sort-packages": true
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd382901fe8a279600c88dc4a11cb003",
+    "content-hash": "83937d97a0c64ad690891d22451ebf98",
     "packages": [
         {
             "name": "colinmollenhour/cache-backend-redis",
@@ -5813,7 +5813,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3 <=8.2",
+        "php": ">=7.4 <=8.2",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",
@@ -5831,7 +5831,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.3"
+        "php": "7.4"
     },
     "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Let's see if we get enough vote to move to PHP 7.4, as it's [being discussed here](https://github.com/OpenMage/magento-lts/discussions/3089).

I think that, since very long time we now about to release a minor, it would be the right time to move to php7.4.