### PR TITLE
Used session_status() instead of $_SESSION in Mage_Core_Model_App

### DIFF
--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -371,7 +371,7 @@ class Mage_Core_Model_App
         } else {
             flush();
         }
-        if (isset($_SESSION)) {
+        if (session_status() === PHP_SESSION_ACTIVE) {
             session_write_close();
         }
 


### PR DESCRIPTION
As @tmotyl pointed out in https://github.com/OpenMage/magento-lts/pull/1592#discussion_r1158255712, quoting [a comment](https://github.com/OpenMage/magento-lts/pull/1592#issuecomment-833249257) by @Flyingmana  it's better to use `session_status()` instead of `$_SESSION`.

### Related Pull Requests
https://github.com/OpenMage/magento-lts/pull/1592