### PR TITLE
Fixed passing null is deprecated for strpos in Mage_Core_Controller_Varien_Action

### DIFF
--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -790,8 +790,7 @@ abstract class Mage_Core_Controller_Varien_Action
         if ($url = $this->getRequest()->getParam(self::PARAM_NAME_URL_ENCODED)) {
             $refererUrl = Mage::helper('core')->urlDecodeAndEscape($url);
         }
-
-        if (!$this->_isUrlInternal($refererUrl)) {
+        if (empty($refererUrl) || !$this->_isUrlInternal($refererUrl)) {
             $refererUrl = Mage::app()->getStore()->getBaseUrl();
         }
         return $refererUrl;


### PR DESCRIPTION
### Description

With Turpentine for Varnish for OpenMage, with PHP 8.1/8.2, we have: `strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated`

![image](https://github.com/OpenMage/magento-lts/assets/78410399/8bbb9e3b-cbe7-4867-975f-f4676f0ca6d8)

We have no other errors for `_isUrlInternal`.
Not sure if it's the best way.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list