### PR TITLE
Removed "MAGE" cache tag

### DIFF
--- a/app/code/core/Mage/Admin/Model/Resource/Block.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Block.php
@@ -70,7 +70,7 @@ class Mage_Admin_Model_Resource_Block extends Mage_Core_Model_Resource_Db_Abstra
         Mage::app()->saveCache(
             Mage::helper('core')->jsonEncode($data),
             self::CACHE_ID,
-            [Mage_Core_Model_App::CACHE_TAG]
+            [Mage_Core_Model_Resource_Db_Collection_Abstract::CACHE_TAG]
         );
     }
 

--- a/app/code/core/Mage/Admin/Model/Resource/Variable.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Variable.php
@@ -38,7 +38,7 @@ class Mage_Admin_Model_Resource_Variable extends Mage_Core_Model_Resource_Db_Abs
         Mage::app()->saveCache(
             Mage::helper('core')->jsonEncode($data),
             self::CACHE_ID,
-            [Mage_Core_Model_App::CACHE_TAG]
+            [Mage_Core_Model_Resource_Db_Collection_Abstract::CACHE_TAG]
         );
     }
 

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -37,12 +37,6 @@ class Mage_Core_Model_App
     public const DISTRO_LOCALE_CODE = 'en_US';
 
     /**
-     * Cache tag for all cache data exclude config cache
-     *
-     */
-    public const CACHE_TAG = 'MAGE';
-
-    /**
      * Default store Id (for install)
      */
     public const DISTRO_STORE_ID       = 1;

--- a/app/code/core/Mage/Core/Model/Cache.php
+++ b/app/code/core/Mage/Core/Model/Cache.php
@@ -421,8 +421,7 @@ class Mage_Core_Model_Cache
             }
             $res = $this->getFrontend()->clean($mode, $this->_tags($tags));
         } else {
-            $res = $this->getFrontend()->clean($mode, [Mage_Core_Model_App::CACHE_TAG]);
-            $res = $res && $this->getFrontend()->clean($mode, [Mage_Core_Model_Config::CACHE_TAG]);
+            $this->flush();
         }
         return $res;
     }

--- a/app/code/core/Mage/Core/Model/Cache.php
+++ b/app/code/core/Mage/Core/Model/Cache.php
@@ -381,12 +381,6 @@ class Mage_Core_Model_Cache
             return true;
         }
 
-        /**
-         * Add global magento cache tag to all cached data exclude config cache
-         */
-        if (!in_array(Mage_Core_Model_Config::CACHE_TAG, $tags)) {
-            $tags[] = Mage_Core_Model_App::CACHE_TAG;
-        }
         return $this->getFrontend()->save((string)$data, $this->_id($id), $this->_tags($tags), $lifeTime);
     }
 

--- a/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
@@ -687,7 +687,6 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends Varien_Da
     protected function _getCacheTags()
     {
         $tags = parent::_getCacheTags();
-        $tags[] = Mage_Core_Model_App::CACHE_TAG;
         $tags[] = self::CACHE_TAG;
         return $tags;
     }


### PR DESCRIPTION
This PR implements the suggestions discussed in https://github.com/OpenMage/magento-lts/issues/1226 and fixes it.

The MAGE cache tag is only used in order to be able to flush all cache without actually flushing the whole cache storage and since sharing the cache storage with another project/software/whatever would be a very bad practice, we can think about safely remove it.

Removing it will allow for less cache storage space usage and less data to process.

### Questions that need to be answered 1

https://github.com/OpenMage/magento-lts/blob/e464b270a1deca5e9dfd8307eeb178d5a5921ce1/app/code/core/Mage/Admin/Model/Resource/Variable.php#L31-L43

This method only uses Mage_Core_Model_App::CACHE_TAG as cache tag, what are we doing with that method?

### Questions that need to be answered 2

https://github.com/OpenMage/magento-lts/blob/e464b270a1deca5e9dfd8307eeb178d5a5921ce1/app/code/core/Mage/Admin/Model/Resource/Block.php#L59-L75

same thing as before

### Questions that need to be answered 3

https://github.com/OpenMage/magento-lts/blob/e464b270a1deca5e9dfd8307eeb178d5a5921ce1/app/code/core/Mage/Core/Model/Cache.php#L421-L434

do we just replace this method with the flush() method?

### Fixed Issues
1. Fixes https://github.com/OpenMage/magento-lts/issues/1226