### PR TITLE
Added PHP8 configurations to .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -40,6 +40,34 @@
 
 </IfModule>
 
+############################################
+## php8 settings
+
+<IfModule mod_php.c>
+
+############################################
+## adjust max execution time
+
+    php_value max_execution_time 18000
+
+############################################
+## disable automatic session start
+## before autoload was initialized
+
+    php_flag session.auto_start off
+
+############################################
+## enable resulting html compression
+
+    #php_flag zlib.output_compression on
+
+###########################################
+# disable user agent verification to not break multiple image upload
+
+    php_flag suhosin.session.cryptua off
+
+</IfModule>
+
 <IfModule mod_security.c>
 ###########################################
 # disable POST processing to not break multiple image upload


### PR DESCRIPTION
This PR copies php7 settings to php8 in our htaccess file, it was reported in https://github.com/OpenMage/magento-lts/issues/3252 and follows https://github.com/OpenMage/magento-lts/pull/2306

there was a question, is it mod_php.c or mod_php8.c but I've tested that mod_php.c works and that's what also magento 2 uses (you could check in their repo)

### Fixed Issues
1. Fixes https://github.com/OpenMage/magento-lts/issues/3252
