### PR TITLE
Avoided unnecessary calls to string translation methods for catalog/sales rules labels

### DIFF
--- a/app/code/core/Mage/CatalogRule/Model/Rule/Action/Product.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Action/Product.php
@@ -42,10 +42,10 @@ class Mage_CatalogRule_Model_Rule_Action_Product extends Mage_Rule_Model_Action_
     public function loadOperatorOptions()
     {
         $this->setOperatorOption([
-            'to_fixed' => Mage::helper('cataloginventory')->__('To Fixed Value'),
-            'to_percent' => Mage::helper('cataloginventory')->__('To Percentage'),
-            'by_fixed' => Mage::helper('cataloginventory')->__('By Fixed value'),
-            'by_percent' => Mage::helper('cataloginventory')->__('By Percentage'),
+            'to_fixed'   => static::$translate ? Mage::helper('cataloginventory')->__('To Fixed Value') : 'To Fixed Value',
+            'to_percent' => static::$translate ? Mage::helper('cataloginventory')->__('To Percentage') : 'To Percentage',
+            'by_fixed'   => static::$translate ? Mage::helper('cataloginventory')->__('By Fixed value') : 'By Fixed value',
+            'by_percent' => static::$translate ? Mage::helper('cataloginventory')->__('By Percentage') : 'By Percentage',
         ]);
         return $this;
     }

