### PR TITLE
Fixed a bug with UPS that prevented saving the shipping methods page from backend

### DIFF
--- a/app/design/adminhtml/default/default/template/system/shipping/ups.phtml
+++ b/app/design/adminhtml/default/default/template/system/shipping/ups.phtml
@@ -108,6 +108,7 @@ if (!Mage::helper('usa')->validateUpsType($storedUpsType)) {
 
             this.setFormValues();
             Event.observe($(this.carriersUpsTypeId), 'change', this.setFormValues.bind(this));
+            Event.observe($('carriers_ups_active'), 'change', this.setFormValues.bind(this));
         },
         updateAllowedMethods: function(originShipmentTitle)
         {
@@ -158,23 +159,15 @@ if (!Mage::helper('usa')->validateUpsType($storedUpsType)) {
         setFormValues: function()
         {
             var a;
-            if ($F(this.carriersUpsTypeId) == 'UPS') {
-                for (a = 0; a < this.checkingUpsXmlId.length; a++) {
-                    $(this.checkingUpsXmlId[a]).removeClassName('required-entry');
-                }
-                for (a = 0; a < this.checkingUpsId.length; a++) {
-                    $(this.checkingUpsXmlId[a]).addClassName('required-entry');
-                }
-                Event.stopObserving($('carriers_ups_origin_shipment'), 'change', this.changeOriginShipment.bind(this));
-                showRowArrayElements(this.onlyUpsElements);
-                hideRowArrayElements(this.onlyUpsXmlElements);
-                this.changeOriginShipment(null, 'default');
-            } else {
-                for (a = 0; a < this.checkingUpsXmlId.length; a++) {
-                    $(this.checkingUpsXmlId[a]).addClassName('required-entry');
-                }
-                for (a = 0; a < this.checkingUpsId.length; a++) {
-                    $(this.checkingUpsXmlId[a]).removeClassName('required-entry');
+            if ($F(this.carriersUpsTypeId) == 'UPS_XML') {
+                if (document.getElementById('carriers_ups_active').value == 1) {
+                    for (a = 0; a < this.checkingUpsXmlId.length; a++) {
+                        $(this.checkingUpsXmlId[a]).addClassName('required-entry');
+                    }
+                } else {
+                    for (a = 0; a < this.checkingUpsXmlId.length; a++) {
+                        $(this.checkingUpsXmlId[a]).removeClassName('required-entry');
+                    }
                 }
                 Event.observe($('carriers_ups_origin_shipment'), 'change', this.changeOriginShipment.bind(this));
                 showRowArrayElements(this.onlyUpsXmlElements);


### PR DESCRIPTION
https://github.com/OpenMage/magento-lts/pull/3287 created a bug that prohibited the user from saving theshipping method backend page, because now these fields are required also when the shipping method is disabled:

<img width="649" alt="Screenshot 2023-07-20 alle 17 17 05" src="https://github.com/OpenMage/magento-lts/assets/909743/be59d060-9935-4e15-acb0-8548239960af">

This PR checks that the method is enabled before adding the required-entry class to those fields.