### PR TITLE
Set sort order and disable click-to-top for coupons grid

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
@@ -27,6 +27,7 @@ class Mage_Adminhtml_Block_Promo_Quote_Edit_Tab_Coupons_Grid extends Mage_Adminh
     {
         parent::__construct();
         $this->setId('couponCodesGrid');
+        $this->setDefaultSort('created_at');
         $this->setUseAjax(true);
     }
 
@@ -127,5 +128,14 @@ class Mage_Adminhtml_Block_Promo_Quote_Edit_Tab_Coupons_Grid extends Mage_Adminh
     public function getGridUrl()
     {
         return $this->getUrl('*/*/couponsGrid', ['_current' => true]);
+    }
+
+    /**
+     * @param Varien_Object $row
+     * @return string
+     */
+    public function getRowUrl($row)
+    {
+        return '';
     }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
@@ -131,8 +131,7 @@ class Mage_Adminhtml_Block_Promo_Quote_Edit_Tab_Coupons_Grid extends Mage_Adminh
     }
 
     /**
-     * @param Varien_Object $row
-     * @return string
+     * @inheritdoc
      */
     public function getRowUrl($row)
     {


### PR DESCRIPTION
### Description 

This small PR update sort order of coupon grid in Promotions > Shopping Cart Price Rules > Any rules with _Use Auto Generation_ > Coupon codes tab. It also disable click-to-top when you click in a row of the grid.

![image](https://user-images.githubusercontent.com/31816829/232717741-fe3bbdb6-3ec2-456e-b3c7-617bc4f1cf33.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list