### PR TITLE
Allowed API insta-login via HTTP Basic Auth

### DIFF
--- a/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
@@ -225,6 +225,10 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
      */
     public function call($sessionId, $apiPath, $args = [])
     {
+        // Allow insta-login via HTTP Basic Auth
+        if ($sessionId === NULL && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
+            $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+        }
         $this->_startSession($sessionId);
 
         if (!$this->_getSession()->isLoggedIn($sessionId)) {
@@ -309,6 +313,10 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
      */
     public function multiCall($sessionId, array $calls = [], $options = [])
     {
+        // Allow insta-login via HTTP Basic Auth
+        if ($sessionId === NULL && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
+            $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+        }
         $this->_startSession($sessionId);
 
         if (!$this->_getSession()->isLoggedIn($sessionId)) {
@@ -437,6 +445,10 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
      */
     public function resources($sessionId)
     {
+        // Allow insta-login via HTTP Basic Auth
+        if ($sessionId === NULL && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
+            $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+        }
         $this->_startSession($sessionId);
 
         if (!$this->_getSession()->isLoggedIn($sessionId)) {
@@ -501,6 +513,10 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
      */
     public function resourceFaults($sessionId, $resourceName)
     {
+        // Allow insta-login via HTTP Basic Auth
+        if ($sessionId === NULL && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
+            $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+        }
         $this->_startSession($sessionId);
 
         if (!$this->_getSession()->isLoggedIn($sessionId)) {
@@ -537,6 +553,10 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
      */
     public function globalFaults($sessionId)
     {
+        // Allow insta-login via HTTP Basic Auth
+        if ($sessionId === NULL && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
+            $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+        }
         $this->_startSession($sessionId);
         return array_values($this->_getConfig()->getFaults());
     }

--- a/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
@@ -226,7 +226,7 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
     public function call($sessionId, $apiPath, $args = [])
     {
         // Allow insta-login via HTTP Basic Auth
-        if ($sessionId === NULL && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
+        if ($sessionId === null && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
             $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
         }
         $this->_startSession($sessionId);
@@ -314,7 +314,7 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
     public function multiCall($sessionId, array $calls = [], $options = [])
     {
         // Allow insta-login via HTTP Basic Auth
-        if ($sessionId === NULL && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
+        if ($sessionId === null && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
             $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
         }
         $this->_startSession($sessionId);
@@ -446,7 +446,7 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
     public function resources($sessionId)
     {
         // Allow insta-login via HTTP Basic Auth
-        if ($sessionId === NULL && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
+        if ($sessionId === null && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
             $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
         }
         $this->_startSession($sessionId);
@@ -514,7 +514,7 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
     public function resourceFaults($sessionId, $resourceName)
     {
         // Allow insta-login via HTTP Basic Auth
-        if ($sessionId === NULL && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
+        if ($sessionId === null && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
             $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
         }
         $this->_startSession($sessionId);
@@ -554,7 +554,7 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
     public function globalFaults($sessionId)
     {
         // Allow insta-login via HTTP Basic Auth
-        if ($sessionId === NULL && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
+        if ($sessionId === null && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
             $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
         }
         $this->_startSession($sessionId);


### PR DESCRIPTION
Using the XMLRPC and JSONRPC API is a hassle because you have to login to get a session id and then use that session id in subsequent requests and then deal with expiration, etc. Some users also create new sessions in every new process so you end up with lots of login calls. This allows one to authenticate to the API without calling the login method but rather passing the username and password using HTTP Basic Auth. This allows a method to be called with a single API request making it much easier to consume the API with low-code tools. Pass `null` as the session id.

Example request (PhpStorm format):
```
### Product list
POST http://openmage-7f000001.nip.io/api/jsonrpc
Content-Type: application/json
Authorization: Basic test VTm5pOQ

{
  "jsonrpc": 2.0,
  "id": 5501,
  "method": "call",
  "params": [
    null,
    "catalog_product.list",
    []
  ]
}
```