### PR TITLE
Fixed $address is null in AddressController.

### DIFF
--- a/app/code/core/Mage/Customer/controllers/AddressController.php
+++ b/app/code/core/Mage/Customer/controllers/AddressController.php
@@ -151,9 +151,11 @@ class Mage_Customer_AddressController extends Mage_Core_Controller_Front_Action
                 $this->_getSession()->setAddressFormData($this->getRequest()->getPost())
                     ->addException($e, $this->__('Cannot save address.'));
             }
+
+            return $this->_redirectError(Mage::getUrl('*/*/edit', ['id' => $address->getId()]));
         }
 
-        return $this->_redirectError(Mage::getUrl('*/*/edit', ['id' => $address->getId()]));
+        $this->_redirectReferer();
     }
 
     /**


### PR DESCRIPTION
### Description (*)
I have this error log in a production instance:

```
Array
(
    [type] => 1:E_ERROR
    [message] => Uncaught Error: Call to a member function getId() on null in /app/code/core/Mage/Customer/controllers/AddressController.php:163
  thrown
    [file] => /app/code/core/Mage/Customer/controllers/AddressController.php
    [line] => 163
    [uri] => /customer/address/formPost/?form_key=llZ2YRTc7teqJ5qD&success_url=&error_url=&firstname=JEMS&middlename=STEV&lastname=LEO&company=%5C&telephone=%27&fax=%27&street%5B%5D=%27&street%5B%5D=%27&city=%27®ion_id=®ion=&postcode=*&country_id=AU&default_billing=1&default_shipping=1
)
```
Looking at the uri, it seems it's an attempt by some bad agent trying something. It needs to extract the `form_key` and test the server to reveal something.

This is because when line 99 `$this->getRequest()->isPost()` is `false`, `$address` is not defined:
https://github.com/OpenMage/magento-lts/blob/d8bd81bd73cd4fc4f84c48069bdb73f2eca5f448/app/code/core/Mage/Customer/controllers/AddressController.php#L93-L102

### Manual Testing

You can extract the form key and then attach the URI to your domain in the browser:

 > /customer/address/formPost/?form_key=**{replace with your key}**&success_url=&error_url=&firstname=JEMS&middlename=STEV&lastname=LEO&company=%5C&telephone=%27&fax=%27&street%5B%5D=%27&street%5B%5D=%27&city=%27®ion_id=®ion=&postcode=*&country_id=AU&default_billing=1&default_shipping=1
)

The output depends on your server config. 


