### PR TITLE
Run install and upgrade scripts within a db transaction

### DIFF
--- a/app/code/core/Mage/Core/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Core/Model/Resource/Setup.php
@@ -603,6 +603,7 @@ class Mage_Core_Model_Resource_Setup
             $fileType = pathinfo($fileName, PATHINFO_EXTENSION);
             $this->getConnection()->disallowDdlCache();
             try {
+                $this->getConnection()->beginTransaction();
                 switch ($fileType) {
                     case 'php':
                         $conn   = $this->getConnection();
@@ -624,7 +625,9 @@ class Mage_Core_Model_Resource_Setup
                 if ($result) {
                     $this->_setResourceVersion($actionType, $file['toVersion']);
                 }
+                $this->getConnection()->commit();
             } catch (Exception $e) {
+                $this->getConnection()->rollBack();
                 throw Mage::exception('Mage_Core', Mage::helper('core')->__('Error in file: "%s" - %s', $fileName, $e->getMessage()));
             }
             $version = $file['toVersion'];


### PR DESCRIPTION
### Description (*)

While investigating the issue I found in https://github.com/OpenMage/magento-lts/pull/2210#issuecomment-1562624227, I had to constantly undo the partial changes made by data upgrade script every time it failed, things like duplicate inserts etc...

I think all install and upgrade scripts should be wrapped in a transaction to prevent the inconvenience of having to reset them.

### Manual testing scenarios (*)

1. Add a new install or upgrade script to any extension with multiple queries and make it throw an error intentionally at +2nd step.
2. After it throws the error, the changes made by the first step should not be persisted.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->