### PR TITLE
Typo in the exception message

### DIFF
--- a/app/code/core/Mage/Payment/Helper/Data.php
+++ b/app/code/core/Mage/Payment/Helper/Data.php
@@ -38,7 +38,7 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
         $key = self::XML_PATH_PAYMENT_METHODS . '/' . $code . '/model';
         $class = Mage::getStoreConfig($key);
         if (is_null($class)) {
-            Mage::logException(new Exception(sprintf('Unkown payment method with code "%s"', $code)));
+            Mage::logException(new Exception(sprintf('Unknown payment method with code "%s"', $code)));
             return false;
         }
         return Mage::getModel($class);


### PR DESCRIPTION
In file /app/code/core/Mage/Payment/Helper/Data.php there is a typo. Unkown => Unknown.

```php
    public function getMethodInstance($code)
    {
        $key = self::XML_PATH_PAYMENT_METHODS . '/' . $code . '/model';
        $class = Mage::getStoreConfig($key);
        if (is_null($class)) {
            Mage::logException(new Exception(sprintf('Unkown payment method with code "%s"', $code)));
            return false;
        }
        return Mage::getModel($class);
    }
```