### PR TITLE
Added info about Mage_Poll removal to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Do not use 20.x.x if you need IE support.
 - enabled website level config cache ([#2355](https://github.com/OpenMage/magento-lts/pull/2355))
 - made overrides of Mage_Core_Model_Resource_Db_Abstract::delete respect parent api ([#1257](https://github.com/OpenMage/magento-lts/pull/1257))
 - rewrote Mage_Eav_Model_Config as cache for all eav entity and attribute reads ([#2993](https://github.com/OpenMage/magento-lts/pull/2993))
+- removed module Mage_Poll ([3098](https://github.com/OpenMage/magento-lts/pull/3098), you can install it with `composer require openmage/module-mage-poll`)
 
 For full list of changes, you can [compare tags](https://github.com/OpenMage/magento-lts/compare/1.9.4.x...20.0).
 


### PR DESCRIPTION
Since in https://github.com/OpenMage/magento-lts/pull/3098 we removed the Mage_Poll module, we've to add a line to the README, but this mod has to be done on the 1.9.4.x branch of the README file, that's why a separate PR.