### PR TITLE
Fix TypeError: Unsupported operand types: string - string in .../Zend…

### DIFF
--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -994,7 +994,7 @@ abstract class Mage_Core_Controller_Varien_Action
         ]);
 
         foreach ($dateFields as $dateField) {
-            if (array_key_exists($dateField, $array) && !empty($dateField)) {
+            if (array_key_exists($dateField, $array) && !empty($dateField) && !empty($array[$dateField])) {
                 $array[$dateField] = $filterInput->filter($array[$dateField]);
                 $array[$dateField] = $filterInternal->filter($array[$dateField]);
             }


### PR DESCRIPTION
…/Locale/Math/PhpMath.php on line 97

I think this is related to PHP 8.2 but I get this fatal error when submitting the Edit CMS Page save action with the Custom Design From/To date fields being empty.

![image](https://user-images.githubusercontent.com/38738/234076253-4c2415b5-e10b-4e06-9fdd-4b1035e4528b.png)

This patch fixes by not filtering empty strings.