### PR TITLE
Avoided calling getBackendModelByFieldConfig with empty field

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/Config/Data.php
+++ b/app/code/core/Mage/Adminhtml/Model/Config/Data.php
@@ -138,7 +138,7 @@ class Mage_Adminhtml_Model_Config_Data extends Varien_Object
                     }
                 }
 
-                $backendClass = $helper->getBackendModelByFieldConfig($fieldConfig);
+                $backendClass = $fieldConfig ? $helper->getBackendModelByFieldConfig($fieldConfig) : false;
                 if (!$backendClass) {
                     $backendClass = 'core/config_data';
                 }


### PR DESCRIPTION
If you open the backend and go to System -> configuration -> advanced -> advanced and just hit save, you'll see this error:

`Uncaught TypeError: Argument 1 passed to Mage_Adminhtml_Helper_Config::getBackendModelByFieldConfig() must be an instance of Varien_Simplexml_Element, bool given, called in app/code/core/Mage/Adminhtml/Model/Config/Data.php on line 141`

This was introduced in https://github.com/OpenMage/magento-lts/pull/2945

With this PR we make sure not to call `$helper->getBackendModelByFieldConfig($fieldConfig)` if we don't have any fieldConfig.

After applying the PR, hit save and it works as expected.