### PR TITLE
Fixed passing null for trim is deprecated in Mage_Catalog_Model_Resource_Category_Flat

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
@@ -31,56 +31,56 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
      *
      * @var int|null
      */
-    protected $_storeId                  = null;
+    protected $_storeId = null;
 
     /**
      * Loaded
      *
      * @var bool
      */
-    protected $_loaded                   = false;
+    protected $_loaded = false;
 
     /**
      * Nodes
      *
      * @var array
      */
-    protected $_nodes                    = [];
+    protected $_nodes = [];
 
     /**
      * Columns
      *
      * @var array
      */
-    protected $_columns                  = null;
+    protected $_columns = null;
 
     /**
      * Columns sql
      *
      * @var array
      */
-    protected $_columnsSql               = null;
+    protected $_columnsSql = null;
 
     /**
      * Attribute codes
      *
      * @var array
      */
-    protected $_attributeCodes           = null;
+    protected $_attributeCodes = null;
 
     /**
      * Inactive categories ids
      *
      * @var array
      */
-    protected $_inactiveCategoryIds      = null;
+    protected $_inactiveCategoryIds = null;
 
     /**
      * Store flag which defines if Catalog Category Flat Data has been initialized
      *
      * @var array
      */
-    protected $_isBuilt                  = [];
+    protected $_isBuilt = [];
 
     /**
      * Store flag which defines if Catalog Category Flat Data has been initialized
@@ -89,7 +89,7 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
      *
      * @var bool|null
      */
-    protected $_isRebuilt                = null;
+    protected $_isRebuilt = null;
 
     /**
      * array with root category id per store
@@ -103,7 +103,7 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
      *
      * @var bool
      */
-    protected $_allowTableChanges        = true;
+    protected $_allowTableChanges = true;
 
     /**
      * Factory instance
@@ -658,7 +658,7 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
             }
             $_is_unsigned = '';
             $ddlType = $helper->getDdlTypeByColumnType($column['DATA_TYPE']);
-            $column['DEFAULT'] = trim($column['DEFAULT'], "' ");
+            $column['DEFAULT'] = empty($column['DEFAULT']) ? $column['DEFAULT'] : trim($column['DEFAULT'], "' ");
             switch ($ddlType) {
                 case Varien_Db_Ddl_Table::TYPE_SMALLINT:
                 case Varien_Db_Ddl_Table::TYPE_INTEGER:


### PR DESCRIPTION
### Description

This fix `passing null to parameter #1 ($string) of type string is deprecated` for `trim` with PHP 8.1/8.2.
Perhaps it's not the best way.

See also this [discussion comment](https://github.com/OpenMage/magento-lts/discussions/3025#discussioncomment-5195497).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list