### PR TITLE
Rewrote part of GA4 to support add/remove quantity from cart and cart_updates

### DIFF
--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -347,7 +347,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                     'currency' => $order->getBaseCurrencyCode(),
                     'transaction_id' => $order->getIncrementId(),
                     'value' => $helper->formatPrice($order->getBaseGrandTotal()),
-                    'coupon' => strtoupper($order->getCouponCode()),
+                    'coupon' => strtoupper((string)$order->getCouponCode()),
                     'shipping' => $helper->formatPrice($order->getBaseShippingAmount()),
                     'tax' => $helper->formatPrice($order->getBaseTaxAmount()),
                     'items' => []
@@ -355,10 +355,10 @@ gtag('set', 'user_id', '{$customer->getId()}');
 
                 /** @var Mage_Sales_Model_Order_Item $item */
                 foreach ($order->getAllItems() as $item) {
-                    if ($productInCart->getParentItem()) {
+                    if ($item->getParentItem()) {
                         continue;
                     }
-                    $_product = $productInCart->getProduct();
+                    $_product = $item->getProduct();
                     $_item = [
                         'item_id' => $item->getSku(),
                         'item_name' => $item->getName(),

--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -140,24 +140,19 @@ gtag('set', 'user_id', '{$customer->getId()}');
         $removedProducts = Mage::getSingleton('core/session')->getRemovedProductsCart();
         if ($removedProducts) {
             foreach ($removedProducts as $removedProduct) {
-                $_removedProduct = Mage::getModel('catalog/product')->load($removedProduct);
                 $eventData = [];
                 $eventData['currency'] = Mage::app()->getStore()->getCurrentCurrencyCode();
-                $eventData['value'] = number_format($_removedProduct->getFinalPrice(), 2, '.', '');
+                $eventData['value'] = number_format($removedProduct['price'] * $removedProduct['qty'], 2, '.', '');
                 $eventData['items'] = [];
                 $_item = [
-                    'item_id' => $_removedProduct->getSku(),
-                    'item_name' => $_removedProduct->getName(),
-                    'price' => number_format($_removedProduct->getFinalPrice(), 2, '.', ''),
+                    'item_id' => $removedProduct['sku'],
+                    'item_name' => $removedProduct['name'],
+                    'price' => number_format($removedProduct['price'], 2, '.', ''),
+                    'quantity' => $removedProduct['qty'],
+                    'item_brand' => $removedProduct['manufacturer'],
+                    'item_category' => $removedProduct['category'],
                 ];
-                if ($_removedProduct->getAttributeText('manufacturer')) {
-                    $_item['item_brand'] = $_removedProduct->getAttributeText('manufacturer');
-                }
-                $itemCategory = Mage::helper('googleanalytics')->getLastCategoryName($_removedProduct);
-                if ($itemCategory) {
-                    $_item['item_category'] = $itemCategory;
-                }
-                array_push($eventData['items'], $_item);
+                $eventData['items'][] = $_item;
                 $result[] = "gtag('event', 'remove_from_cart', " . json_encode($eventData, JSON_THROW_ON_ERROR) . ");";
             }
             Mage::getSingleton('core/session')->unsRemovedProductsCart();

--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -149,7 +149,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                     'item_id' => $removedProduct['sku'],
                     'item_name' => $removedProduct['name'],
                     'price' => $helper->formatPrice($removedProduct['price']),
-                    'quantity' => (int)$removedProduct['qty'],
+                    'quantity' => (int) $removedProduct['qty'],
                     'item_brand' => $removedProduct['manufacturer'],
                     'item_category' => $removedProduct['category'],
                 ];
@@ -175,7 +175,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                     'item_id' => $_addedProduct['sku'],
                     'item_name' => $_addedProduct['name'],
                     'price' => $helper->formatPrice($_addedProduct['price']),
-                    'quantity' => (int)$_addedProduct['qty'],
+                    'quantity' => (int) $_addedProduct['qty'],
                     'item_brand' => $_addedProduct['manufacturer'],
                     'item_category' => $_addedProduct['category'],
                 ];

--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -270,7 +270,9 @@ gtag('set', 'user_id', '{$customer->getId()}');
             $eventData['items'] = [];
 
             foreach ($productCollection as $productInCart) {
-                if ($productInCart->getParentItem()) continue;
+                if ($productInCart->getParentItem()) {
+                    continue;
+                }
                 $_product = $productInCart->getProduct();
                 $_item = [
                     'item_id' => $_product->getSku(),
@@ -281,7 +283,6 @@ gtag('set', 'user_id', '{$customer->getId()}');
                 if ($_product->getAttributeText('manufacturer')) {
                     $_item['item_brand'] = $_product->getAttributeText('manufacturer');
                 }
-
                 $itemCategory = $helper->getLastCategoryName($_product);
                 if ($itemCategory) {
                     $_item['item_category'] = $itemCategory;
@@ -306,7 +307,9 @@ gtag('set', 'user_id', '{$customer->getId()}');
                 $eventData['value'] = 0.00;
                 $eventData['items'] = [];
                 foreach ($productCollection as $productInCart) {
-                    if ($productInCart->getParentItem()) continue;
+                    if ($productInCart->getParentItem()) {
+                        continue;
+                    }
                     $_product = $productInCart->getProduct();
                     $_item = [
                         'item_id' => $_product->getSku(),
@@ -317,7 +320,6 @@ gtag('set', 'user_id', '{$customer->getId()}');
                     if ($_product->getAttributeText('manufacturer')) {
                         $_item['item_brand'] = $_product->getAttributeText('manufacturer');
                     }
-
                     $itemCategory = $helper->getLastCategoryName($_product);
                     if ($itemCategory) {
                         $_item['item_category'] = $itemCategory;
@@ -353,7 +355,9 @@ gtag('set', 'user_id', '{$customer->getId()}');
 
                 /** @var Mage_Sales_Model_Order_Item $item */
                 foreach ($order->getAllItems() as $item) {
-                    if ($productInCart->getParentItem()) continue;
+                    if ($productInCart->getParentItem()) {
+                        continue;
+                    }
                     $_product = $productInCart->getProduct();
                     $_item = [
                         'item_id' => $item->getSku(),
@@ -365,7 +369,6 @@ gtag('set', 'user_id', '{$customer->getId()}');
                     if ($_product->getAttributeText('manufacturer')) {
                         $_item['item_brand'] = $_product->getAttributeText('manufacturer');
                     }
-
                     $itemCategory = $helper->getLastCategoryName($_product);
                     if ($itemCategory) {
                         $_item['item_category'] = $itemCategory;

--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -137,7 +137,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
          *
          * @link https://developers.google.com/tag-platform/gtagjs/reference/events#remove_from_cart
          */
-        $removedProducts = Mage::getSingleton('core/session')->getRemovedProductsCart();
+        $removedProducts = Mage::getSingleton('core/session')->getRemovedProductsForAnalytics();
         if ($removedProducts) {
             foreach ($removedProducts as $removedProduct) {
                 $eventData = [];
@@ -155,7 +155,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                 $eventData['items'][] = $_item;
                 $result[] = "gtag('event', 'remove_from_cart', " . json_encode($eventData, JSON_THROW_ON_ERROR) . ");";
             }
-            Mage::getSingleton('core/session')->unsRemovedProductsCart();
+            Mage::getSingleton('core/session')->unsRemovedProductsForAnalytics();
         }
 
         /**
@@ -163,7 +163,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
          *
          * @link https://developers.google.com/tag-platform/gtagjs/reference/events#add_to_cart
          */
-        $addedProducts = Mage::getSingleton('core/session')->getAddedProductsCart();
+        $addedProducts = Mage::getSingleton('core/session')->getAddedProductsForAnalytics();
         if ($addedProducts) {
             foreach ($addedProducts as $_addedProduct) {
                 $eventData = [];
@@ -180,7 +180,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                 ];
                 $eventData['items'][] = $_item;
                 $result[] = "gtag('event', 'add_to_cart', " . json_encode($eventData, JSON_THROW_ON_ERROR) . ");";
-                Mage::getSingleton('core/session')->unsAddedProductsCart();
+                Mage::getSingleton('core/session')->unsAddedProductsForAnalytics();
             }
         }
 

--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -131,6 +131,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
         $request = $this->getRequest();
         $moduleName = $request->getModuleName();
         $controllerName = $request->getControllerName();
+        $helper = Mage::helper('googleanalytics');
 
         /**
          * This event signifies that an item was removed from a cart.
@@ -142,12 +143,12 @@ gtag('set', 'user_id', '{$customer->getId()}');
             foreach ($removedProducts as $removedProduct) {
                 $eventData = [];
                 $eventData['currency'] = Mage::app()->getStore()->getCurrentCurrencyCode();
-                $eventData['value'] = number_format($removedProduct['price'] * $removedProduct['qty'], 2, '.', '');
+                $eventData['value'] = $helper->formatPrice($removedProduct['price'] * $removedProduct['qty']);
                 $eventData['items'] = [];
                 $_item = [
                     'item_id' => $removedProduct['sku'],
                     'item_name' => $removedProduct['name'],
-                    'price' => number_format($removedProduct['price'], 2, '.', ''),
+                    'price' => $helper->formatPrice($removedProduct['price']),
                     'quantity' => $removedProduct['qty'],
                     'item_brand' => $removedProduct['manufacturer'],
                     'item_category' => $removedProduct['category'],
@@ -168,12 +169,12 @@ gtag('set', 'user_id', '{$customer->getId()}');
             foreach ($addedProducts as $_addedProduct) {
                 $eventData = [];
                 $eventData['currency'] = Mage::app()->getStore()->getCurrentCurrencyCode();
-                $eventData['value'] = number_format($_addedProduct['price'] * $_addedProduct['qty'], 2, '.', '');
+                $eventData['value'] = $helper->formatPrice($_addedProduct['price'] * $_addedProduct['qty']);
                 $eventData['items'] = [];
                 $_item = [
                     'item_id' => $_addedProduct['sku'],
                     'item_name' => $_addedProduct['name'],
-                    'price' => number_format($_addedProduct['price'], 2, '.', ''),
+                    'price' => $helper->formatPrice($_addedProduct['price']),
                     'quantity' => $_addedProduct['qty'],
                     'item_brand' => $_addedProduct['manufacturer'],
                     'item_category' => $_addedProduct['category'],
@@ -194,14 +195,14 @@ gtag('set', 'user_id', '{$customer->getId()}');
             $category = Mage::registry('current_category') ? Mage::registry('current_category')->getName() : false;
             $eventData = [];
             $eventData['currency'] = Mage::app()->getStore()->getCurrentCurrencyCode();
-            $eventData['value'] = number_format($productViewed->getFinalPrice(), 2, '.', '');
+            $eventData['value'] = $helper->formatPrice($productViewed->getFinalPrice());
             $eventData['items'] = [];
             $_item = [
                 'item_id' => $productViewed->getSku(),
                 'item_name' => $productViewed->getName(),
                 'list_name' => 'Product Detail Page',
                 'item_category' => $category,
-                'price' => number_format($productViewed->getFinalPrice(), 2, '.', ''),
+                'price' => $helper->formatPrice($productViewed->getFinalPrice()),
             ];
             if ($productViewed->getAttributeText('manufacturer')) {
                 $_item['item_brand'] = $productViewed->getAttributeText('manufacturer');
@@ -240,7 +241,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                     'item_id' => $productViewed->getSku(),
                     'index' => $index,
                     'item_name' => $productViewed->getName(),
-                    'price' => number_format($productViewed->getFinalPrice(), 2, '.', ''),
+                    'price' => $helper->formatPrice($productViewed->getFinalPrice()),
                 ];
                 if ($productViewed->getAttributeText('manufacturer')) {
                     $_item['item_brand'] = $productViewed->getAttributeText('manufacturer');
@@ -252,7 +253,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                 $index++;
                 $eventData['value'] += $productViewed->getFinalPrice();
             }
-            $eventData['value'] = number_format($eventData['value'], 2, '.', '');
+            $eventData['value'] = $helper->formatPrice($eventData['value']);
             $result[] = "gtag('event', 'view_item_list', " . json_encode($eventData, JSON_THROW_ON_ERROR) . ");";
         }
 
@@ -273,21 +274,21 @@ gtag('set', 'user_id', '{$customer->getId()}');
                 $_item = [
                     'item_id' => $_product->getSku(),
                     'item_name' => $_product->getName(),
-                    'price' => number_format($_product->getFinalPrice(), 2, '.', ''),
+                    'price' => $helper->formatPrice($_product->getFinalPrice()),
                     'quantity' => (int) $productInCart->getQty(),
                 ];
                 if ($_product->getAttributeText('manufacturer')) {
                     $_item['item_brand'] = $_product->getAttributeText('manufacturer');
                 }
 
-                $itemCategory = Mage::helper('googleanalytics')->getLastCategoryName($_product);
+                $itemCategory = $helper->getLastCategoryName($_product);
                 if ($itemCategory) {
                     $_item['item_category'] = $itemCategory;
                 }
                 array_push($eventData['items'], $_item);
                 $eventData['value'] += $_product->getFinalPrice();
             }
-            $eventData['value'] = number_format($eventData['value'], 2, '.', '');
+            $eventData['value'] = $helper->formatPrice($eventData['value']);
             $result[] = "gtag('event', 'view_cart', " . json_encode($eventData, JSON_THROW_ON_ERROR) . ");";
         }
 
@@ -308,21 +309,21 @@ gtag('set', 'user_id', '{$customer->getId()}');
                     $_item = [
                         'item_id' => $_product->getSku(),
                         'item_name' => $_product->getName(),
-                        'price' => number_format($_product->getFinalPrice(), 2, '.', ''),
+                        'price' => $helper->formatPrice($_product->getFinalPrice()),
                         'quantity' => (int) $productInCart->getQty(),
                     ];
                     if ($_product->getAttributeText('manufacturer')) {
                         $_item['item_brand'] = $_product->getAttributeText('manufacturer');
                     }
 
-                    $itemCategory = Mage::helper('googleanalytics')->getLastCategoryName($_product);
+                    $itemCategory = $helper->getLastCategoryName($_product);
                     if ($itemCategory) {
                         $_item['item_category'] = $itemCategory;
                     }
                     array_push($eventData['items'], $_item);
                     $eventData['value'] += $_product->getFinalPrice();
                 }
-                $eventData['value'] = number_format($eventData['value'], 2, '.', '');
+                $eventData['value'] = $helper->formatPrice($eventData['value']);
                 $result[] = "gtag('event', 'begin_checkout', " . json_encode($eventData, JSON_THROW_ON_ERROR) . ");";
             }
         }
@@ -341,10 +342,10 @@ gtag('set', 'user_id', '{$customer->getId()}');
                 $orderData = [
                     'currency' => $order->getBaseCurrencyCode(),
                     'transaction_id' => $order->getIncrementId(),
-                    'value' => number_format($order->getBaseGrandTotal(), 2, '.', ''),
+                    'value' => $helper->formatPrice($order->getBaseGrandTotal()),
                     'coupon' => strtoupper($order->getCouponCode()),
-                    'shipping' => number_format($order->getBaseShippingAmount(), 2, '.', ''),
-                    'tax' => number_format($order->getBaseTaxAmount(), 2, '.', ''),
+                    'shipping' => $helper->formatPrice($order->getBaseShippingAmount()),
+                    'tax' => $helper->formatPrice($order->getBaseTaxAmount()),
                     'items' => []
                 ];
 
@@ -354,15 +355,15 @@ gtag('set', 'user_id', '{$customer->getId()}');
                         'item_id' => $item->getSku(),
                         'item_name' => $item->getName(),
                         'quantity' => (int) $item->getQtyOrdered(),
-                        'price' => number_format($item->getBasePrice(), 2, '.', ''),
-                        'discount' => number_format($item->getBaseDiscountAmount(), 2, '.', '')
+                        'price' => $helper->formatPrice($item->getBasePrice()),
+                        'discount' => $helper->formatPrice($item->getBaseDiscountAmount())
                     ];
                     $_product = Mage::getModel('catalog/product')->load($item->getProductId());
                     if ($_product->getAttributeText('manufacturer')) {
                         $_item['item_brand'] = $_product->getAttributeText('manufacturer');
                     }
 
-                    $itemCategory = Mage::helper('googleanalytics')->getLastCategoryName($_product);
+                    $itemCategory = $helper->getLastCategoryName($_product);
                     if ($itemCategory) {
                         $_item['item_category'] = $itemCategory;
                     }

--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -170,26 +170,20 @@ gtag('set', 'user_id', '{$customer->getId()}');
          */
         $addedProducts = Mage::getSingleton('core/session')->getAddedProductsCart();
         if ($addedProducts) {
-            foreach ($addedProducts as $addedProduct) {
-                $_addedProduct = Mage::getModel('catalog/product')->load($addedProduct);
+            foreach ($addedProducts as $_addedProduct) {
                 $eventData = [];
                 $eventData['currency'] = Mage::app()->getStore()->getCurrentCurrencyCode();
-                $eventData['value'] = number_format($_addedProduct->getFinalPrice(), 2, '.', '');
+                $eventData['value'] = number_format($_addedProduct['price'] * $_addedProduct['qty'], 2, '.', '');
                 $eventData['items'] = [];
                 $_item = [
-                    'item_id' => $_addedProduct->getSku(),
-                    'item_name' => $_addedProduct->getName(),
-                    'price' => number_format($_addedProduct->getFinalPrice(), 2, '.', ''),
+                    'item_id' => $_addedProduct['sku'],
+                    'item_name' => $_addedProduct['name'],
+                    'price' => number_format($_addedProduct['price'], 2, '.', ''),
+                    'quantity' => $_addedProduct['qty'],
+                    'item_brand' => $_addedProduct['manufacturer'],
+                    'item_category' => $_addedProduct['category'],
                 ];
-                if ($_addedProduct->getAttributeText('manufacturer')) {
-                    $_item['item_brand'] = $_addedProduct->getAttributeText('manufacturer');
-                }
-
-                $itemCategory = Mage::helper('googleanalytics')->getLastCategoryName($_addedProduct);
-                if ($itemCategory) {
-                    $_item['item_category'] = $itemCategory;
-                }
-                array_push($eventData['items'], $_item);
+                $eventData['items'][] = $_item;
                 $result[] = "gtag('event', 'add_to_cart', " . json_encode($eventData, JSON_THROW_ON_ERROR) . ");";
                 Mage::getSingleton('core/session')->unsAddedProductsCart();
             }

--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -149,7 +149,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                     'item_id' => $removedProduct['sku'],
                     'item_name' => $removedProduct['name'],
                     'price' => $helper->formatPrice($removedProduct['price']),
-                    'quantity' => $removedProduct['qty'],
+                    'quantity' => (int)$removedProduct['qty'],
                     'item_brand' => $removedProduct['manufacturer'],
                     'item_category' => $removedProduct['category'],
                 ];
@@ -175,7 +175,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                     'item_id' => $_addedProduct['sku'],
                     'item_name' => $_addedProduct['name'],
                     'price' => $helper->formatPrice($_addedProduct['price']),
-                    'quantity' => $_addedProduct['qty'],
+                    'quantity' => (int)$_addedProduct['qty'],
                     'item_brand' => $_addedProduct['manufacturer'],
                     'item_category' => $_addedProduct['category'],
                 ];

--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -286,7 +286,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                     $_item['item_category'] = $itemCategory;
                 }
                 array_push($eventData['items'], $_item);
-                $eventData['value'] += $_product->getFinalPrice();
+                $eventData['value'] += $_product->getFinalPrice() * $productInCart->getQty();
             }
             $eventData['value'] = $helper->formatPrice($eventData['value']);
             $result[] = "gtag('event', 'view_cart', " . json_encode($eventData, JSON_THROW_ON_ERROR) . ");";

--- a/app/code/core/Mage/GoogleAnalytics/Helper/Data.php
+++ b/app/code/core/Mage/GoogleAnalytics/Helper/Data.php
@@ -184,4 +184,13 @@ class Mage_GoogleAnalytics_Helper_Data extends Mage_Core_Helper_Abstract
         }
         return '';
     }
+
+    /**
+     * @param int|float|string $price
+     * @return string
+     */
+    public function formatPrice($price): string
+    {
+        return number_format($price, 2, '.', '');
+    }
 }

--- a/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
+++ b/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
@@ -56,7 +56,7 @@ class Mage_GoogleAnalytics_Model_Observer
 
         if ($item->isObjectNew()) {
             $addedQty = $item->getQty();
-        } elseif($item->isDeleted()) {
+        } elseif ($item->isDeleted()) {
             $removedQty = $item->getQty();
         } elseif ($item->hasDataChanges()) {
             $newQty = $item->getQty();

--- a/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
+++ b/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
@@ -47,6 +47,10 @@ class Mage_GoogleAnalytics_Model_Observer
     {
         /** @var Mage_Sales_Model_Quote_Item $item */
         $item = $observer->getEvent()->getItem();
+        if ($item->getParentItem()) {
+            return;
+        }
+
         $addedQty = 0;
         $removedQty = 0;
 

--- a/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
+++ b/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
@@ -51,9 +51,17 @@ class Mage_GoogleAnalytics_Model_Observer
             return;
         }
 
+        // avoid to process the same quote_item more than once
+        // this could happen in case of double save of the same quote_item
+        $processedProductsRegistry = Mage::registry('processed_quote_items_for_analytics') ?? new ArrayObject();
+        if ($processedProductsRegistry->offsetExists($item->getId())) {
+            return;
+        }
+        $processedProductsRegistry[$item->getId()] = true;
+        Mage::register('processed_quote_items_for_analytics', $processedProductsRegistry, true);
+
         $addedQty = 0;
         $removedQty = 0;
-
         if ($item->isObjectNew()) {
             $addedQty = $item->getQty();
         } elseif ($item->isDeleted()) {

--- a/app/code/core/Mage/GoogleAnalytics/etc/config.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/config.xml
@@ -72,22 +72,22 @@
                     </googleanalytics_order_success>
                 </observers>
             </checkout_multishipping_controller_success_action>
-            <sales_quote_remove_item>
+            <sales_quote_item_save_after>
                 <observers>
-                    <googleanalytics_remove_item>
+                    <mage_googleanalytics>
                         <class>googleanalytics/observer</class>
-                        <method>removeItemFromCartGoogleAnalytics</method>
-                    </googleanalytics_remove_item>
+                        <method>processItemsAddedOrRemovedFromCart</method>
+                    </mage_googleanalytics>
                 </observers>
-            </sales_quote_remove_item>
-            <sales_quote_product_add_after>
+            </sales_quote_item_save_after>
+            <sales_quote_item_delete_after>
                 <observers>
-                    <googleanalytics_add_item>
+                    <mage_googleanalytics>
                         <class>googleanalytics/observer</class>
-                        <method>addItemToCartGoogleAnalytics</method>
-                    </googleanalytics_add_item>
+                        <method>processItemsAddedOrRemovedFromCart</method>
+                    </mage_googleanalytics>
                 </observers>
-            </sales_quote_product_add_after>
+            </sales_quote_item_delete_after>
         </events>
         <layout>
             <updates>

--- a/app/code/core/Mage/GoogleAnalytics/etc/config.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/config.xml
@@ -80,14 +80,14 @@
                     </googleanalytics_remove_item>
                 </observers>
             </sales_quote_remove_item>
-            <sales_quote_add_item>
+            <sales_quote_product_add_after>
                 <observers>
                     <googleanalytics_add_item>
                         <class>googleanalytics/observer</class>
                         <method>addItemToCartGoogleAnalytics</method>
                     </googleanalytics_add_item>
                 </observers>
-            </sales_quote_add_item>
+            </sales_quote_product_add_after>
         </events>
         <layout>
             <updates>


### PR DESCRIPTION
The previous implementation:
- didn't support the add_to_cart quantity parameter, this was a problem when there are products with minimum_quantity (meaning you will have to add X amount to the cart, not only 1, while ga4 was tracking only 1).
- was forcing a `Mage::getModel('catalog/product')->load()` for every product, which is now removed since it was unneeded
- wasn't working with cart_updates (when you change the quantity of a product in the cart page), now this PR calculates the difference and triggers add_to_cart or remove_to_cart events

This version should be much more complete than before, hope you like it.