### PR TITLE
Added check for coupon expiration date

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Validator.php
+++ b/app/code/core/Mage/SalesRule/Model/Validator.php
@@ -179,6 +179,11 @@ class Mage_SalesRule_Model_Validator extends Mage_Core_Model_Abstract
                         $rule->setIsValidForAddress($address, false);
                         return false;
                     }
+                    // check coupon expiration
+                    if ($coupon->hasExpirationDate() && ($coupon->getExpirationDate() < Mage::getModel('core/date')->date())) {
+                        $rule->setIsValidForAddress($address, false);
+                        return false;
+                    }
                     // check per customer usage limit
                     $customerId = $address->getQuote()->getCustomerId();
                     if ($customerId && $coupon->getUsagePerCustomer()) {


### PR DESCRIPTION
Mage_SalesRule_Model_Validator::_canProcessRule() checks the validity of a coupon code that is in the process of being added to the cart, but it doesn't check for the single coupon expiration date. This PR adds this check.

### Manual testing scenarios (*)
1. in the backend go to "promotions -> Shopping Cart Price Rules"
2. create a new rule with "specific coupon" (but also autogenerated coupons have the same issue) and type a coupon code
3. be sure that the rule also has some "action", ex: 10% discount
4. save the rule and check that it's working on the frontend

Now, what we're about to check isn't really supported by the core but I think it's still worth fixing.

5. open your database console and check for the `salesrule_coupon` table, you'll find a record with the coupon code you just created above
6. modify the `expiration_date` column for that specific coupon and set it in the past
7. go to the frontend, apply the coupon and notice that it gets applied anyway

It is true that the core wouldn't manage the expiration_date column but, since it exists, I know extensions (actually I was developing one today when I found this bug) that set the expiration_data for a single coupon (let's say you want a coupon to be usable only for 7 days after its generation), and it doesn't make sense to me that the core doesn't check for the expiration_date of a coupon.

After applying this PR you'll notice that the expiration_date gets correctly checked, if present.

### Related PRs
This PR was already approved in https://github.com/OpenMage/magento-lts/pull/3029 but I had to recreate it due to rebasing problems.