### PR TITLE
Allowed admin grid row to open in new tab

### DIFF
--- a/js/mage/adminhtml/grid.js
+++ b/js/mage/adminhtml/grid.js
@@ -439,7 +439,11 @@ varienGridMassaction.prototype = {
                 return;
             }
             if (trElement.title) {
-                setLocation(trElement.title);
+                if (evt.ctrlKey) {
+                    window.open(trElement.title, '_blank');
+                } else {
+                    setLocation(trElement.title);
+                }
             }
             else{
                 var checkbox = Element.select(trElement, 'input');

--- a/js/mage/adminhtml/grid.js
+++ b/js/mage/adminhtml/grid.js
@@ -311,13 +311,19 @@ varienGrid.prototype = {
     }
 };
 
+function shouldOpenGridRowNewTab(evt){
+    return evt.ctrlKey // Windows ctrl + click
+        || evt.metaKey // macOS command + click
+        || evt.button == 1 // Middle mouse click
+}
+
 function openGridRow(grid, evt){
     var trElement = Event.findElement(evt, 'tr');
     if(['a', 'input', 'select', 'option'].indexOf(Event.element(evt).tagName.toLowerCase())!=-1) {
         return;
     }
     if(trElement.title){
-        if (evt.ctrlKey || evt.button == 1) {
+        if (shouldOpenGridRowNewTab(evt)) {
             window.open(trElement.title, '_blank');
         } else {
             setLocation(trElement.title);
@@ -440,6 +446,7 @@ varienGridMassaction.prototype = {
         this.getOldCallback('init_row')(grid, row);
     },
     onGridRowClick: function(grid, evt) {
+
         var tdElement = Event.findElement(evt, 'td');
         var trElement = Event.findElement(evt, 'tr');
 
@@ -448,7 +455,7 @@ varienGridMassaction.prototype = {
                 return;
             }
             if (trElement.title) {
-                if (evt.ctrlKey || evt.button == 1) {
+                if (shouldOpenGridRowNewTab(evt)) {
                     window.open(trElement.title, '_blank');
                 } else {
                     setLocation(trElement.title);

--- a/js/mage/adminhtml/grid.js
+++ b/js/mage/adminhtml/grid.js
@@ -120,6 +120,12 @@ varienGrid.prototype = {
         Element.removeClassName(element, 'on-mouse');
     },
     rowMouseClick : function(event){
+        if (event.button != 1 && event.type == "mousedown") {
+            return; // Ignore mousedown for any button except middle
+        }
+        if (event.button == 2) {
+            return; // Ignore right click
+        }
         if(this.rowClickCallback){
             try{
                 this.rowClickCallback(this, event);
@@ -306,13 +312,6 @@ varienGrid.prototype = {
 };
 
 function openGridRow(grid, evt){
-    if (evt.button != 1 && evt.type == "mousedown") {
-        return; // Ignore mousedown for any button except middle
-    }
-    if (evt.button == 2) {
-        return; // Ignore right click
-    }
-
     var trElement = Event.findElement(evt, 'tr');
     if(['a', 'input', 'select', 'option'].indexOf(Event.element(evt).tagName.toLowerCase())!=-1) {
         return;
@@ -441,13 +440,6 @@ varienGridMassaction.prototype = {
         this.getOldCallback('init_row')(grid, row);
     },
     onGridRowClick: function(grid, evt) {
-        if (evt.button != 1 && evt.type == "mousedown") {
-            return; // Ignore mousedown for any button except middle
-        }
-        if (evt.button == 2) {
-            return; // Ignore right click
-        }
-
         var tdElement = Event.findElement(evt, 'td');
         var trElement = Event.findElement(evt, 'tr');
 

--- a/js/mage/adminhtml/grid.js
+++ b/js/mage/adminhtml/grid.js
@@ -57,7 +57,7 @@ varienGrid.prototype = {
                 Event.observe(this.rows[row],'mouseover',this.trOnMouseOver);
                 Event.observe(this.rows[row],'mouseout',this.trOnMouseOut);
                 Event.observe(this.rows[row],'mousedown',this.trOnClick);
-                Event.observe(this.rows[row],'mouseup',this.trOnClick);
+                Event.observe(this.rows[row],'click',this.trOnClick);
                 Event.observe(this.rows[row],'dblclick',this.trOnDblClick);
             }
         }

--- a/js/mage/adminhtml/grid.js
+++ b/js/mage/adminhtml/grid.js
@@ -309,9 +309,12 @@ function openGridRow(grid, event){
     if(['a', 'input', 'select', 'option'].indexOf(Event.element(event).tagName.toLowerCase())!=-1) {
         return;
     }
-
     if(element.title){
-        setLocation(element.title);
+        if (event.ctrlKey) {
+            window.open(element.title, '_blank');
+        } else {
+            setLocation(element.title);
+        }
     }
 }
 

--- a/js/mage/adminhtml/grid.js
+++ b/js/mage/adminhtml/grid.js
@@ -56,7 +56,8 @@ varienGrid.prototype = {
 
                 Event.observe(this.rows[row],'mouseover',this.trOnMouseOver);
                 Event.observe(this.rows[row],'mouseout',this.trOnMouseOut);
-                Event.observe(this.rows[row],'click',this.trOnClick);
+                Event.observe(this.rows[row],'mousedown',this.trOnClick);
+                Event.observe(this.rows[row],'mouseup',this.trOnClick);
                 Event.observe(this.rows[row],'dblclick',this.trOnDblClick);
             }
         }
@@ -304,16 +305,23 @@ varienGrid.prototype = {
     }
 };
 
-function openGridRow(grid, event){
-    var element = Event.findElement(event, 'tr');
-    if(['a', 'input', 'select', 'option'].indexOf(Event.element(event).tagName.toLowerCase())!=-1) {
+function openGridRow(grid, evt){
+    if (evt.button != 1 && evt.type == "mousedown") {
+        return; // Ignore mousedown for any button except middle
+    }
+    if (evt.button == 2) {
+        return; // Ignore right click
+    }
+
+    var trElement = Event.findElement(evt, 'tr');
+    if(['a', 'input', 'select', 'option'].indexOf(Event.element(evt).tagName.toLowerCase())!=-1) {
         return;
     }
-    if(element.title){
-        if (event.ctrlKey) {
-            window.open(element.title, '_blank');
+    if(trElement.title){
+        if (evt.ctrlKey || evt.button == 1) {
+            window.open(trElement.title, '_blank');
         } else {
-            setLocation(element.title);
+            setLocation(trElement.title);
         }
     }
 }
@@ -433,6 +441,12 @@ varienGridMassaction.prototype = {
         this.getOldCallback('init_row')(grid, row);
     },
     onGridRowClick: function(grid, evt) {
+        if (evt.button != 1 && evt.type == "mousedown") {
+            return; // Ignore mousedown for any button except middle
+        }
+        if (evt.button == 2) {
+            return; // Ignore right click
+        }
 
         var tdElement = Event.findElement(evt, 'td');
         var trElement = Event.findElement(evt, 'tr');
@@ -442,7 +456,7 @@ varienGridMassaction.prototype = {
                 return;
             }
             if (trElement.title) {
-                if (evt.ctrlKey) {
+                if (evt.ctrlKey || evt.button == 1) {
                     window.open(trElement.title, '_blank');
                 } else {
                     setLocation(trElement.title);


### PR DESCRIPTION
### Description (*)
This always bugged me. On any admin grid, you can click the row to open whatever URL was set with the `getRowUrl` method in the Block class. But the link opens via JS `window.location.href`, so you cannot open in a new tab.

This PR improves the handling of row clicks, see manual testing scenarios.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
In both a mass action grid (i.e. Sales > Orders) and a regular grid (i.e. Promotions > Catalog Price Rules), try on a row:

1. left click -> should open in existing tab (same as before)
2. ctrl+click (Windows) -> should open new tab
3. command+click (macOS) -> should open new tab
4. middle click -> should open new tab
5. right click -> nothing

### Questions or comments


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
