### PR TITLE
Replaced Mage_Exception usages with Mage_Core_Exception

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/System/Config/System/StorageController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Config/System/StorageController.php
@@ -126,7 +126,7 @@ class Mage_Adminhtml_System_Config_System_StorageController extends Mage_Adminht
                         if (is_array($flagData)
                             && !(isset($flagData['timeout_reached']) && $flagData['timeout_reached'])
                         ) {
-                            Mage::logException(new Mage_Exception(
+                            Mage::logException(new Mage_Core_Exception(
                                 Mage::helper('adminhtml')->__('Timeout limit for response from synchronize process was reached.')
                             ));
 

--- a/app/code/core/Mage/Adminhtml/controllers/System/DesignController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/DesignController.php
@@ -125,7 +125,7 @@ class Mage_Adminhtml_System_DesignController extends Mage_Adminhtml_Controller_A
 
                 Mage::getSingleton('adminhtml/session')
                     ->addSuccess($this->__('The design change has been deleted.'));
-            } catch (Mage_Exception $e) {
+            } catch (Mage_Core_Exception $e) {
                 Mage::getSingleton('adminhtml/session')
                     ->addError($e->getMessage());
             } catch (Exception $e) {

--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -62,14 +62,14 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
      * Set back redirect url to response
      *
      * @return $this
-     * @throws Mage_Exception
+     * @throws Mage_Core_Exception
      */
     protected function _goBack()
     {
         $returnUrl = $this->getRequest()->getParam('return_url');
         if ($returnUrl) {
             if (!$this->_isUrlInternal($returnUrl)) {
-                throw new Mage_Exception('External urls redirect to "' . $returnUrl . '" denied!');
+                throw new Mage_Core_Exception('External urls redirect to "' . $returnUrl . '" denied!');
             }
 
             $this->_getSession()->getMessages(true);
@@ -192,7 +192,7 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
     /**
      * Add product to shopping cart action
      *
-     * @throws Mage_Exception
+     * @throws Mage_Core_Exception
      */
     public function addAction()
     {

--- a/app/code/core/Mage/Weee/Helper/Data.php
+++ b/app/code/core/Mage/Weee/Helper/Data.php
@@ -443,7 +443,7 @@ class Mage_Weee_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Returns all summed weee taxes with all local taxes applied
      *
-     * @throws Mage_Exception
+     * @throws Mage_Core_Exception
      * @param array $attributes Array of Varien_Object, result from getProductWeeeAttributes()
      * @return float
      */
@@ -456,7 +456,7 @@ class Mage_Weee_Helper_Data extends Mage_Core_Helper_Abstract
                 $amount += $attribute->getAmount() + $attribute->getTaxAmount();
             }
         } else {
-            throw new Mage_Exception('$attributes must be an array');
+            throw new Mage_Core_Exception('$attributes must be an array');
         }
 
         return (float)$amount;


### PR DESCRIPTION
In https://github.com/OpenMage/magento-lts/pull/3205 we had a talk about the files in lib/Mage (which are mostly unused), the only one that's actually used in the core is the Mage_Exception.

This class is anyway used only in really few places, so it's probably worth replacing it with Mage_Core_Exception, which is the really used one.