### PR TITLE
Fix admin menu ACL mismatch in OAuth (#3272)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1382,6 +1382,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "Tomasz-Silpion",
+      "name": "Tomasz Gregorczyk",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5328659?v=4",
+      "profile": "https://github.com/Tomasz-Silpion",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/Admin/TokenController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/Admin/TokenController.php
@@ -155,6 +155,6 @@ class Mage_Oauth_Adminhtml_Oauth_Admin_TokenController extends Mage_Adminhtml_Co
     {
         /** @var Mage_Admin_Model_Session $session */
         $session = Mage::getSingleton('admin/session');
-        return $session->isAllowed('system/acl/admin_token');
+        return $session->isAllowed('system/api/oauth_admin_token');
     }
 }

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizedTokensController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizedTokensController.php
@@ -149,7 +149,7 @@ class Mage_Oauth_Adminhtml_Oauth_AuthorizedTokensController extends Mage_Adminht
     {
         /** @var Mage_Admin_Model_Session $session */
         $session = Mage::getSingleton('admin/session');
-        return $session->isAllowed('system/oauth/authorizedTokens');
+        return $session->isAllowed('system/api/authorizedTokens');
     }
 
     /**

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/ConsumerController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/ConsumerController.php
@@ -240,7 +240,7 @@ class Mage_Oauth_Adminhtml_Oauth_ConsumerController extends Mage_Adminhtml_Contr
         }
         /** @var Mage_Admin_Model_Session $session */
         $session = Mage::getSingleton('admin/session');
-        return $session->isAllowed('system/oauth/consumer' . $action);
+        return $session->isAllowed('system/api/consumer' . $action);
     }
 
     /**

--- a/app/code/core/Mage/Oauth/etc/adminhtml.xml
+++ b/app/code/core/Mage/Oauth/etc/adminhtml.xml
@@ -66,16 +66,16 @@
             <children>
                 <api>
                     <children>
-                        <oauth_consumer translate="title" module="oauth">
+                        <consumer translate="title" module="oauth">
                             <title>REST - OAuth Consumers</title>
                             <sort_order>50</sort_order>
                             <action>adminhtml/oauth_consumer</action>
-                        </oauth_consumer>
-                        <oauth_authorized_tokens translate="title" module="oauth">
+                        </consumer>
+                        <authorizedTokens translate="title" module="oauth">
                             <title>REST - OAuth Authorized Tokens</title>
                             <sort_order>60</sort_order>
                             <action>adminhtml/oauth_authorizedTokens</action>
-                        </oauth_authorized_tokens>
+                        </authorizedTokens>
                         <oauth_admin_token translate="title" module="oauth">
                             <title>REST - My Apps</title>
                             <sort_order>70</sort_order>


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This PR fixes ACL issue in Mage_Oauth adminhtml.xml that causes silent Zend_Acl_Exception throw on every admin page and no access to REST consumers/tokens for users with custom role resource access

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#3272

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create admin user with custom resource access including full System -> Web Service
2. Login as that admin user
3. Try to find REST - OAuth Consumers or REST - OAuth Authorized Tokens in System -> Web Service menu

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All automated tests passed successfully (all builds are green)
 - [X] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->