### PR TITLE
[PHP 8.2] Fixed deprecation warning in Mage_CatalogInventory_Model_Observer

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -228,7 +228,7 @@ class Mage_CatalogInventory_Model_Observer
             $item->setData('use_config_notify_stock_qty', false);
         }
         $originalQty = $product->getData('stock_data/original_inventory_qty');
-        if (strlen($originalQty) > 0) {
+        if (is_numeric($originalQty)) {
             $item->setQtyCorrection($item->getQty() - $originalQty);
         }
         if (!is_null($product->getData('stock_data/enable_qty_increments'))


### PR DESCRIPTION
With developer mode enabled, going to the backend, opening a product and saving it, it gives me a deprecation error:

`Deprecated functionality: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in app/code/core/Mage/CatalogInventory/Model/Observer.php on line 231`


This PR should fix it.