### PR TITLE
Fix PHP_OS check in cron.php

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -42,14 +42,15 @@ try {
 umask(0);
 
 $disabledFuncs = array_map('trim', preg_split("/,|\s+/", strtolower(ini_get('disable_functions'))));
+$isWinOS = !str_contains(strtolower(PHP_OS), 'darwin') && str_contains(strtolower(PHP_OS), 'win');
 $isShellDisabled = in_array('shell_exec', $disabledFuncs)
-    || !str_contains(strtolower(PHP_OS), 'win')
+    || $isWinOS
     || !shell_exec('which expr 2>/dev/null')
     || !shell_exec('which ps 2>/dev/null')
     || !shell_exec('which sed 2>/dev/null');
 
 try {
-    if (stripos(PHP_OS, 'win') === false) {
+    if (!$isWinOS) {
         $options = getopt('m::');
         if (isset($options['m'])) {
             if ($options['m'] == 'always') {


### PR DESCRIPTION
### Description (*)

Some improvements were done previously to `cron.php` in #2380, including a refactor to `$isShellDisabled` which decides whether or not to use the shell generate the cron schedules and run them.

The problem comes from the condition `!str_contains(strtolower(PHP_OS), 'win')`, which is the opposite of what it should be and it'll cause the cron events to be dispatched twice from the lines below:
https://github.com/OpenMage/magento-lts/blob/e2d5fed660af577477936eda18ab207789856cfb/cron.php#L74-L79

This was likely caused by confusion over the fact that PHP_OS is set to Darwin in macOS (@fballiano's OS), so with the negation operator it's actually resulting in false which is what you'd expect in a non-win system.

### Related Pull Requests

- See https://github.com/OpenMage/magento-lts/pull/2380

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#3112

### Manual testing scenarios (*)

1. Add a `var_dump($isShellDisabled)` to `cron.php` before the `try catch` block, and observe the value before and after.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->