### PR TITLE
RWD theme: Focus on the search field when clicking on the search button

### DIFF
--- a/skin/frontend/rwd/default/js/app.js
+++ b/skin/frontend/rwd/default/js/app.js
@@ -719,6 +719,12 @@ $j(document).ready(function () {
             self.addClass('skip-active');
             elem.addClass('skip-active');
         }
+
+        if (target == '#header-search') {
+            try {
+                document.getElementById('search').focus();
+            } catch (e) {}
+        }
     });
 
     $j('.skip-links').on('click', '#header-cart .skip-link-close', function(e) {


### PR DESCRIPTION
In the RWD theme, mobile version, when you click the search button here:

<img width="504" alt="Screenshot 2023-03-16 alle 19 01 36" src="https://user-images.githubusercontent.com/909743/225726640-94dc9f8d-2bdc-4708-aed5-a8d1ce9bb8a9.png">

it shows the search field but you've to tap on it in order to be able to write the search query.

I think this is not the best behaviour, when clicking on the search button I'd like the search field to be shown with the focus already in the field, so that I can directly start to type without another (unnecessary) click.

This PR adds a few lines of js in order to implement that.

Note: there's a try/catch just in case a custom there doesn't have the #search field (although it's very unlikely).