### PR TITLE
Fixed monthly report dates

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Grid/Column/Renderer/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Grid/Column/Renderer/Date.php
@@ -89,7 +89,7 @@ class Mage_Adminhtml_Block_Report_Sales_Grid_Column_Renderer_Date extends Mage_A
             try {
                 $data = ($this->getColumn()->getGmtoffset())
                     ? Mage::app()->getLocale()->date($data, $dateFormat)->toString($format)
-                    : Mage::getSingleton('core/locale')->date($data, Zend_Date::ISO_8601, null, false)->toString($format);
+                    : Mage::getSingleton('core/locale')->date($data, $dateFormat, null, false)->toString($format);
             } catch (Exception $e) {
                 $data = ($this->getColumn()->getTimezone())
                     ? Mage::app()->getLocale()->date($data, $dateFormat)->toString($format)


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

I dont see what changed with zf1 ... :(

`Zend_Date::ISO_8601` expects a date like `2014-05-02`, but for monthly reports the given date is only `2014-05`.

Edit: https://github.com/Shardj/zf1-future/commit/c7a5cf6dcd36bffefd7dd30e68db49b35966bee1#diff-fe1df84ebe2100899bfee24bd49ccecc97ee11538d93723a69632a9f9e5c021bR2045-R2059

### Related Pull Requests
<!-- related pull request placeholder -->

1. See OpenMage/magento-lts#2827

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#3122

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. open Sales -> Order reports
2. monthly period

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->