### PR TITLE
Fixed passing null for unserialize is deprecated in Mage_Sales_Model_Quote_Address

### DIFF
--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -1167,8 +1167,12 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
      */
     public function getAppliedTaxes()
     {
+        $tax = $this->getData('applied_taxes');
+        if (empty($tax)) {
+            return [];
+        }
         try {
-            $return = Mage::helper('core/unserializeArray')->unserialize($this->getData('applied_taxes'));
+            $return = Mage::helper('core/unserializeArray')->unserialize($tax);
         } catch (Exception $e) {
             $return = [];
         }


### PR DESCRIPTION
### Description

This fix `passing null to parameter #1 ($string) of type string is deprecated` for `unserialize` with PHP 8.1/8.2.
Perhaps it's not the best way. Not sure if it's due to a third party code or not.

See also this [discussion comment](https://github.com/OpenMage/magento-lts/discussions/3025#discussioncomment-5195497).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list