### PR TITLE
Removed all @author tags from docblocks

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -49,8 +49,6 @@ foreach (glob(BP . DS . 'app' . DS . 'etc' . DS . 'includes' . DS . '*.php') as 
 
 /**
  * Main Mage hub class
- *
- * @author      Magento Core Team <core@magentocommerce.com>
  */
 final class Mage
 {

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Formkey.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Formkey.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Adminhtml
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Adminhtml_Block_Checkout_Formkey extends Mage_Adminhtml_Block_Template
 {

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Addresses.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Addresses.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Adminhtml
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Adminhtml_Block_Customer_Edit_Tab_Addresses extends Mage_Adminhtml_Block_Widget_Form
 {

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Graph.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Graph.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Adminhtml
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Adminhtml_Block_Dashboard_Graph extends Mage_Adminhtml_Block_Dashboard_Abstract
 {

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Abstract.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Adminhtml
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Adminhtml_Block_Report_Grid_Abstract extends Mage_Adminhtml_Block_Widget_Grid
 {

--- a/app/code/core/Mage/Adminhtml/Helper/Config.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Config.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
  *
  * @category   Mage
  * @package    Mage_Adminhtml
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Adminhtml_Helper_Config extends Mage_Core_Helper_Abstract
 {

--- a/app/code/core/Mage/Adminhtml/Model/Config/Data.php
+++ b/app/code/core/Mage/Adminhtml/Model/Config/Data.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Adminhtml
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method array getGroups()
  * @method $this setGroups(array $value)

--- a/app/code/core/Mage/Api/Controller/Action.php
+++ b/app/code/core/Mage/Api/Controller/Action.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
 */
 class Mage_Api_Controller_Action extends Mage_Core_Controller_Front_Action
 {

--- a/app/code/core/Mage/Api/Exception.php
+++ b/app/code/core/Mage/Api/Exception.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Exception extends Mage_Core_Exception
 {

--- a/app/code/core/Mage/Api/Helper/Data.php
+++ b/app/code/core/Mage/Api/Helper/Data.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Helper_Data extends Mage_Core_Helper_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Acl.php
+++ b/app/code/core/Mage/Api/Model/Acl.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Acl extends Zend_Acl
 {

--- a/app/code/core/Mage/Api/Model/Acl/Assert/Ip.php
+++ b/app/code/core/Mage/Api/Model/Acl/Assert/Ip.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Acl_Assert_Ip implements Zend_Acl_Assert_Interface
 {

--- a/app/code/core/Mage/Api/Model/Acl/Assert/Time.php
+++ b/app/code/core/Mage/Api/Model/Acl/Assert/Time.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Acl_Assert_Time implements Zend_Acl_Assert_Interface
 {

--- a/app/code/core/Mage/Api/Model/Acl/Resource.php
+++ b/app/code/core/Mage/Api/Model/Acl/Resource.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Acl_Resource extends Zend_Acl_Resource
 {

--- a/app/code/core/Mage/Api/Model/Acl/Role.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Api_Model_Resource_Role _getResource()
  * @method Mage_Api_Model_Resource_Role getResource()

--- a/app/code/core/Mage/Api/Model/Acl/Role/Generic.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/Generic.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Acl_Role_Generic extends Zend_Acl_Role
 {

--- a/app/code/core/Mage/Api/Model/Acl/Role/Group.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/Group.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Acl_Role_Group extends Mage_Api_Model_Acl_Role_Generic
 {

--- a/app/code/core/Mage/Api/Model/Acl/Role/Registry.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/Registry.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Acl_Role_Registry extends Zend_Acl_Role_Registry
 {

--- a/app/code/core/Mage/Api/Model/Acl/Role/User.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/User.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Acl_Role_User extends Mage_Api_Model_Acl_Role_Generic
 {

--- a/app/code/core/Mage/Api/Model/Config.php
+++ b/app/code/core/Mage/Api/Model/Config.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Config extends Varien_Simplexml_Config
 {

--- a/app/code/core/Mage/Api/Model/Mysql4/Acl.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Acl.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Api_Model_Mysql4_Acl extends Mage_Api_Model_Resource_Acl

--- a/app/code/core/Mage/Api/Model/Mysql4/Acl/Role.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Acl/Role.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Api_Model_Mysql4_Acl_Role extends Mage_Api_Model_Resource_Acl_Role

--- a/app/code/core/Mage/Api/Model/Mysql4/Acl/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Acl/Role/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Api_Model_Mysql4_Acl_Role_Collection extends Mage_Api_Model_Resource_Acl_Role_Collection

--- a/app/code/core/Mage/Api/Model/Mysql4/Permissions/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Permissions/Collection.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Api_Model_Mysql4_Permissions_Collection extends Mage_Api_Model_Resource_Permissions_Collection

--- a/app/code/core/Mage/Api/Model/Mysql4/Role.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Role.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Api_Model_Mysql4_Role extends Mage_Api_Model_Resource_Role

--- a/app/code/core/Mage/Api/Model/Mysql4/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Role/Collection.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Api_Model_Mysql4_Role_Collection extends Mage_Api_Model_Resource_Role_Collection

--- a/app/code/core/Mage/Api/Model/Mysql4/Roles.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Roles.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Api_Model_Mysql4_Roles extends Mage_Api_Model_Resource_Roles

--- a/app/code/core/Mage/Api/Model/Mysql4/Roles/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Roles/Collection.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Api_Model_Mysql4_Roles_Collection extends Mage_Api_Model_Resource_Roles_Collection

--- a/app/code/core/Mage/Api/Model/Mysql4/Roles/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Roles/User/Collection.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Api_Model_Mysql4_Roles_User_Collection extends Mage_Api_Model_Resource_Roles_User_Collection

--- a/app/code/core/Mage/Api/Model/Mysql4/Rules.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Rules.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Api_Model_Mysql4_Rules extends Mage_Api_Model_Resource_Rules

--- a/app/code/core/Mage/Api/Model/Mysql4/Rules/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Rules/Collection.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Api_Model_Mysql4_Rules_Collection extends Mage_Api_Model_Resource_Rules_Collection

--- a/app/code/core/Mage/Api/Model/Mysql4/User.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/User.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Api_Model_Mysql4_User extends Mage_Api_Model_Resource_User

--- a/app/code/core/Mage/Api/Model/Mysql4/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/User/Collection.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Api_Model_Mysql4_User_Collection extends Mage_Api_Model_Resource_User_Collection

--- a/app/code/core/Mage/Api/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Resource/Abstract.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Resource_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Resource/Acl.php
+++ b/app/code/core/Mage/Api/Model/Resource/Acl.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Resource/Acl/Role.php
+++ b/app/code/core/Mage/Api/Model/Resource/Acl/Role.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method $this setCreated(string $value)
  */

--- a/app/code/core/Mage/Api/Model/Resource/Acl/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Acl/Role/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Resource_Acl_Role_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Resource/Permissions/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Permissions/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Resource_Permissions_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Resource/Role.php
+++ b/app/code/core/Mage/Api/Model/Resource/Role.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Resource_Role extends Mage_Core_Model_Resource_Db_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Resource/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Role/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Resource_Role_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Resource/Roles.php
+++ b/app/code/core/Mage/Api/Model/Resource/Roles.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Resource_Roles extends Mage_Core_Model_Resource_Db_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Resource/Roles/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Roles/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Resource_Roles_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Resource/Roles/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Roles/User/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Resource_Roles_User_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Resource/Rules.php
+++ b/app/code/core/Mage/Api/Model/Resource/Rules.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Resource_Rules extends Mage_Core_Model_Resource_Db_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Resource/Rules/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Rules/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Resource_Rules_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Resource/User.php
+++ b/app/code/core/Mage/Api/Model/Resource/User.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Resource/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/User/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Resource_User_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Role.php
+++ b/app/code/core/Mage/Api/Model/Role.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Api_Model_Resource_Role _getResource()
  * @method Mage_Api_Model_Resource_Role getResource()

--- a/app/code/core/Mage/Api/Model/Roles.php
+++ b/app/code/core/Mage/Api/Model/Roles.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Api_Model_Resource_Roles _getResource()
  * @method Mage_Api_Model_Resource_Roles getResource()

--- a/app/code/core/Mage/Api/Model/Rules.php
+++ b/app/code/core/Mage/Api/Model/Rules.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Api_Model_Resource_Rules _getResource()
  * @method Mage_Api_Model_Resource_Rules getResource()

--- a/app/code/core/Mage/Api/Model/Server.php
+++ b/app/code/core/Mage/Api/Model/Server.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Server
 {

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Interface.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Interface.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 interface Mage_Api_Model_Server_Adapter_Interface
 {

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Server_Adapter_Soap extends Varien_Object implements Mage_Api_Model_Server_Adapter_Interface
 {

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Xmlrpc.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Xmlrpc.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Server_Adapter_Xmlrpc extends Varien_Object implements Mage_Api_Model_Server_Adapter_Interface
 {

--- a/app/code/core/Mage/Api/Model/Server/Handler.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Server_Handler extends Mage_Api_Model_Server_Handler_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class Mage_Api_Model_Server_Handler_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Server/V2/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/V2/Adapter/Soap.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Server_V2_Adapter_Soap extends Mage_Api_Model_Server_Adapter_Soap
 {

--- a/app/code/core/Mage/Api/Model/Server/V2/Handler.php
+++ b/app/code/core/Mage/Api/Model/Server/V2/Handler.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Server_V2_Handler extends Mage_Api_Model_Server_Handler_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Server/Wsi/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/Wsi/Adapter/Soap.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Server_Wsi_Adapter_Soap extends Mage_Api_Model_Server_Adapter_Soap
 {

--- a/app/code/core/Mage/Api/Model/Server/Wsi/Handler.php
+++ b/app/code/core/Mage/Api/Model/Server/Wsi/Handler.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Server_Wsi_Handler extends Mage_Api_Model_Server_Handler_Abstract
 {

--- a/app/code/core/Mage/Api/Model/Session.php
+++ b/app/code/core/Mage/Api/Model/Session.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Api_Model_User getUser()
  * @method $this setUser(Mage_Api_Model_User $user)

--- a/app/code/core/Mage/Api/Model/User.php
+++ b/app/code/core/Mage/Api/Model/User.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Api_Model_Resource_User _getResource()
  * @method Mage_Api_Model_Resource_User getResource()

--- a/app/code/core/Mage/Api/Model/Wsdl/Config.php
+++ b/app/code/core/Mage/Api/Model/Wsdl/Config.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Wsdl_Config extends Mage_Api_Model_Wsdl_Config_Base
 {

--- a/app/code/core/Mage/Api/Model/Wsdl/Config/Base.php
+++ b/app/code/core/Mage/Api/Model/Wsdl/Config/Base.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Wsdl_Config_Base extends Varien_Simplexml_Config
 {

--- a/app/code/core/Mage/Api/Model/Wsdl/Config/Element.php
+++ b/app/code/core/Mage/Api/Model/Wsdl/Config/Element.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_Model_Wsdl_Config_Element extends Varien_Simplexml_Element
 {

--- a/app/code/core/Mage/Api/controllers/IndexController.php
+++ b/app/code/core/Mage/Api/controllers/IndexController.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_IndexController extends Mage_Api_Controller_Action
 {

--- a/app/code/core/Mage/Api/controllers/SoapController.php
+++ b/app/code/core/Mage/Api/controllers/SoapController.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_SoapController extends Mage_Api_Controller_Action
 {

--- a/app/code/core/Mage/Api/controllers/V2/SoapController.php
+++ b/app/code/core/Mage/Api/controllers/V2/SoapController.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_V2_SoapController extends Mage_Api_Controller_Action
 {

--- a/app/code/core/Mage/Api/controllers/XmlrpcController.php
+++ b/app/code/core/Mage/Api/controllers/XmlrpcController.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Api_XmlrpcController extends Mage_Api_Controller_Action
 {

--- a/app/code/core/Mage/CatalogInventory/Helper/Data.php
+++ b/app/code/core/Mage/CatalogInventory/Helper/Data.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_CatalogInventory
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_CatalogInventory_Helper_Data extends Mage_Core_Helper_Abstract
 {

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Action/Product.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Action/Product.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_CatalogRule
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method $this setAttributeOption(array $value)
  * @method $this setOperatorOption(array $value)

--- a/app/code/core/Mage/Cms/Block/Block.php
+++ b/app/code/core/Mage/Cms/Block/Block.php
@@ -21,7 +21,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Block_Block extends Mage_Core_Block_Abstract
 {

--- a/app/code/core/Mage/Cms/Block/Page.php
+++ b/app/code/core/Mage/Cms/Block/Page.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method int getPageId()
  */

--- a/app/code/core/Mage/Cms/Block/Widget/Block.php
+++ b/app/code/core/Mage/Cms/Block/Widget/Block.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method int getBlockId()
  * @method $this setText(string $value)

--- a/app/code/core/Mage/Cms/Block/Widget/Page/Link.php
+++ b/app/code/core/Mage/Cms/Block/Widget/Page/Link.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Block_Widget_Page_Link extends Mage_Core_Block_Html_Link implements Mage_Widget_Block_Interface
 {

--- a/app/code/core/Mage/Cms/Controller/Router.php
+++ b/app/code/core/Mage/Cms/Controller/Router.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Controller_Router extends Mage_Core_Controller_Varien_Router_Abstract
 {

--- a/app/code/core/Mage/Cms/Helper/Data.php
+++ b/app/code/core/Mage/Cms/Helper/Data.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Helper_Data extends Mage_Core_Helper_Abstract
 {

--- a/app/code/core/Mage/Cms/Helper/Page.php
+++ b/app/code/core/Mage/Cms/Helper/Page.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Helper_Page extends Mage_Core_Helper_Abstract
 {

--- a/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
+++ b/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Helper_Wysiwyg_Images extends Mage_Core_Helper_Abstract
 {

--- a/app/code/core/Mage/Cms/Model/Adminhtml/Template/Filter.php
+++ b/app/code/core/Mage/Cms/Model/Adminhtml/Template/Filter.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Model_Adminhtml_Template_Filter extends Mage_Cms_Model_Template_Filter
 {

--- a/app/code/core/Mage/Cms/Model/Block.php
+++ b/app/code/core/Mage/Cms/Model/Block.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Cms_Model_Resource_Block _getResource()
  * @method Mage_Cms_Model_Resource_Block getResource()

--- a/app/code/core/Mage/Cms/Model/Mysql4/Block.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Block.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Cms_Model_Mysql4_Block extends Mage_Cms_Model_Resource_Block

--- a/app/code/core/Mage/Cms/Model/Mysql4/Block/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Block/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Cms_Model_Mysql4_Block_Collection extends Mage_Cms_Model_Resource_Block_Collection

--- a/app/code/core/Mage/Cms/Model/Mysql4/Page.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Page.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Cms_Model_Mysql4_Page extends Mage_Cms_Model_Resource_Page

--- a/app/code/core/Mage/Cms/Model/Mysql4/Page/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Page/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Cms_Model_Mysql4_Page_Collection extends Mage_Cms_Model_Resource_Page_Collection

--- a/app/code/core/Mage/Cms/Model/Mysql4/Page/Service.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Page/Service.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Cms_Model_Mysql4_Page_Service extends Mage_Cms_Model_Resource_Page_Service

--- a/app/code/core/Mage/Cms/Model/Observer.php
+++ b/app/code/core/Mage/Cms/Model/Observer.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Model_Observer
 {

--- a/app/code/core/Mage/Cms/Model/Page.php
+++ b/app/code/core/Mage/Cms/Model/Page.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Cms_Model_Resource_Page _getResource()
  * @method Mage_Cms_Model_Resource_Page getResource()

--- a/app/code/core/Mage/Cms/Model/Resource/Block.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Block.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Model_Resource_Block extends Mage_Core_Model_Resource_Db_Abstract
 {

--- a/app/code/core/Mage/Cms/Model/Resource/Block/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Block/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Model_Resource_Block_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {

--- a/app/code/core/Mage/Cms/Model/Resource/Page.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Page.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Model_Resource_Page extends Mage_Core_Model_Resource_Db_Abstract
 {

--- a/app/code/core/Mage/Cms/Model/Resource/Page/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Page/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Model_Resource_Page_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {

--- a/app/code/core/Mage/Cms/Model/Resource/Page/Service.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Page/Service.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Model_Resource_Page_Service extends Mage_Core_Model_Resource_Db_Abstract
 {

--- a/app/code/core/Mage/Cms/Model/Template/Filter.php
+++ b/app/code/core/Mage/Cms/Model/Template/Filter.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Model_Template_Filter extends Mage_Core_Model_Email_Template_Filter
 {

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Config.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Config.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method string getStoreId()
  * @method $this setStoreId(string $value)

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Model_Wysiwyg_Images_Storage extends Varien_Object
 {

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_Model_Wysiwyg_Images_Storage_Collection extends Varien_Data_Collection_Filesystem
 {

--- a/app/code/core/Mage/Cms/controllers/IndexController.php
+++ b/app/code/core/Mage/Cms/controllers/IndexController.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_IndexController extends Mage_Core_Controller_Front_Action
 {

--- a/app/code/core/Mage/Cms/controllers/PageController.php
+++ b/app/code/core/Mage/Cms/controllers/PageController.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Cms
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Cms_PageController extends Mage_Core_Controller_Front_Action
 {

--- a/app/code/core/Mage/Contacts/controllers/IndexController.php
+++ b/app/code/core/Mage/Contacts/controllers/IndexController.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Contacts
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Contacts_IndexController extends Mage_Core_Controller_Front_Action
 {

--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -21,7 +21,6 @@
  *
  * @category   Mage
  * @package    Mage_Core
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method $this setAdditionalHtml(string $value)
  * @method $this setBlockParams(array $value)

--- a/app/code/core/Mage/Core/Controller/Front/Action.php
+++ b/app/code/core/Mage/Core/Controller/Front/Action.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Core
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Core_Controller_Front_Action extends Mage_Core_Controller_Varien_Action
 {

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Core
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class Mage_Core_Helper_Abstract
 {

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Core
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
 {

--- a/app/code/core/Mage/Core/Helper/Http.php
+++ b/app/code/core/Mage/Core/Helper/Http.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Core
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Core_Helper_Http extends Mage_Core_Helper_Abstract
 {

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -20,7 +20,6 @@
  *
  * @category   Mage
  * @package    Mage_Core
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Core_Model_App
 {

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Core
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
 {

--- a/app/code/core/Mage/Core/Model/Translate.php
+++ b/app/code/core/Mage/Core/Model/Translate.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Core
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Core_Model_Translate
 {

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Js.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Js.php
@@ -17,7 +17,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Block_Adminhtml_Attribute_Edit_Js extends Mage_Adminhtml_Block_Template
 {

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Main/Abstract.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Main/Abstract.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class Mage_Eav_Block_Adminhtml_Attribute_Edit_Main_Abstract extends Mage_Adminhtml_Block_Widget_Form
 {

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Options/Abstract.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Options/Abstract.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class Mage_Eav_Block_Adminhtml_Attribute_Edit_Options_Abstract extends Mage_Adminhtml_Block_Widget
 {

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Grid/Abstract.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Grid/Abstract.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Adminhtml
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class Mage_Eav_Block_Adminhtml_Attribute_Grid_Abstract extends Mage_Adminhtml_Block_Widget_Grid
 {

--- a/app/code/core/Mage/Eav/Exception.php
+++ b/app/code/core/Mage/Eav/Exception.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Exception extends Mage_Core_Exception
 {

--- a/app/code/core/Mage/Eav/Model/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Attribute.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class Mage_Eav_Model_Attribute extends Mage_Eav_Model_Entity_Attribute
 {

--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Config
 {

--- a/app/code/core/Mage/Eav/Model/Convert/Adapter/Entity.php
+++ b/app/code/core/Mage/Eav/Model/Convert/Adapter/Entity.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Convert_Adapter_Entity extends Mage_Dataflow_Model_Convert_Adapter_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Convert/Adapter/Grid.php
+++ b/app/code/core/Mage/Eav/Model/Convert/Adapter/Grid.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method $this setExceptionLocation(string $string)
  */

--- a/app/code/core/Mage/Eav/Model/Convert/Parser/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Convert/Parser/Abstract.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class Mage_Eav_Model_Convert_Parser_Abstract extends Mage_Dataflow_Model_Convert_Parser_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity.php
+++ b/app/code/core/Mage/Eav/Model/Entity.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity extends Mage_Eav_Model_Entity_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Abstract.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_Abstract implements Mage_Eav_Model_Entity_Interface
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Eav_Model_Resource_Entity_Attribute _getResource()
  * @method Mage_Eav_Model_Resource_Entity_Attribute getResource()

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method bool hasAttributeSetInfo()
  * @method array getAttributeSetInfo()

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Abstract.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class Mage_Eav_Model_Entity_Attribute_Backend_Abstract implements Mage_Eav_Model_Entity_Attribute_Backend_Interface
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Array.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Array.php
@@ -17,7 +17,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Attribute_Backend_Array extends Mage_Eav_Model_Entity_Attribute_Backend_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Datetime.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Datetime.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Attribute_Backend_Datetime extends Mage_Eav_Model_Entity_Attribute_Backend_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Default.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Default.php
@@ -17,7 +17,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Attribute_Backend_Default extends Mage_Eav_Model_Entity_Attribute_Backend_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Increment.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Increment.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Attribute_Backend_Increment extends Mage_Eav_Model_Entity_Attribute_Backend_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Interface.php
@@ -21,7 +21,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 interface Mage_Eav_Model_Entity_Attribute_Backend_Interface
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Serialized.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Serialized.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Attribute_Backend_Serialized extends Mage_Eav_Model_Entity_Attribute_Backend_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Store.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Attribute_Backend_Store extends Mage_Eav_Model_Entity_Attribute_Backend_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Created.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Created.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Attribute_Backend_Time_Created extends Mage_Eav_Model_Entity_Attribute_Backend_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Updated.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Updated.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Attribute_Backend_Time_Updated extends Mage_Eav_Model_Entity_Attribute_Backend_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Exception.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Exception.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Attribute_Exception extends Exception
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Abstract.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class Mage_Eav_Model_Entity_Attribute_Frontend_Abstract implements Mage_Eav_Model_Entity_Attribute_Frontend_Interface
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Datetime.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Datetime.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Attribute_Frontend_Datetime extends Mage_Eav_Model_Entity_Attribute_Frontend_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Default.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Default.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Attribute_Frontend_Default extends Mage_Eav_Model_Entity_Attribute_Frontend_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Interface.php
@@ -20,7 +20,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 interface Mage_Eav_Model_Entity_Attribute_Frontend_Interface
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Group.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Group.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Eav_Model_Resource_Entity_Attribute_Group _getResource()
  * @method Mage_Eav_Model_Resource_Entity_Attribute_Group getResource()

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Interface.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 interface Mage_Eav_Model_Entity_Attribute_Interface
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Option.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Option.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Eav_Model_Resource_Entity_Attribute_Option _getResource()
  * @method Mage_Eav_Model_Resource_Entity_Attribute_Option getResource()

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Set.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Set.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Eav_Model_Resource_Entity_Attribute_Set _getResource()
  * @method Mage_Eav_Model_Resource_Entity_Attribute_Set getResource()

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Abstract.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class Mage_Eav_Model_Entity_Attribute_Source_Abstract implements Mage_Eav_Model_Entity_Attribute_Source_Interface
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Boolean.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Boolean.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Attribute_Source_Boolean extends Mage_Eav_Model_Entity_Attribute_Source_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Config.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Config.php
@@ -20,7 +20,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Attribute_Source_Config extends Mage_Eav_Model_Entity_Attribute_Source_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Interface.php
@@ -20,7 +20,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 interface Mage_Eav_Model_Entity_Attribute_Source_Interface
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Store.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Attribute_Source_Store extends Mage_Eav_Model_Entity_Attribute_Source_Table
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Attribute_Source_Table extends Mage_Eav_Model_Entity_Attribute_Source_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection.php
@@ -15,7 +15,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Collection extends Mage_Eav_Model_Entity_Collection_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Abstract.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method string getLastId()
  * @method string getPrefix()

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Alphanum.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Alphanum.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Increment_Alphanum extends Mage_Eav_Model_Entity_Increment_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Interface.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 interface Mage_Eav_Model_Entity_Increment_Interface
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Entity_Increment_Numeric extends Mage_Eav_Model_Entity_Increment_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Interface.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 interface Mage_Eav_Model_Entity_Interface
 {

--- a/app/code/core/Mage/Eav/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Setup.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method array getDefaultEntities()
  */

--- a/app/code/core/Mage/Eav/Model/Entity/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Store.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Eav_Model_Resource_Entity_Store _getResource()
  * @method Mage_Eav_Model_Resource_Entity_Store getResource()

--- a/app/code/core/Mage/Eav/Model/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Type.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Eav_Model_Resource_Entity_Type _getResource()
  * @method Mage_Eav_Model_Resource_Entity_Type getResource()

--- a/app/code/core/Mage/Eav/Model/Form.php
+++ b/app/code/core/Mage/Eav/Model/Form.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class Mage_Eav_Model_Form
 {

--- a/app/code/core/Mage/Eav/Model/Form/Element.php
+++ b/app/code/core/Mage/Eav/Model/Form/Element.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Eav_Model_Resource_Form_Element _getResource()
  * @method Mage_Eav_Model_Resource_Form_Element getResource()

--- a/app/code/core/Mage/Eav/Model/Form/Fieldset.php
+++ b/app/code/core/Mage/Eav/Model/Form/Fieldset.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Eav_Model_Resource_Form_Fieldset _getResource()
  * @method Mage_Eav_Model_Resource_Form_Fieldset getResource()

--- a/app/code/core/Mage/Eav/Model/Form/Type.php
+++ b/app/code/core/Mage/Eav/Model/Form/Type.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Eav_Model_Resource_Form_Type _getResource()
  * @method Mage_Eav_Model_Resource_Form_Type getResource()

--- a/app/code/core/Mage/Eav/Model/Mysql4/Config.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Config.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Config extends Mage_Eav_Model_Resource_Config

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Entity_Attribute extends Mage_Eav_Model_Resource_Entity_Attribute

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Entity_Attribute_Collection extends Mage_Eav_Model_Resource_Entity_Attribute_Collection

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Entity_Attribute_Group extends Mage_Eav_Model_Resource_Entity_Attribute_Group

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group/Collection.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Entity_Attribute_Group_Collection extends Mage_Eav_Model_Resource_Entity_Attribute_Group_Collection

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Entity_Attribute_Option extends Mage_Eav_Model_Resource_Entity_Attribute_Option

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Entity_Attribute_Option_Collection extends Mage_Eav_Model_Resource_Entity_Attribute_Option_Collection

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Entity_Attribute_Set extends Mage_Eav_Model_Resource_Entity_Attribute_Set

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set/Collection.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Entity_Attribute_Set_Collection extends Mage_Eav_Model_Resource_Entity_Attribute_Set_Collection

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Store.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Store.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Entity_Store extends Mage_Eav_Model_Resource_Entity_Store

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Entity_Type extends Mage_Eav_Model_Resource_Entity_Type

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type/Collection.php
@@ -16,7 +16,6 @@
 /**
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Entity_Type_Collection extends Mage_Eav_Model_Resource_Entity_Type_Collection

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Element.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Element.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Form_Element extends Mage_Eav_Model_Resource_Form_Element

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Element/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Element/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Form_Element_Collection extends Mage_Eav_Model_Resource_Form_Element_Collection

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Form_Fieldset extends Mage_Eav_Model_Resource_Form_Fieldset

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Form_Fieldset_Collection extends Mage_Eav_Model_Resource_Form_Fieldset_Collection

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Type.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Type.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Form_Type extends Mage_Eav_Model_Resource_Form_Type

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Type/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Type/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  * @deprecated
  */
 class Mage_Eav_Model_Mysql4_Form_Type_Collection extends Mage_Eav_Model_Resource_Form_Type_Collection

--- a/app/code/core/Mage/Eav/Model/Observer.php
+++ b/app/code/core/Mage/Eav/Model/Observer.php
@@ -23,7 +23,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     David Hiendl
  */
 class Mage_Eav_Model_Observer
 {

--- a/app/code/core/Mage/Eav/Model/Resource/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Attribute.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class Mage_Eav_Model_Resource_Attribute extends Mage_Eav_Model_Resource_Entity_Attribute
 {

--- a/app/code/core/Mage/Eav/Model/Resource/Config.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Config.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Resource_Config extends Mage_Core_Model_Resource_Db_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Store.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Store.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Resource_Entity_Store extends Mage_Core_Model_Resource_Db_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Type.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Resource_Entity_Type extends Mage_Core_Model_Resource_Db_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Attribute.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class Mage_Eav_Model_Resource_Form_Attribute extends Mage_Core_Model_Resource_Db_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Element.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Element.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Resource_Form_Element extends Mage_Core_Model_Resource_Db_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Element/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Element/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Resource_Form_Element_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Resource_Form_Fieldset extends Mage_Core_Model_Resource_Db_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Resource_Form_Fieldset_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Type.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Type.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method bool hasEntityTypes()
  */

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Type/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Type/Collection.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Eav
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Eav_Model_Resource_Form_Type_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {

--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_GoogleAnalytics_Block_Ga extends Mage_Core_Block_Template
 {

--- a/app/code/core/Mage/Newsletter/controllers/SubscriberController.php
+++ b/app/code/core/Mage/Newsletter/controllers/SubscriberController.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Newsletter
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Newsletter_SubscriberController extends Mage_Core_Controller_Front_Action
 {

--- a/app/code/core/Mage/Sales/Helper/Data.php
+++ b/app/code/core/Mage/Sales/Helper/Data.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Sales
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Mage_Sales_Helper_Data extends Mage_Core_Helper_Data
 {

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -25,7 +25,6 @@
  *
  * @category   Mage
  * @package    Mage_Sales
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method Mage_Sales_Model_Resource_Order _getResource()
  * @method Mage_Sales_Model_Resource_Order getResource()

--- a/app/code/core/Mage/SalesRule/Model/Validator.php
+++ b/app/code/core/Mage/SalesRule/Model/Validator.php
@@ -20,7 +20,6 @@
  *
  * @category   Mage
  * @package    Mage_SalesRule
- * @author     Magento Core Team <core@magentocommerce.com>
  *
  * @method string getCouponCode()
  * @method $this setCouponCode(string $value)

--- a/js/mage/adminhtml/giftoptions/tooltip.js
+++ b/js/mage/adminhtml/giftoptions/tooltip.js
@@ -16,7 +16,6 @@
  * 
  * @category    Mage
  * @package     Mage_Adminhtml
- * @author      Magento Core Team <core@magentocommerce.com>
  */
 GiftOptionsTooltip = Class.create();
 GiftOptionsTooltip.prototype = {

--- a/js/varien/product.js
+++ b/js/varien/product.js
@@ -18,11 +18,6 @@ if(typeof Product=='undefined') {
 /********************* IMAGE ZOOMER ***********************/
 
 Product.Zoom = Class.create();
-/**
- * Image zoom control
- *
- * @author      Magento Core Team <core@magentocommerce.com>
- */
 Product.Zoom.prototype = {
     initialize: function(imageEl, trackEl, handleEl, zoomInEl, zoomOutEl, hintEl){
         this.containerEl = $(imageEl).parentNode;

--- a/shell/abstract.php
+++ b/shell/abstract.php
@@ -18,7 +18,6 @@
  *
  * @category   Mage
  * @package    Mage_Shell
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class Mage_Shell_Abstract
 {


### PR DESCRIPTION
The `@author ` tag is used to document the author of Structural Elements as stated in https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/author.html#author

I think it shouldn't be considered as a copyright/license tag (that info is elsewhere) and since we (as in openmage contributors) do not add the author of every patch in the source code (it would be extremely overkill and `git` has the info anyway in the `git blame`) I think we can safely remove all of those tags.

Also, the email written in the removed tags is probably dead since years.