### PR TITLE
Added support for Google Tag Manager injection, compatible with Analytics 4 and enhanced ecommerce data

### DIFF
--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -109,15 +109,10 @@ gtag('set', 'user_id', '{$customer->getId()}');
      *
      * @return string
      * @throws Mage_Core_Model_Store_Exception
+     * @deprecated
      */
     protected function _getOrdersTrackingCode()
     {
-        /** @var Mage_GoogleAnalytics_Helper_Data $helper */
-        $helper = $this->helper('googleanalytics');
-        if ($helper->isUseAnalytics4()) {
-            return $this->_getOrdersTrackingCodeAnalytics4();
-        }
-
         return '';
     }
 
@@ -127,7 +122,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
      * @return string
      * @throws JsonException
      */
-    protected function _getOrdersTrackingCodeAnalytics4()
+    protected function _getEnhancedEcommerceDataForAnalytics4()
     {
         $result = [];
         $request = $this->getRequest();

--- a/app/code/core/Mage/GoogleAnalytics/Block/Gtm.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Gtm.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   Mage
+ * @package    Mage_GoogleAnalytics
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
+ * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * GoogleTagManager Page Block
+ *
+ * @category   Mage
+ * @package    Mage_GoogleAnalytics
+ */
+class Mage_GoogleAnalytics_Block_Gtm extends Mage_Core_Block_Template
+{
+    /**
+     * @return bool
+     */
+    protected function _isAvailable()
+    {
+        return Mage::helper('googleanalytics')->isGoogleTagManagerAvailable();
+    }
+
+    /**
+     * Render GA tracking scripts
+     *
+     * @return string
+     */
+    protected function _toHtml()
+    {
+        if (!$this->_isAvailable()) {
+            return '';
+        }
+        return parent::_toHtml();
+    }
+}

--- a/app/code/core/Mage/GoogleAnalytics/Helper/Data.php
+++ b/app/code/core/Mage/GoogleAnalytics/Helper/Data.php
@@ -30,6 +30,9 @@ class Mage_GoogleAnalytics_Helper_Data extends Mage_Core_Helper_Abstract
     public const XML_PATH_DEBUG         = 'google/analytics/debug';
     public const XML_PATH_USERID        = 'google/analytics/user_id';
 
+    public const XML_PATH_GTM_ACTIVE    = 'google/gtm/active';
+    public const XML_PATH_GTM_CONTAINER_ID   = 'google/gtm/container_id';
+
     /**
      * @var string google analytics 4
      */
@@ -39,6 +42,18 @@ class Mage_GoogleAnalytics_Helper_Data extends Mage_Core_Helper_Abstract
      * @var string
      */
     protected $_moduleName = 'Mage_GoogleAnalytics';
+
+    /**
+     * Whether GTM is ready to use
+     *
+     * @param mixed $store
+     * @return bool
+     */
+    public function isGoogleTagManagerAvailable($store = null)
+    {
+        $containerId = Mage::getStoreConfig(self::XML_PATH_GTM_CONTAINER_ID, $store);
+        return $containerId && Mage::getStoreConfigFlag(self::XML_PATH_GTM_ACTIVE, $store);
+    }
 
     /**
      * Whether GA is ready to use
@@ -76,6 +91,17 @@ class Mage_GoogleAnalytics_Helper_Data extends Mage_Core_Helper_Abstract
     }
 
     /**
+     * Get GTM account id
+     *
+     * @param string $store
+     * @return string
+     */
+    public function getGoogleTagManagerContainerId($store = null)
+    {
+        return Mage::getStoreConfig(self::XML_PATH_GTM_CONTAINER_ID, $store);
+    }
+
+    /**
      * Returns true if should use Google Universal Analytics
      *
      * @param string $store
@@ -85,6 +111,17 @@ class Mage_GoogleAnalytics_Helper_Data extends Mage_Core_Helper_Abstract
     public function isUseUniversalAnalytics($store = null)
     {
         return false;
+    }
+
+    /**
+     * Returns true if should use Google Tag Manager
+     *
+     * @param string $store
+     * @return bool
+     */
+    public function isUseGoogleTagManager($store = null)
+    {
+        return Mage::getStoreConfigFlag(self::XML_PATH_GTM_ACTIVE, $store);
     }
 
     /**

--- a/app/code/core/Mage/GoogleAnalytics/etc/system.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/system.xml
@@ -51,7 +51,7 @@
                 </gtm>
                 <analytics translate="label">
                     <label>Google Analytics</label>
-                    <sort_order>20</sort_order>
+                    <sort_order>10</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>

--- a/app/code/core/Mage/GoogleAnalytics/etc/system.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/system.xml
@@ -24,9 +24,34 @@
             <show_in_website>1</show_in_website>
             <show_in_store>1</show_in_store>
             <groups>
+                <gtm translate="label">
+                    <label>Google Tag Manager</label>
+                    <sort_order>10</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+                    <fields>
+                        <active translate="label">
+                            <label>Enable</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </active>
+                        <container_id translate="label">
+                            <label>Container ID</label>
+                            <sort_order>20</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </container_id>
+                    </fields>
+                </gtm>
                 <analytics translate="label">
                     <label>Google Analytics</label>
-                    <sort_order>10</sort_order>
+                    <sort_order>20</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
@@ -83,18 +108,6 @@
                               <type>analytics4</type>
                             </depends>
                         </debug>
-                        <anonymization translate="label">
-                            <label>Enable IP anonymization</label>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>30</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                            <depends>
-                                <type>universal</type>
-                            </depends>
-                        </anonymization>
                     </fields>
                 </analytics>
             </groups>

--- a/app/design/frontend/base/default/layout/googleanalytics.xml
+++ b/app/design/frontend/base/default/layout/googleanalytics.xml
@@ -23,6 +23,7 @@ Default layout, loads most of the pages
     <default>
         <!-- Mage_GoogleAnalytics -->
         <reference name="head" before="-">
+            <block type="googleanalytics/gtm" name="google_tag_manager" as="google_tag_manager" template="googleanalytics/gtm.phtml" />
             <block type="googleanalytics/ga" name="google_analytics" as="google_analytics" template="googleanalytics/ga.phtml" />
         </reference>
     </default>

--- a/app/design/frontend/base/default/template/googleanalytics/ga.phtml
+++ b/app/design/frontend/base/default/template/googleanalytics/ga.phtml
@@ -16,50 +16,18 @@
 <?php
 /** @var Mage_GoogleAnalytics_Block_Ga $this */
 $_helper = $this->helper('googleanalytics');
-$_accountId = $_helper->getAccountId();
 ?>
 <?php if (!$this->helper('core/cookie')->isUserNotAllowSaveCookie()): ?>
     <?php if ($_helper->isUseAnalytics4()): ?>
+        <?php $_gaAccountId = $_helper->getAccountId() ?>
         <!-- BEGIN GOOGLE ANALYTICS 4 CODE -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=<?= $_accountId ?>"></script>
+        <script async src="https://www.googletagmanager.com/gtag/js?id=<?= $_gaAccountId ?>"></script>
         <script>
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
-            <?php echo $this->_getPageTrackingCode($_accountId) ?>
-            <?php echo $this->_getOrdersTrackingCodeAnalytics4() ?>
+            <?php echo $this->_getPageTrackingCode($_gaAccountId) ?>
+            <?php echo $this->_getEnhancedEcommerceDataForAnalytics4() ?>
         </script>
         <!-- END GOOGLE ANALYTICS 4 CODE -->
-    <?php elseif ($_helper->isUseUniversalAnalytics()): ?>
-        <!-- BEGIN GOOGLE UNIVERSAL ANALYTICS CODE -->
-        <script type="text/javascript">
-        //<![CDATA[
-            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-            <?php echo $this->_getPageTrackingCode($_accountId) ?>
-            <?php echo $this->_getOrdersTrackingCode() ?>
-
-        //]]>
-        </script>
-        <!-- END GOOGLE UNIVERSAL ANALYTICS CODE -->
-    <?php else: ?>
-        <!-- BEGIN GOOGLE ANALYTICS CODE -->
-        <script type="text/javascript">
-        //<![CDATA[
-            var _gaq = _gaq || [];
-            <?php echo $this->_getPageTrackingCode($_accountId) ?>
-            <?php echo $this->_getOrdersTrackingCode() ?>
-
-            (function() {
-                var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-                var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-            })();
-
-        //]]>
-        </script>
-        <!-- END GOOGLE ANALYTICS CODE -->
     <?php endif ?>
 <?php endif ?>

--- a/app/design/frontend/base/default/template/googleanalytics/gtm.phtml
+++ b/app/design/frontend/base/default/template/googleanalytics/gtm.phtml
@@ -1,0 +1,33 @@
+<?php
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE_AFL.txt.
+ * It is also available at https://opensource.org/license/afl-3-0-php
+ *
+ * @category    design
+ * @package     base_default
+ * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
+ * @copyright   Copyright (c) 2021 The OpenMage Contributors (https://www.openmage.org)
+ * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+?>
+<?php
+/** @var Mage_GoogleAnalytics_Block_Gtm $this */
+$_helper = $this->helper('googleanalytics');
+?>
+<?php if (!$this->helper('core/cookie')->isUserNotAllowSaveCookie()): ?>
+    <?php if ($_helper->isUseGoogleTagManager()): ?>
+        <?php $_gtmAccountId = $_helper->getGoogleTagManagerContainerId() ?>
+        <!-- BEGIN GOOGLE TAG MANAGER CODE -->
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer','<?= $_gtmAccountId ?>');</script>
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<?= $_gtmAccountId ?>"
+                          height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+        <!-- END GOOGLE TAG MANAGER CODE -->
+    <?php endif ?>
+<?php endif ?>


### PR DESCRIPTION
This PR does a minor refactor of some GA4 code and adds the support for the injection of Google Tag Manager.

### A screenshot of the backend
<img width="695" alt="Screenshot 2023-06-27 alle 23 53 25" src="https://github.com/OpenMage/magento-lts/assets/909743/2ba06e65-cdcb-465e-8890-09a7ee15845e">

### Tests I've done
- GA4 alone: working and sending enhanced ecommerce
- GTM injecting GA4: working and sending enhanced ecommerce
- GTM not injecting GA4 working and sending enhanced ecommerce

If you check the code, you may thing that GA4 scripts will be added to the HTML also when GTM is injecting them. I've done multiple tests but GTM is somehow detecting it and not injecting GA4 if it's already in the HTML. So, I think we could leave it like this.

### Notes
I've renamed the _getOrdersTrackingCodeAnalytics4() method to _getEnhancedEcommerceDataForAnalytics4() since it's really not about order tracking, it does much more than that, and it's a new method so it's not a problem to rename it.

### Questions
- Should I have done a new helper instead of using the default one?