### PR TITLE
Replaced setData by setEvent

### DIFF
--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -1376,7 +1376,7 @@ class Mage_Core_Model_App
             }
 
             foreach ($events[$eventName]['observers'] as $obsName => $obs) {
-                $observer->setData(['event' => $event]);
+                $observer->setEvent($event);
                 Varien_Profiler::start('OBSERVER: ' . $obsName);
                 switch ($obs['type']) {
                     case 'disabled':


### PR DESCRIPTION
### Description

This small PR replace `setData` by `setEvent`.
I found that with Blackfire some months ago, but I lost the before/after.

https://github.com/OpenMage/magento-lts/blob/cbdac32a562b8622340c1d4fc77b964ee09dcd58/lib/Varien/Event/Observer.php#L121-L127

Yes this will not change many things, but this + many others...

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list