### PR TITLE
Fix price expression SQL in layered navigation

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Price.php
@@ -309,7 +309,7 @@ class Mage_Catalog_Model_Resource_Layer_Filter_Price extends Mage_Core_Model_Res
         if (!is_null($upperPrice)) {
             $select->where("$priceExpression < " . $this->_getComparingValue($upperPrice, $filter));
         }
-        $select->order("$priceExpression ASC")->limit($limit, $offset);
+        $select->order(new Zend_Db_Expr("$priceExpression ASC"))->limit($limit, $offset);
 
         return $this->_getReadAdapter()->fetchCol($select);
     }
@@ -372,7 +372,7 @@ class Mage_Catalog_Model_Resource_Layer_Filter_Price extends Mage_Core_Model_Res
         if (!is_null($upperPrice)) {
             $pricesSelect->where("$priceExpression < " . $this->_getComparingValue($upperPrice, $filter));
         }
-        $pricesSelect->order("$priceExpression DESC")->limit($rightIndex - $offset + 1, $offset - 1);
+        $pricesSelect->order(new Zend_Db_Expr("$priceExpression DESC"))->limit($rightIndex - $offset + 1, $offset - 1);
 
         return array_reverse($this->_getReadAdapter()->fetchCol($pricesSelect));
     }


### PR DESCRIPTION
### Description (*)

Another fix for an SQL expression that needed to be wrapped in a `Zend_Db_Expr` to prevent it from being incorrectly escaped.

Needs to be backported to `v19`.

### Related Pull Requests

- See #2861

### Fixed Issues (if relevant)

1. Fixes OpenMage/magento-lts#3213

### Manual testing scenarios (*)

1. Go to System -> Configuration -> Tax -> Calculation Settings -> Catalog Prices and set it to "Including Tax"
2. Go to the frontend and browse any Category, page should render properly and no exception is logged.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->