### PR TITLE
Move login page title to controller

### DIFF
--- a/app/code/core/Mage/Customer/Block/Form/Login.php
+++ b/app/code/core/Mage/Customer/Block/Form/Login.php
@@ -27,15 +27,6 @@ class Mage_Customer_Block_Form_Login extends Mage_Core_Block_Template
     private $_username = -1;
 
     /**
-     * @inheritDoc
-     */
-    protected function _prepareLayout()
-    {
-        $this->getLayout()->getBlock('head')->setTitle(Mage::helper('customer')->__('Customer Login'));
-        return parent::_prepareLayout();
-    }
-
-    /**
      * Retrieve form posting url
      *
      * @return string

--- a/app/code/core/Mage/Customer/controllers/AccountController.php
+++ b/app/code/core/Mage/Customer/controllers/AccountController.php
@@ -125,6 +125,7 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
         $this->loadLayout();
         $this->_initLayoutMessages('customer/session');
         $this->_initLayoutMessages('catalog/session');
+        $this->getLayout()->getBlock('head')->setTitle($this->__('Customer Login'));
         $this->renderLayout();
     }
 


### PR DESCRIPTION
### Description

This small PR move the definition of the title of the login page from the _block_ to the _controller_. This allow to reuse the block elsewhere without modifying the page title.

Go to customer login page to check the page title.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list