### PR TITLE
Mage_Rules now truncates strings after 100 characters instead of 33 in the backend

### DIFF
--- a/app/code/core/Mage/Rule/Block/Editable.php
+++ b/app/code/core/Mage/Rule/Block/Editable.php
@@ -46,8 +46,9 @@ class Mage_Rule_Block_Editable extends Mage_Core_Block_Abstract implements Varie
 
             $translate = Mage::getSingleton('core/translate_inline');
 
-            $html .= $translate->isAllowed() ? Mage::helper('core')->escapeHtml($valueName) :
-                Mage::helper('core')->escapeHtml(Mage::helper('core/string')->truncate($valueName, 100, '...'));
+            $html .= $translate->isAllowed()
+                ? Mage::helper('core')->escapeHtml($valueName)
+                : Mage::helper('core')->escapeHtml(Mage::helper('core/string')->truncate($valueName, 100, '...'));
 
             $html .= '</a><span class="element"> ' . $element->getElementHtml();
 

--- a/app/code/core/Mage/Rule/Block/Editable.php
+++ b/app/code/core/Mage/Rule/Block/Editable.php
@@ -47,7 +47,7 @@ class Mage_Rule_Block_Editable extends Mage_Core_Block_Abstract implements Varie
             $translate = Mage::getSingleton('core/translate_inline');
 
             $html .= $translate->isAllowed() ? Mage::helper('core')->escapeHtml($valueName) :
-                Mage::helper('core')->escapeHtml(Mage::helper('core/string')->truncate($valueName, 33, '...'));
+                Mage::helper('core')->escapeHtml(Mage::helper('core/string')->truncate($valueName, 100, '...'));
 
             $html .= '</a><span class="element"> ' . $element->getElementHtml();
 

--- a/js/mage/adminhtml/rules.js
+++ b/js/mage/adminhtml/rules.js
@@ -245,8 +245,8 @@ VarienRulesForm.prototype = {
                 elem.value = str;
                 if (str=='') {
                     str = '...';
-                } else if (str.length>30) {
-                    str = str.substr(0, 30)+'...';
+                } else if (str.length>100) {
+                    str = str.substr(0, 100)+'...';
                 }
                 label.innerHTML = str.escapeHTML();
             }


### PR DESCRIPTION
We have more pixies than in 2008

<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->