### PR TITLE
Fixed eav_config_entity throwing error message on removed entity model

### DIFF
--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -198,7 +198,7 @@ class Mage_Eav_Model_Config
                 if (Mage::getIsDeveloperMode()) {
                     throw new Exception('Failed loading of eav entity type because it does not exist: ' . $entityModelClass);
                 } else {
-                    Mage::log('skipped loading of eav entity type because it does not exist: ' . $entityModelClass);
+                    Mage::log('Skipped loading of eav entity type because it does not exist: ' . $entityModelClass);
                 }
                 continue;
             }

--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -196,7 +196,7 @@ class Mage_Eav_Model_Config
             $fqEntityModelClass = Mage::getConfig()->getModelClassName($entityModelClass);
             if (!class_exists($fqEntityModelClass)) {
                 if (Mage::getIsDeveloperMode()) {
-                    throw new Exception('failed loading of eav entity type because it does not exist: ' . $entityModelClass);
+                    throw new Exception('Failed loading of eav entity type because it does not exist: ' . $entityModelClass);
                 } else {
                     Mage::log('skipped loading of eav entity type because it does not exist: ' . $entityModelClass);
                 }

--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -189,7 +189,6 @@ class Mage_Eav_Model_Config
 
         /** @var Mage_Eav_Model_Entity_Type $entityType */
         foreach ($entityTypeCollection as $entityType) {
-
             // Ensure eav entity type model class is defined, otherwise skip processing it.
             // This check prevents leftover eav_entity_type entries from disabled/removed modules creating errors and
             // is necessary because the entire EAV model is now loaded eagerly for performance optimization.

--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -186,8 +186,24 @@ class Mage_Eav_Model_Config
         $this->_entityTypes = [];
         $this->_entityTypeByCode = [];
         $entityTypeCollection = Mage::getResourceModel('eav/entity_type_collection');
+
         /** @var Mage_Eav_Model_Entity_Type $entityType */
         foreach ($entityTypeCollection as $entityType) {
+
+            // Ensure eav entity type model class is defined, otherwise skip processing it.
+            // This check prevents leftover eav_entity_type entries from disabled/removed modules creating errors and
+            // is necessary because the entire EAV model is now loaded eagerly for performance optimization.
+            $entityModelClass = $entityType['entity_model'];
+            $fqEntityModelClass = Mage::getConfig()->getModelClassName($entityModelClass);
+            if (!class_exists($fqEntityModelClass)) {
+                if (Mage::getIsDeveloperMode()) {
+                    throw new Exception('failed loading of eav entity type because it does not exist: ' . $entityModelClass);
+                } else {
+                    Mage::log('skipped loading of eav entity type because it does not exist: ' . $entityModelClass);
+                }
+                continue;
+            }
+
             $this->_entityTypes[$entityType->getId()] = $entityType;
             $this->_entityTypeByCode[$entityType->getEntityTypeCode()] = $entityType;
         }


### PR DESCRIPTION
A fix for https://github.com/OpenMage/magento-lts/issues/3175 ensuring that the eav entity type class is present before proceeding to load it to gracefully handle removed modules and/or leftover data.

Purposely throws exception in developer mode to highlight the leftover data and only logs a statement once every time data is loaded from the database.

### Related Pull Requests
- Introduced with https://github.com/OpenMage/magento-lts/pull/2993 cache/performance optimization due to eagerly loading all data 

### Fixed Issues (if relevant)
- https://github.com/OpenMage/magento-lts/issues/3175 

### Manual testing scenarios (*)
1. Disable eav cache
2. Add entry to eav_entity_type table with non-existent model class
