### PR TITLE
Allow System Config of Type Serialized Array to <depend> on other field 

### DIFF
--- a/js/mage/adminhtml/form.js
+++ b/js/mage/adminhtml/form.js
@@ -496,7 +496,12 @@ FormElementDependenceController.prototype = {
         }
         return result;
     },
-
+    hideElem : function(ele) {
+        ele.hide();
+    },
+    showElem : function(ele) {
+        ele.show();
+    },
     /**
      * Define whether target element should be toggled and show/hide its row
      *
@@ -507,8 +512,17 @@ FormElementDependenceController.prototype = {
      */
     trackChange : function(e, idTo, valuesFrom)
     {
+        let upLevels = this._config.levels_up;
+        let ele;
         if (!$(idTo)) {
-            return;
+            if ($('row_' + idTo)) {
+                idTo = 'row_' + idTo;
+                ele = $(idTo);
+            } else {
+                return;
+            }
+        } else {
+            ele = $(idTo).up(upLevels);
         }
 
         // define whether the target should show up
@@ -536,22 +550,22 @@ FormElementDependenceController.prototype = {
         // toggle target row
         if (shouldShowUp) {
             var currentConfig = this._config;
-            $(idTo).up(this._config.levels_up).select('input', 'select', 'td').each(function (item) {
+            ele.select('input', 'select', 'td').each(function (item) {
                 // don't touch hidden inputs (and Use Default inputs too), bc they may have custom logic
                 if ((!item.type || item.type != 'hidden') && !($(item.id+'_inherit') && $(item.id+'_inherit').checked)
                     && !(currentConfig.can_edit_price != undefined && !currentConfig.can_edit_price)) {
                     item.disabled = false;
                 }
             });
-            $(idTo).up(this._config.levels_up).show();
+            this.showElem(ele);
         } else {
-            $(idTo).up(this._config.levels_up).select('input', 'select', 'td').each(function (item){
+            ele.select('input', 'select', 'td', 'div').each(function (item){
                 // don't touch hidden inputs (and Use Default inputs too), bc they may have custom logic
                 if ((!item.type || item.type != 'hidden') && !($(item.id+'_inherit') && $(item.id+'_inherit').checked)) {
                     item.disabled = true;
                 }
             });
-            $(idTo).up(this._config.levels_up).hide();
+            this.hideElem(ele);
         }
     }
 };

--- a/js/mage/adminhtml/form.js
+++ b/js/mage/adminhtml/form.js
@@ -515,10 +515,9 @@ FormElementDependenceController.prototype = {
         let upLevels = this._config.levels_up;
         let ele;
         if (!$(idTo)) {
-            if ($('row_' + idTo)) {
-                idTo = 'row_' + idTo;
-                ele = $(idTo);
-            } else {
+            idTo = 'row_' + idTo;
+            ele = $(idTo);
+            if (!ele) {
                 return;
             }
         } else {


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

If you have a serialized array config and want it to "\<depend\>" on some… other field, in the original core this wasn't possible. The js simply didn't work in this scenario and thus the field was always visible.

This branch fixes this, by allowing both: regular (normal fields) and "serialized array" type of fields.

### Related Pull Requests
None

### Fixed Issues (if relevant)
None

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Find a system config which is type "serialized array" (ie: design/theme/template_ua_regexp)
2. Add this field right above this config temporarly 

```xml
<xx translate="label">
    <label>xx</label>
    <frontend_type>select</frontend_type>
    <source_model>adminhtml/system_config_source_yesno</source_model>
    <sort_order>10</sort_order>
    <show_in_default>1</show_in_default>
    <show_in_website>1</show_in_website>
    <show_in_store>1</show_in_store>
</xx>
```

3. Add a "\<depends\>" node to its declaration (app/code/core/Mage/Core/etc/system.xml around line 339)

```xml
<depends><xx><value>1</value></xx></depends>
```

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->