### PR TITLE
Removed double save on quote in Mage_Checkout_CartController::ajaxUpdateAction()

### DIFF
--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -680,7 +680,7 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
                 if ($qty == 0) {
                     $cart->removeItem($id);
                 } else {
-                    $quoteItem->setQty($qty)->save();
+                    $quoteItem->setQty($qty);
                 }
                 $this->_getCart()->save();
 


### PR DESCRIPTION
While developing https://github.com/OpenMage/magento-lts/pull/3377 we found out that the popup ajax cart:
<img width="603" alt="Screenshot 2023-07-12 alle 15 22 20" src="https://github.com/OpenMage/magento-lts/assets/909743/651e2785-63f0-4e13-8b0f-131d9c896ea6">


is actually saving the quote two times with this code:
<img width="341" alt="Screenshot 2023-07-12 alle 15 22 46" src="https://github.com/OpenMage/magento-lts/assets/909743/ef19a5a7-ab22-4621-87fa-6df3b59f232f">


the first save is not needed, so this PR removes it, making it look like this:
<img width="446" alt="Screenshot 2023-07-12 alle 15 23 26" src="https://github.com/OpenMage/magento-lts/assets/909743/78df5375-0db2-46f9-8f3d-2c783eda9c87">


You can check that the update product quantity, in the ajax cart, still works the same.
I've also checked the data on the database and it's consistent.