### PR TITLE
Revert "Deprecation errors are not suppressed anymore" #3102

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,13 @@ grep -rn 'urn:Magento' --include \*.xml
 - Open your site in browser
   ```bash
   ddev launch
-  ``` 
+  ```
+
+## Development with PHP 8.1+
+
+Deprecation errors are supressed by default.
+
+If you want to work on PHP 8.1+ support, set environment variable `DEV_PHP_STRICT` to `1`, to show all errors.
 
 ## PhpStorm Factory Helper
 

--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -118,8 +118,8 @@ function mageCoreErrorHandler($errno, $errstr, $errfile, $errline)
     }
 
     // Suppress deprecation warnings on PHP 7.x
-    // set environment variable DEV_PHP_STRICT to 1 will show E_DEPRECATED errors
-    if ((!isset($_ENV['DEV_PHP_STRICT']) || $_ENV['DEV_PHP_STRICT'] != '1')
+    // set environment variable DEV_PHP_STRICT to 0 will hide E_DEPRECATED errors
+    if ((isset($_ENV['DEV_PHP_STRICT']) && $_ENV['DEV_PHP_STRICT'] == '0')
         && $errno == E_DEPRECATED
         && version_compare(PHP_VERSION, '7.0.0', '>=')
     ) {

--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -117,6 +117,15 @@ function mageCoreErrorHandler($errno, $errstr, $errfile, $errline)
         return false;
     }
 
+    // Suppress deprecation warnings on PHP 7.x
+    // set environment variable DEV_PHP_STRICT to 1 will show E_DEPRECATED errors
+    if ((!isset($_ENV['DEV_PHP_STRICT']) || $_ENV['DEV_PHP_STRICT'] != '1')
+        && $errno == E_DEPRECATED
+        && version_compare(PHP_VERSION, '7.0.0', '>=')
+    ) {
+        return true;
+    }
+
     // PEAR specific message handling
     if (stripos($errfile . $errstr, 'pear') !== false) {
         // ignore strict and deprecated notices


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Please revert #3102!

With php 81. i _cant_ neither use `main` because of #3175 nor `v19` with enabled dev-mode because of deprecation errors.

### Related Pull Requests
<!-- related pull request placeholder -->

1. See OpenMage/magento-lts#3176

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. use php8.1
2. enable developer mode
3. run into errors
4. ....

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->