### PR TITLE
Clear config cache after maintenance check for DB Update

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -247,7 +247,7 @@
         Order allow,deny
         Deny from all
     </FilesMatch>
-    <FilesMatch \.(dist|lock|md|neon|sample|sh|yml|yaml)$>
+    <FilesMatch \.(dist|flag|ip|lock|md|neon|sample|sh|yml|yaml)$>
         Order allow,deny
         Deny from all
     </FilesMatch>

--- a/index.php
+++ b/index.php
@@ -51,7 +51,8 @@ if (file_exists($maintenanceFile)) {
         include_once __DIR__ . '/errors/503.php';
         exit;
     }
-    // need to remove Config Cache make it check for DB updates
+
+    // remove config cache to make the system check for DB updates
     $config = Mage::app()->getConfig();
     $config->getCache()->remove($config->getCacheId());
 }

--- a/index.php
+++ b/index.php
@@ -51,6 +51,9 @@ if (file_exists($maintenanceFile)) {
         include_once __DIR__ . '/errors/503.php';
         exit;
     }
+    // need to remove Config Cache make it check for DB updates
+    $config = Mage::app()->getConfig();
+    $config->getCache()->remove($config->getCacheId());
 }
 
 Mage::run($mageRunCode, $mageRunType);


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

if using `maintenance.ip` to bypass `maintenance.flag`, it stops DB Updates. This should fix it.

### Related Pull Requests
<!-- related pull request placeholder -->
Fixes DB Update problem from #1449

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. use `maintenance.flag` with `maintenance.ip`
2. have an Magento Module that still has DB Update scripts to run
3. try to clean up the Cache to make Magento run the DB Updates
4. This currently fails because the does already exist (See Description on  #1449 )


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->

`App::init` does create the Config Cache, so when it `App::run` is called with `_initModules` and `loadModulesCache`, it sees the Cache Config Cache is already created and doesn't ask again.
The added Lines do clear up the part of this specific config does, so it calls `Mage_Core_Model_Resource_Setup::applyAllUpdates`