### PR TITLE
Added decimal/thousand separator specification when sending Analytics4 data

### DIFF
--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -320,6 +320,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                         'item_id' => $_product->getSku(),
                         'item_name' => $_product->getName(),
                         'price' => number_format($_product->getFinalPrice(), 2, '.', ''),
+                        'quantity' => (int) $productInCart->getQty(),
                     ];
                     if ($_product->getAttributeText('manufacturer')) {
                         $_item['item_brand'] = $_product->getAttributeText('manufacturer');

--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -143,12 +143,12 @@ gtag('set', 'user_id', '{$customer->getId()}');
                 $_removedProduct = Mage::getModel('catalog/product')->load($removedProduct);
                 $eventData = [];
                 $eventData['currency'] = Mage::app()->getStore()->getCurrentCurrencyCode();
-                $eventData['value'] = number_format($_removedProduct->getFinalPrice(), 2);
+                $eventData['value'] = number_format($_removedProduct->getFinalPrice(), 2, '.', '');
                 $eventData['items'] = [];
                 $_item = [
                     'item_id' => $_removedProduct->getSku(),
                     'item_name' => $_removedProduct->getName(),
-                    'price' => number_format($_removedProduct->getFinalPrice(), 2),
+                    'price' => number_format($_removedProduct->getFinalPrice(), 2, '.', ''),
                 ];
                 if ($_removedProduct->getAttributeText('manufacturer')) {
                     $_item['item_brand'] = $_removedProduct->getAttributeText('manufacturer');
@@ -174,12 +174,12 @@ gtag('set', 'user_id', '{$customer->getId()}');
                 $_addedProduct = Mage::getModel('catalog/product')->load($addedProduct);
                 $eventData = [];
                 $eventData['currency'] = Mage::app()->getStore()->getCurrentCurrencyCode();
-                $eventData['value'] = number_format($_addedProduct->getFinalPrice(), 2);
+                $eventData['value'] = number_format($_addedProduct->getFinalPrice(), 2, '.', '');
                 $eventData['items'] = [];
                 $_item = [
                     'item_id' => $_addedProduct->getSku(),
                     'item_name' => $_addedProduct->getName(),
-                    'price' => number_format($_addedProduct->getFinalPrice(), 2),
+                    'price' => number_format($_addedProduct->getFinalPrice(), 2, '.', ''),
                 ];
                 if ($_addedProduct->getAttributeText('manufacturer')) {
                     $_item['item_brand'] = $_addedProduct->getAttributeText('manufacturer');
@@ -205,14 +205,14 @@ gtag('set', 'user_id', '{$customer->getId()}');
             $category = Mage::registry('current_category') ? Mage::registry('current_category')->getName() : false;
             $eventData = [];
             $eventData['currency'] = Mage::app()->getStore()->getCurrentCurrencyCode();
-            $eventData['value'] = number_format($productViewed->getFinalPrice(), 2);
+            $eventData['value'] = number_format($productViewed->getFinalPrice(), 2, '.', '');
             $eventData['items'] = [];
             $_item = [
                 'item_id' => $productViewed->getSku(),
                 'item_name' => $productViewed->getName(),
                 'list_name' => 'Product Detail Page',
                 'item_category' => $category,
-                'price' => number_format($productViewed->getFinalPrice(), 2),
+                'price' => number_format($productViewed->getFinalPrice(), 2, '.', ''),
             ];
             if ($productViewed->getAttributeText('manufacturer')) {
                 $_item['item_brand'] = $productViewed->getAttributeText('manufacturer');
@@ -251,7 +251,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                     'item_id' => $productViewed->getSku(),
                     'index' => $index,
                     'item_name' => $productViewed->getName(),
-                    'price' => number_format($productViewed->getFinalPrice(), 2),
+                    'price' => number_format($productViewed->getFinalPrice(), 2, '.', ''),
                 ];
                 if ($productViewed->getAttributeText('manufacturer')) {
                     $_item['item_brand'] = $productViewed->getAttributeText('manufacturer');
@@ -263,7 +263,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                 $index++;
                 $eventData['value'] += $productViewed->getFinalPrice();
             }
-            $eventData['value'] = number_format($eventData['value'], 2);
+            $eventData['value'] = number_format($eventData['value'], 2, '.', '');
             $result[] = "gtag('event', 'view_item_list', " . json_encode($eventData, JSON_THROW_ON_ERROR) . ");";
         }
 
@@ -284,7 +284,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                 $_item = [
                     'item_id' => $_product->getSku(),
                     'item_name' => $_product->getName(),
-                    'price' => number_format($_product->getFinalPrice(), 2),
+                    'price' => number_format($_product->getFinalPrice(), 2, '.', ''),
                     'quantity' => (int) $productInCart->getQty(),
                 ];
                 if ($_product->getAttributeText('manufacturer')) {
@@ -298,7 +298,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                 array_push($eventData['items'], $_item);
                 $eventData['value'] += $_product->getFinalPrice();
             }
-            $eventData['value'] = number_format($eventData['value'], 2);
+            $eventData['value'] = number_format($eventData['value'], 2, '.', '');
             $result[] = "gtag('event', 'view_cart', " . json_encode($eventData, JSON_THROW_ON_ERROR) . ");";
         }
 
@@ -319,7 +319,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                     $_item = [
                         'item_id' => $_product->getSku(),
                         'item_name' => $_product->getName(),
-                        'price' => number_format($_product->getFinalPrice(), 2),
+                        'price' => number_format($_product->getFinalPrice(), 2, '.', ''),
                     ];
                     if ($_product->getAttributeText('manufacturer')) {
                         $_item['item_brand'] = $_product->getAttributeText('manufacturer');
@@ -332,7 +332,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                     array_push($eventData['items'], $_item);
                     $eventData['value'] += $_product->getFinalPrice();
                 }
-                $eventData['value'] = number_format($eventData['value'], 2);
+                $eventData['value'] = number_format($eventData['value'], 2, '.', '');
                 $result[] = "gtag('event', 'begin_checkout', " . json_encode($eventData, JSON_THROW_ON_ERROR) . ");";
             }
         }
