### PR TITLE
Fixed type casting for Analytics 4

### DIFF
--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -209,10 +209,10 @@ _gaq.push(['_trackPageview'{$optPageURL}]);
             $orderData = [
                 'currency' => $order->getBaseCurrencyCode(),
                 'transaction_id' => $order->getIncrementId(),
-                'value' => number_format($order->getBaseGrandTotal(), 2),
+                'value' => (float)number_format($order->getBaseGrandTotal(), 2),
                 'coupon' => strtoupper($order->getCouponCode()),
-                'shipping' => number_format($order->getBaseShippingAmount(), 2),
-                'tax' => number_format($order->getBaseTaxAmount(), 2),
+                'shipping' => (float)number_format($order->getBaseShippingAmount(), 2),
+                'tax' => (float)number_format($order->getBaseTaxAmount(), 2),
                 'items' => []
             ];
 

--- a/app/design/frontend/base/default/template/googleanalytics/ga.phtml
+++ b/app/design/frontend/base/default/template/googleanalytics/ga.phtml
@@ -14,6 +14,7 @@
  */
 ?>
 <?php
+/** @var Mage_GoogleAnalytics_Block_Ga $this */
 $_helper = $this->helper('googleanalytics');
 $_accountId = $_helper->getAccountId();
 ?>


### PR DESCRIPTION
In https://github.com/OpenMage/magento-lts/issues/3228 it was pointed out that maybe some of the types in the Google Analytics 4 implementation of the "purchase" event may not be correct.

Mainly because the `number_format` function (required to return only a specific number of decimal) returns a string.

With this PR those values are casted back to float.

GA4 documentation: https://developers.google.com/analytics/devguides/collection/ga4/reference/events