### PR TITLE
 Fixed passing null is deprecated for htmlspecialchars in Mage_Core_Helper_Abstract

### DIFF
--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -343,6 +343,7 @@ abstract class Mage_Core_Helper_Abstract
      */
     public function quoteEscape($data, $addSlashes = false)
     {
+        $data = (string)$data;
         if ($addSlashes === true) {
             $data = addslashes($data);
         }

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -343,7 +343,9 @@ abstract class Mage_Core_Helper_Abstract
      */
     public function quoteEscape($data, $addSlashes = false)
     {
-        $data = (string)$data;
+        if (!$data) {
+            return $data;
+        }
         if ($addSlashes === true) {
             $data = addslashes($data);
         }


### PR DESCRIPTION
### Description

This fix `passing null to parameter 1 of type string is deprecated` for `htmlspecialchars` with PHP 8.1/8.2.
Perhaps it's not the best way (I never had this warning when `$addSlashes=true`).
It seems that this appear on backend customer edit page.

See also this [discussion comment](https://github.com/OpenMage/magento-lts/discussions/3025#discussioncomment-5195497).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list