### PR TITLE
RWD: removed useless code

### DIFF
--- a/skin/frontend/rwd/default/js/app.js
+++ b/skin/frontend/rwd/default/js/app.js
@@ -777,23 +777,6 @@ $j(document).ready(function () {
     });
 
     // ==============================================
-    // Enquire JS
-    // ==============================================
-
-    enquire.register('screen and (min-width: ' + (bp.medium + 1) + 'px)', {
-        match: function () {
-            $j('.menu-active').removeClass('menu-active');
-            $j('.sub-menu-active').removeClass('sub-menu-active');
-            $j('.skip-active').removeClass('skip-active');
-        },
-        unmatch: function () {
-            $j('.menu-active').removeClass('menu-active');
-            $j('.sub-menu-active').removeClass('sub-menu-active');
-            $j('.skip-active').removeClass('skip-active');
-        }
-    });
-
-    // ==============================================
     // UI Pattern - Media Switcher
     // ==============================================
 


### PR DESCRIPTION
If I'm not mistaken this code doesn't precisely nothing:

```
    enquire.register('screen and (min-width: ' + (bp.medium + 1) + 'px)', {
        match: function () {
            $j('.menu-active').removeClass('menu-active');
            $j('.sub-menu-active').removeClass('sub-menu-active');
            $j('.skip-active').removeClass('skip-active');
        },
        unmatch: function () {
            $j('.menu-active').removeClass('menu-active');
            $j('.sub-menu-active').removeClass('sub-menu-active');
            $j('.skip-active').removeClass('skip-active');
        }
    });
```

since the match and unmatch code is exactly the same.

This PR removed this part of code.