### PR TITLE
Added buttons to configuration pages

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Edit.php
@@ -67,8 +67,10 @@ class Mage_Adminhtml_Block_System_Config_Edit extends Mage_Adminhtml_Block_Widge
     {
         $buttonsNode = $this->_section->buttons;
         if (!empty($buttonsNode)) {
-            $buttons = [];
-            foreach ($buttonsNode->children() as $buttonNode) {
+            $buttons  = [];
+            $allNodes = (array)$buttonsNode->children();
+            usort($allNodes, [$this, '_sort']);
+            foreach ($allNodes as $buttonNode) {
                 $buttons[] = $this->getLayout()->createBlock('adminhtml/widget_button')
                     ->setData([
                         'label'   => Mage::helper($buttonNode->getAttribute('module') ?? 'adminhtml')->__((string)$buttonNode->title),
@@ -80,6 +82,16 @@ class Mage_Adminhtml_Block_System_Config_Edit extends Mage_Adminhtml_Block_Widge
             return implode($buttons);
         }
         return '';
+    }
+
+    /**
+     * @param Mage_Core_Model_Config_Element $a
+     * @param Mage_Core_Model_Config_Element $b
+     * @return int
+     */
+    protected function _sort($a, $b)
+    {
+        return (int)$a->sort_order < (int)$b->sort_order ? -1 : ((int)$a->sort_order > (int)$b->sort_order ? 1 : 0);
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Edit.php
@@ -52,9 +52,9 @@ class Mage_Adminhtml_Block_System_Config_Edit extends Mage_Adminhtml_Block_Widge
             'save_button',
             $this->getLayout()->createBlock('adminhtml/widget_button')
                 ->setData([
-                    'label'     => Mage::helper('adminhtml')->__('Save Config'),
-                    'onclick'   => 'configForm.submit()',
-                    'class' => 'save',
+                    'label'   => Mage::helper('adminhtml')->__('Save Config'),
+                    'onclick' => 'configForm.submit()',
+                    'class'   => 'save',
                 ])
         );
         return parent::_prepareLayout();
@@ -65,7 +65,22 @@ class Mage_Adminhtml_Block_System_Config_Edit extends Mage_Adminhtml_Block_Widge
      */
     public function getSaveButtonHtml()
     {
-        return $this->getChildHtml('save_button');
+        $buttons = [];
+        $buttonsNode = $this->_section->buttons;
+
+        if (!empty($buttonsNode)) {
+            foreach ($buttonsNode->children() as $buttonNode) {
+                $buttons[] = $this->getLayout()->createBlock('adminhtml/widget_button')
+                    ->setData([
+                        'label'   => Mage::helper($buttonNode->getAttribute('module') ?? 'adminhtml')->__((string)$buttonNode->title),
+                        'onclick' => $buttonNode->action ? Mage::helper('core/js')->getSetLocationJs($this->getUrl((string)$buttonNode->action)) : (string)$buttonNode->onclick,
+                        'class'   => (string)$buttonNode->class,
+                    ])
+                    ->toHtml();
+            }
+        }
+
+        return implode($buttons).$this->getChildHtml('save_button');
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Edit.php
@@ -63,12 +63,11 @@ class Mage_Adminhtml_Block_System_Config_Edit extends Mage_Adminhtml_Block_Widge
     /**
      * @return string
      */
-    public function getSaveButtonHtml()
+    public function getAdditionalButtonsHtml()
     {
-        $buttons = [];
         $buttonsNode = $this->_section->buttons;
-
         if (!empty($buttonsNode)) {
+            $buttons = [];
             foreach ($buttonsNode->children() as $buttonNode) {
                 $buttons[] = $this->getLayout()->createBlock('adminhtml/widget_button')
                     ->setData([
@@ -78,9 +77,17 @@ class Mage_Adminhtml_Block_System_Config_Edit extends Mage_Adminhtml_Block_Widge
                     ])
                     ->toHtml();
             }
+            return implode($buttons);
         }
+        return '';
+    }
 
-        return implode($buttons).$this->getChildHtml('save_button');
+    /**
+     * @return string
+     */
+    public function getSaveButtonHtml()
+    {
+        return $this->getChildHtml('save_button');
     }
 
     /**

--- a/app/code/core/Mage/Catalog/etc/system.xml
+++ b/app/code/core/Mage/Catalog/etc/system.xml
@@ -33,10 +33,12 @@
                 <products translate="title" module="catalog">
                     <title>Products</title>
                     <action>adminhtml/catalog_product/index</action>
+                    <sort_order>1</sort_order>
                 </products>
                 <categories translate="title" module="catalog">
                     <title>Categories</title>
                     <action>adminhtml/catalog_category/index</action>
+                    <sort_order>2</sort_order>
                 </categories>
             </buttons>
             <groups>

--- a/app/code/core/Mage/Catalog/etc/system.xml
+++ b/app/code/core/Mage/Catalog/etc/system.xml
@@ -30,6 +30,16 @@
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
             <show_in_store>1</show_in_store>
+            <buttons>
+                <products translate="title" module="catalog">
+                    <title>Products</title>
+                    <action>adminhtml/catalog_product/index</action>
+                </products>
+                <categories translate="title" module="catalog">
+                    <title>Categories</title>
+                    <action>adminhtml/catalog_category/index</action>
+                </categories>
+            </buttons>
             <groups>
                 <frontend translate="label">
                     <label>Frontend</label>

--- a/app/code/core/Mage/Catalog/etc/system.xml
+++ b/app/code/core/Mage/Catalog/etc/system.xml
@@ -23,7 +23,6 @@
     </tabs>
     <sections>
         <catalog translate="label" module="catalog">
-            <class>separator-top</class>
             <label>Catalog</label>
             <tab>catalog</tab>
             <sort_order>40</sort_order>

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -125,7 +125,6 @@
             </groups>
         </advanced>
         <trans_email translate="label" module="core">
-            <class>separator-top</class>
             <label>Store Email Addresses</label>
             <tab>general</tab>
             <sort_order>90</sort_order>
@@ -895,7 +894,6 @@
             </groups>
         </general>
         <system translate="label" module="core">
-            <class>separator-top</class>
             <label>System</label>
             <tab>advanced</tab>
             <sort_order>900</sort_order>

--- a/app/code/core/Mage/Customer/etc/system.xml
+++ b/app/code/core/Mage/Customer/etc/system.xml
@@ -23,7 +23,6 @@
     </tabs>
     <sections>
         <customer translate="label" module="customer">
-            <class>separator-top</class>
             <label>Customers</label>
             <tab>customer</tab>
             <sort_order>100</sort_order>

--- a/app/code/core/Mage/Customer/etc/system.xml
+++ b/app/code/core/Mage/Customer/etc/system.xml
@@ -24,12 +24,18 @@
     <sections>
         <customer translate="label" module="customer">
             <class>separator-top</class>
-            <label>Customer Configuration</label>
+            <label>Customers</label>
             <tab>customer</tab>
-            <sort_order>130</sort_order>
+            <sort_order>100</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
             <show_in_store>1</show_in_store>
+            <buttons>
+                <customers translate="title" module="customer">
+                    <title>Customers</title>
+                    <action>adminhtml/customer/index</action>
+                </customers>
+            </buttons>
             <groups>
                 <account_share translate="label">
                     <label>Account Sharing Options</label>

--- a/app/code/core/Mage/Persistent/etc/system.xml
+++ b/app/code/core/Mage/Persistent/etc/system.xml
@@ -17,14 +17,12 @@
 <config>
     <sections>
         <persistent translate="label" module="persistent">
-            <class>separator-top</class>
             <label>Persistent Shopping Cart</label>
             <tab>customer</tab>
             <sort_order>500</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
             <show_in_store>0</show_in_store>
-
             <groups>
                 <options translate="label" module="persistent">
                     <label>General Options</label>
@@ -32,7 +30,6 @@
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>0</show_in_store>
-
                     <fields>
                         <enabled translate="label" module="persistent">
                             <label>Enable Persistence</label>
@@ -43,7 +40,6 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </enabled>
-
                         <lifetime translate="label" module="persistent">
                             <label>Persistence Lifetime (seconds)</label>
                             <validate>validate-digits validate-digits-range digits-range-0-3153600000</validate>
@@ -53,7 +49,6 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </lifetime>
-
                         <remember_enabled translate="label" module="persistent">
                             <label>Enable &quot;Remember Me&quot;</label>
                             <frontend_type>select</frontend_type>
@@ -64,7 +59,6 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </remember_enabled>
-
                         <remember_default translate="label" module="persistent">
                             <label>&quot;Remember Me&quot; Default Value</label>
                             <frontend_type>select</frontend_type>
@@ -75,7 +69,6 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </remember_default>
-
                         <logout_clear translate="label" module="persistent">
                             <label>Clear Persistence on Log Out</label>
                             <frontend_type>select</frontend_type>
@@ -86,7 +79,6 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </logout_clear>
-
                         <shopping_cart translate="label" module="persistent">
                             <label>Persist Shopping Cart</label>
                             <frontend_type>select</frontend_type>

--- a/app/code/core/Mage/Sales/etc/system.xml
+++ b/app/code/core/Mage/Sales/etc/system.xml
@@ -23,7 +23,6 @@
     </tabs>
     <sections>
         <sales translate="label" module="sales">
-            <class>separator-top</class>
             <label>Sales</label>
             <tab>sales</tab>
             <sort_order>300</sort_order>

--- a/app/code/core/Mage/SalesRule/etc/system.xml
+++ b/app/code/core/Mage/SalesRule/etc/system.xml
@@ -17,7 +17,6 @@
 <config>
     <sections>
         <promo translate="label" module="salesrule">
-            <class>separator-top</class>
             <label>Promotions</label>
             <tab>customer</tab>
             <sort_order>400</sort_order>

--- a/app/code/core/Mage/Tax/etc/system.xml
+++ b/app/code/core/Mage/Tax/etc/system.xml
@@ -17,7 +17,6 @@
 <config>
     <sections>
         <tax translate="label" module="tax">
-            <class>separator-top</class>
             <label>Tax</label>
             <tab>sales</tab>
             <sort_order>303</sort_order>

--- a/app/design/adminhtml/default/default/template/system/config/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/edit.phtml
@@ -13,28 +13,24 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<?php
-/**
- * @methods
- *  getTitle() - string
- *  getSaveUrl() - string
- *  getSections() - array
- *  getForm() - html
- */
-?>
 
 <div class="content-header">
     <table cellspacing="0">
         <tr>
             <td>
-                <h3<?php if($this->getHeaderCss()): ?> class="<?php echo $this->getHeaderCss()?>"<?php endif ?>><?php echo Mage::helper('adminhtml')->__($this->getTitle()) ?></h3>
+                <h3<?php if ($this->getHeaderCss()): ?> class="<?php echo $this->getHeaderCss() ?>"<?php endif ?>>
+                    <?php echo Mage::helper('adminhtml')->__($this->getTitle()) ?>
+                </h3>
             </td>
-            <td class="form-buttons"><?php echo $this->getSaveButtonHtml() ?></td>
+            <td class="form-buttons">
+                <?php echo $this->getAdditionalButtonsHtml() ?>
+                <?php echo $this->getSaveButtonHtml() ?>
+            </td>
          </tr>
     </table>
 </div>
 <form action="<?php echo $this->getSaveUrl() ?>" method="post" id="config_edit_form" enctype="multipart/form-data">
-    <?php echo $this->getBlockHtml('formkey')?>
+    <?php echo $this->getBlockHtml('formkey') ?>
     <?php echo $this->getChildHtml('form') ?>
 </form>
 <script type="text/javascript">

--- a/app/locale/en_US/Mage_Customer.csv
+++ b/app/locale/en_US/Mage_Customer.csv
@@ -94,7 +94,6 @@
 "Customer Account Logout Success","Customer Account Logout Success"
 "Customer Account Registration Form","Customer Account Registration Form"
 "Customer Addresses","Customer Addresses"
-"Customer Configuration","Customer Configuration"
 "Customer Forgot Password Form","Customer Forgot Password Form"
 "Customer Group","Customer Group"
 "Customer Groups","Customer Groups"


### PR DESCRIPTION
### Description

A new simple feature for _System > Configuration_ pages.

For example, add the following `<buttons>` tag in _app/code/core/Mage/Core/etc/system.xml_ line ~731:
```xml
        <general translate="label" module="core">
            <label>General</label>
            [...]
            <buttons>
                <products translate="title">
                    <title>Products</title>
                    <action>adminhtml/catalog_product/index</action>
                </products>
            </buttons>
```
Tags: `<title>` + `<action>` or `<onclick>` + `<class>` + `<sort_order>`.

![image](https://user-images.githubusercontent.com/31816829/232848033-0a72947d-810e-419c-b337-34e72ad64f5c.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list