### PR TITLE
Allowed customization of the checkout page identifiers for the Mage_GoogleAnalytics module

### DIFF
--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -21,6 +21,9 @@
  */
 class Mage_GoogleAnalytics_Block_Ga extends Mage_Core_Block_Template
 {
+    protected const CHECKOUT_MODULE_NAME = "checkout";
+    protected const CHECKOUT_CONTROLLER_NAME = "onepage";
+
     /**
      * Render regular page tracking javascript code
      * The custom "page name" may be set from layout or somewhere else. It must start from slash.
@@ -304,7 +307,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
          *
          * @link https://developers.google.com/tag-platform/gtagjs/reference/events#begin_checkout
          */
-        elseif ($moduleName == 'checkout' && $controllerName == 'onepage') {
+        elseif ($moduleName == static::CHECKOUT_MODULE_NAME && $controllerName == static::CHECKOUT_CONTROLLER_NAME) {
             $productCollection = Mage::getSingleton('checkout/session')->getQuote()->getAllVisibleItems();
             if ($productCollection) {
                 $eventData = [];
@@ -342,7 +345,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
         $orderIds = $this->getOrderIds();
         if (!empty($orderIds) && is_array($orderIds)) {
             $collection = Mage::getResourceModel('sales/order_collection')
-                              ->addFieldToFilter('entity_id', ['in' => $orderIds]);
+                ->addFieldToFilter('entity_id', ['in' => $orderIds]);
             /** @var Mage_Sales_Model_Order $order */
             foreach ($collection as $order) {
                 $orderData = [


### PR DESCRIPTION
While implementing the new GA4 feature for a customer I found out that, with a custom checkout, it doesn't track the begin_checkout event.

So I thought to create a couple of constants that can be easily overridden to allow for this feature to work for any checkout, in fact, for my customer I've simply create a class like this:

```php
<?php
 
class Customernme_Analytics4_Block_GoogleAnalytics_Ga extends Mage_GoogleAnalytics_Block_Ga
{
    protected const CHECKOUT_MODULE_NAME = "firecheckout";
    protected const CHECKOUT_CONTROLLER_NAME = "index";
}
```

and now it tracks the checkout event.

there are probably better ways, any suggestion is welcome.