### PR TITLE
Cache Order status labels in an array

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Config.php
+++ b/app/code/core/Mage/Sales/Model/Order/Config.php
@@ -29,6 +29,13 @@ class Mage_Sales_Model_Order_Config extends Mage_Core_Model_Config_Base
     protected $_stateStatuses;
 
     /**
+     * Statuses array
+     *
+     * @var array
+     */
+    protected $_statuses;
+
+    /**
      * States array
      *
      * @var array
@@ -84,9 +91,12 @@ class Mage_Sales_Model_Order_Config extends Mage_Core_Model_Config_Base
      */
     public function getStatusLabel($code)
     {
-        $status = Mage::getModel('sales/order_status')
-            ->load($code);
-        return $status->getStoreLabel();
+        $key = $code.'/'.Mage::app()->getStore()->getStoreId();
+        if (!isset($this->_statuses[$key])) {
+            $status = Mage::getModel('sales/order_status')->load($code);
+            $this->_statuses[$key] = $status->getStoreLabel();
+        }
+        return $this->_statuses[$key];
     }
 
     /**

--- a/app/code/core/Mage/Sales/Model/Order/Config.php
+++ b/app/code/core/Mage/Sales/Model/Order/Config.php
@@ -91,7 +91,7 @@ class Mage_Sales_Model_Order_Config extends Mage_Core_Model_Config_Base
      */
     public function getStatusLabel($code)
     {
-        $key = $code.'/'.Mage::app()->getStore()->getStoreId();
+        $key = $code . '/' . Mage::app()->getStore()->getStoreId();
         if (!isset($this->_statuses[$key])) {
             $status = Mage::getModel('sales/order_status')->load($code);
             $this->_statuses[$key] = $status->getStoreLabel();


### PR DESCRIPTION

### Description (*)

A small performance improvement when retrieving Order status labels (either from `Mage_Sales_Model_Order` or `Mage_Sales_Model_Order_Status_History`) which is now going to check an array that serves as a cache first before loading them from the database if they don't exist.

Before, this resulted in a database query per every invocation, which resulted in many duplicate queries (found it by DebugBar extension I'm creating ;) ).

### Manual testing scenarios

```php
<?php

require 'app/Mage.php';

Mage::app();

Mage::getSingleton('sales/order_config')->getStatusLabel('pending');
// performs a db request and returns "Pending"

Mage::getSingleton('sales/order_config')->getStatusLabel('pending');
// returns immediately "Pending"

Mage::app()->setCurrentStore(2);

Mage::getSingleton('sales/order_config')->getStatusLabel('pending');
// performs a db request and returns "En attente" assuming store has different label
```

### Questions or comments

The key consists of the store id as well to prevent issues with emulation when labels are localized.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
