### PR TITLE
Allow soap_v2 style request in JSON-RPC and add event 'api_server_ada…

### DIFF
--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -81,7 +81,7 @@
 | adminhtml_widget_grid_filter_collection | 1.9.4.5 |
 | after_reindex_process_[getIndexerCode] | 1.9.4.5 |
 | ajax_cart_remove_item_success | 1.9.4.5 |
-| api_server_adapter_jsonrpc_run_after | 20.1.0 |
+| api_server_adapter_jsonrpc_run_after | 20.1.1 |
 | api_user_authenticated | 1.9.4.5 |
 | api_user_html_before | 1.9.4.5 |
 | application_clean_cache | 1.9.4.5 |

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -81,6 +81,7 @@
 | adminhtml_widget_grid_filter_collection | 1.9.4.5 |
 | after_reindex_process_[getIndexerCode] | 1.9.4.5 |
 | ajax_cart_remove_item_success | 1.9.4.5 |
+| api_server_adapter_jsonrpc_run_after | 20.1.0 |
 | api_user_authenticated | 1.9.4.5 |
 | api_user_html_before | 1.9.4.5 |
 | application_clean_cache | 1.9.4.5 |
@@ -246,7 +247,7 @@
 | newsletter_send_after | 19.5.0 / 20.1.0 |
 | on_view_report | 1.9.4.5 |
 | order_cancel_after | 1.9.4.5 |
- | order_status_changed_before_save | 19.5.0 / 20.1.0 |
+| order_status_changed_before_save | 19.5.0 / 20.1.0 |
 | page_block_html_topmenu_gethtml_after | 1.9.4.5 |
 | page_block_html_topmenu_gethtml_before | 1.9.4.5 |
 | payment_form_block_to_html_before | 1.9.4.5 |


### PR DESCRIPTION
…pter_jsonrpc_run_after'

### Description (*)
This allows soap_v2 style:

```php
$client = new Krixon_JsonRpc_Client($url);
//...
$result = $client->call('magento.info', [$sessionId]); // v2 style
$result = $client->call('call', [$sessionId, 'magento.info', []]); // v1 style
```

A new event 'api_server_adapter_jsonrpc_run_after' is added. This is useful to log incoming requests and responses.

In one of my projects, I have custom APIs which I need to provide documentation with. I find v2 style is easier for the clients. In v1 style, the method/procedure is always `call()`, the name of the actual procedure is in the params. In v2 style, it makes more sense because as the name RPC implies, the client call the procedure by name.