### PR TITLE
Fixed passing null for number_format is deprecated for downloadable products

### DIFF
--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -151,18 +151,19 @@ class Mage_Downloadable_Block_Adminhtml_Catalog_Product_Edit_Tab_Downloadable_Li
         $links = $productType->getLinks($this->getProduct());
         $priceWebsiteScope = Mage::helper('downloadable')->getIsPriceWebsiteScope();
         foreach ($links as $item) {
+            $price = $item->getPrice();
             $tmpLinkItem = [
-                'link_id' => $item->getId(),
-                'title' => $this->escapeHtml($item->getTitle()),
-                'price' => $this->getCanReadPrice() ? $this->getPriceValue($item->getPrice()) : '',
+                'link_id'      => $item->getId(),
+                'title'        => $this->escapeHtml($item->getTitle()),
+                'price'        => (isset($price) && $this->getCanReadPrice()) ? $this->getPriceValue($price) : '',
                 'number_of_downloads' => $item->getNumberOfDownloads(),
                 'is_shareable' => $item->getIsShareable(),
-                'link_url' => $item->getLinkUrl(),
-                'link_type' => $item->getLinkType(),
-                'sample_file' => $item->getSampleFile(),
-                'sample_url' => $item->getSampleUrl(),
-                'sample_type' => $item->getSampleType(),
-                'sort_order' => $item->getSortOrder(),
+                'link_url'     => $item->getLinkUrl(),
+                'link_type'    => $item->getLinkType(),
+                'sample_file'  => $item->getSampleFile(),
+                'sample_url'   => $item->getSampleUrl(),
+                'sample_type'  => $item->getSampleType(),
+                'sort_order'   => $item->getSortOrder(),
             ];
 
             if ($item->getLinkFile()) {
@@ -181,10 +182,10 @@ class Mage_Downloadable_Block_Adminhtml_Catalog_Product_Edit_Tab_Downloadable_Li
                         ]) . '">' . Mage::helper('downloadable/file')->getFileFromPathFile($item->getLinkFile()) . '</a>';
                     $tmpLinkItem['file_save'] = [
                         [
-                            'file' => $item->getLinkFile(),
-                            'name' => $name,
-                            'size' => filesize($file),
-                            'status' => 'old'
+                            'file'   => $item->getLinkFile(),
+                            'name'   => $name,
+                            'size'   => filesize($file),
+                            'status' => 'old',
                         ]
                     ];
                 }
@@ -197,10 +198,10 @@ class Mage_Downloadable_Block_Adminhtml_Catalog_Product_Edit_Tab_Downloadable_Li
                 if (is_file($sampleFile)) {
                     $tmpLinkItem['sample_file_save'] = [
                         [
-                            'file' => $item->getSampleFile(),
-                            'name' => Mage::helper('downloadable/file')->getFileFromPathFile($item->getSampleFile()),
-                            'size' => filesize($sampleFile),
-                            'status' => 'old'
+                            'file'   => $item->getSampleFile(),
+                            'name'   => Mage::helper('downloadable/file')->getFileFromPathFile($item->getSampleFile()),
+                            'size'   => filesize($sampleFile),
+                            'status' => 'old',
                         ]
                     ];
                 }


### PR DESCRIPTION
### Description

This fix `passing null to parameter #1 ($num) of type float is deprecated` for `number_format` with PHP 8.1/8.2.
Perhaps it's not the best way.

See also this [discussion comment](https://github.com/OpenMage/magento-lts/discussions/3025#discussioncomment-5195497).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list