### PR TITLE
Fixed deprecation warning in Mage_SalesRule_Model_Rule

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule.php
@@ -200,7 +200,7 @@ class Mage_SalesRule_Model_Rule extends Mage_Rule_Model_Abstract
      */
     protected function _afterSave()
     {
-        $couponCode = trim($this->getCouponCode());
+        $couponCode = trim((string)$this->getCouponCode());
         if (strlen($couponCode)
             && $this->getCouponType() == self::COUPON_TYPE_SPECIFIC
             && !$this->getUseAutoGeneration()


### PR DESCRIPTION
This PR should fix point number 3 of https://github.com/OpenMage/magento-lts/issues/3184, super easy, in this case I think a cast should be ok