### PR TITLE
Fixed passing null is deprecated for explode in Mage_Catalog_Model_Resource_Product_Indexer_Eav_Source

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
@@ -228,7 +228,7 @@ class Mage_Catalog_Model_Resource_Product_Indexer_Eav_Source extends Mage_Catalo
         $data  = [];
         $query = $select->query();
         while ($row = $query->fetch()) {
-            $values = array_unique(explode(',', $row['value']));
+            $values = empty($row['value']) ? [] : array_unique(explode(',', $row['value']));
             foreach ($values as $valueId) {
                 if (isset($options[$row['attribute_id']][$valueId])) {
                     $data[] = [


### PR DESCRIPTION
### Description

This fix `passing null to parameter 2 of type string is deprecated` for `explode` with PHP 8.1/8.2.
Perhaps it's not the best way.

See also this [discussion comment](https://github.com/OpenMage/magento-lts/discussions/3025#discussioncomment-5195497).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list