### PR TITLE
Fixed PHP8.2 deprecated warning in Mage_Cron_Model_Observer

### DIFF
--- a/app/code/core/Mage/Cron/Model/Observer.php
+++ b/app/code/core/Mage/Cron/Model/Observer.php
@@ -220,7 +220,7 @@ class Mage_Cron_Model_Observer
 
         $now = time();
         foreach ($history->getIterator() as $record) {
-            if (strtotime($record->getExecutedAt()) < $now - $historyLifetimes[$record->getStatus()]) {
+            if (strtotime($record->getExecutedAt() ?? '') < $now - $historyLifetimes[$record->getStatus()]) {
                 $record->delete();
             }
         }


### PR DESCRIPTION
This was reported by https://github.com/OpenMage/magento-lts/issues/3184#issuecomment-1546858817