### PR TITLE
Deprecation errors are not suppressed anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Most important changes will be listed here, all other changes since `19.4.0` can
 - search for "NULL" in backend grids ([#1203](https://github.com/OpenMage/magento-lts/pull/1203))
 - removed `lib/flex` containing unused ActionScript "file uploader" files ([#2271](https://github.com/OpenMage/magento-lts/pull/2271))
 - Mage_Catalog_Model_Resource_Abstract::getAttributeRawValue() now returns `'0'` instead of `false` if the value stored in the database is `0` ([#572](https://github.com/OpenMage/magento-lts/pull/572))
+- PHP extension `intl` is required
+- Deprecation errors are not suppressed anymore
 - removed modules:
   - `Mage_Backup` ([#2811](https://github.com/OpenMage/magento-lts/pull/2811))
   - `Mage_Compiler`
@@ -191,10 +193,6 @@ _If you rely on those modules you can reinstall them with composer:_
 - `Mage_Backup`: `composer require openmage/module-mage-backup`
 - `Mage_PageCache`: `composer require openmage/module-mage-pagecache`
 - `Legacy frontend themes`: `composer require openmage/legacy-frontend-themes`
-
-### Between OpenMage 19.4.18 / 20.0.16 and 19.4.19 / 20.0.17
-
-- PHP extension `intl` is required
 
 ### Between OpenMage 19.x and 20.x
 
@@ -305,13 +303,7 @@ grep -rn 'urn:Magento' --include \*.xml
 - Open your site in browser
   ```bash
   ddev launch
-  ```
-
-## Development with PHP 8.1+
-
-Deprecation errors are supressed by default.
-
-If you want to work on PHP 8.1+ support, set environment variable `DEV_PHP_STRICT` to `1`, to show all errors.  
+  ``` 
 
 ## PhpStorm Factory Helper
 

--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -123,15 +123,6 @@ function mageCoreErrorHandler($errno, $errstr, $errfile, $errline)
         return false;
     }
 
-    // Suppress deprecation warnings on PHP 7.x
-    // set environment variable DEV_PHP_STRICT to 1 will show E_DEPRECATED errors
-    if ((!isset($_ENV['DEV_PHP_STRICT']) || $_ENV['DEV_PHP_STRICT'] != '1')
-        && $errno == E_DEPRECATED
-        && version_compare(PHP_VERSION, '7.0.0', '>=')
-    ) {
-        return true;
-    }
-
     // PEAR specific message handling
     if (stripos($errfile . $errstr, 'pear') !== false) {
         // ignore strict and deprecated notices


### PR DESCRIPTION
Since we're moving forward with PHP versions and people will need to upgrade their stack sooner or later I think it's time to avoid suppressing deprecation errors.

Without the special treatment that you see in app/code/core/Mage/Core/functions.php all deprecation errors will be logged, and if DEVELOPER_MODE is enabled then they will trigger an error.

Why I did this? Cause it's better that people start to see this logs and fix their deprecation errors because they will become errors with new versions of PHP.

Also this PR removes the need for the specific DEV_PHP_STRICT that way introduced lately.

### Manual testing scenarios (*)
1. test with php 8.1
2. edit a header.phtml and add a `trim();` (which triggers a deprecation error)
3. refresh, now there's an error logged in system.log
4. enable developer mode
5. refresh, now the deprecation error is a full error shown on page