### PR TITLE
Fixed logException twice in CartController.php

### DIFF
--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -263,7 +263,6 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
             }
         } catch (Exception $e) {
             $this->_getSession()->addException($e, $this->__('Cannot add the item to shopping cart.'));
-            Mage::logException($e);
             $this->_goBack();
         }
     }
@@ -299,7 +298,6 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
                 }
             } catch (Exception $e) {
                 $this->_getSession()->addException($e, $this->__('Cannot add the item to shopping cart.'));
-                Mage::logException($e);
                 $this->_goBack();
             }
         }
@@ -418,7 +416,6 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
             }
         } catch (Exception $e) {
             $this->_getSession()->addException($e, $this->__('Cannot update the item.'));
-            Mage::logException($e);
             $this->_goBack();
         }
         $this->_redirect('*/*');
@@ -480,7 +477,6 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
             $this->_getSession()->addError(Mage::helper('core')->escapeHtml($e->getMessage()));
         } catch (Exception $e) {
             $this->_getSession()->addException($e, $this->__('Cannot update shopping cart.'));
-            Mage::logException($e);
         }
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
See line 226 https://github.com/OpenMage/magento-lts/blob/1243a217d1aa9882759c710dd7a40a8c3e88287d/app/code/core/Mage/Core/Model/Session/Abstract.php#L224-L229

The exception is logged, no need to do it twice.

I searched and checked the entire repo, it seems this only happens in CartController.php.



