### PR TITLE
New feature to repopulate product form in frontend on errors.

### DIFF
--- a/app/code/core/Mage/Catalog/Helper/Product/View.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/View.php
@@ -118,7 +118,9 @@ class Mage_Catalog_Helper_Product_View extends Mage_Core_Helper_Abstract
             throw new Mage_Core_Exception($this->__('Product is not loaded'), $this->ERR_NO_PRODUCT_LOADED);
         }
 
-        $buyRequest = $params->getBuyRequest();
+        /** @see Mage_Checkout_CartController::_setProductBuyRequest() */
+        $checkoutBuyRequest = Mage::getSingleton('checkout/session')->getProductBuyRequest(true);
+        $buyRequest = $params->getBuyRequest() ?: $checkoutBuyRequest;
         if ($buyRequest) {
             $productHelper->prepareProductOptions($product, $buyRequest);
         }

--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -257,11 +257,13 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
 
             $url = $this->_getSession()->getRedirectUrl(true);
             if ($url) {
+                $this->_setProductBuyRequest();
                 $this->getResponse()->setRedirect($url);
             } else {
                 $this->_redirectReferer(Mage::helper('checkout/cart')->getCartUrl());
             }
         } catch (Exception $e) {
+            $this->_setProductBuyRequest();
             $this->_getSession()->addException($e, $this->__('Cannot add the item to shopping cart.'));
             $this->_goBack();
         }
@@ -415,6 +417,7 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
                 $this->_redirectReferer(Mage::helper('checkout/cart')->getCartUrl());
             }
         } catch (Exception $e) {
+            $this->_setProductBuyRequest();
             $this->_getSession()->addException($e, $this->__('Cannot update the item.'));
             $this->_goBack();
         }
@@ -710,5 +713,17 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
     protected function _getCustomerSession()
     {
         return Mage::getSingleton('customer/session');
+    }
+
+    /**
+     * Set product form data in checkout session for populating the product form
+     * in case of errors in add to cart process.
+     */
+    protected function _setProductBuyRequest()
+    {
+        $buyRequest = $this->getRequest()->getPost();
+        $buyRequestObject = new Varien_Object($buyRequest);
+        $this->_getSession()->setProductBuyRequest($buyRequestObject);
+        return;
     }
 }

--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -724,6 +724,5 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
         $buyRequest = $this->getRequest()->getPost();
         $buyRequestObject = new Varien_Object($buyRequest);
         $this->_getSession()->setProductBuyRequest($buyRequestObject);
-        return;
     }
 }

--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -251,7 +251,7 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
             } else {
                 $messages = array_unique(explode("\n", $e->getMessage()));
                 foreach ($messages as $message) {
-                    $this->_getSession()->addError(Mage::helper('core')->escapeHtml($message));
+                    $this->_getSession()->addError(Mage::helper('core')->escapeHtml($message, ['em']));
                 }
             }
 
@@ -718,6 +718,7 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
     /**
      * Set product form data in checkout session for populating the product form
      * in case of errors in add to cart process.
+     *
      * @return void
      */
     protected function _setProductBuyRequest(): void

--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -718,8 +718,9 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
     /**
      * Set product form data in checkout session for populating the product form
      * in case of errors in add to cart process.
+     * @return void
      */
-    protected function _setProductBuyRequest()
+    protected function _setProductBuyRequest(): void
     {
         $buyRequest = $this->getRequest()->getPost();
         $buyRequestObject = new Varien_Object($buyRequest);


### PR DESCRIPTION
### Description (*)
For products with custom options, when validation fails and the page is redirected to the product, all inputs would be lost. The user would need to reenter all the fields. With this PR, the product form will be repopulated thereby improving the user experience. Tested for all product custom option types except file. File upload is not applicable because it's not possible to re-attach the file in the browser.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. [backend] Create a simple product, set _Maximum Qty Allowed in Shopping Cart_ to 10; in _Custom Options_ tab, add different input types: text, area, drop-down, checkbox, etc. except file type.
2. [frontend] On the product page, fill all the fields, set _Qty_ to 11. Click the _Add to Cart_ button. 
3. Error "The maximum quantity allowed for purchase is 10." appears. All input fields are empty.
4. Apply this PR, repeat step 2. The product form is repopulated.

