### PR TITLE
Fixed passing null is deprecated for stripos in Mage_Core_Model_Resource_Helper_Abstract

### DIFF
--- a/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
@@ -299,7 +299,7 @@ abstract class Mage_Core_Model_Resource_Helper_Abstract
             'unsigned' => $column['unsigned'],
             'nullable' => $column['is_null'],
             'default'  => $column['default'],
-            'identity' => stripos($column['extra'], 'auto_increment') !== false
+            'identity' => !empty($column['extra']) && (stripos($column['extra'], 'auto_increment') !== false),
         ];
 
         /**


### PR DESCRIPTION
### Description

This fix `passing null to parameter 1 of type string is deprecated` for `stripos` with PHP 8.1/8.2.
Perhaps it's not the best way.

See also this [discussion comment](https://github.com/OpenMage/magento-lts/discussions/3025#discussioncomment-5195497).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list