### PR TITLE
Fixes system config dependencies multi value

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
@@ -335,8 +335,8 @@ class Mage_Adminhtml_Block_System_Config_Form extends Mage_Adminhtml_Block_Widge
                             . $dependentFieldNameValue;
                         $shouldBeAddedDependence = true;
                         $dependentValue = (string)(isset($dependent->value) ? $dependent->value : $dependent);
-                        if (isset($dependent['separator'])) {
-                            $dependentValue = explode((string)$dependent['separator'], $dependentValue);
+                        if (isset($dependent->separator)) {
+                            $dependentValue = explode((string)$dependent->separator, $dependentValue);
                         }
                         $dependentFieldName = $fieldPrefix . $dependent->getName();
                         $dependentField     = $dependentFieldGroup->fields->$dependentFieldName;


### PR DESCRIPTION
### Description
I'm not sure if this is an old bug or if I am missing something in order to achieve the same result, but it seems that the ability to specify multiple values for configurations has already been implemented. However, it appears to be buggy.

In this configuration example the "wysiwyg/skin" configuration should only be displayed if the "wysiwyg/enabled" field has one of the following values: enabled, hidden. To achieve this, a "separator" field has been added to allow for the separation of multiple values.

```
<wysiwyg translate="label">
    <label>WYSIWYG Options</label>
    <sort_order>100</sort_order>
    <show_in_default>1</show_in_default>
    <show_in_website>1</show_in_website>
    <show_in_store>1</show_in_store>
    <fields>
        <enabled translate="label">
            <label>Enable WYSIWYG Editor</label>
            <frontend_type>select</frontend_type>
            <source_model>adminhtml/system_config_source_cms_wysiwyg_enabled</source_model>
            <sort_order>1</sort_order>
            <show_in_default>1</show_in_default>
            <show_in_website>1</show_in_website>
            <show_in_store>1</show_in_store>
        </enabled>
        <skin translate="label">
            <label>Skin WYSIWYG Editor</label>
            <frontend_type>select</frontend_type>
            <source_model>adminhtml/system_config_source_cms_wysiwyg_skin</source_model>
            <sort_order>1</sort_order>
            <show_in_default>1</show_in_default>
            <show_in_website>1</show_in_website>
            <show_in_store>1</show_in_store>
            <depends>
                <enabled>
                    <value>enabled|hidden</value>
                    <separator>|</separator>
                </enabled>
            </depends>
        </skin>
    </fields>
</wysiwyg>
```

I have searched through the PRs, but I haven't found a solution to achieve the same result.

Upon investigating the code in Form.php, it appears that this issue has remained unresolved for the past 12 years. This suggests that it may be an old bug that still needs to be addressed. Additionally, it should be noted that the variable "$dependent" cannot be an array, but rather an object.

![blame](https://github.com/empiricompany/openmage/assets/5071467/ecd53fa4-6c59-4168-94b0-8d32528da237)
