### PR TITLE
getAttributeCode() on null prevention by moving after AttributeAbstract check

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute/Collection.php
@@ -230,10 +230,10 @@ class Mage_Catalog_Model_Resource_Product_Type_Configurable_Attribute_Collection
             $sortOrder = 1;
             foreach ($this->_items as $item) {
                 $productAttribute = $item->getProductAttribute();
-                $productAttributeCode = $productAttribute->getAttributeCode();
                 if (!($productAttribute instanceof Mage_Eav_Model_Entity_Attribute_Abstract)) {
                     continue;
                 }
+                $productAttributeCode = $productAttribute->getAttributeCode();
                 $options = $productAttribute->getFrontend()->getSelectOptions();
 
                 $optionsByValue = [];


### PR DESCRIPTION
### Description (*)
Move productAttributeCode until after the check to ensure productAttribute is not null.

Encountered during a product export
```
Fatal error: Uncaught Error: Call to a member function getAttributeCode() on null in /app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute/Collection.php:240 
```


### Related Pull Requests
Appears to have been introduced in #2605 

### Fixed Issues (if relevant)


### Manual testing scenarios (*)


### Questions or comments


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->