### PR TITLE
Resized panels height in attribute set backend view

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
@@ -117,6 +117,9 @@ abstract class Mage_Catalog_Model_Resource_Abstract extends Mage_Eav_Model_Entit
             ->from(['attr_table' => $table], [])
             ->where("attr_table.{$this->getEntityIdField()} = ?", $object->getId())
             ->where('attr_table.store_id IN (?)', $storeIds);
+        if (count($storeIds) > 1) {
+            $select->order('attr_table.store_id ASC');
+        }
         if ($setId) {
             $select->join(
                 ['set_table' => $this->getTable('eav/entity_attribute')],

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
@@ -60,7 +60,7 @@
                     </tbody>
                 </table>
             </div>
-            <div id="tree-div2" style="height:600px;margin-top:5px;overflow:auto"></div>
+            <div id="tree-div2" style="height:500px;margin-top:5px;overflow:auto"></div>
             <script type="text/javascript">
             //<![CDATA[
             var allowDragAndDrop = <?php echo ($this->getIsReadOnly() ? 'false' : 'true'); ?>;

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
@@ -60,7 +60,7 @@
                     </tbody>
                 </table>
             </div>
-            <div id="tree-div2" style="height:400px; margin-top:5px;overflow:auto"></div>
+            <div id="tree-div2" style="margin-top:5px"></div>
             <script type="text/javascript">
             //<![CDATA[
             var allowDragAndDrop = <?php echo ($this->getIsReadOnly() ? 'false' : 'true'); ?>;

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
@@ -60,7 +60,7 @@
                     </tbody>
                 </table>
             </div>
-            <div id="tree-div2" style="margin-top:5px"></div>
+            <div id="tree-div2" style="height:600px;margin-top:5px;overflow:auto"></div>
             <script type="text/javascript">
             //<![CDATA[
             var allowDragAndDrop = <?php echo ($this->getIsReadOnly() ? 'false' : 'true'); ?>;

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
@@ -60,7 +60,7 @@
                     </tbody>
                 </table>
             </div>
-            <div id="tree-div2" style="height:500px;margin-top:5px;overflow:auto"></div>
+            <div id="tree-div2" style="height:550px;margin-top:5px;overflow:auto"></div>
             <script type="text/javascript">
             //<![CDATA[
             var allowDragAndDrop = <?php echo ($this->getIsReadOnly() ? 'false' : 'true'); ?>;

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/group.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/group.phtml
@@ -12,4 +12,4 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<div id="tree-div1" style="width:320px;height:400px;margin-top:5px;overflow:auto"></div>
+<div id="tree-div1" style="width:320px;margin-top:5px"></div>

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/group.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/group.phtml
@@ -12,4 +12,4 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<div id="tree-div1" style="width:320px;height:600px;margin-top:5px;overflow:auto"></div>
+<div id="tree-div1" style="width:320px;height:500px;margin-top:5px;overflow:auto"></div>

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/group.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/group.phtml
@@ -12,4 +12,4 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<div id="tree-div1" style="width:320px;margin-top:5px"></div>
+<div id="tree-div1" style="width:320px;height:600px;margin-top:5px;overflow:auto"></div>


### PR DESCRIPTION
This PR replaces https://github.com/OpenMage/magento-lts/pull/1311 and it is coauthored by @loekvangool.

This PR is slightly different cause it doesn't force any height/overflow, reducing the forced CSS lines and letting the browser fill all space

BEFORE:
<img width="1185" alt="Screenshot 2023-05-12 alle 18 22 44" src="https://github.com/OpenMage/magento-lts/assets/909743/c99e6698-4278-425b-899e-87f8c30f32b9">

AFTER:
<img width="1187" alt="Screenshot 2023-05-12 alle 18 22 18" src="https://github.com/OpenMage/magento-lts/assets/909743/9fcb3dee-5106-4f74-b715-749a16275342">
