### PR TITLE
Fixed deprecation warning in Mage_Downloadable_Helper_Catalog_Product_Configuration

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -127,7 +127,6 @@
  * @method $this setLinksExist(bool $value)
  * @method bool getLinksPurchasedSeparately()
  * @method $this setLinksPurchasedSeparately(bool $value)
- * @method string getLinksTitle()
  * @method array getListSwatchAttrValues()
  *
  * @method array getMatchedRules()
@@ -261,9 +260,8 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
      * Entity code.
      * Can be used as part of method name for entity processing
      */
-    public const ENTITY                 = 'catalog_product';
-
-    public const CACHE_TAG              = 'catalog_product';
+    public const ENTITY          = 'catalog_product';
+    public const CACHE_TAG       = 'catalog_product';
     protected $_cacheTag         = 'catalog_product';
     protected $_eventPrefix      = 'catalog_product';
     protected $_eventObject      = 'product';
@@ -673,6 +671,14 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
         }
 
         return $attributes;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLinksTitle()
+    {
+        return (string)$this->_getData('links_title');
     }
 
     /**

--- a/app/code/core/Mage/Downloadable/Helper/Catalog/Product/Configuration.php
+++ b/app/code/core/Mage/Downloadable/Helper/Catalog/Product/Configuration.php
@@ -59,7 +59,8 @@ class Mage_Downloadable_Helper_Catalog_Product_Configuration extends Mage_Core_H
         if (strlen($title)) {
             return $title;
         }
-        return Mage::getStoreConfig(Mage_Downloadable_Model_Link::XML_PATH_LINKS_TITLE);
+
+        return (string)Mage::getStoreConfig(Mage_Downloadable_Model_Link::XML_PATH_LINKS_TITLE);
     }
 
     /**


### PR DESCRIPTION
This PR solved point number 1 of https://github.com/OpenMage/magento-lts/issues/3184

I thought it was better to create a method for getLinksTitle instead of just casting, since getLinksTitle should always return a string anyway (it was marked as a string in the `@method string getLinksTitle()` notation)

do you think that's ok?