### PR TITLE
Fixed display of products count for categories tree

### DIFF
--- a/app/design/adminhtml/default/default/template/catalog/product/edit/categories.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/categories.phtml
@@ -26,7 +26,7 @@
 <script type="text/javascript">
 Ext.EventManager.onDocumentReady(function() {
     var categoryLoader = new Ext.tree.TreeLoader({
-       dataUrl: '<?php echo $this->getLoadTreeUrl()?>'
+       dataUrl: '<?php echo $this->getLoadTreeUrl() ?>'
     });
 
     categoryLoader.createNode = function(config) {
@@ -71,7 +71,7 @@ Ext.EventManager.onDocumentReady(function() {
 
     // set the root node
     var root = new Ext.tree.TreeNode({
-        text: '<?php echo $this->jsQuoteEscape($this->getRootNode()->getName()) ?>',
+        text: '<?php echo $this->jsQuoteEscape($this->buildNodeName($this->getRootNode())) ?>',
         draggable:false,
         checked:'<?php echo $this->getRootNode()->getChecked() ?>',
         id:'<?php echo $this->getRootNode()->getId() ?>',
@@ -89,11 +89,12 @@ Ext.EventManager.onDocumentReady(function() {
     //tree.expandAll();
 });
 
-function bildCategoryTree(parent, config){
-    if (!config) return null;
-
-    if (parent && config && config.length){
-        for (var i = 0; i < config.length; i++){
+function bildCategoryTree(parent, config) {
+    if (!config) {
+        return null;
+    }
+    if (parent && config && config.length) {
+        for (var i = 0; i < config.length; i++) {
             config[i].uiProvider = Ext.tree.CheckboxNodeUI;
             var node;
             var _node = Object.clone(config[i]);
@@ -106,14 +107,14 @@ function bildCategoryTree(parent, config){
             }
             parent.appendChild(node);
             node.loader = node.getOwnerTree().loader;
-            if(config[i].children){
+            if (config[i].children) {
                 bildCategoryTree(node, config[i].children);
             }
         }
     }
 }
 
-function categoryClick(node, e){
+function categoryClick(node, e) {
     if (node.disabled) {
         return;
     }


### PR DESCRIPTION
### Description

Go to _Catalog > Products > Any product > Categories_ (default values).
You will found the root category name with products count.

If you change to any store view, without the PR you will found the root category name WITHOUT products count.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list