### PR TITLE
Fixed Undefined variable $res in Mage_Core_Model_Cache

### DIFF
--- a/app/code/core/Mage/Core/Model/Cache.php
+++ b/app/code/core/Mage/Core/Model/Cache.php
@@ -419,11 +419,10 @@ class Mage_Core_Model_Cache
             if (!is_array($tags)) {
                 $tags = [$tags];
             }
-            $res = $this->getFrontend()->clean($mode, $this->_tags($tags));
-        } else {
-            $this->flush();
+            return $this->getFrontend()->clean($mode, $this->_tags($tags));
         }
-        return $res;
+
+        return $this->flush();
     }
 
     /**


### PR DESCRIPTION
After https://github.com/OpenMage/magento-lts/pull/3246 a new error is generated: https://github.com/OpenMage/magento-lts/pull/3246#issuecomment-1546943406 and it's pretty clear (from the code) why.

to reproduce go to the backend, system -> cache and press "flush openmage cache"