### PR TITLE
Fixed passing null for number_format is deprecated for downloadable products

### DIFF
--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -227,7 +227,7 @@ class Mage_Downloadable_Block_Adminhtml_Catalog_Product_Edit_Tab_Downloadable_Li
      */
     public function getPriceValue($value)
     {
-        return number_format($value, 2, null, '');
+        return number_format($value ?? 0, 2, null, '');
     }
 
     /**


### PR DESCRIPTION
This PR is an alternative version of #3340 based on the suggestions of @kiatng.
Original author @kyrena

Closes #3340