### PR TITLE
Added DDEV command to install OM (incl. sample data)

### DIFF
--- a/.ddev/commands/web/install-openmage
+++ b/.ddev/commands/web/install-openmage
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+## Description: Install OpenMage
+## Usage: install-openmage
+## Example: ddev install-openmage
+
+ROOT="${PWD}"
+
+LOCALXML="${ROOT}/app/etc/local.xml"
+if [ -f "${LOCALXML}" ]; then
+  read -r -p "OpenMage is already installed. Delete local.xml and drop database[y/N]:" DELETE
+  DELETE=${DELETE,,} # to lower
+  if [[ "${DELETE}" =~ ^(yes|y) ]]; then
+    mysql -u db -h db -e "DROP SCHEMA IF EXISTS db; CREATE SCHEMA db;";
+    rm "${LOCALXML}"
+  else
+    exit 1
+  fi
+fi
+
+read -r -p "Install sample data? [y/N]" INSTALL_SAMPLE_DATA
+INSTALL_SAMPLE_DATA=${INSTALL_SAMPLE_DATA,,} # to lower
+if [[ $INSTALL_SAMPLE_DATA =~ ^(yes|y) ]]; then
+  SAMPLE_DATA_URL=https://github.com/Vinai/compressed-magento-sample-data/raw/master/compressed-magento-sample-data-1.9.2.4.tgz
+  SAMPLE_DATA_DIRECTORY="${ROOT}/.sampleData"
+  SAMPLE_DATA_FILE=sample_data.tgz
+
+  if [[ ! -d "${SAMPLE_DATA_DIRECTORY}" ]]; then
+    echo "Creating backup directory"
+    mkdir -p "${SAMPLE_DATA_DIRECTORY}"
+  fi
+
+  cd "${SAMPLE_DATA_DIRECTORY}" || exit
+  if [[ ! -f "${SAMPLE_DATA_DIRECTORY}/${SAMPLE_DATA_FILE}" ]]; then
+    echo "Downloading sample data"
+    wget "${SAMPLE_DATA_URL}" -O "${SAMPLE_DATA_FILE}"
+  fi
+
+  echo "Uncompress sample data"
+  tar xf "${SAMPLE_DATA_FILE}"
+
+  echo "Copy sample data"
+  cp -r magento-sample-data-1.9.2.4/* "${PWD}/"
+
+  echo "Import sample data"
+  mysql -u db -h db db < "${SAMPLE_DATA_DIRECTORY}/magento-sample-data-1.9.2.4/magento_sample_data_for_1.9.2.4.sql"
+
+  # remove sample data
+  if [[ "${SAMPLE_DATA_KEEP_FLAG}" ]]; then
+    rm -rf $(
+      find . -maxdepth 1 -type f -name "*" ! -name "${SAMPLE_DATA_FILE}")
+  else
+    cd "${ROOT}" || exit
+    rm -rf "${SAMPLE_DATA_DIRECTORY}"
+  fi
+fi
+
+cd "${ROOT}" || exit
+
+read -r -p "Admin user [admin]:" ADMIN_USER
+ADMIN_USER=${ADMIN_USER:-admin}
+read -r -p "Admin firstname [OpenMage]:" ADMIN_FIRSTNAME
+ADMIN_FIRSTNAME=${ADMIN_FIRSTNAME:-OpenMage}
+read -r -p "Admin lastname [User]:" ADMIN_LASTNAME
+ADMIN_LASTNAME=${ADMIN_LASTNAME:-User}
+read -r -p "Admin email [admin@example.com]:" ADMIN_EMAIL
+ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
+read -r -p "Admin password [veryl0ngpassw0rd]:" ADMIN_PASSWORD
+ADMIN_PASSWORD=${ADMIN_PASSWORD:-veryl0ngpassw0rd}
+
+php -f install.php -- \
+  --license_agreement_accepted 'yes' \
+  --locale 'en_US' \
+  --timezone 'America/New_York' \
+  --db_host 'db' \
+  --db_name 'db' \
+  --db_user 'db' \
+  --db_pass 'db' \
+  --db_prefix '' \
+  --url "${DDEV_PRIMARY_URL}" \
+  --use_rewrites 'yes' \
+  --use_secure 'no' \
+  --secure_base_url "${DDEV_PRIMARY_URL}" \
+  --use_secure_admin 'no' \
+  --admin_username "${ADMIN_USER}" \
+  --admin_lastname "${ADMIN_LASTNAME}" \
+  --admin_firstname "${ADMIN_FIRSTNAME}" \
+  --admin_email "${ADMIN_EMAIL}" \
+  --admin_password "${ADMIN_PASSWORD}" \
+  --session_save 'files' \
+  --admin_frontname 'admin' \
+  --backend_frontname 'admin' \
+  --default_currency 'USD' \
+  --skip_url_validation 'yes'

--- a/.ddev/commands/web/install-openmage
+++ b/.ddev/commands/web/install-openmage
@@ -2,26 +2,40 @@
 
 ## Description: Install OpenMage
 ## Usage: install-openmage
-## Example: ddev install-openmage -d -s -k
+## Example: ddev install-openmage -d -s -k -q
 
 ROOT="${PWD}"
 
+QUIET_INSTALL_FLAG=''
 SAMPLE_DATA_FLAG=''
 SAMPLE_DATA_KEEP_FLAG=''
 USE_DEFAULT_FLAG=''
 
-while getopts 'dsk' flag; do
+while getopts 'dskq' flag; do
   case "${flag}" in
     d) USE_DEFAULT_FLAG='true' ;;
     s) SAMPLE_DATA_FLAG='true' ;;
     k) SAMPLE_DATA_KEEP_FLAG='true' ;;
+    q) QUIET_INSTALL_FLAG='true' ;;
   esac
 done
 
+
+#quiet install
+if [[ "${QUIET_INSTALL_FLAG}" ]]; then
+  USE_DEFAULT_FLAG='true'
+  SAMPLE_DATA_FLAG='true'
+fi
+
 LOCALXML="${ROOT}/app/etc/local.xml"
 if [ -f "${LOCALXML}" ]; then
-  read -r -p "OpenMage is already installed. Delete local.xml and drop database[y/N]:" DELETE
-  DELETE=${DELETE,,} # to lower
+  if [[ "${QUIET_INSTALL_FLAG}" ]]; then
+    DELETE='y'
+  else
+    read -r -p "OpenMage is already installed. Delete local.xml and drop database[y/N]:" DELETE
+    DELETE=${DELETE,,} # to lower
+  fi
+
   if [[ "${DELETE}" =~ ^(yes|y) ]]; then
     mysql -u db -h db -e "DROP SCHEMA IF EXISTS db; CREATE SCHEMA db;";
     rm "${LOCALXML}"
@@ -31,7 +45,7 @@ if [ -f "${LOCALXML}" ]; then
 fi
 
 # install sample data
-if [[ "${SAMPLE_DATA_KEEP_FLAG}" ]]; then
+if [[ "${SAMPLE_DATA_FLAG}" ]]; then
   INSTALL_SAMPLE_DATA='y'
 else
   read -r -p "Install sample data? [y/N]" INSTALL_SAMPLE_DATA

--- a/.ddev/commands/web/install-openmage
+++ b/.ddev/commands/web/install-openmage
@@ -2,9 +2,21 @@
 
 ## Description: Install OpenMage
 ## Usage: install-openmage
-## Example: ddev install-openmage
+## Example: ddev install-openmage -d -s -k
 
 ROOT="${PWD}"
+
+SAMPLE_DATA_FLAG=''
+SAMPLE_DATA_KEEP_FLAG=''
+USE_DEFAULT_FLAG=''
+
+while getopts 'dsk' flag; do
+  case "${flag}" in
+    d) USE_DEFAULT_FLAG='true' ;;
+    s) SAMPLE_DATA_FLAG='true' ;;
+    k) SAMPLE_DATA_KEEP_FLAG='true' ;;
+  esac
+done
 
 LOCALXML="${ROOT}/app/etc/local.xml"
 if [ -f "${LOCALXML}" ]; then
@@ -18,8 +30,14 @@ if [ -f "${LOCALXML}" ]; then
   fi
 fi
 
-read -r -p "Install sample data? [y/N]" INSTALL_SAMPLE_DATA
-INSTALL_SAMPLE_DATA=${INSTALL_SAMPLE_DATA,,} # to lower
+# install sample data
+if [[ "${SAMPLE_DATA_KEEP_FLAG}" ]]; then
+  INSTALL_SAMPLE_DATA='y'
+else
+  read -r -p "Install sample data? [y/N]" INSTALL_SAMPLE_DATA
+  INSTALL_SAMPLE_DATA=${INSTALL_SAMPLE_DATA,,} # to lower
+fi
+
 if [[ $INSTALL_SAMPLE_DATA =~ ^(yes|y) ]]; then
   SAMPLE_DATA_URL=https://github.com/Vinai/compressed-magento-sample-data/raw/master/compressed-magento-sample-data-1.9.2.4.tgz
   SAMPLE_DATA_DIRECTORY="${ROOT}/.sampleData"
@@ -57,18 +75,27 @@ fi
 
 cd "${ROOT}" || exit
 
-read -r -p "Admin user [admin]:" ADMIN_USER
-ADMIN_USER=${ADMIN_USER:-admin}
-read -r -p "Admin firstname [OpenMage]:" ADMIN_FIRSTNAME
-ADMIN_FIRSTNAME=${ADMIN_FIRSTNAME:-OpenMage}
-read -r -p "Admin lastname [User]:" ADMIN_LASTNAME
-ADMIN_LASTNAME=${ADMIN_LASTNAME:-User}
-read -r -p "Admin email [admin@example.com]:" ADMIN_EMAIL
-ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
-read -r -p "Admin password [veryl0ngpassw0rd]:" ADMIN_PASSWORD
-ADMIN_PASSWORD=${ADMIN_PASSWORD:-veryl0ngpassw0rd}
-read -r -p "Database prefix []:" DB_PREFIX
-DB_PREFIX=${DB_PREFIX:-}
+if [[ "${USE_DEFAULT_FLAG}" ]]; then
+  ADMIN_USER='admin'
+  ADMIN_FIRSTNAME='OpenMage'
+  ADMIN_LASTNAME='User'
+  ADMIN_EMAIL='admin@example.com'
+  ADMIN_PASSWORD='veryl0ngpassw0rd'
+  DB_PREFIX=''
+else
+  read -r -p "Admin user [admin]:" ADMIN_USER
+  ADMIN_USER=${ADMIN_USER:-admin}
+  read -r -p "Admin firstname [OpenMage]:" ADMIN_FIRSTNAME
+  ADMIN_FIRSTNAME=${ADMIN_FIRSTNAME:-OpenMage}
+  read -r -p "Admin lastname [User]:" ADMIN_LASTNAME
+  ADMIN_LASTNAME=${ADMIN_LASTNAME:-User}
+  read -r -p "Admin email [admin@example.com]:" ADMIN_EMAIL
+  ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
+  read -r -p "Admin password [veryl0ngpassw0rd]:" ADMIN_PASSWORD
+  ADMIN_PASSWORD=${ADMIN_PASSWORD:-veryl0ngpassw0rd}
+  read -r -p "Database prefix []:" DB_PREFIX
+  DB_PREFIX=${DB_PREFIX:-}
+fi
 
 php -f install.php -- \
   --license_agreement_accepted 'yes' \

--- a/.ddev/commands/web/install-openmage
+++ b/.ddev/commands/web/install-openmage
@@ -67,6 +67,8 @@ read -r -p "Admin email [admin@example.com]:" ADMIN_EMAIL
 ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
 read -r -p "Admin password [veryl0ngpassw0rd]:" ADMIN_PASSWORD
 ADMIN_PASSWORD=${ADMIN_PASSWORD:-veryl0ngpassw0rd}
+read -r -p "Database prefix []:" DB_PREFIX
+DB_PREFIX=${DB_PREFIX:-}
 
 php -f install.php -- \
   --license_agreement_accepted 'yes' \
@@ -76,7 +78,7 @@ php -f install.php -- \
   --db_name 'db' \
   --db_user 'db' \
   --db_pass 'db' \
-  --db_prefix '' \
+  --db_prefix "${DB_PREFIX}" \
   --url "${DDEV_PRIMARY_URL}" \
   --use_rewrites 'yes' \
   --use_secure 'no' \

--- a/.ddev/commands/web/openmage-install
+++ b/.ddev/commands/web/openmage-install
@@ -22,7 +22,10 @@ while :; do
          -k|--keep)
             SAMPLE_DATA_KEEP_FLAG='true' ;;
          -q|--quiet)
-            QUIET_INSTALL_FLAG='true' ;;
+            QUIET_INSTALL_FLAG='true'
+            USE_DEFAULT_FLAG='true'
+            SAMPLE_DATA_FLAG='true'
+            ;;
          --)              # End of all options.
              shift
              break
@@ -36,12 +39,6 @@ while :; do
 
      shift
  done
-
-#quiet install
-if [[ "${QUIET_INSTALL_FLAG}" ]]; then
-  USE_DEFAULT_FLAG='true'
-  SAMPLE_DATA_FLAG='true'
-fi
 
 LOCALXML="${ROOT}/app/etc/local.xml"
 if [ -f "${LOCALXML}" ]; then

--- a/.ddev/commands/web/openmage-install
+++ b/.ddev/commands/web/openmage-install
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 ## Description: Install OpenMage
-## Usage: install-openmage
-## Example: ddev install-openmage -d -s -k -q
+## Usage: openmage-install
+## Example: ddev openmage-install -d -s -k -q
 
 ROOT="${PWD}"
 
@@ -32,7 +32,7 @@ if [ -f "${LOCALXML}" ]; then
   if [[ "${QUIET_INSTALL_FLAG}" ]]; then
     DELETE='y'
   else
-    read -r -p "OpenMage is already installed. Delete local.xml and drop database[y/N]:" DELETE
+    read -r -p "OpenMage is already installed. Delete local.xml and drop database [y/N]: " DELETE
     DELETE=${DELETE,,} # to lower
   fi
 
@@ -48,7 +48,7 @@ fi
 if [[ "${SAMPLE_DATA_FLAG}" ]]; then
   INSTALL_SAMPLE_DATA='y'
 else
-  read -r -p "Install sample data? [y/N]" INSTALL_SAMPLE_DATA
+  read -r -p "Install sample data? [y/N]: " INSTALL_SAMPLE_DATA
   INSTALL_SAMPLE_DATA=${INSTALL_SAMPLE_DATA,,} # to lower
 fi
 
@@ -92,23 +92,23 @@ cd "${ROOT}" || exit
 if [[ "${USE_DEFAULT_FLAG}" ]]; then
   ADMIN_USER='admin'
   ADMIN_FIRSTNAME='OpenMage'
-  ADMIN_LASTNAME='User'
+  ADMIN_LASTNAME='Administrator'
   ADMIN_EMAIL='admin@example.com'
   ADMIN_PASSWORD='veryl0ngpassw0rd'
-  DB_PREFIX=''
+  TABLE_PREFIX=''
 else
-  read -r -p "Admin user [admin]:" ADMIN_USER
+  read -r -p "Admin user [admin]: " ADMIN_USER
   ADMIN_USER=${ADMIN_USER:-admin}
-  read -r -p "Admin firstname [OpenMage]:" ADMIN_FIRSTNAME
+  read -r -p "Admin firstname [OpenMage]: " ADMIN_FIRSTNAME
   ADMIN_FIRSTNAME=${ADMIN_FIRSTNAME:-OpenMage}
-  read -r -p "Admin lastname [User]:" ADMIN_LASTNAME
-  ADMIN_LASTNAME=${ADMIN_LASTNAME:-User}
-  read -r -p "Admin email [admin@example.com]:" ADMIN_EMAIL
+  read -r -p "Admin lastname [Administrator]: " ADMIN_LASTNAME
+  ADMIN_LASTNAME=${ADMIN_LASTNAME:-Administrator}
+  read -r -p "Admin email [admin@example.com]: " ADMIN_EMAIL
   ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
-  read -r -p "Admin password [veryl0ngpassw0rd]:" ADMIN_PASSWORD
+  read -r -p "Admin password [veryl0ngpassw0rd]: " ADMIN_PASSWORD
   ADMIN_PASSWORD=${ADMIN_PASSWORD:-veryl0ngpassw0rd}
-  read -r -p "Database prefix []:" DB_PREFIX
-  DB_PREFIX=${DB_PREFIX:-}
+  read -r -p "Table prefix []: " TABLE_PREFIX
+  TABLE_PREFIX=${TABLE_PREFIX:-}
 fi
 
 php -f install.php -- \
@@ -119,12 +119,12 @@ php -f install.php -- \
   --db_name 'db' \
   --db_user 'db' \
   --db_pass 'db' \
-  --db_prefix "${DB_PREFIX}" \
+  --db_prefix "${TABLE_PREFIX}" \
   --url "${DDEV_PRIMARY_URL}" \
   --use_rewrites 'yes' \
-  --use_secure 'no' \
+  --use_secure 'yes' \
   --secure_base_url "${DDEV_PRIMARY_URL}" \
-  --use_secure_admin 'no' \
+  --use_secure_admin 'yes' \
   --admin_username "${ADMIN_USER}" \
   --admin_lastname "${ADMIN_LASTNAME}" \
   --admin_firstname "${ADMIN_FIRSTNAME}" \
@@ -134,4 +134,5 @@ php -f install.php -- \
   --admin_frontname 'admin' \
   --backend_frontname 'admin' \
   --default_currency 'USD' \
+  --enable_charts 'yes' \
   --skip_url_validation 'yes'

--- a/.ddev/commands/web/openmage-install
+++ b/.ddev/commands/web/openmage-install
@@ -81,13 +81,13 @@ if [[ $INSTALL_SAMPLE_DATA =~ ^(yes|y) ]]; then
     wget "${SAMPLE_DATA_URL}" -O "${SAMPLE_DATA_FILE}"
   fi
 
-  echo "Uncompress sample data ..."
+  echo "Uncompressing sample data ..."
   tar xf "${SAMPLE_DATA_FILE}"
 
-  echo "Copy sample data ..."
+  echo "Copying sample data ..."
   cp -r magento-sample-data-1.9.2.4/* "${PWD}/"
 
-  echo "Import sample data ..."
+  echo "Importing sample data ..."
   mysql -u db -h db db < "${SAMPLE_DATA_DIRECTORY}/magento-sample-data-1.9.2.4/magento_sample_data_for_1.9.2.4.sql"
 
   # remove sample data

--- a/.ddev/commands/web/openmage-install
+++ b/.ddev/commands/web/openmage-install
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+## ProjectTypes: magento
 ## Description: Install OpenMage
-## Usage: openmage-install
-## Example: ddev openmage-install -d -s -k -q
+## Usage: openmage-install [-d|--default] [-s|--sampledata] [-k|--keep] [-q|--quiet]
+## Example: ddev openmage-install -d -s -k
+## Flags: [{"Name":"default","Shorthand":"d","Usage":"use default values"},{"Name":"sampledata","Shorthand":"s","Usage":"install sample data"},{"Name":"keep","Shorthand":"k","Usage":"keep sample data package"},{"Name":"quiet","Shorthand":"q","Usage":"silent install with sample data"}]
 
 ROOT="${PWD}"
 
@@ -11,15 +13,29 @@ SAMPLE_DATA_FLAG=''
 SAMPLE_DATA_KEEP_FLAG=''
 USE_DEFAULT_FLAG=''
 
-while getopts 'dskq' flag; do
-  case "${flag}" in
-    d) USE_DEFAULT_FLAG='true' ;;
-    s) SAMPLE_DATA_FLAG='true' ;;
-    k) SAMPLE_DATA_KEEP_FLAG='true' ;;
-    q) QUIET_INSTALL_FLAG='true' ;;
-  esac
-done
+while :; do
+     case ${1:-} in
+         -d|--default)
+            USE_DEFAULT_FLAG='true' ;;
+         -s|--sampledata)
+            SAMPLE_DATA_FLAG='true' ;;
+         -k|--keep)
+            SAMPLE_DATA_KEEP_FLAG='true' ;;
+         -q|--quiet)
+            QUIET_INSTALL_FLAG='true' ;;
+         --)              # End of all options.
+             shift
+             break
+             ;;
+         -?*)
+             printf 'WARN: Unknown option (ignored): %s\n' "$1" >&2
+             ;;
+         *)               # Default case: No more options, so break out of the loop.
+             break
+     esac
 
+     shift
+ done
 
 #quiet install
 if [[ "${QUIET_INSTALL_FLAG}" ]]; then
@@ -32,7 +48,7 @@ if [ -f "${LOCALXML}" ]; then
   if [[ "${QUIET_INSTALL_FLAG}" ]]; then
     DELETE='y'
   else
-    read -r -p "OpenMage is already installed. Delete local.xml and drop database [y/N]: " DELETE
+    read -r -p "OpenMage is already installed. Delete local.xml and drop database [y/N] " DELETE
     DELETE=${DELETE,,} # to lower
   fi
 
@@ -48,7 +64,7 @@ fi
 if [[ "${SAMPLE_DATA_FLAG}" ]]; then
   INSTALL_SAMPLE_DATA='y'
 else
-  read -r -p "Install sample data? [y/N]: " INSTALL_SAMPLE_DATA
+  read -r -p "Install sample data? [y/N] " INSTALL_SAMPLE_DATA
   INSTALL_SAMPLE_DATA=${INSTALL_SAMPLE_DATA,,} # to lower
 fi
 
@@ -58,23 +74,23 @@ if [[ $INSTALL_SAMPLE_DATA =~ ^(yes|y) ]]; then
   SAMPLE_DATA_FILE=sample_data.tgz
 
   if [[ ! -d "${SAMPLE_DATA_DIRECTORY}" ]]; then
-    echo "Creating backup directory"
+    echo "Creating backup directory ..."
     mkdir -p "${SAMPLE_DATA_DIRECTORY}"
   fi
 
   cd "${SAMPLE_DATA_DIRECTORY}" || exit
   if [[ ! -f "${SAMPLE_DATA_DIRECTORY}/${SAMPLE_DATA_FILE}" ]]; then
-    echo "Downloading sample data"
+    echo "Downloading sample data ..."
     wget "${SAMPLE_DATA_URL}" -O "${SAMPLE_DATA_FILE}"
   fi
 
-  echo "Uncompress sample data"
+  echo "Uncompress sample data ..."
   tar xf "${SAMPLE_DATA_FILE}"
 
-  echo "Copy sample data"
+  echo "Copy sample data ..."
   cp -r magento-sample-data-1.9.2.4/* "${PWD}/"
 
-  echo "Import sample data"
+  echo "Import sample data ..."
   mysql -u db -h db db < "${SAMPLE_DATA_DIRECTORY}/magento-sample-data-1.9.2.4/magento_sample_data_for_1.9.2.4.sql"
 
   # remove sample data

--- a/.ddev/commands/web/openmage-install
+++ b/.ddev/commands/web/openmage-install
@@ -45,7 +45,7 @@ if [ -f "${LOCALXML}" ]; then
   if [[ "${QUIET_INSTALL_FLAG}" ]]; then
     DELETE='y'
   else
-    read -r -p "OpenMage is already installed. Delete local.xml and drop database [y/N] " DELETE
+    read -r -p "OpenMage is already installed. Delete local.xml and drop the database? [y/N] " DELETE
     DELETE=${DELETE,,} # to lower
   fi
 
@@ -61,7 +61,7 @@ fi
 if [[ "${SAMPLE_DATA_FLAG}" ]]; then
   INSTALL_SAMPLE_DATA='y'
 else
-  read -r -p "Install sample data? [y/N] " INSTALL_SAMPLE_DATA
+  read -r -p "Install Sample Data? [y/N] " INSTALL_SAMPLE_DATA
   INSTALL_SAMPLE_DATA=${INSTALL_SAMPLE_DATA,,} # to lower
 fi
 
@@ -71,23 +71,23 @@ if [[ $INSTALL_SAMPLE_DATA =~ ^(yes|y) ]]; then
   SAMPLE_DATA_FILE=sample_data.tgz
 
   if [[ ! -d "${SAMPLE_DATA_DIRECTORY}" ]]; then
-    echo "Creating backup directory ..."
+    echo "Creating Sample Data directory..."
     mkdir -p "${SAMPLE_DATA_DIRECTORY}"
   fi
 
   cd "${SAMPLE_DATA_DIRECTORY}" || exit
   if [[ ! -f "${SAMPLE_DATA_DIRECTORY}/${SAMPLE_DATA_FILE}" ]]; then
-    echo "Downloading sample data ..."
+    echo "Downloading Sample Data..."
     wget "${SAMPLE_DATA_URL}" -O "${SAMPLE_DATA_FILE}"
   fi
 
-  echo "Uncompressing sample data ..."
+  echo "Uncompressing Sample Data..."
   tar xf "${SAMPLE_DATA_FILE}"
 
-  echo "Copying sample data ..."
-  cp -r magento-sample-data-1.9.2.4/* "${PWD}/"
+  echo "Copying Sample Data into the OpenMage directory..."
+  cp -r magento-sample-data-1.9.2.4/* "${ROOT}/"
 
-  echo "Importing sample data ..."
+  echo "Importing Sample Data into the database..."
   mysql -u db -h db db < "${SAMPLE_DATA_DIRECTORY}/magento-sample-data-1.9.2.4/magento_sample_data_for_1.9.2.4.sql"
 
   # remove sample data
@@ -110,20 +110,20 @@ if [[ "${USE_DEFAULT_FLAG}" ]]; then
   ADMIN_PASSWORD='veryl0ngpassw0rd'
   TABLE_PREFIX='om_'
 else
-  read -r -p "Admin user [admin]: " ADMIN_USER
+  read -r -p "Admin User [admin]: " ADMIN_USER
   ADMIN_USER=${ADMIN_USER:-admin}
-  read -r -p "Admin firstname [OpenMage]: " ADMIN_FIRSTNAME
+  read -r -p "Admin Firstname [OpenMage]: " ADMIN_FIRSTNAME
   ADMIN_FIRSTNAME=${ADMIN_FIRSTNAME:-OpenMage}
-  read -r -p "Admin lastname [Administrator]: " ADMIN_LASTNAME
+  read -r -p "Admin Lastname [Administrator]: " ADMIN_LASTNAME
   ADMIN_LASTNAME=${ADMIN_LASTNAME:-Administrator}
-  read -r -p "Admin email [admin@example.com]: " ADMIN_EMAIL
+  read -r -p "Admin Email [admin@example.com]: " ADMIN_EMAIL
   ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
-  read -r -p "Admin password [veryl0ngpassw0rd]: " ADMIN_PASSWORD
+  read -r -p "Admin Password [veryl0ngpassw0rd]: " ADMIN_PASSWORD
   ADMIN_PASSWORD=${ADMIN_PASSWORD:-veryl0ngpassw0rd}
   if [[ $INSTALL_SAMPLE_DATA =~ ^(yes|y) ]]; then
     TABLE_PREFIX=''
   else
-    read -r -e -i 'om_' -p "Table prefix [om_]: " TABLE_PREFIX
+    read -r -e -i 'om_' -p "Table Prefix [om_]: " TABLE_PREFIX
   fi
 fi
 

--- a/.ddev/commands/web/openmage-install
+++ b/.ddev/commands/web/openmage-install
@@ -120,8 +120,12 @@ else
   ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
   read -r -p "Admin password [veryl0ngpassw0rd]: " ADMIN_PASSWORD
   ADMIN_PASSWORD=${ADMIN_PASSWORD:-veryl0ngpassw0rd}
-  read -r -p "Table prefix []: " TABLE_PREFIX
-  TABLE_PREFIX=${TABLE_PREFIX:-}
+  if [[ $INSTALL_SAMPLE_DATA =~ ^(yes|y) ]]; then
+    TABLE_PREFIX=''
+  else
+    read -r -p "Table prefix []: " TABLE_PREFIX
+    TABLE_PREFIX=${TABLE_PREFIX:-}
+  fi
 fi
 
 php -f install.php -- \

--- a/.ddev/commands/web/openmage-install
+++ b/.ddev/commands/web/openmage-install
@@ -108,7 +108,7 @@ if [[ "${USE_DEFAULT_FLAG}" ]]; then
   ADMIN_LASTNAME='Administrator'
   ADMIN_EMAIL='admin@example.com'
   ADMIN_PASSWORD='veryl0ngpassw0rd'
-  TABLE_PREFIX=''
+  TABLE_PREFIX='om_'
 else
   read -r -p "Admin user [admin]: " ADMIN_USER
   ADMIN_USER=${ADMIN_USER:-admin}
@@ -123,8 +123,8 @@ else
   if [[ $INSTALL_SAMPLE_DATA =~ ^(yes|y) ]]; then
     TABLE_PREFIX=''
   else
-    read -r -p "Table prefix []: " TABLE_PREFIX
-    TABLE_PREFIX=${TABLE_PREFIX:-}
+    read -r -p "Table prefix [om_]: " TABLE_PREFIX
+    TABLE_PREFIX=${TABLE_PREFIX:-om_}
   fi
 fi
 

--- a/.ddev/commands/web/openmage-install
+++ b/.ddev/commands/web/openmage-install
@@ -123,8 +123,7 @@ else
   if [[ $INSTALL_SAMPLE_DATA =~ ^(yes|y) ]]; then
     TABLE_PREFIX=''
   else
-    read -r -p "Table prefix [om_]: " TABLE_PREFIX
-    TABLE_PREFIX=${TABLE_PREFIX:-om_}
+    read -r -e -i 'om_' -p "Table prefix [om_]: " TABLE_PREFIX
   fi
 fi
 


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Adds ddev-command `ddev install-openmage` to install OM w/ or w/o sample data.

There a three optional flags ...

`-d` use default values for admin-user, db, ... w/o getting asked for
`-s` install sample data ...
`-k` keep sample data package (to avoid to download it again and again)
`-q` drop current install and re-install with default values

Run `ddev install-openmage -d -s` to install OM /w sample data.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

Install works only WITH sample data!

php7.4
```
FAILED
ERROR: Error in file: "/var/www/html/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.7-1.4.0.0.8.php" - Notice: Undefined offset: 0  in /var/www/html/app/code/core/Mage/Core/Model/App.php on line 1005
```

php8.1
```
FAILED
ERROR: Error in file: "/var/www/html/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.7-1.4.0.0.8.php" - Warning: Undefined array key 0  in /var/www/html/app/code/core/Mage/Core/Model/App.php on line 1005
```

Updates welcome.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->