### PR TITLE
Fixed "passing null to parameter" in Mage_Core_Helper_String

### DIFF
--- a/app/code/core/Mage/Core/Helper/String.php
+++ b/app/code/core/Mage/Core/Helper/String.php
@@ -44,7 +44,7 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
     public function truncate($string, $length = 80, $etc = '...', &$remainder = '', $breakWords = true)
     {
         $remainder = '';
-        if ($length == 0) {
+        if (is_null($string) || $length == 0) {
             return '';
         }
 
@@ -75,7 +75,7 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
      */
     public function strlen($string)
     {
-        return iconv_strlen($string, self::ICONV_CHARSET);
+        return is_null($string) ? 0 : iconv_strlen($string, self::ICONV_CHARSET);
     }
 
     /**
@@ -88,6 +88,9 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
      */
     public function substr($string, $offset, $length = null)
     {
+        if (is_null($string)) {
+            return '';
+        }
         $string = $this->cleanString($string);
         if (is_null($length)) {
             $length = $this->strlen($string) - $offset;
@@ -246,6 +249,9 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
      */
     public function splitWords($str, $uniqueOnly = false, $maxWordLength = 0, $wordSeparatorRegexp = '\s')
     {
+        if (is_null($str)) {
+            return [];
+        }
         $result = [];
         $split = preg_split('#' . $wordSeparatorRegexp . '#siu', $str, -1, PREG_SPLIT_NO_EMPTY);
         foreach ($split as $word) {
@@ -269,8 +275,12 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
      */
     public function cleanString($string)
     {
-        return '"libiconv"' == ICONV_IMPL ?
-            iconv(self::ICONV_CHARSET, self::ICONV_CHARSET . '//IGNORE', $string) : $string;
+        if (is_null($string)) {
+            return '';
+        }
+        return '"libiconv"' == ICONV_IMPL
+            ? iconv(self::ICONV_CHARSET, self::ICONV_CHARSET . '//IGNORE', $string)
+            : $string;
     }
 
     /**
@@ -279,11 +289,11 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
      * @param string $haystack
      * @param string $needle
      * @param int $offset
-     * @return int
+     * @return int|false
      */
-    public function strpos($haystack, $needle, $offset = null)
+    public function strpos($haystack, $needle, $offset = 0)
     {
-        return iconv_strpos($haystack, $needle, $offset, self::ICONV_CHARSET);
+        return iconv_strpos((string) $haystack, (string) $needle, $offset, self::ICONV_CHARSET);
     }
 
     /**
@@ -315,6 +325,9 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
      */
     public function parseQueryStr($str)
     {
+        if (is_null($str)) {
+            return [];
+        }
         $argSeparator = '&';
         $result = [];
         $partsQueryStr = explode($argSeparator, $str);
@@ -510,6 +523,9 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
      */
     public function unserialize($str)
     {
+        if (is_null($str)) {
+            return null;
+        }
         $reader = new Unserialize_Reader_ArrValue('data');
         $prevChar = null;
         for ($i = 0; $i < strlen($str); $i++) {


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
I used https://onlinephp.io/ for testing. As an example:

```php
$haystack = null;
$needle = null;
$offset = null;
$result = iconv_strpos($haystack, $needle, $offset, 'UTF-8');
var_dump($result);
```

produces

> Deprecated: iconv_strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /home/user/scripts/code.php on line 5
> 
> Deprecated: iconv_strpos(): Passing null to parameter #2 ($needle) of type string is deprecated in /home/user/scripts/code.php on line 5
> 
> Deprecated: iconv_strpos(): Passing null to parameter #3 ($offset) of type int is deprecated in /home/user/scripts/code.php on line 5
bool(false)

### Related Pull Requests
PR #3329



