### PR TITLE
Fix E_DEPRECATED str_replace(): Passing null in Translate.php

### DIFF
--- a/app/code/core/Mage/Core/Model/Translate.php
+++ b/app/code/core/Mage/Core/Model/Translate.php
@@ -196,7 +196,7 @@ class Mage_Core_Model_Translate
      * Loading data from module translation files
      *
      * @param string $moduleName
-     * @param string $files
+     * @param array $files
      * @param bool $forceReload
      * @return $this
      */
@@ -224,7 +224,7 @@ class Mage_Core_Model_Translate
                 continue;
             }
             $key    = $this->_prepareDataString($key);
-            $value  = $this->_prepareDataString($value);
+            $value  = $value === null ? '' : $this->_prepareDataString($value);
             if ($scope && isset($this->_dataScope[$key]) && !$forceReload) {
                 /**
                  * Checking previos value

--- a/phpstan.dist.baseline.neon
+++ b/phpstan.dist.baseline.neon
@@ -2346,11 +2346,6 @@ parameters:
 			path: app/code/core/Mage/Core/Model/Store.php
 
 		-
-			message: "#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: app/code/core/Mage/Core/Model/Translate.php
-
-		-
 			message: "#^Method Mage_Core_Model_Url\\:\\:getRequest\\(\\) should return Mage_Core_Controller_Request_Http but returns Zend_Controller_Request_Http\\.$#"
 			count: 1
 			path: app/code/core/Mage/Core/Model/Url.php


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#3291

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Insert `"abc"` in the file `app\locale\en_US\Mage_Api.csv`
2. Execute `$result = [Mage::helper('api')->__('abc'), error_get_last()]; `
`$result` is 
Before PR:
```php
 array(2) {
  [0] => string(0) ""
  [1] => array(4) {
    ["type"] => int(8192)
    ["message"] => string(89) "str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated"
    ["file"] => string(70) "/home/celeraes/public_html/app/code/core/Mage/Core/Model/Translate.php"
    ["line"] => int(260)
  }
}
```
After PR
```php
 array(2) {
  [0] => string(0) ""
  [1] => NULL
}
```

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->