--- a/app/code/core/Mage/Rule/Model/Action/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Action/Abstract.php
@@ -36,8 +36,20 @@
  */
 abstract class Mage_Rule_Model_Action_Abstract extends Varien_Object implements Mage_Rule_Model_Action_Interface
 {
+    /**
+     * Flag to enable translation for loadOperatorOptions/loadValueOptions/loadAggregatorOptions/getDefaultOperatorOptions
+     * It's useless to translate these data on frontend
+     *
+     * @var bool
+     */
+    protected static $translate;
+
     public function __construct()
     {
+        if (!is_bool(static::$translate)) {
+            static::$translate = Mage::app()->getStore()->isAdmin();
+        }
+
         parent::__construct();
         $this->loadAttributeOptions()->loadOperatorOptions()->loadValueOptions();
 
@@ -137,8 +149,8 @@ abstract class Mage_Rule_Model_Action_Abstract extends Varien_Object implements 
     public function loadOperatorOptions()
     {
         $this->setOperatorOption([
-            '=' => Mage::helper('rule')->__('to'),
-            '+=' => Mage::helper('rule')->__('by'),
+            '='  => static::$translate ? Mage::helper('rule')->__('to') : 'to',
+            '+=' => static::$translate ? Mage::helper('rule')->__('by') : 'by',
         ]);
         return $this;
     }

--- a/app/code/core/Mage/Rule/Model/Condition/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Abstract.php
@@ -50,6 +50,14 @@
 abstract class Mage_Rule_Model_Condition_Abstract extends Varien_Object implements Mage_Rule_Model_Condition_Interface
 {
     /**
+     * Flag to enable translation for loadOperatorOptions/loadValueOptions/loadAggregatorOptions/getDefaultOperatorOptions
+     * It's useless to translate these data on frontend
+     *
+     * @var bool
+     */
+    protected static $translate;
+
+    /**
      * Defines which operators will be available for this condition
      *
      * @var string
@@ -76,6 +84,10 @@ abstract class Mage_Rule_Model_Condition_Abstract extends Varien_Object implemen
 
     public function __construct()
     {
+        if (!is_bool(static::$translate)) {
+            static::$translate = Mage::app()->getStore()->isAdmin();
+        }
+
         parent::__construct();
 
         $this->loadAttributeOptions()->loadOperatorOptions()->loadValueOptions();
@@ -137,18 +149,18 @@ abstract class Mage_Rule_Model_Condition_Abstract extends Varien_Object implemen
     {
         if ($this->_defaultOperatorOptions === null) {
             $this->_defaultOperatorOptions = [
-                '=='  => Mage::helper('rule')->__('is'),
-                '!='  => Mage::helper('rule')->__('is not'),
-                '>='  => Mage::helper('rule')->__('equals or greater than'),
-                '<='  => Mage::helper('rule')->__('equals or less than'),
-                '>'   => Mage::helper('rule')->__('greater than'),
-                '<'   => Mage::helper('rule')->__('less than'),
-                '{}'  => Mage::helper('rule')->__('contains'),
-                '!{}' => Mage::helper('rule')->__('does not contain'),
-                '[]'  => Mage::helper('rule')->__('contains'),
-                '![]' => Mage::helper('rule')->__('does not contain'),
-                '()'  => Mage::helper('rule')->__('is one of'),
-                '!()' => Mage::helper('rule')->__('is not one of')
+                '=='  => static::$translate ? Mage::helper('rule')->__('is') : 'is',
+                '!='  => static::$translate ? Mage::helper('rule')->__('is not') : 'is not',
+                '>='  => static::$translate ? Mage::helper('rule')->__('equals or greater than') : 'equals or greater than',
+                '<='  => static::$translate ? Mage::helper('rule')->__('equals or less than') : 'equals or less than',
+                '>'   => static::$translate ? Mage::helper('rule')->__('greater than') : 'greater than',
+                '<'   => static::$translate ? Mage::helper('rule')->__('less than') : 'less than',
+                '{}'  => static::$translate ? Mage::helper('rule')->__('contains') : 'contains',
+                '!{}' => static::$translate ? Mage::helper('rule')->__('does not contain') : 'does not contain',
+                '[]'  => static::$translate ? Mage::helper('rule')->__('contains') : 'contains',
+                '![]' => static::$translate ? Mage::helper('rule')->__('does not contain') : 'does not contain',
+                '()'  => static::$translate ? Mage::helper('rule')->__('is one of') : 'is one of',
+                '!()' => static::$translate ? Mage::helper('rule')->__('is not one of') : 'is not one of',
             ];
         }
         return $this->_defaultOperatorOptions;

--- a/app/code/core/Mage/Rule/Model/Condition/Combine.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Combine.php
@@ -109,8 +109,8 @@ class Mage_Rule_Model_Condition_Combine extends Mage_Rule_Model_Condition_Abstra
     public function loadAggregatorOptions()
     {
         $this->setAggregatorOption([
-            'all' => Mage::helper('rule')->__('ALL'),
-            'any' => Mage::helper('rule')->__('ANY'),
+            'all' => static::$translate ? Mage::helper('rule')->__('ALL') : 'ALL',
+            'any' => static::$translate ? Mage::helper('rule')->__('ANY') : 'ANY',
         ]);
         return $this;
     }
@@ -161,8 +161,8 @@ class Mage_Rule_Model_Condition_Combine extends Mage_Rule_Model_Condition_Abstra
     public function loadValueOptions()
     {
         $this->setValueOption([
-            1 => Mage::helper('rule')->__('TRUE'),
-            0 => Mage::helper('rule')->__('FALSE'),
+            1 => static::$translate ? Mage::helper('rule')->__('TRUE') : 'TRUE',
+            0 => static::$translate ? Mage::helper('rule')->__('FALSE') : 'FALSE',
         ]);
         return $this;
     }

--- a/app/code/core/Mage/SalesRule/Model/Rule/Action/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Action/Product.php
@@ -37,10 +37,10 @@ class Mage_SalesRule_Model_Rule_Action_Product extends Mage_Rule_Model_Action_Ab
     public function loadOperatorOptions()
     {
         $this->setOperatorOption([
-            'to_fixed' => Mage::helper('salesrule')->__('To Fixed Value'),
-            'to_percent' => Mage::helper('salesrule')->__('To Percentage'),
-            'by_fixed' => Mage::helper('salesrule')->__('By Fixed value'),
-            'by_percent' => Mage::helper('salesrule')->__('By Percentage'),
+            'to_fixed'   => static::$translate ? Mage::helper('salesrule')->__('To Fixed Value') : 'To Fixed Value',
+            'to_percent' => static::$translate ? Mage::helper('salesrule')->__('To Percentage') : 'To Percentage',
+            'by_fixed'   => static::$translate ? Mage::helper('salesrule')->__('By Fixed value') : 'By Fixed value',
+            'by_percent' => static::$translate ? Mage::helper('salesrule')->__('By Percentage') : 'By Percentage',
         ]);
         return $this;
     }

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Found.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Found.php
@@ -38,8 +38,8 @@ class Mage_SalesRule_Model_Rule_Condition_Product_Found extends Mage_SalesRule_M
     public function loadValueOptions()
     {
         $this->setValueOption([
-            1 => Mage::helper('salesrule')->__('FOUND'),
-            0 => Mage::helper('salesrule')->__('NOT FOUND')
+            1 => static::$translate ? Mage::helper('salesrule')->__('FOUND') : 'FOUND',
+            0 => static::$translate ? Mage::helper('salesrule')->__('NOT FOUND') : 'NOT FOUND',
         ]);
         return $this;
     }

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Subselect.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Subselect.php
@@ -83,14 +83,14 @@ class Mage_SalesRule_Model_Rule_Condition_Product_Subselect extends Mage_SalesRu
     public function loadOperatorOptions()
     {
         $this->setOperatorOption([
-            '=='  => Mage::helper('rule')->__('is'),
-            '!='  => Mage::helper('rule')->__('is not'),
-            '>='  => Mage::helper('rule')->__('equals or greater than'),
-            '<='  => Mage::helper('rule')->__('equals or less than'),
-            '>'   => Mage::helper('rule')->__('greater than'),
-            '<'   => Mage::helper('rule')->__('less than'),
-            '()'  => Mage::helper('rule')->__('is one of'),
-            '!()' => Mage::helper('rule')->__('is not one of'),
+            '=='  => static::$translate ? Mage::helper('rule')->__('is') : 'is',
+            '!='  => static::$translate ? Mage::helper('rule')->__('is not') : 'is not',
+            '>='  => static::$translate ? Mage::helper('rule')->__('equals or greater than') : 'equals or greater than',
+            '<='  => static::$translate ? Mage::helper('rule')->__('equals or less than') : 'equals or less than',
+            '>'   => static::$translate ? Mage::helper('rule')->__('greater than') : 'greater than',
+            '<'   => static::$translate ? Mage::helper('rule')->__('less than') : 'less than',
+            '()'  => static::$translate ? Mage::helper('rule')->__('is one of') : 'is one of',
+            '!()' => static::$translate ? Mage::helper('rule')->__('is not one of') : 'is not one of',
         ]);
         return $this;
     }


### PR DESCRIPTION
### Description

This PR stop translations of rules labels from frontend.
Perhaps the best way is to remove all translations from model, and translate only from blocks? I don't know.

Here a before/after with Blackfire with a cart with ~50 products (simple, configurable, bundles):

original (before):
![big-cart-before](https://user-images.githubusercontent.com/31816829/230009873-a0e7ee95-85e8-4c25-b45a-1880bdd26d7b.png)

after without the static property:
![big-cart-after-effect](https://user-images.githubusercontent.com/31816829/230010023-7bf750e7-c3b2-40a3-ab20-92b2a9dac142.png)

after:
![static](https://user-images.githubusercontent.com/31816829/230010283-64e1bc74-1ad4-4199-bab9-c2741a9332ae.png)
![big-cart-after](https://user-images.githubusercontent.com/31816829/230010059-06ec73fb-ad1a-4e94-9aaa-c576b2eaaff8.png)


Can fix partially #3127 or not.
Tested with PHP 8.0 and 8.2 with OM rc2.

If you have others modules or custom dev, that do the same, you need to update your files to have better performance on your website. Example with [HiPay module's](https://github.com/hipay/hipay-fullservice-sdk-magento1/blob/master/src/app/code/community/Allopass/Hipay/Model/Rule/Condition/Product/Subselect.php).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list