### PR TITLE
Avoid JS errors if the zipcode field has no label

### DIFF
--- a/js/varien/form.js
+++ b/js/varien/form.js
@@ -410,7 +410,7 @@ ZipUpdater.prototype = {
                 wildCard.hide();
             }
         } else {
-            if (label != undefined && !label.hasClassName('required')) {
+            if (label !== undefined && !label.hasClassName('required')) {
                 label.addClassName('required');
             }
             this.zipElement.addClassName('required-entry');

--- a/js/varien/form.js
+++ b/js/varien/form.js
@@ -384,13 +384,13 @@ ZipUpdater.prototype = {
 
     _setPostcodeOptional: function(){
         this.zipElement = $(this.zipElement);
-        if (this.zipElement == undefined) {
+        if (this.zipElement === undefined) {
             return false;
         }
 
         // find label
         var label = $$('label[for="' + this.zipElement.id + '"]')[0];
-        if (label != undefined) {
+        if (label !== undefined) {
             var wildCard = label.down('em') || label.down('span.required');
             if (!wildCard) {
                 label.insert(' <span class="required">*</span>');
@@ -406,7 +406,7 @@ ZipUpdater.prototype = {
             while (this.zipElement.hasClassName('required-entry')) {
                 this.zipElement.removeClassName('required-entry');
             }
-            if (wildCard != undefined) {
+            if (wildCard !== undefined) {
                 wildCard.hide();
             }
         } else {
@@ -414,7 +414,7 @@ ZipUpdater.prototype = {
                 label.addClassName('required');
             }
             this.zipElement.addClassName('required-entry');
-            if (wildCard != undefined) {
+            if (wildCard !== undefined) {
                 wildCard.show();
             }
         }

--- a/js/varien/form.js
+++ b/js/varien/form.js
@@ -400,7 +400,7 @@ ZipUpdater.prototype = {
 
         // Make Zip and its label required/optional
         if (optionalZipCountries.indexOf(this.country) != -1) {
-            if (label.hasClassName('required')) {
+            if (label != undefined && label.hasClassName('required')) {
                 label.removeClassName('required');
             }
             while (this.zipElement.hasClassName('required-entry')) {
@@ -410,7 +410,7 @@ ZipUpdater.prototype = {
                 wildCard.hide();
             }
         } else {
-            if (!label.hasClassName('required')) {
+            if (label != undefined && !label.hasClassName('required')) {
                 label.addClassName('required');
             }
             this.zipElement.addClassName('required-entry');

--- a/js/varien/form.js
+++ b/js/varien/form.js
@@ -400,7 +400,7 @@ ZipUpdater.prototype = {
 
         // Make Zip and its label required/optional
         if (optionalZipCountries.indexOf(this.country) != -1) {
-            if (label != undefined && label.hasClassName('required')) {
+            if (label !== undefined && label.hasClassName('required')) {
                 label.removeClassName('required');
             }
             while (this.zipElement.hasClassName('required-entry')) {


### PR DESCRIPTION
### Description
This PR solves a JS error that can happen if the theme used does not have a label for the zipcode field. The possibly buggy behavior was introduced by https://github.com/OpenMage/magento-lts/commit/34c0acf5b974d043fdeefab5bbdee9adf961affa

### Steps to reproduce
* start with a clean installation of magento LTS;
* customize the frontend theme so that the zipcode address field has no label;
* go to the checkout and choose to add a new address.

### Expected result
No JS errors should be thrown;

### Actual result
There is a JS error on line 403 or 413 of the js/varien/form.js file since the "label" variable is undefined.