### PR TITLE
Fixed passing null for str_replace is deprecated for downloadable products

### DIFF
--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -164,41 +164,46 @@ class Mage_Downloadable_Block_Adminhtml_Catalog_Product_Edit_Tab_Downloadable_Li
                 'sample_type' => $item->getSampleType(),
                 'sort_order' => $item->getSortOrder(),
             ];
-            $file = Mage::helper('downloadable/file')->getFilePath(
-                Mage_Downloadable_Model_Link::getBasePath(),
-                $item->getLinkFile()
-            );
 
-            if ($item->getLinkFile() && !is_file($file)) {
-                Mage::helper('core/file_storage_database')->saveFileToFilesystem($file);
+            if ($item->getLinkFile()) {
+                $file = Mage::helper('downloadable/file')->getFilePath(
+                    Mage_Downloadable_Model_Link::getBasePath(),
+                    $item->getLinkFile()
+                );
+                if (!is_file($file)) {
+                    Mage::helper('core/file_storage_database')->saveFileToFilesystem($file);
+                }
+                if (is_file($file)) {
+                    $name = '<a href="'
+                        . $this->getUrl('*/downloadable_product_edit/link', [
+                            'id' => $item->getId(),
+                            '_secure' => true
+                        ]) . '">' . Mage::helper('downloadable/file')->getFileFromPathFile($item->getLinkFile()) . '</a>';
+                    $tmpLinkItem['file_save'] = [
+                        [
+                            'file' => $item->getLinkFile(),
+                            'name' => $name,
+                            'size' => filesize($file),
+                            'status' => 'old'
+                        ]
+                    ];
+                }
             }
-
-            if ($item->getLinkFile() && is_file($file)) {
-                $name = '<a href="'
-                    . $this->getUrl('*/downloadable_product_edit/link', [
-                        'id' => $item->getId(),
-                        '_secure' => true
-                    ]) . '">' . Mage::helper('downloadable/file')->getFileFromPathFile($item->getLinkFile()) . '</a>';
-                $tmpLinkItem['file_save'] = [
-                    [
-                        'file' => $item->getLinkFile(),
-                        'name' => $name,
-                        'size' => filesize($file),
-                        'status' => 'old'
-                    ]];
-            }
-            $sampleFile = Mage::helper('downloadable/file')->getFilePath(
-                Mage_Downloadable_Model_Link::getBaseSamplePath(),
-                $item->getSampleFile()
-            );
-            if ($item->getSampleFile() && is_file($sampleFile)) {
-                $tmpLinkItem['sample_file_save'] = [
-                    [
-                        'file' => $item->getSampleFile(),
-                        'name' => Mage::helper('downloadable/file')->getFileFromPathFile($item->getSampleFile()),
-                        'size' => filesize($sampleFile),
-                        'status' => 'old'
-                    ]];
+            if ($item->getSampleFile()) {
+                $sampleFile = Mage::helper('downloadable/file')->getFilePath(
+                    Mage_Downloadable_Model_Link::getBaseSamplePath(),
+                    $item->getSampleFile()
+                );
+                if (is_file($sampleFile)) {
+                    $tmpLinkItem['sample_file_save'] = [
+                        [
+                            'file' => $item->getSampleFile(),
+                            'name' => Mage::helper('downloadable/file')->getFileFromPathFile($item->getSampleFile()),
+                            'size' => filesize($sampleFile),
+                            'status' => 'old'
+                        ]
+                    ];
+                }
             }
             if ($item->getNumberOfDownloads() == '0') {
                 $tmpLinkItem['is_unlimited'] = ' checked="checked"';


### PR DESCRIPTION
### Description

This fix `passing null to parameter #3 ($subject) of type array|string is deprecated` for `str_replace` with PHP 8.1/8.2.
Perhaps it's not the best way. Only for download product edit page in backend.

The deprecated notice is triggered by `_prepareFileForPath` of `Mage_Downloadable_Helper_File`.

See also this [discussion comment](https://github.com/OpenMage/magento-lts/discussions/3025#discussioncomment-5195497).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list