### PR TITLE
Updated docker-compose to mysql8 and redis7

### DIFF
--- a/dev/openmage/docker-compose.yml
+++ b/dev/openmage/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - "apache:${HOST_NAME:-openmage-7f000001.nip.io}"
 
   mysql:
-    image: mysql:5.7
+    image: mysql:8.0
     ports:
       - 3306
     command: --default-authentication-plugin=mysql_native_password
@@ -58,7 +58,7 @@ services:
       - mysql:/var/lib/mysql
 
   redis:
-    image: redis:6-alpine
+    image: redis:7-alpine
     command: redis-server --appendonly yes --maxmemory 10m
     volumes:
       - redis:/data


### PR DESCRIPTION
Since mysql8.0 and redis7 are supported, I think they could be enabled in the docker-compose