### PR TITLE
GitHub Actions - `check-files` workflow - split into steps as a workaround for step template size limit

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1382,6 +1382,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "gorbunovav",
+      "name": "Andrey Gorbunov",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2665015?v=4",
+      "profile": "https://github.com/gorbunovav",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -41,16 +41,16 @@ jobs:
     name: Changed
     runs-on: [ubuntu-latest]
     outputs:
-      composer: ${{ steps.all.outputs.composer }}
-      php: ${{ steps.all.outputs.php }}
-      xml: ${{ steps.all.outputs.xml }}
-      workflow: ${{ steps.all.outputs.workflow }}
-      phpcs: ${{ steps.all.outputs.phpcs }}
-      php-cs-fixer: ${{ steps.all.outputs.php-cs-fixer }}
-      phpstan: ${{ steps.all.outputs.phpstan }}
-      phpunit-test: ${{ steps.all.outputs.phpunit-test }}
-      phpunit: ${{ steps.all.outputs.phpunit }}
-      sonar: ${{ steps.all.outputs.sonar }}
+      composer: ${{ steps.changes-composer.outputs.composer }}
+      php: ${{ steps.changes-php.outputs.php }}
+      xml: ${{ steps.changes-xml.outputs.xml }}
+      workflow: ${{ steps.changes-workflow.outputs.workflow }}
+      phpcs: ${{ steps.changes-phpcs.outputs.phpcs }}
+      php-cs-fixer: ${{ steps.changes-php-cs-fixer.outputs.php-cs-fixer }}
+      phpstan: ${{ steps.changes-phpstan.outputs.phpstan }}
+      phpunit-test: ${{ steps.changes-phpunit-test.outputs.phpunit-test }}
+      phpunit: ${{ steps.changes-phpunit.outputs.phpunit }}
+      sonar: ${{ steps.changes-sonar.outputs.sonar }}
 
     steps:
       - name: Checkout code
@@ -86,8 +86,8 @@ jobs:
             dev/phpunit*
             dev/sonar*
 
-      - name: Run step if any file(s) changed
-        id: all
+      - name: Check if composer files changed
+        id: changes-composer
         if: steps.changed-files-specific.outputs.any_modified == 'true'
         run: |
           echo "One or more files have changed."
@@ -96,38 +96,74 @@ jobs:
           echo "$count Composer file(s) changed"
           echo "composer=$count" >> $GITHUB_OUTPUT
 
+      - name: Check if PHP files changed
+        id: changes-php
+        if: steps.changed-files-specific.outputs.any_modified == 'true'
+        run: |
           count="$(grep -oE "*.php" <<< "${{ steps.changed-files-specific.outputs.all_modified_files }}" | wc -l)"
           echo "$count PHP file(s) changed"
           echo "php=$count" >> $GITHUB_OUTPUT
 
+      - name: Check if XML files changed
+        id: changes-xml
+        if: steps.changed-files-specific.outputs.any_modified == 'true'
+        run: |
           count="$(grep -oE "*.xml" <<< "${{ steps.changed-files-specific.outputs.all_modified_files }}" | wc -l)"
           echo "$count XML file(s) changed"
           echo "xml=$count" >> $GITHUB_OUTPUT
 
+      - name: Check if Workflow files changed
+        id: changes-workflow
+        if: steps.changed-files-specific.outputs.any_modified == 'true'
+        run: |
           count="$(grep -oE ".github/workflows/**" <<< "${{ steps.changed-files-specific.outputs.all_modified_files }}" | wc -l)"
           echo "$count Workflow file(s) changed"
           echo "workflow=$count" >> $GITHUB_OUTPUT
 
+      - name: Check if PHPCS test files changed
+        id: changes-phpcs
+        if: steps.changed-files-specific.outputs.any_modified == 'true'
+        run: |
           count="$(grep -oE "**phpcs**" <<< "${{ steps.changed-files-specific.outputs.all_modified_files }}" | wc -l)"
           echo "$count PHPCS file(s) changed"
           echo "phpcs=$count" >> $GITHUB_OUTPUT
 
+      - name: Check if PHP-CS-Fixer files changed 
+        id: changes-php-cs-fixer
+        if: steps.changed-files-specific.outputs.any_modified == 'true'
+        run: |
           count="$(grep -oE "**php-cs-fixer**" <<< "${{ steps.changed-files-specific.outputs.all_modified_files }}" | wc -l)"
           echo "$count PHP-CS-Fixer file(s) changed"
           echo "php-cs-fixer=$count" >> $GITHUB_OUTPUT
 
+      - name: Check if PHPStan files changed
+        id: changes-phpstan
+        if: steps.changed-files-specific.outputs.any_modified == 'true'
+        run: |
           count="$(grep -oE "**phpstan**" <<< "${{ steps.changed-files-specific.outputs.all_modified_files }}" | wc -l)"
           echo "$count PHPStan file(s) changed"
           echo "phpstan=$count" >> $GITHUB_OUTPUT
 
+      - name: Check if PHPUnit test files changed
+        id: changes-phpunit-test
+        if: steps.changed-files-specific.outputs.any_modified == 'true'
+        run: |
           count="$(grep -oE "dev/tests/" <<< "${{ steps.changed-files-specific.outputs.all_modified_files }}" | wc -l)"
           echo "$count UnitTest test file(s) changed"
           echo "phpunit-test=$count" >> $GITHUB_OUTPUT
 
+      - name: Check if PHPUnit files changed
+        id: changes-phpunit
+        if: steps.changed-files-specific.outputs.any_modified == 'true'
+        run: |
           count="$(grep -oE "dev/phpunit*" <<< "${{ steps.changed-files-specific.outputs.all_modified_files }}" | wc -l)"
-          echo "$count UnitTest file(s) changed"
+          echo "$count PHPUnit file(s) changed"
           echo "phpunit=$count" >> $GITHUB_OUTPUT
 
+      - name: Check if Sonar files changed
+        id: changes-sonar
+        if: steps.changed-files-specific.outputs.any_modified == 'true'
+        run: |
           count="$(grep -oE "dev/sonar*" <<< "${{ steps.changed-files-specific.outputs.all_modified_files }}" | wc -l)"
           echo "$count Sonar file(s) changed"
           echo "sonar=$count" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description (*)

Splits `check-files` job into more steps to workaround the template size limit issue.

### Fixed Issues (if relevant)

Fixes OpenMage/magento-lts#3275

### Manual testing scenarios (*)

1. Create a PR with several thousands of changed files
2. Check that `check-files` job has completed succesfully and emits relevant output values

### Contribution checklist (*)

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
