### PR TITLE
Fixed allowed PHP version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "type": "magento-source",
     "require": {
-        "php": ">=7.4 <=8.2",
+        "php": ">=7.4 <8.3",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "83937d97a0c64ad690891d22451ebf98",
+    "content-hash": "a65b51d7b5b96774393d7a4dc6d53f95",
     "packages": [
         {
             "name": "colinmollenhour/cache-backend-redis",
@@ -5813,7 +5813,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4 <=8.2",
+        "php": ">=7.4 <8.3",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",


### PR DESCRIPTION
If I try to install openmage with PHP 8.2 using the instructions in the README I get this error message:

```
openmage/magento-lts v20.1.0-rc2 requires php >=7.3 <=8.2 -> your php version (8.2.4) does not satisfy that requirement.
```

So this PR changes the composer.json in order to fix this.