### PR TITLE
Fixed issue #3392 clearInstance() method in Mage_Catalog_Model_Product.

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -2263,6 +2263,15 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
         $this->_defaultValues       = [];
         $this->_storeValuesFlags    = [];
         $this->_lockedAttributes    = [];
+        $this->_typeInstance        = null;
+        $this->_typeInstanceSingleton = null;
+        $this->_linkInstance        = null;
+        $this->_reservedAttributes  = null;
+        $this->_isDuplicable        = true;
+        $this->_calculatePrice      = true;
+        $this->_stockItem           = null;
+        $this->_isDeleteable        = true;
+        $this->_isReadonly          = false;
 
         return $this;
     }

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -270,7 +270,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     /**
      * Product type instance
      *
-     * @var Mage_Catalog_Model_Product_Type_Abstract
+     * @var Mage_Catalog_Model_Product_Type_Abstract|null
      */
     protected $_typeInstance            = null;
 
@@ -282,7 +282,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     /**
      * Product link instance
      *
-     * @var Mage_Catalog_Model_Product_Link
+     * @var Mage_Catalog_Model_Product_Link|null
      */
     protected $_linkInstance;
 
@@ -296,7 +296,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     /**
      * Product Url Instance
      *
-     * @var Mage_Catalog_Model_Product_Url
+     * @var Mage_Catalog_Model_Product_Url|null
      */
     protected $_urlModel = null;
 
@@ -329,7 +329,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     protected $_calculatePrice = true;
 
     /**
-     * @var Mage_CatalogInventory_Model_Stock_Item
+     * @var Mage_CatalogInventory_Model_Stock_Item|null
      */
     protected $_stockItem;
 

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -270,7 +270,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     /**
      * Product type instance
      *
-     * @var Mage_Catalog_Model_Product_Type_Abstract|null
+     * @var Mage_Catalog_Model_Product_Type_Abstract|null|false
      */
     protected $_typeInstance            = null;
 
@@ -698,7 +698,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     }
 
     /**
-     * @param Varien_Object|Mage_CatalogInventory_Model_Stock_Item $stockItem
+     * @param Mage_CatalogInventory_Model_Stock_Item $stockItem
      * @return $this
      */
     public function setStockItem($stockItem)

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -2255,23 +2255,23 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
 
         $this->setData([]);
         $this->setOrigData();
-        $this->_customOptions       = [];
-        $this->_optionInstance      = null;
-        $this->_options             = [];
-        $this->_canAffectOptions    = false;
-        $this->_errors              = [];
-        $this->_defaultValues       = [];
-        $this->_storeValuesFlags    = [];
-        $this->_lockedAttributes    = [];
-        $this->_typeInstance        = null;
+        $this->_customOptions         = [];
+        $this->_optionInstance        = null;
+        $this->_options               = [];
+        $this->_canAffectOptions      = false;
+        $this->_errors                = [];
+        $this->_defaultValues         = [];
+        $this->_storeValuesFlags      = [];
+        $this->_lockedAttributes      = [];
+        $this->_typeInstance          = null;
         $this->_typeInstanceSingleton = null;
-        $this->_linkInstance        = null;
-        $this->_reservedAttributes  = null;
-        $this->_isDuplicable        = true;
-        $this->_calculatePrice      = true;
-        $this->_stockItem           = null;
-        $this->_isDeleteable        = true;
-        $this->_isReadonly          = false;
+        $this->_linkInstance          = null;
+        $this->_reservedAttributes    = null;
+        $this->_isDuplicable          = true;
+        $this->_calculatePrice        = true;
+        $this->_stockItem             = null;
+        $this->_isDeleteable          = true;
+        $this->_isReadonly            = false;
 
         return $this;
     }

--- a/phpstan.dist.baseline.neon
+++ b/phpstan.dist.baseline.neon
@@ -1586,16 +1586,6 @@ parameters:
 			path: app/code/core/Mage/Catalog/Model/Product.php
 
 		-
-			message: "#^Property Mage_Catalog_Model_Product\\:\\:\\$_stockItem \\(Mage_CatalogInventory_Model_Stock_Item\\) does not accept Varien_Object\\.$#"
-			count: 1
-			path: app/code/core/Mage/Catalog/Model/Product.php
-
-		-
-			message: "#^Property Mage_Catalog_Model_Product\\:\\:\\$_typeInstance \\(Mage_Catalog_Model_Product_Type_Abstract\\) does not accept Mage_Core_Model_Abstract\\|false\\.$#"
-			count: 1
-			path: app/code/core/Mage/Catalog/Model/Product.php
-
-		-
 			message: "#^Parameter \\#3 \\$attributes \\(stdClass\\) of method Mage_Catalog_Model_Product_Api_V2\\:\\:info\\(\\) should be compatible with parameter \\$attributes \\(array\\) of method Mage_Catalog_Model_Product_Api\\:\\:info\\(\\)$#"
 			count: 1
 			path: app/code/core/Mage/Catalog/Model/Product/Api/V2.php


### PR DESCRIPTION
### Description (*)
As explained in issue #3392, `clearInstance()` kept the previous product type. The reason is because the properties `$_typeInstance` and `$_typeInstanceSingleton` were not reset. I reviewed all other properties in `Mage_Catalog_Model_Product` and its parent `Mage_Catalog_Model_Abstract` and reset them.

### Fixed Issues (if relevant)
1. Issue #3392 

### Manual testing scenarios (*)
Test script:
In my test, product 1 is type downloadable, product 2 is type virtual.
```php
    $p = Mage::getModel('catalog/product')->load(1);
    $r['downloadable'] = get_class($p->getTypeInstance(true));
    $p->clearInstance()->load(2);
    $r['virtual'] = get_class($p->getTypeInstance(true));
```

Expected result (with this PR):
```
 array(2) {
  ["downloadable"] => string(36) "Mage_Downloadable_Model_Product_Type"
  ["virtual"] => string(39) "Mage_Catalog_Model_Product_Type_Virtual"
}
```

But actual result (without this PR):

```
 array(2) {
  ["downloadable"] => string(36) "Mage_Downloadable_Model_Product_Type"
  ["virtual"] => string(36) "Mage_Downloadable_Model_Product_Type"
}
```
