### PR TITLE
[PHP 8.2] Fixed deprecated dynamic property creation

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Config.php
@@ -25,8 +25,6 @@
  * @category   Mage
  * @package    Mage_Catalog
  * @author     Magento Core Team <core@magentocommerce.com>
- *
- * @property array $_productTypesByName
  */
 class Mage_Catalog_Model_Config extends Mage_Eav_Model_Config
 {
@@ -38,7 +36,15 @@ class Mage_Catalog_Model_Config extends Mage_Eav_Model_Config
     protected $_attributeGroupsById;
     protected $_attributeGroupsByName;
 
+    /**
+     * @var array
+     */
     protected $_productTypesById;
+
+    /**
+     * @var array
+     */
+    protected $_productTypesByName;
 
     /**
      * Array of attributes codes needed for product load

--- a/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
@@ -25,8 +25,6 @@
  * @category   Mage
  * @package    Mage_Catalog
  * @author     Magento Core Team <core@magentocommerce.com>
- *
- * @property string $_storesIdCode
  */
 class Mage_Catalog_Model_Convert_Adapter_Product extends Mage_Eav_Model_Convert_Adapter_Entity
 {
@@ -64,6 +62,11 @@ class Mage_Catalog_Model_Convert_Adapter_Product extends Mage_Eav_Model_Convert_
     protected $_productAttributeSets;
 
     protected $_stores;
+
+    /**
+     * @var array
+     */
+    protected $_storesIdCode = [];
 
     protected $_attributes = [];
 

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Default.php
@@ -26,8 +26,6 @@
  * @package    Mage_Catalog
  * @author     Magento Core Team <core@magentocommerce.com>
  *
- * @property string $_formattedOptionValue
- *
  * @method $this setConfigurationItemOption(Varien_Object $value)
  * @method bool getIsValid()
  * @method $this setIsValid(bool $value)
@@ -58,6 +56,11 @@ class Mage_Catalog_Model_Product_Option_Type_Default extends Varien_Object
      * @var    mixed
      */
     protected $_productOptions = [];
+
+    /**
+     * @var string|null
+     */
+    protected $_formattedOptionValue = null;
 
     /**
      * Option Instance setter

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Minimalprice.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Minimalprice.php
@@ -26,8 +26,6 @@
  * @package    Mage_CatalogIndex
  * @author     Magento Core Team <core@magentocommerce.com>
  *
- * @property Mage_Directory_Model_Currency $_currencyModel
- *
  * @method Mage_CatalogIndex_Model_Resource_Indexer_Minimalprice _getResource()
  * @method Mage_CatalogIndex_Model_Resource_Indexer_Minimalprice getResource()
  * @method $this setEntityId(int $value)
@@ -44,7 +42,16 @@
  */
 class Mage_CatalogIndex_Model_Indexer_Minimalprice extends Mage_CatalogIndex_Model_Indexer_Abstract
 {
-    protected $_customerGroups = [];
+    /**
+     * @var Mage_Directory_Model_Currency
+     */
+    protected $_currencyModel;
+
+    /**
+     * @var Mage_Customer_Model_Resource_Group_Collection
+     */
+    protected $_customerGroups;
+
     protected $_runOnce = true;
     protected $_processChildren = false;
 

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Tierprice.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Tierprice.php
@@ -26,9 +26,6 @@
  * @package    Mage_CatalogIndex
  * @author     Magento Core Team <core@magentocommerce.com>
  *
- * @property Mage_Directory_Model_Currency $_currencyModel
- * @property Mage_Customer_Model_Resource_Group_Collection $_customerGroups
- *
  * @method Mage_CatalogIndex_Model_Resource_Indexer_Price _getResource()
  * @method Mage_CatalogIndex_Model_Resource_Indexer_Price getResource()
  *
@@ -52,6 +49,16 @@
  */
 class Mage_CatalogIndex_Model_Indexer_Tierprice extends Mage_CatalogIndex_Model_Indexer_Abstract
 {
+    /**
+     * @var Mage_Directory_Model_Currency
+     */
+    protected $_currencyModel;
+
+    /**
+     * @var Mage_Customer_Model_Resource_Group_Collection
+     */
+    protected $_customerGroups;
+
     protected $_processChildren = false;
 
     protected function _construct()

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Abstract.php
@@ -25,13 +25,24 @@
  * @category   Mage
  * @package    Mage_CatalogIndex
  * @author     Magento Core Team <core@magentocommerce.com>
- *
- * @property string $_attributeIdFieldName
- * @property string $_entityIdFieldName
- * @property string $_storeIdFieldName
  */
 class Mage_CatalogIndex_Model_Resource_Indexer_Abstract extends Mage_Core_Model_Resource_Db_Abstract
 {
+    /**
+     * @var string
+     */
+    protected $_attributeIdFieldName;
+
+    /**
+     * @var string
+     */
+    protected $_entityIdFieldName;
+
+    /**
+     * @var string
+     */
+    protected $_storeIdFieldName;
+
     /**
      * should be defined because abstract
      *

--- a/app/code/core/Mage/CurrencySymbol/Block/Adminhtml/System/Currencysymbol.php
+++ b/app/code/core/Mage/CurrencySymbol/Block/Adminhtml/System/Currencysymbol.php
@@ -25,23 +25,9 @@
  * @category   Mage
  * @package    Mage_CurrencySymbol
  * @author     Magento Core Team <core@magentocommerce.com>
- *
- * @property string $_blockGroup
  */
 class Mage_CurrencySymbol_Block_Adminhtml_System_Currencysymbol extends Mage_Adminhtml_Block_Widget_Form
 {
-    /**
-     * @var string
-     */
-    private $_controller;
-
-    public function __construct()
-    {
-        $this->_blockGroup = 'currencysymbol_system';
-        $this->_controller = 'adminhtml_system_currencysymbol';
-        parent::__construct();
-    }
-
     /**
      * Custom currency symbol properties
      *

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Newsletter.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Newsletter.php
@@ -25,11 +25,14 @@
  * @category   Mage
  * @package    Mage_Customer
  * @author     Magento Core Team <core@magentocommerce.com>
- *
- * @property Mage_Newsletter_Model_Subscriber|null $_subscription
  */
 class Mage_Customer_Block_Account_Dashboard_Newsletter extends Mage_Core_Block_Template
 {
+    /**
+     * @var Mage_Newsletter_Model_Subscriber|null
+     */
+    protected $_subscription = null;
+
     /**
      * @return Mage_Newsletter_Model_Subscriber
      */

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Abstract.php
@@ -25,8 +25,6 @@
  * @category   Mage
  * @package    Mage_ImportExport
  * @author     Magento Core Team <core@magentocommerce.com>
- *
- * @property array $_invalidRows
  */
 abstract class Mage_ImportExport_Model_Export_Entity_Abstract
 {
@@ -71,6 +69,11 @@ abstract class Mage_ImportExport_Model_Export_Entity_Abstract
      * @var array
      */
     protected $_errors = [];
+
+    /**
+     * @var array
+     */
+    protected $_invalidRows = [];
 
     /**
      * Error counter.

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Collection.php
@@ -25,8 +25,6 @@
  * @category   Mage
  * @package    Mage_Reports
  * @author     Magento Core Team <core@magentocommerce.com>
- *
- * @property Varien_Object $_totals
  */
 class Mage_Reports_Model_Resource_Product_Collection extends Mage_Catalog_Model_Resource_Product_Collection
 {
@@ -158,8 +156,6 @@ class Mage_Reports_Model_Resource_Product_Collection extends Mage_Catalog_Model_
      */
     protected function _joinFields()
     {
-        $this->_totals = new Varien_Object();
-
         $this->addAttributeToSelect('entity_id')
             ->addAttributeToSelect('name')
             ->addAttributeToSelect('price');

--- a/app/code/core/Mage/Review/Block/Customer/Recent.php
+++ b/app/code/core/Mage/Review/Block/Customer/Recent.php
@@ -25,11 +25,14 @@
  * @category   Mage
  * @package    Mage_Review
  * @author     Magento Core Team <core@magentocommerce.com>
- *
- * @property Mage_Review_Model_Resource_Review_Product_Collection $_collection
  */
 class Mage_Review_Block_Customer_Recent extends Mage_Core_Block_Template
 {
+    /**
+     * @var Mage_Review_Model_Resource_Review_Product_Collection
+     */
+    protected $_collection;
+
     public function __construct()
     {
         parent::__construct();

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -25,8 +25,6 @@
  * @category   Varien
  * @package    Varien_Io
  * @author     Magento Core Team <core@magentocommerce.com>
- *
- * @property mixed $_streamException
  */
 class Varien_Io_File extends Varien_Io_Abstract
 {
@@ -94,6 +92,11 @@ class Varien_Io_File extends Varien_Io_Abstract
      * @var bool
      */
     protected $_streamLocked = false;
+
+    /**
+     * @var Exception
+     */
+    protected $_streamException;
 
     public function __construct()
     {

--- a/phpstan.dist.baseline.neon
+++ b/phpstan.dist.baseline.neon
@@ -2501,11 +2501,6 @@ parameters:
 			path: app/code/core/Mage/Core/functions.php
 
 		-
-			message: "#^Property Mage_CurrencySymbol_Block_Adminhtml_System_Currencysymbol\\:\\:\\$_controller is never read, only written\\.$#"
-			count: 1
-			path: app/code/core/Mage/CurrencySymbol/Block/Adminhtml/System/Currencysymbol.php
-
-		-
 			message: "#^Property Mage_CurrencySymbol_Model_System_Currencysymbol\\:\\:\\$_storeId \\(string\\|null\\) does not accept int\\|null\\.$#"
 			count: 1
 			path: app/code/core/Mage/CurrencySymbol/Model/System/Currencysymbol.php


### PR DESCRIPTION
### Description (*)
This PR will fix some PHP 8.2 deprecations related to [dynamic property creation](https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties), I found these by searching for doc blocks containing `@property`, so it's possible that there's more.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->