### PR TITLE
Fix #3312 ExtJS Tree Checkbox Update

### DIFF
--- a/js/extjs/ext-tree-checkbox.js
+++ b/js/extjs/ext-tree-checkbox.js
@@ -65,7 +65,7 @@ Ext.extend(Ext.tree.CheckboxNodeUI, Ext.tree.TreeNodeUI, {
     render : function(bulkRender){
         var n = this.node;
         var targetNode = n.parentNode ?
-            n.parentNode.ui.getContainer() : n.ownerTree.container.dom; /* in later svn builds this changes to n.ownerTree.innerCt.dom */
+            n.parentNode.ui.getContainer() : n.ownerTree.innerCt.dom; /* in previous svn builds this was n.ownerTree.container.dom */
         if(!this.rendered){
             this.rendered = true;
             var a = n.attributes;


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
PR #2473 upgraded ExtJS from 1.0.1 to 1.1.1, but there was a breaking change in that library. So, the `extjs-tree-checkbox.js` file needed to be updated. The checkbox tree file was not part of ExtJS, but a plugin that somebody wrote and included into Magento. Luckily, the author wrote a comment with the fix.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#3312

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to Products > Any Product > Categories, at store view level
2. Should see no errors

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
We have an alternate solution:

```js
var targetNode = 
    n.parentNode ? n.parentNode.ui.getContainer() : 
    (n.ownerTree.container ? n.ownerTree.container.dom : n.ownerTree.innerCt.dom);
```

But I don't think it's necessary, since ExtJS renamed container -> innerCt. The above would only be necessary if we need to support someone who is still using ExtJS 1.0.1.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->