### PR TITLE
Fixed passing null for iconv_substr is deprecated in Mage_Catalog_Block_Product_View

### DIFF
--- a/app/code/core/Mage/Catalog/Block/Product/View.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View.php
@@ -61,9 +61,12 @@ class Mage_Catalog_Block_Product_View extends Mage_Catalog_Block_Product_Abstrac
             }
             $description = $product->getMetaDescription();
             if ($description) {
-                $headBlock->setDescription(($description));
+                $headBlock->setDescription($description);
             } else {
-                $headBlock->setDescription(Mage::helper('core/string')->substr($product->getDescription(), 0, 255));
+                $description = $product->getDescription();
+                if ($description) {
+                    $headBlock->setDescription(Mage::helper('core/string')->substr($description, 0, 255));
+                }
             }
 
             /** @var Mage_Catalog_Helper_Product $helper */

--- a/app/code/core/Mage/Catalog/Block/Product/View.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View.php
@@ -66,7 +66,7 @@ class Mage_Catalog_Block_Product_View extends Mage_Catalog_Block_Product_Abstrac
                 $description = $product->getDescription();
                 if ($description) {
                     $headBlock->setDescription(Mage::helper('core/string')->substr($description, 0, 255));
-               } else {
+                } else {
                     $headBlock->setDescription('');
                 }
             }

--- a/app/code/core/Mage/Catalog/Block/Product/View.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View.php
@@ -66,6 +66,8 @@ class Mage_Catalog_Block_Product_View extends Mage_Catalog_Block_Product_Abstrac
                 $description = $product->getDescription();
                 if ($description) {
                     $headBlock->setDescription(Mage::helper('core/string')->substr($description, 0, 255));
+               } else {
+                    $headBlock->setDescription('');
                 }
             }
 


### PR DESCRIPTION
### Description

This fix `passing null to parameter 1 of type string is deprecated` for `iconv_substr` with PHP 8.1/8.2.
Perhaps it's not the best way. Only when description of product is empty.

See also this [discussion comment](https://github.com/OpenMage/magento-lts/discussions/3025#discussioncomment-5195497).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list