### PR TITLE
 Fixed foreach argument must be of type array with API

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Api/V2.php
@@ -33,12 +33,17 @@ class Mage_Sales_Model_Order_Invoice_Api_V2 extends Mage_Sales_Model_Order_Invoi
      */
     public function create($invoiceIncrementId, $itemsQty = [], $comment = null, $email = false, $includeComment = false)
     {
+        if (!is_array($itemsQty)) {
+            $itemsQty = [];
+        }
+
+        /** @var Mage_Sales_Model_Order $order */
         $order = Mage::getModel('sales/order')->loadByIncrementId($invoiceIncrementId);
         $itemsQty = $this->_prepareItemQtyData($itemsQty);
-        /** @var Mage_Sales_Model_Order $order */
+
         /**
-          * Check order existing
-          */
+         * Check order existing
+         */
         if (!$order->getId()) {
             $this->_fault('order_not_exists');
         }

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Api/V2.php
@@ -53,11 +53,16 @@ class Mage_Sales_Model_Order_Shipment_Api_V2 extends Mage_Sales_Model_Order_Ship
         $email = false,
         $includeComment = false
     ) {
+        if (!is_array($itemsQty)) {
+            $itemsQty = [];
+        }
+
         $order = Mage::getModel('sales/order')->loadByIncrementId($orderIncrementId);
         $itemsQty = $this->_prepareItemQtyData($itemsQty);
+
         /**
-          * Check order existing
-          */
+         * Check order existing
+         */
         if (!$order->getId()) {
             $this->_fault('order_not_exists');
         }


### PR DESCRIPTION
### Description 

Not sure if it's due to PHP 8.1/8.2 or not, but this appear with the following examples:

```php
// v1
$proxy = new SoapClient('https://example.org/api/soap/?wsdl', ['trace' => 1, 'user_agent' => 'Local/Test']);
$sessionId = $proxy->login('covid', $pass);
$start = microtime(true);
$oiid = 123456789;
var_dump($proxy->call($sessionId, 'sales_order.info', $oiid));
var_dump($proxy->call($sessionId, 'sales_order_invoice.create', $oiid)); // HERE
$siid = $proxy->call($sessionId, 'sales_order_shipment.create', $oiid); // HERE
var_dump($siid);
var_dump($proxy->call($sessionId, 'sales_order_creditmemo.create', $oiid));
var_dump($proxy->call($sessionId, 'sales_order_shipment.addTrack', [$siid, 'custom', 'Test apiv1', '123', 5]));
echo microtime(true) - $start,"\n";

// v2
$proxy = new SoapClient('https://example.org/api/v2_soap/?wsdl', ['trace' => 1, 'user_agent' => 'Local/Test']);
$sessionId = $proxy->login('covid', $pass);
$start = microtime(true);
$oiid = 123456789;
var_dump($proxy->salesOrderInfo($sessionId, $oiid));
var_dump($proxy->salesOrderInvoiceCreate($sessionId, $oiid)); // HERE
$siid = $proxy->salesOrderShipmentCreate($sessionId, $oiid); // HERE
var_dump($siid);
var_dump($proxy->salesOrderCreditmemoCreate($sessionId, $oiid));
var_dump($proxy->salesOrderShipmentAddTrack($sessionId, $siid, 'custom', 'Test apiv2', '123', 5));
echo microtime(true) - $start,"\n";

```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list