### PR TITLE
Improved handling of ignore_user_agents

### DIFF
--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -105,11 +105,12 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
         if ($ignoreAgents) {
             $ignoreAgents = $ignoreAgents->asArray();
             $userAgent = $this->_httpHelper->getHttpUserAgent();
-            array_walk($ignoreAgents, function ($item) use ($userAgent) {
-                if (stristr($userAgent, $item)) {
+            foreach ($ignoreAgents as $ignoreAgent) {
+                if (stripos($userAgent, $ignoreAgent) !== false) {
                     $this->_skipRequestLogging = true;
+                    break;
                 }
-            });
+            })
         }
         if ($this->_logCondition->isLogDisabled()) {
             $this->_skipRequestLogging = true;

--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -105,7 +105,7 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
         $ignoreAgents = $this->_config->getNode('global/ignore_user_agents');
         if ($ignoreAgents) {
             $ignoreAgents = $ignoreAgents->asArray();
-            if (in_array($userAgent, $ignoreAgents)) {
+            if (in_array($userAgent, $ignoreAgents) || stristr($userAgent, $ignoreAgents)) {
                 $this->_skipRequestLogging = true;
             }
         }

--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -101,13 +101,15 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
     protected function _construct()
     {
         $this->_init('log/visitor');
-        $userAgent = $this->_httpHelper->getHttpUserAgent();
         $ignoreAgents = $this->_config->getNode('global/ignore_user_agents');
         if ($ignoreAgents) {
             $ignoreAgents = $ignoreAgents->asArray();
-            if (in_array($userAgent, $ignoreAgents) || stristr($userAgent, $ignoreAgents)) {
-                $this->_skipRequestLogging = true;
-            }
+            $userAgent = $this->_httpHelper->getHttpUserAgent();
+            array_walk($ignoreAgents, function ($item) use ($userAgent) {
+                if (stristr($userAgent, $item)) {
+                    $this->_skipRequestLogging = true;
+                }
+            });
         }
         if ($this->_logCondition->isLogDisabled()) {
             $this->_skipRequestLogging = true;

--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -110,11 +110,17 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
         if ($ignoreAgents) {
             $ignoreAgents = $ignoreAgents->asArray();
             $userAgent = $this->_httpHelper->getHttpUserAgent();
-            foreach ($ignoreAgents as $ignoreAgent) {
-                if (stripos($userAgent, $ignoreAgent) !== false) {
+            try {
+                $ignoreAgents = array_map(function ($userAgent) {
+                    return preg_quote($userAgent, '/');
+                }, $ignoreAgents);
+                $ignoreAgentRegex = implode('|', $ignoreAgents);
+                
+                if (preg_match("/{$ignoreAgentRegex}/i", $userAgent)) {
                     $this->_skipRequestLogging = true;
-                    break;
                 }
+            } catch (Exception $e) {
+                Mage::logException($e);
             }
         }
     }

--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -110,17 +110,11 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
         if ($ignoreAgents) {
             $ignoreAgents = $ignoreAgents->asArray();
             $userAgent = $this->_httpHelper->getHttpUserAgent();
-            try {
-                $ignoreAgents = array_map(function ($userAgent) {
-                    return preg_quote($userAgent, '/');
-                }, $ignoreAgents);
-                $ignoreAgentRegex = implode('|', $ignoreAgents);
-                
-                if (preg_match("/{$ignoreAgentRegex}/i", $userAgent)) {
+            foreach ($ignoreAgents as $ignoreAgent) {
+                if (stripos($userAgent, $ignoreAgent) !== false) {
                     $this->_skipRequestLogging = true;
+                    break;
                 }
-            } catch (Exception $e) {
-                Mage::logException($e);
             }
         }
     }

--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -101,6 +101,11 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
     protected function _construct()
     {
         $this->_init('log/visitor');
+        if ($this->_logCondition->isLogDisabled()) {
+            $this->_skipRequestLogging = true;
+            return;
+        }
+
         $ignoreAgents = $this->_config->getNode('global/ignore_user_agents');
         if ($ignoreAgents) {
             $ignoreAgents = $ignoreAgents->asArray();
@@ -110,10 +115,7 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
                     $this->_skipRequestLogging = true;
                     break;
                 }
-            })
-        }
-        if ($this->_logCondition->isLogDisabled()) {
-            $this->_skipRequestLogging = true;
+            }
         }
     }
 

--- a/app/code/core/Mage/Log/etc/config.xml
+++ b/app/code/core/Mage/Log/etc/config.xml
@@ -46,7 +46,7 @@
             <semrushbot>SemrushBot</semrushbot>
             <alphabot>AlphaBot</alphabot>
             <facebookexternalhit>facebookexternalhit</facebookexternalhit>
-            <seotester2>SEOTesterBot/seotester2</seotester2>
+            <seotester2>SEOTesterBot</seotester2>
             <ZoominfoBot>ZoominfoBot</ZoominfoBot>
             <amazonbot>Amazonbot</amazonbot>
         </ignore_user_agents>

--- a/app/code/core/Mage/Log/etc/config.xml
+++ b/app/code/core/Mage/Log/etc/config.xml
@@ -40,7 +40,6 @@
             <mod_pagespeed>mod_pagespeed</mod_pagespeed>
             <mj12bot>MJ12bot</mj12bot>
             <yandexbot>YandexMobileBot</yandexbot>
-            <yandexmobile>YandexMobileBot</yandexmobile>
             <yandeximage>YandexImages</yandeximage>
             <opensiteexplorer>spbot</opensiteexplorer>
             <semrushbot>SemrushBot</semrushbot>

--- a/app/code/core/Mage/Log/etc/config.xml
+++ b/app/code/core/Mage/Log/etc/config.xml
@@ -44,7 +44,7 @@
             <semrushbot>SemrushBot</semrushbot>
             <alphabot>AlphaBot</alphabot>
             <facebookexternalhit>facebookexternalhit</facebookexternalhit>
-            <seotester2>SEOTesterBot</seotester2>
+            <seotester>SEOTesterBot</seotester>
             <ZoominfoBot>ZoominfoBot</ZoominfoBot>
             <amazonbot>Amazonbot</amazonbot>
         </ignore_user_agents>

--- a/app/code/core/Mage/Log/etc/config.xml
+++ b/app/code/core/Mage/Log/etc/config.xml
@@ -29,9 +29,26 @@
             </entities>
         </ignoredModules>
         <ignore_user_agents>
-            <google1>Googlebot/1.0 (googlebot@googlebot.com http://googlebot.com/)</google1>
-            <google2>Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)</google2>
-            <google3>Googlebot/2.1 (+http://www.googlebot.com/bot.html)</google3>
+            <google1>Googlebot</google1>
+            <googleimage>Googlebot-Image</googleimage>
+            <mauibot>MauiBot</mauibot>
+            <blexbot>BLEXBot</blexbot>
+            <hrefsbot>AhrefsBot</hrefsbot>
+            <bingbot>bingbot</bingbot>
+            <dotbot>DotBot</dotbot>
+            <istellabot>istellabot</istellabot>
+            <mod_pagespeed>mod_pagespeed</mod_pagespeed>
+            <mj12bot>MJ12bot</mj12bot>
+            <yandexbot>YandexMobileBot</yandexbot>
+            <yandexmobile>YandexMobileBot</yandexmobile>
+            <yandeximage>YandexImages</yandeximage>
+            <opensiteexplorer>spbot</opensiteexplorer>
+            <semrushbot>SemrushBot</semrushbot>
+            <alphabot>AlphaBot</alphabot>
+            <facebookexternalhit>facebookexternalhit</facebookexternalhit>
+            <seotester2>SEOTesterBot/seotester2</seotester2>
+            <ZoominfoBot>ZoominfoBot</ZoominfoBot>
+            <amazonbot>Amazonbot</amazonbot>
         </ignore_user_agents>
         <helpers>
             <log>

--- a/app/code/core/Mage/Log/etc/config.xml
+++ b/app/code/core/Mage/Log/etc/config.xml
@@ -30,7 +30,6 @@
         </ignoredModules>
         <ignore_user_agents>
             <google1>Googlebot</google1>
-            <googleimage>Googlebot-Image</googleimage>
             <mauibot>MauiBot</mauibot>
             <blexbot>BLEXBot</blexbot>
             <hrefsbot>AhrefsBot</hrefsbot>

--- a/app/code/core/Mage/Log/etc/config.xml
+++ b/app/code/core/Mage/Log/etc/config.xml
@@ -29,7 +29,7 @@
             </entities>
         </ignoredModules>
         <ignore_user_agents>
-            <google1>Googlebot</google1>
+            <google>Googlebot</google>
             <mauibot>MauiBot</mauibot>
             <blexbot>BLEXBot</blexbot>
             <hrefsbot>AhrefsBot</hrefsbot>

--- a/app/code/core/Mage/Log/etc/config.xml
+++ b/app/code/core/Mage/Log/etc/config.xml
@@ -29,24 +29,28 @@
             </entities>
         </ignoredModules>
         <ignore_user_agents>
-            <google>Googlebot</google>
-            <mauibot>MauiBot</mauibot>
-            <blexbot>BLEXBot</blexbot>
-            <hrefsbot>AhrefsBot</hrefsbot>
-            <bingbot>bingbot</bingbot>
-            <dotbot>DotBot</dotbot>
-            <istellabot>istellabot</istellabot>
-            <mod_pagespeed>mod_pagespeed</mod_pagespeed>
-            <mj12bot>MJ12bot</mj12bot>
-            <yandexbot>YandexMobileBot</yandexbot>
-            <yandeximage>YandexImages</yandeximage>
-            <opensiteexplorer>spbot</opensiteexplorer>
-            <semrushbot>SemrushBot</semrushbot>
+            <adsbot>AdsBot</adsbot>
             <alphabot>AlphaBot</alphabot>
-            <facebookexternalhit>facebookexternalhit</facebookexternalhit>
-            <seotester>SEOTesterBot</seotester>
-            <ZoominfoBot>ZoominfoBot</ZoominfoBot>
             <amazonbot>Amazonbot</amazonbot>
+            <bingbot>bingbot</bingbot>
+            <blexbot>BLEXBot</blexbot>
+            <dotbot>DotBot</dotbot>
+            <facebookexternalhit>facebookexternalhit</facebookexternalhit>
+            <google>Googlebot</google>
+            <google-site-verification>Google-Site-Verification</google-site-verification>
+            <hrefsbot>AhrefsBot</hrefsbot>
+            <istellabot>istellabot</istellabot>
+            <mauibot>MauiBot</mauibot>
+            <mj12bot>MJ12bot</mj12bot>
+            <mod_pagespeed>mod_pagespeed</mod_pagespeed>
+            <opensiteexplorer>spbot</opensiteexplorer>
+            <pinterestbot>Pinterestbot</pinterestbot>
+            <semrushbot>SemrushBot</semrushbot>
+            <seotester>SEOTesterBot</seotester>
+            <yandexbot>YandexBot</yandexbot>
+            <yandeximage>YandexImages</yandeximage>
+            <yandexmobilebot>YandexMobileBot</yandexmobilebot>
+            <zoominfobot>ZoominfoBot</zoominfobot>
         </ignore_user_agents>
         <helpers>
             <log>


### PR DESCRIPTION
Modified the code to skip request logging for all user agents that contain any substring of an ignored agent in the ignore_user_agents config. The previous code only matched the exact string of user_agent with the ignore_user_agents config using in_array function, which resulted in some requests not being skipped from logging. Now, the code uses stristr function to match the string partially and case-insensitive, which improves the functionality of ignore_user_agents.
