### PR TITLE
Fixed "object could not be converted to int" in Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Super_Config_Simple

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Simple.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Simple.php
@@ -67,7 +67,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Super_Config_Simple extends 
                     // If not applied to configurable
                     && !in_array(Mage_Catalog_Model_Product_Type::TYPE_CONFIGURABLE, $attribute->getApplyTo())
                     // If not used in configurable
-                    && !in_array($attribute->getId(), $usedAttributes))
+                    && !array_key_exists($attribute->getId(), $usedAttributes))
                 // Or in additional
                 || in_array($attributeCode, $attributesConfig['additional'])
             ) {


### PR DESCRIPTION
### Description

This PR fix `Notice: Object of class Mage_Catalog_Model_Resource_Eav_Attribute could not be converted to int  in app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Simple.php on line 70` when you go to _Catalog > Products > Any configurable product_.

PHP 8.0 & 8.2 (dev on).

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list