### PR TITLE
Updating the information about Mage_Poll in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,12 +212,14 @@ Most important changes will be listed here, all other changes since `19.4.0` can
   - `Mage_Compiler`
   - `Mage_GoogleBase`
   - `Mage_PageCache` ([#2258](https://github.com/OpenMage/magento-lts/pull/2258))
+  - `Mage_Poll`  ([#3098](https://github.com/OpenMage/magento-lts/pull/3098))
   - `Mage_Xmlconnect`
   - `Phoenix_Moneybookers`
 
 _If you rely on those modules you can reinstall them with composer:_
 - `Mage_Backup`: `composer require openmage/module-mage-backup`
 - `Mage_PageCache`: `composer require openmage/module-mage-pagecache`
+- `Mage_Poll`: `composer require openmage/module-mage-poll`
 - `Legacy frontend themes`: `composer require openmage/legacy-frontend-themes`
 
 ### Between OpenMage 19.x and 20.x
@@ -233,7 +235,6 @@ Do not use 20.x.x if you need IE support.
 - enabled website level config cache ([#2355](https://github.com/OpenMage/magento-lts/pull/2355))
 - made overrides of Mage_Core_Model_Resource_Db_Abstract::delete respect parent api ([#1257](https://github.com/OpenMage/magento-lts/pull/1257))
 - rewrote Mage_Eav_Model_Config as cache for all eav entity and attribute reads ([#2993](https://github.com/OpenMage/magento-lts/pull/2993))
-- removed module Mage_Poll ([3098](https://github.com/OpenMage/magento-lts/pull/3098), you can install it with `composer require openmage/module-mage-poll`)
 
 For full list of changes, you can [compare tags](https://github.com/OpenMage/magento-lts/compare/1.9.4.x...20.0).
 


### PR DESCRIPTION
As you may know, the Poll module was removed in PR https://github.com/OpenMage/magento-lts/pull/3098, but checking the README file I found that the information was omitted in the same format as was done for the other removed modules, such as Mage_Backup. 

This PR fixes the issue.