### PR TITLE
Load all child blocks in Adminhtml Head block

### DIFF
--- a/app/design/adminhtml/default/default/template/page/head.phtml
+++ b/app/design/adminhtml/default/default/template/page/head.phtml
@@ -50,5 +50,4 @@
 </script>
 
 <?php echo $this->helper('core/js')->getTranslatorScript() ?>
-<?php echo $this->getChildHtml('calendar'); ?>
-<?php echo $this->getChildHtml('optional_zip_countries'); ?>
+<?php echo $this->getChildHtml(); ?>


### PR DESCRIPTION

### Description (*)

First roadblock I encountered when creating the extension mentioned in #3219, I can't add a custom child block to admin head 😢, and since the content is dynamically created through calling PHP code I can't use `addJs` either.

I don't know why this change wasn't done before, maybe it caused some issue? but it seems to work fine for me.

### Manual testing scenarios (*)

1. Go to layout xml of any module and try to add a child block to adminhtml head, in my case:
```xml
...
<default>
    <reference name="head">
        <block type="elidrissidev_debugbar/head" name="debugbar_head" />
    </reference>
</default>
...
```

Should be loaded after this change.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->