### PR TITLE
Fixed getQuote() returns null in quote item and quote address objects.

### DIFF
--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -427,6 +427,9 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
      */
     public function getQuote()
     {
+        if (is_null($this->_quote)) {
+            $this->_quote = Mage::getModel('sales/quote')->load($this->getQuoteId());
+        }
         return $this->_quote;
     }
 

--- a/app/code/core/Mage/Sales/Model/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item.php
@@ -272,6 +272,9 @@ class Mage_Sales_Model_Quote_Item extends Mage_Sales_Model_Quote_Item_Abstract
      */
     public function getQuote()
     {
+        if (is_null($this->_quote)) {
+            $this->_quote = Mage::getModel('sales/quote')->load($this->getQuoteId());
+        }
         return $this->_quote;
     }
 


### PR DESCRIPTION
### Description (*)
Example:
```php
$quoteItem = Mage::getModel('sales/quote_item')->load($itemId);
$quote = $quoteItem->getQuote(); // null value but it should not be!
```




