### PR TITLE
Fix for export failing when product_id missing from cataloginventory_stock_item

### DIFF
--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
@@ -926,7 +926,7 @@ class Mage_ImportExport_Model_Export_Entity_Product extends Mage_ImportExport_Mo
                         $dataRow[self::COL_TYPE]     = null;
                     } else {
                         $dataRow[self::COL_STORE] = null;
-                        if ((!empty($stockItemRows[$productId]))&&(is_numeric($stockItemRows[$productId]))) {
+                        if (!empty($stockItemRows[$productId]) && is_numeric($stockItemRows[$productId])) {
                             $dataRow += $stockItemRows[$productId];
                         }
                     }

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
@@ -926,7 +926,7 @@ class Mage_ImportExport_Model_Export_Entity_Product extends Mage_ImportExport_Mo
                         $dataRow[self::COL_TYPE]     = null;
                     } else {
                         $dataRow[self::COL_STORE] = null;
-                        if (!empty($stockItemRows[$productId])) {
+                        if ((!empty($stockItemRows[$productId]))&&(is_numeric($stockItemRows[$productId]))) {
                             $dataRow += $stockItemRows[$productId];
                         }
                     }

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
@@ -926,7 +926,7 @@ class Mage_ImportExport_Model_Export_Entity_Product extends Mage_ImportExport_Mo
                         $dataRow[self::COL_TYPE]     = null;
                     } else {
                         $dataRow[self::COL_STORE] = null;
-                        if ($stockItemRows[$productId]) {
+                        if (!empty($stockItemRows[$productId])) {
                             $dataRow += $stockItemRows[$productId];
                         }
                     }

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
@@ -927,7 +927,7 @@ class Mage_ImportExport_Model_Export_Entity_Product extends Mage_ImportExport_Mo
                     } else {
                         $dataRow[self::COL_STORE] = null;
                         if ($stockItemRows[$productId]) {
-							$dataRow += $stockItemRows[$productId];
+                            $dataRow += $stockItemRows[$productId];
                         }
                     }
 

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
@@ -926,7 +926,9 @@ class Mage_ImportExport_Model_Export_Entity_Product extends Mage_ImportExport_Mo
                         $dataRow[self::COL_TYPE]     = null;
                     } else {
                         $dataRow[self::COL_STORE] = null;
-                        $dataRow += $stockItemRows[$productId];
+                        if ($stockItemRows[$productId]) {
+							$dataRow += $stockItemRows[$productId];
+                        }
                     }
 
                     $this->_updateDataWithCategoryColumns($dataRow, $rowCategories, $productId);

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
@@ -926,7 +926,7 @@ class Mage_ImportExport_Model_Export_Entity_Product extends Mage_ImportExport_Mo
                         $dataRow[self::COL_TYPE]     = null;
                     } else {
                         $dataRow[self::COL_STORE] = null;
-                        if (!empty($stockItemRows[$productId]) && is_numeric($stockItemRows[$productId])) {
+                        if (!empty($stockItemRows[$productId]) && is_array($stockItemRows[$productId])) {
                             $dataRow += $stockItemRows[$productId];
                         }
                     }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Export from admin panel would fail if a `product_id` listed in `catalog_product_entity` is not in the `cataloginventory_stock_item` table. This shouldn't be the case, but one of our sites encountered this issue.

This PR prevents the export from failing with a 500 error.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. `catalog_product_entity` row listed without a SKU (for unknown reason)
2. `entity_id` not referenced in `cataloginventory_stock_item` `product_id` column
3. Generates 500 error on Import/Export -> Export -> products csv

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