@@ -351,10 +351,10 @@ gtag('set', 'user_id', '{$customer->getId()}');
                 $orderData = [
                     'currency' => $order->getBaseCurrencyCode(),
                     'transaction_id' => $order->getIncrementId(),
-                    'value' => number_format($order->getBaseGrandTotal(), 2),
+                    'value' => number_format($order->getBaseGrandTotal(), 2, '.', ''),
                     'coupon' => strtoupper($order->getCouponCode()),
-                    'shipping' => number_format($order->getBaseShippingAmount(), 2),
-                    'tax' => number_format($order->getBaseTaxAmount(), 2),
+                    'shipping' => number_format($order->getBaseShippingAmount(), 2, '.', ''),
+                    'tax' => number_format($order->getBaseTaxAmount(), 2, '.', ''),
                     'items' => []
                 ];
 
@@ -364,8 +364,8 @@ gtag('set', 'user_id', '{$customer->getId()}');
                         'item_id' => $item->getSku(),
                         'item_name' => $item->getName(),
                         'quantity' => (int) $item->getQtyOrdered(),
-                        'price' => number_format($item->getBasePrice(), 2),
-                        'discount' => number_format($item->getBaseDiscountAmount(), 2)
+                        'price' => number_format($item->getBasePrice(), 2, '.', ''),
+                        'discount' => number_format($item->getBaseDiscountAmount(), 2, '.', '')
                     ];
                     $_product = Mage::getModel('catalog/product')->load($item->getProductId());
                     if ($_product->getAttributeText('manufacturer')) {


### PR DESCRIPTION
when product price is higher than a thousand EUR, it gets sent to analytics this way:

`"currency":"EUR","value":"4,245.42"`

This PR removes the thousand separator, so that it gets sent this way:

`"currency":"EUR","value":"4245.42"`

This PR also adds "quantity" to the begin_checkout data, which was missing.