### PR TITLE
Fixed exception in Dob.php during customer registration.

### DIFF
--- a/app/code/core/Mage/Customer/Block/Form/Register.php
+++ b/app/code/core/Mage/Customer/Block/Form/Register.php
@@ -88,6 +88,10 @@ class Mage_Customer_Block_Form_Register extends Mage_Directory_Block_Data
             if (isset($data['region_id'])) {
                 $data['region_id'] = (int)$data['region_id'];
             }
+            if ($data->getDob()) {
+                $dob = $data->getYear() . '-' . $data->getMonth() . '-' . $data->getDay();
+                $data->setDob($dob);
+            }
             $this->setData('form_data', $data);
         }
         return $data;


### PR DESCRIPTION
### Description (*)
I have this in exception.log:
```
2023-07-11T04:35:28+00:00 ERR (3) [/customer/account/create/]: 
Exception: DateTime::__construct(): Failed to parse time string (29/04/1975) at position 0 (2): Unexpected character in /app/code/core/Mage/Customer/Block/Widget/Dob.php:71
Stack trace:
#0 /app/code/core/Mage/Customer/Block/Widget/Dob.php(71): DateTime->__construct('29/04/1975')
#1 /app/design/frontend/xxx/default/template/customer/form/register.phtml(44): Mage_Customer_Block_Widget_Dob->setDate('29/04/1975')
```

This is because `$date` in https://github.com/OpenMage/magento-lts/blob/d8bd81bd73cd4fc4f84c48069bdb73f2eca5f448/app/code/core/Mage/Customer/Block/Widget/Dob.php#L64-L64

cannot be formatted in `d/m/Y`.  See https://onlinephp.io/c/5f39a


### Related Pull Requests
PR #1851 

### Manual testing scenarios (*)
1. [backend] System configuration, catalog tab: 
![image](https://github.com/OpenMage/magento-lts/assets/1106470/62dcdb34-8eb0-4368-909a-e5ca9fd2396e)
Set the date fields order in Day, Month, Year.
2. [backend] Enabled "Show Date of Birth" in customer configuration tab > Name and Address Options
2. [frontend] Navigate to /customer/account/create/
3. [frontend] Register with an existing email in your database to effect the error "There is already an account with this email address. If you are sure that it is your email address, to get your password and access your account."
4. [frontned] After form submission, the DOB fields are empty. Check your exception.log, it should log an exception "DateTime::__construct(): Failed to parse time string"
5. Apply this PR and repeat the above steps, DOB fields are pre-populated, and no exception log.

