### PR TITLE
forcing log, ignoring developer mode and error level.

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -871,7 +871,7 @@ final class Mage
 
         $level  = is_null($level) ? Zend_Log::DEBUG : $level;
 
-        if (!self::$_isDeveloperMode && $level > $maxLogLevel) {
+        if (!self::$_isDeveloperMode && $level > $maxLogLevel && !$forceLog) {
             return;
         }
 


### PR DESCRIPTION
Some extensions use `Mage::log` to enable custom debug log files, but even if they set `$forceLog = true`, the log won't be written if the level is lower (e.g. Zend_Log::INFO) and Magento is not in developer mode.