### PR TITLE
Allow app request to be initialized and `isCurrentlySecure` to be che…

### DIFF
--- a/app/code/core/Mage/Core/Controller/Request/Http.php
+++ b/app/code/core/Mage/Core/Controller/Request/Http.php
@@ -307,7 +307,7 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
     {
         return $this->getServer('HTTPS') == 'on'
           || $this->getServer('HTTP_X_FORWARDED_PROTO') == 'https'
-          || (Mage::isInstalled() && Mage::app()->getStore()->isCurrentlySecure()) ?
+          || (Mage::isInstalled() && Mage::app()->isCurrentlySecure()) ?
             self::SCHEME_HTTPS :
             self::SCHEME_HTTP;
     }

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -1295,6 +1295,34 @@ class Mage_Core_Model_App
         return $this;
     }
 
+    public function isCurrentlySecure()
+    {
+        if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
+            return true;
+        }
+
+        if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+            return true;
+        }
+
+        if (isset($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == 443)) {
+            return true;
+        }
+
+        if (Mage::isInstalled()) {
+            $offloaderHeader = strtoupper(trim((string) Mage::getConfig()->getNode(Mage_Core_Model_Store::XML_PATH_OFFLOADER_HEADER, 'default')));
+            if ($offloaderHeader) {
+                $offloaderHeader = preg_replace('/[^A-Z]+/', '_', $offloaderHeader);
+                $offloaderHeader = strpos($offloaderHeader, 'HTTP_') === 0 ? $offloaderHeader : 'HTTP_' . $offloaderHeader;
+                if (!empty($_SERVER[$offloaderHeader]) && $_SERVER[$offloaderHeader] !== 'http') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Retrieve response object
      *

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -1295,6 +1295,9 @@ class Mage_Core_Model_App
         return $this;
     }
 
+    /**
+     * @return bool
+     */
     public function isCurrentlySecure()
     {
         if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -753,30 +753,7 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
      */
     public function isCurrentlySecure()
     {
-        if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
-            return true;
-        }
-
-        if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
-            return true;
-        }
-
-        if (isset($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == 443)) {
-            return true;
-        }
-
-        if (Mage::isInstalled()) {
-            $offloaderHeader = strtoupper(trim((string) Mage::getStoreConfig(self::XML_PATH_OFFLOADER_HEADER)));
-            if ($offloaderHeader) {
-                $offloaderHeader = preg_replace('/[^A-Z]+/', '_', $offloaderHeader);
-                $offloaderHeader = strpos($offloaderHeader, 'HTTP_') === 0 ? $offloaderHeader : 'HTTP_' . $offloaderHeader;
-                if (!empty($_SERVER[$offloaderHeader]) && $_SERVER[$offloaderHeader] !== 'http') {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return Mage::app()->isCurrentlySecure();
     }
 
     /*************************************************************************************

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -749,6 +749,7 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
     /**
      * Check if request was secure
      *
+     * @deprecated
      * @return bool
      */
     public function isCurrentlySecure()

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -1499,6 +1499,10 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <comment><![CDATA[
+                                Provide the name of the request header set by the upstream proxy to indicate a secure connection.
+                                The header <code>X-Forwarded-Proto: https</code> is already checked by default regardless of this configuration option.
+                            ]]></comment>
                         </offloader_header>
                     </fields>
                 </secure>


### PR DESCRIPTION
I brushed the dust off of [Cm_Diehard](https://github.com/colinmollenhour/Cm_Diehard) and it seems it was broken by one of my own PRs (#1462).. When generating the cache key before the full init, it checks the request scheme which tries to load the store which hasn't been initialized yet so throws `Mage_Core_Model_Store_Exception`.

This PR moves the `isCurrentlySecure` method (and keeps the old one as a wrapper for BC) to `Mage_Core_Model_App` so that it can be called earlier in the request cycle without causing a `Mage_Core_Model_Store_Exception`. I don't know if any other modules require this but there is no regression.

I also added a comment to "Offloader header" to clarify it's utility.

Just for kicks, here are the results with the "Local" backend on a clean installation with `Cm_DiehardSample` (`Cm_Diehard` on the left, no FPC on the right):

![image](https://user-images.githubusercontent.com/38738/235262432-f3520f09-c3da-4ec7-abce-71cd6148fce0.png)
