### PR TITLE
Removed unexisting branch alias from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,9 +84,6 @@
         }
     },
     "extra": {
-        "branch-alias": {
-            "dev-main": "1.9.4.x-dev"
-        },
         "magento-root-dir": ".",
         "magento-deploystrategy": "copy",
         "magento-deploystrategy-dev": "symlink",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e73fdcac234fc7d39e4487ab1e2d80a3",
+    "content-hash": "bcf4c7beaca0c503bdd487b27bb863b6",
     "packages": [
         {
             "name": "colinmollenhour/cache-backend-redis",


### PR DESCRIPTION
Since branch 1.9.4.x doesn't exist anymore I think we should be able to remove this alias from composer.json