### PR TITLE
Fixed Illegal offset type in Mage_Tag

### DIFF
--- a/app/code/core/Mage/Tag/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Product/Collection.php
@@ -462,7 +462,7 @@ class Mage_Tag_Model_Resource_Product_Collection extends Mage_Catalog_Model_Reso
 
             $appliedOrders = [];
             foreach ($orders as $order) {
-                $appliedOrders[$order[0]] = true;
+                $appliedOrders[(string)$order[0]] = true;
             }
 
             foreach ($this->_orders as $field => $direction) {


### PR DESCRIPTION
Update: Occurs when using https://github.com/tzyganu/EasylifeTag
So maybe not the best fix, when tags without this extension is called via Id instead of a string.

**EasylifeTag:**
_What it does_

_It changes the urls for tag pages from tag/product/list/tagId/10 to tag/clothes._
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
When clicking a Tag on frontend the site returns an error - HTTP 500.


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Install https://github.com/tzyganu/EasylifeTag
2. create a Tag
3. Click in on the frontend

### Questions or comments


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->