### PR TITLE
[PHP 8.2] Fixed deprecation error for creation of dynamic property

### DIFF
--- a/app/code/core/Mage/Paypal/Model/Config.php
+++ b/app/code/core/Mage/Paypal/Model/Config.php
@@ -19,32 +19,6 @@
  *
  * @category   Mage
  * @package    Mage_Paypal
- *
- * @property mixed $allow_ba_signup;
- * @property mixed $api_cert;
- * @property mixed $api_password;
- * @property mixed $api_signature;
- * @property mixed $api_username;
- * @property mixed $apiAuthentication;
- * @property mixed $apiPassword;
- * @property mixed $apiSignature;
- * @property mixed $apiUsername;
- * @property mixed $business_account;
- * @property mixed $businessAccount;
- * @property mixed $buttonFlavor;
- * @property mixed $buttonType;
- * @property mixed $cctypes;
- * @property mixed $debug;
- * @property mixed $lineItemsEnabled;
- * @property mixed $lineItemsSummary;
- * @property mixed $payment_action;
- * @property mixed $paymentAction;
- * @property mixed $paymentMarkSize;
- * @property mixed $requireBillingAddress;
- * @property mixed $sandboxFlag;
- * @property mixed $solutionType;
- * @property mixed $transferShippingOptions;
- * @property mixed $verifyPeer;
  */
 class Mage_Paypal_Model_Config
 {
@@ -619,8 +593,10 @@ class Mage_Paypal_Model_Config
         'zh_XC',
     ];
 
-    public $visible_on_cart;
-    public $visible_on_product;
+    /**
+     * @var array
+     */
+    protected $_config = [];
 
     /**
      * Set method and store id, if specified
@@ -776,11 +752,19 @@ class Mage_Paypal_Model_Config
      */
     public function __get($key)
     {
+        if (array_key_exists($key, $this->_config)) {
+            return $this->_config[$key];
+        }
+
         $underscored = strtolower(preg_replace('/(.)([A-Z])/', "$1_$2", $key));
+        if (array_key_exists($underscored, $this->_config)) {
+            return $this->_config[$underscored];
+        }
+
         $value = Mage::getStoreConfig($this->_getSpecificConfigPath($underscored), $this->_storeId);
         $value = $this->_prepareValue($underscored, $value);
-        $this->$key = $value;
-        $this->$underscored = $value;
+        $this->_config[$key] = $value;
+        $this->_config[$underscored] = $value;
         return $value;
     }
 

--- a/app/code/core/Mage/Paypal/Model/Config.php
+++ b/app/code/core/Mage/Paypal/Model/Config.php
@@ -45,8 +45,6 @@
  * @property mixed $solutionType;
  * @property mixed $transferShippingOptions;
  * @property mixed $verifyPeer;
- * @property mixed $visible_on_cart;
- * @property mixed $visible_on_product;
  */
 class Mage_Paypal_Model_Config
 {

--- a/app/code/core/Mage/Paypal/Model/Config.php
+++ b/app/code/core/Mage/Paypal/Model/Config.php
@@ -19,6 +19,34 @@
  *
  * @category   Mage
  * @package    Mage_Paypal
+ *
+ * @property mixed $allow_ba_signup;
+ * @property mixed $api_cert;
+ * @property mixed $api_password;
+ * @property mixed $api_signature;
+ * @property mixed $api_username;
+ * @property mixed $apiAuthentication;
+ * @property mixed $apiPassword;
+ * @property mixed $apiSignature;
+ * @property mixed $apiUsername;
+ * @property mixed $business_account;
+ * @property mixed $businessAccount;
+ * @property mixed $buttonFlavor;
+ * @property mixed $buttonType;
+ * @property mixed $cctypes;
+ * @property mixed $debug;
+ * @property mixed $lineItemsEnabled;
+ * @property mixed $lineItemsSummary;
+ * @property mixed $payment_action;
+ * @property mixed $paymentAction;
+ * @property mixed $paymentMarkSize;
+ * @property mixed $requireBillingAddress;
+ * @property mixed $sandboxFlag;
+ * @property mixed $solutionType;
+ * @property mixed $transferShippingOptions;
+ * @property mixed $verifyPeer;
+ * @property mixed $visible_on_cart;
+ * @property mixed $visible_on_product;
  */
 class Mage_Paypal_Model_Config
 {

--- a/app/code/core/Mage/Paypal/Model/Config.php
+++ b/app/code/core/Mage/Paypal/Model/Config.php
@@ -621,6 +621,9 @@ class Mage_Paypal_Model_Config
         'zh_XC',
     ];
 
+    public $visible_on_cart;
+    public $visible_on_product;
+
     /**
      * Set method and store id, if specified
      *


### PR DESCRIPTION
After https://github.com/OpenMage/magento-lts/pull/2759, when visiting a product page or the cart page (with developer mode) we get:

`Deprecated functionality: Creation of dynamic property Mage_Paypal_Model_Config::$visible_on_product is deprecated  in app/code/core/Mage/Paypal/Model/Config.php on line 781"`

This PR partially reverts #2759 but only for 2 specific properties

How to test:
- enable developer mode
- visit product page or cart