### PR TITLE
Fixed logging too many exceptions for payment methods

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -393,7 +393,7 @@ final class Mage
      *
      * @param string $path
      * @param null|string|bool|int|Mage_Core_Model_Store $store
-     * @return string|null
+     * @return mixed
      */
     public static function getStoreConfig($path, $store = null)
     {

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -393,7 +393,7 @@ final class Mage
      *
      * @param string $path
      * @param null|string|bool|int|Mage_Core_Model_Store $store
-     * @return mixed
+     * @return string|null
      */
     public static function getStoreConfig($path, $store = null)
     {

--- a/app/code/core/Mage/Payment/Helper/Data.php
+++ b/app/code/core/Mage/Payment/Helper/Data.php
@@ -173,7 +173,7 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
             }
 
             $method = Mage::getModel($paymentMethodModelClassName);
-            if ($method->canManageRecurringProfiles()) {
+            if ($method && $method->canManageRecurringProfiles()) {
                 $result[] = $method;
             }
         }

--- a/app/code/core/Mage/Payment/Helper/Data.php
+++ b/app/code/core/Mage/Payment/Helper/Data.php
@@ -27,6 +27,18 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
     protected $_moduleName = 'Mage_Payment';
 
     /**
+     * Retrieve the class name of the payment method's model
+     *
+     * @param $code
+     * @return string|null
+     */
+    public function getMethodModelClassName($code)
+    {
+        $key = self::XML_PATH_PAYMENT_METHODS . '/' . $code . '/model';
+        return Mage::getStoreConfig($key);
+    }
+
+    /**
      * Retrieve method model object
      *
      * @param   string $code
@@ -34,8 +46,7 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function getMethodInstance($code)
     {
-        $key = self::XML_PATH_PAYMENT_METHODS . '/' . $code . '/model';
-        $class = Mage::getStoreConfig($key);
+        $class = $this->getMethodModelClassName($code);
         if (is_null($class)) {
             Mage::logException(new Exception(sprintf('Unknown payment method with code "%s"', $code)));
             return false;
@@ -207,8 +218,9 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
             if ((isset($data['title']))) {
                 $methods[$code] = $data['title'];
             } else {
-                if ($this->getMethodInstance($code)) {
-                    $methods[$code] = $this->getMethodInstance($code)->getConfigData('title', $store);
+                $paymentMethodModelClassName = $this->getMethodModelClassName($code);
+                if ($paymentMethodModelClassName) {
+                    $methods[$code] = Mage::getModel($paymentMethodModelClassName)->getConfigData('title', $store);
                 }
             }
             if ($asLabelValue && $withGroups && isset($data['group'])) {
@@ -241,6 +253,8 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
             }
             return $labelValues;
         }
+
+        print_r($methods);die();
 
         return $methods;
     }

--- a/app/code/core/Mage/Payment/Helper/Data.php
+++ b/app/code/core/Mage/Payment/Helper/Data.php
@@ -172,6 +172,7 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
                 continue;
             }
 
+            /** @var Mage_Payment_Model_Method_Abstract $method */
             $method = Mage::getModel($paymentMethodModelClassName);
             if ($method && $method->canManageRecurringProfiles()) {
                 $result[] = $method;

--- a/app/code/core/Mage/Payment/Helper/Data.php
+++ b/app/code/core/Mage/Payment/Helper/Data.php
@@ -167,8 +167,13 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
     {
         $result = [];
         foreach ($this->getPaymentMethods($store) as $code => $data) {
-            $method = $this->getMethodInstance($code);
-            if ($method && $method->canManageRecurringProfiles()) {
+            $paymentMethodModelClassName = $this->getMethodModelClassName($code);
+            if (!$paymentMethodModelClassName) {
+                continue;
+            }
+
+            $method = Mage::getModel($paymentMethodModelClassName);
+            if ($method->canManageRecurringProfiles()) {
                 $result[] = $method;
             }
         }

--- a/app/code/core/Mage/Payment/Helper/Data.php
+++ b/app/code/core/Mage/Payment/Helper/Data.php
@@ -254,8 +254,6 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
             return $labelValues;
         }
 
-        print_r($methods);die();
-
         return $methods;
     }
 


### PR DESCRIPTION
In https://github.com/OpenMage/magento-lts/issues/3179 @ADDISON74 pointed out that, using the backend, and opening an order detail page, some exceptions were logged about missing payment methods.

This is because the list of payment methods tries to load the model (for the payment method) and logs an exception if it's not found.

This is ok in some cases (when the order was paid with a method that has been removed later) but not in all the other cases.

So I thought to kinda rewrite the getPaymentMethodList method of Mage_Payment_Helper_Data.

If I'm not mistaken the before/after output of the getPaymentMethodList method stays the same:
before:
<img width="617" alt="Screenshot 2023-04-15 alle 16 33 49" src="https://user-images.githubusercontent.com/909743/232235385-27fc219f-f663-422d-82aa-0ec8319fbd4f.png">

after:
<img width="650" alt="Screenshot 2023-04-15 alle 16 33 21" src="https://user-images.githubusercontent.com/909743/232235395-9a92356a-e4a8-49d0-898e-69ba8328903b.png">


### Related Pull Requests
https://github.com/OpenMage/magento-lts/pull/2939

### Fixed Issues
1. Fixes https://github.com/OpenMage/magento-lts/issues/3179