### PR TITLE
Removed scriptaculous/dragdrop.js from frontend

### DIFF
--- a/app/design/frontend/base/default/layout/oauth.xml
+++ b/app/design/frontend/base/default/layout/oauth.xml
@@ -24,7 +24,6 @@
             <action method="removeItem"><type>js</type><name>lib/ccard.js</name></action>
             <action method="removeItem"><type>js</type><name>scriptaculous/controls.js</name></action>
             <action method="removeItem"><type>js</type><name>scriptaculous/builder.js</name></action>
-            <action method="removeItem"><type>js</type><name>scriptaculous/dragdrop.js</name></action>
             <action method="removeItem"><type>js</type><name>scriptaculous/controls.js</name></action>
             <action method="removeItem"><type>js</type><name>scriptaculous/slider.js</name></action>
             <action method="removeItem"><type>js</type><name>varien/js.js</name></action>

--- a/app/design/frontend/base/default/layout/page.xml
+++ b/app/design/frontend/base/default/layout/page.xml
@@ -29,7 +29,6 @@ Default layout, loads most of the pages
                 <action method="addJs"><script>prototype/validation.js</script></action>
                 <action method="addJs"><script>scriptaculous/builder.js</script></action>
                 <action method="addJs"><script>scriptaculous/effects.js</script></action>
-                <action method="addJs"><script>scriptaculous/dragdrop.js</script></action>
                 <action method="addJs"><script>scriptaculous/controls.js</script></action>
                 <action method="addJs"><script>scriptaculous/slider.js</script></action>
                 <action method="addJs"><script>varien/js.js</script></action>

--- a/app/design/frontend/rwd/default/layout/oauth.xml
+++ b/app/design/frontend/rwd/default/layout/oauth.xml
@@ -24,7 +24,6 @@
             <action method="removeItem"><type>js</type><name>lib/ccard.js</name></action>
             <action method="removeItem"><type>js</type><name>scriptaculous/controls.js</name></action>
             <action method="removeItem"><type>js</type><name>scriptaculous/builder.js</name></action>
-            <action method="removeItem"><type>js</type><name>scriptaculous/dragdrop.js</name></action>
             <action method="removeItem"><type>js</type><name>scriptaculous/controls.js</name></action>
             <action method="removeItem"><type>js</type><name>scriptaculous/slider.js</name></action>
             <action method="removeItem"><type>js</type><name>varien/js.js</name></action>

--- a/app/design/frontend/rwd/default/layout/page.xml
+++ b/app/design/frontend/rwd/default/layout/page.xml
@@ -31,7 +31,6 @@
                 <action method="addJs"><script>prototype/validation.js</script></action>
                 <action method="addJs"><script>scriptaculous/builder.js</script></action>
                 <action method="addJs"><script>scriptaculous/effects.js</script></action>
-                <action method="addJs"><script>scriptaculous/dragdrop.js</script></action>
                 <action method="addJs"><script>scriptaculous/controls.js</script></action>
                 <action method="addJs"><script>scriptaculous/slider.js</script></action>
                 <action method="addJs"><script>varien/js.js</script></action>


### PR DESCRIPTION
This PR removes the inclusion of scriptaculous/dragdrop.js from the frontend pages of OpenMage, it is considered a breaking change so it targets the `next` branch.

After removing this file I've browsed many frontend pages without encountering a problem. I've searched for references to the code present in dragdrop.js and it seems there's none.

We still have to keep the file itself and its reference in the backend, it's used and necessary there.

### Manual testing scenarios

Not much I can say here...