### PR TITLE
[PHP 8.2] Fixed some deprecation warnings

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Coupons/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Coupons/Form.php
@@ -27,6 +27,9 @@ class Mage_Adminhtml_Block_Sales_Order_Create_Coupons_Form extends Mage_Adminhtm
         $this->setId('sales_order_create_coupons_form');
     }
 
+    /**
+     * @return string
+     */
     public function getCouponCode()
     {
         return $this->getParentBlock()->getQuote()->getCouponCode();

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
@@ -75,7 +75,9 @@ class Mage_ConfigurableSwatches_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public static function normalizeKey($key)
     {
-        if ($key === null || $key === '') return '';
+        if ($key === null || $key === '') {
+             return '';
+        }
         if (function_exists('mb_strtolower')) {
             return trim(mb_strtolower($key, 'UTF-8'));
         }

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
@@ -75,6 +75,7 @@ class Mage_ConfigurableSwatches_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public static function normalizeKey($key)
     {
+        if ($key === null || $key === '') return '';
         if (function_exists('mb_strtolower')) {
             return trim(mb_strtolower($key, 'UTF-8'));
         }

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
@@ -76,7 +76,7 @@ class Mage_ConfigurableSwatches_Helper_Data extends Mage_Core_Helper_Abstract
     public static function normalizeKey($key)
     {
         if ($key === null || $key === '') {
-             return '';
+            return '';
         }
         if (function_exists('mb_strtolower')) {
             return trim(mb_strtolower($key, 'UTF-8'));

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
@@ -75,7 +75,7 @@ class Mage_Eav_Model_Entity_Attribute_Source_Table extends Mage_Eav_Model_Entity
     public function getOptionText($value)
     {
         $isMultiple = false;
-        if (strpos($value, ',')) {
+        if (strpos($value ?? '', ',')) {
             $isMultiple = true;
             $value = explode(',', $value);
         }

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
@@ -75,7 +75,7 @@ class Mage_Eav_Model_Entity_Attribute_Source_Table extends Mage_Eav_Model_Entity
     public function getOptionText($value)
     {
         $isMultiple = false;
-        if (strpos($value ?? '', ',')) {
+        if ($value && strpos($value, ',')) {
             $isMultiple = true;
             $value = explode(',', $value);
         }

--- a/app/code/core/Mage/Rule/Model/Condition/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Abstract.php
@@ -815,7 +815,7 @@ abstract class Mage_Rule_Model_Condition_Abstract extends Varien_Object implemen
         if ($strict && is_numeric($validatedValue) && is_numeric($value)) {
             return $validatedValue == $value;
         } else {
-             $validatedValue = $validatedValue ?? '';
+            $validatedValue = $validatedValue ?? '';
             $validatePattern = preg_quote($validatedValue, '~');
             if ($strict) {
                 $validatePattern = '^' . $validatePattern . '$';

--- a/app/code/core/Mage/Rule/Model/Condition/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Abstract.php
@@ -812,10 +812,10 @@ abstract class Mage_Rule_Model_Condition_Abstract extends Varien_Object implemen
      */
     protected function _compareValues($validatedValue, $value, $strict = true)
     {
-        $validatedValue = $validatedValue ?? '';
         if ($strict && is_numeric($validatedValue) && is_numeric($value)) {
             return $validatedValue == $value;
         } else {
+             $validatedValue = $validatedValue ?? '';
             $validatePattern = preg_quote($validatedValue, '~');
             if ($strict) {
                 $validatePattern = '^' . $validatePattern . '$';

--- a/app/code/core/Mage/Rule/Model/Condition/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Abstract.php
@@ -812,6 +812,7 @@ abstract class Mage_Rule_Model_Condition_Abstract extends Varien_Object implemen
      */
     protected function _compareValues($validatedValue, $value, $strict = true)
     {
+        $validatedValue = $validatedValue ?? '';
         if ($strict && is_numeric($validatedValue) && is_numeric($value)) {
             return $validatedValue == $value;
         } else {

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -2100,7 +2100,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
      * @param string $couponCode
      * @return $this
      */
-    public function setCouponCode(string $couponCode) #static with php74
+    public function setCouponCode(string $couponCode)
     {
         return $this->setData('coupon_code', $couponCode);
     }

--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -82,7 +82,6 @@
  * @method $this setCompany(string $value)
  * @method string getCountryId()
  * @method $this setCountryId(string $value)
- * @method string getCouponCode()
  * @method $this setCouponCode(string $value)
  * @method string getCreatedAt()
  * @method $this setCreatedAt(string $value)
@@ -1334,5 +1333,13 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
     public function getSubtotalWithDiscount()
     {
         return $this->getSubtotal() + $this->getDiscountAmount();
+    }
+
+    /**
+     * @return string
+     */
+    public function getCouponCode(): string
+    {
+        return (string)$this->_getData('coupon_code');
     }
 }

--- a/app/code/core/Mage/SalesRule/Model/Validator.php
+++ b/app/code/core/Mage/SalesRule/Model/Validator.php
@@ -962,7 +962,7 @@ class Mage_SalesRule_Model_Validator extends Mage_Core_Model_Abstract
         $label = '';
         if ($ruleLabel) {
             $label = $ruleLabel;
-        } elseif (strlen($address->getCouponCode() ?? '')) {
+        } elseif (strlen($address->getCouponCode())) {
             $label = $address->getCouponCode();
         }
 

--- a/app/code/core/Mage/SalesRule/Model/Validator.php
+++ b/app/code/core/Mage/SalesRule/Model/Validator.php
@@ -962,7 +962,7 @@ class Mage_SalesRule_Model_Validator extends Mage_Core_Model_Abstract
         $label = '';
         if ($ruleLabel) {
             $label = $ruleLabel;
-        } elseif (strlen($address->getCouponCode())) {
+        } elseif (strlen($address->getCouponCode() ?? '')) {
             $label = $address->getCouponCode();
         }
 

--- a/app/design/adminhtml/default/default/template/widget/tabs.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabs.phtml
@@ -26,7 +26,7 @@
 <?php foreach ($tabs as $_tab): ?>
 <?php if (!$this->canShowTab($_tab)): continue;  endif; ?>
     <li <?php if($this->getTabIsHidden($_tab)): ?> style="display:none"<?php endif ?>>
-        <a href="<?php echo $this->getTabUrl($_tab) ?>" id="<?php echo $this->getTabId($_tab) ?>" name="<?php echo $this->getTabId($_tab, false) ?>" title="<?php echo Mage::helper('core')->quoteEscape($this->getTabTitle($_tab)) ?>" class="tab-item-link <?php echo $this->getTabClass($_tab) ?><?php if (preg_match('/\s?ajax\s?/', $_tab->getClass())) {?> notloaded<?php }?>">
+        <a href="<?php echo $this->getTabUrl($_tab) ?>" id="<?php echo $this->getTabId($_tab) ?>" name="<?php echo $this->getTabId($_tab, false) ?>" title="<?php echo Mage::helper('core')->quoteEscape($this->getTabTitle($_tab)) ?>" class="tab-item-link <?php echo $this->getTabClass($_tab) ?><?php if (preg_match('/\s?ajax\s?/', $_tab->getClass() ?? '')) {?> notloaded<?php }?>">
             <span><span class="changed" title="<?php echo Mage::helper('core')->quoteEscape($this->__('The information in this tab has been changed.')) ?>"></span><span class="error" title="<?php echo Mage::helper('core')->quoteEscape($this->__('This tab contains invalid data. Please solve the problem before saving.')) ?>"></span><?php echo $this->getTabLabel($_tab); ?></span>
         </a>
         <div id="<?php echo $this->getTabId($_tab) ?>_content" style="display:none;"><?php echo $this->getTabContent($_tab) ?></div>


### PR DESCRIPTION
In https://github.com/OpenMage/magento-lts/issues/3152 @ADDISON74 found out some PHP 8.2 deprecation warnings, this PR should fix them.

Note: at the moment it still doesn't fix the problems with Mage_Paypal_Model_Config that apparently were introduced with https://github.com/OpenMage/magento-lts/pull/2759


### Related Pull Requests
1. https://github.com/OpenMage/magento-lts/pull/2759

### Fixed Issues
1. Fixes https://github.com/OpenMage/magento-lts/issues/3152