### PR TITLE
Added methods to support "error state" for cron schedule

### DIFF
--- a/app/code/core/Mage/Cron/Model/Observer.php
+++ b/app/code/core/Mage/Cron/Model/Observer.php
@@ -326,6 +326,11 @@ class Mage_Cron_Model_Observer
             $schedule->setStatus($errorStatus)
                 ->setMessages($e->__toString());
         }
+
+        if ($schedule->getIsError()) {
+            $schedule->setStatus(Mage_Cron_Model_Schedule::STATUS_ERROR);
+        }
+
         $schedule->save();
 
         return $this;

--- a/app/code/core/Mage/Cron/Model/Schedule.php
+++ b/app/code/core/Mage/Cron/Model/Schedule.php
@@ -22,6 +22,7 @@
  * @method Mage_Cron_Model_Resource_Schedule _getResource()
  * @method Mage_Cron_Model_Resource_Schedule getResource()
  * @method Mage_Cron_Model_Resource_Schedule_Collection getCollection()
+ * @method $this setIsError(bool $value)
  * @method string getJobCode()
  * @method $this setJobCode(string $value)
  * @method string getStatus()
@@ -51,6 +52,14 @@ class Mage_Cron_Model_Schedule extends Mage_Core_Model_Abstract
     public function _construct()
     {
         $this->_init('cron/schedule');
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsError()
+    {
+        return !empty($this->getData('is_error'));
     }
 
     /**

--- a/app/code/core/Mage/Cron/Model/Schedule.php
+++ b/app/code/core/Mage/Cron/Model/Schedule.php
@@ -57,7 +57,7 @@ class Mage_Cron_Model_Schedule extends Mage_Core_Model_Abstract
     /**
      * @return bool
      */
-    public function getIsError()
+    public function getIsError(): bool
     {
         return !empty($this->getData('is_error'));
     }


### PR DESCRIPTION
### Description

This PR allow user to set cron on error without throwing an exception.
Example:

```php
public function testcron($cron = null) {

    $msg = [];
    $objects = Mage::getResourceModel('customer/customer_collection')->setPageSize(5);

    foreach ($objects as $oid => $object) {

        try {
            throw new Exception('test');
            $msg[] = $oid.' OK!';
        }
        catch (Throwable $t) {
            Mage::logException($t);
            $msg[] = $oid.' ERR '.$t->getMessage();
            if (is_object($cron))
                $cron->setIsError(true);
        }
    }

    if (is_object($cron)) {
        $cron->setData('messages', 'memory: '.((int) (memory_get_peak_usage(true) / 1024 / 1024)).
            'M (max: '.ini_get('memory_limit').')'."\n".implode("\n", $msg));
        if (!method_exists($cron, 'getIsError') && ($cron->getIsError() === true)) // without PR 3310
            Mage::throwException('At least one error occurred while...'."\n\n".
                $cron->getData('messages')."\n\n");
    }

    return $msg;
}
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list