### PR TITLE
Fixed passing null for trim is deprecated in Mage_Catalog_Model_Attribute_Backend_Customlayoutupdate

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Attribute/Backend/Customlayoutupdate.php
+++ b/app/code/core/Mage/Catalog/Model/Attribute/Backend/Customlayoutupdate.php
@@ -32,7 +32,7 @@ class Mage_Catalog_Model_Attribute_Backend_Customlayoutupdate extends Mage_Eav_M
     public function validate($object)
     {
         $attributeName = $this->getAttribute()->getName();
-        $xml = trim($object->getData($attributeName));
+        $xml = trim((string)$object->getData($attributeName));
 
         if (!$this->getAttribute()->getIsRequired() && empty($xml)) {
             return true;
@@ -42,7 +42,7 @@ class Mage_Catalog_Model_Attribute_Backend_Customlayoutupdate extends Mage_Eav_M
         $validator = Mage::getModel('adminhtml/layoutUpdate_validator');
         if (!$validator->isValid($xml)) {
             $messages = $validator->getMessages();
-            //Add first message to exception
+            // add first message to exception
             $massage = array_shift($messages);
             $eavExc = new Mage_Eav_Model_Entity_Attribute_Exception($massage);
             $eavExc->setAttributeCode($attributeName);


### PR DESCRIPTION
### Description

This fix `passing null to parameter #1 ($string) of type string is deprecated` for `trim` with PHP 8.1/8.2.
Perhaps it's not the best way.

I get this notice when I save a simple product associated to a configurable product at store view level.
See also this [discussion comment](https://github.com/OpenMage/magento-lts/discussions/3025#discussioncomment-5195497).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list