### PR TITLE
Fixed passing null is deprecated for htmlspecialchars in Mage_Adminhtml_Block_System_Config_Form_Field

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
@@ -78,7 +78,7 @@ class Mage_Adminhtml_Block_System_Config_Form_Field extends Mage_Adminhtml_Block
         $html .= '</td>';
 
         if ($addInheritCheckbox) {
-            $defText = $element->getDefaultValue();
+            $defText = (string)$element->getDefaultValue();
             if ($options) {
                 $defTextArr = [];
                 foreach ($options as $k => $v) {
@@ -107,7 +107,7 @@ class Mage_Adminhtml_Block_System_Config_Form_Field extends Mage_Adminhtml_Block
                 . $namePrefix . '[inherit]" type="checkbox" value="1" class="checkbox config-inherit" '
                 . $inherit . ' onclick="toggleValueElements(this, Element.previous(this.parentNode))" /> ';
             $html .= '<label for="' . $id . '_inherit" class="inherit" title="'
-                . htmlspecialchars((string)$defText) . '">' . $checkboxLabel . '</label>';
+                . htmlspecialchars($defText) . '">' . $checkboxLabel . '</label>';
             $html .= '</td>';
         }
 

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
@@ -107,7 +107,7 @@ class Mage_Adminhtml_Block_System_Config_Form_Field extends Mage_Adminhtml_Block
                 . $namePrefix . '[inherit]" type="checkbox" value="1" class="checkbox config-inherit" '
                 . $inherit . ' onclick="toggleValueElements(this, Element.previous(this.parentNode))" /> ';
             $html .= '<label for="' . $id . '_inherit" class="inherit" title="'
-                . htmlspecialchars($defText) . '">' . $checkboxLabel . '</label>';
+                . htmlspecialchars((string)$defText) . '">' . $checkboxLabel . '</label>';
             $html .= '</td>';
         }
 


### PR DESCRIPTION
### Description

This fix `passing null to parameter 1 of type string is deprecated` for `htmlspecialchars` with PHP 8.1/8.2.
Perhaps it's not the best way.

See also this [discussion comment](https://github.com/OpenMage/magento-lts/discussions/3025#discussioncomment-5195497).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list