### PR TITLE
Removed auto_detect_line_endings since it's deprecated in 8.1

### DIFF
--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -124,7 +124,7 @@ class Varien_Io_File extends Varien_Io_Abstract
             throw new Exception('Permission denied for write to ' . $this->getFilteredPath($this->_cwd));
         }
 
-        if (!ini_get('auto_detect_line_endings')) {
+        if (PHP_VERSION_ID < 80100 && !ini_get('auto_detect_line_endings')) {
             ini_set('auto_detect_line_endings', 1);
         }
 


### PR DESCRIPTION
In https://github.com/OpenMage/magento-lts/issues/3281#issuecomment-1565841710 @TangLiang reported that auto_detect_line_endings is nowadays deprecated, more info about it here: https://php.watch/versions/8.1/auto_detect_line_endings-ini-deprecated

