### PR TITLE
Adds product image column to product grid

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Product.php
@@ -83,6 +83,8 @@ class Mage_Adminhtml_Block_Catalog_Category_Tab_Product extends Mage_Adminhtml_B
                 'category_id=' . (int) $this->getRequest()->getParam('id', 0),
                 'left'
             );
+        $collection->joinAttribute('image', 'catalog_product/image', 'entity_id', null, 'left');
+
         $this->setCollection($collection);
 
         if ($this->getCategory()->getProductsReadonly()) {
@@ -118,6 +120,14 @@ class Mage_Adminhtml_Block_Catalog_Category_Tab_Product extends Mage_Adminhtml_B
             'width'     => '60',
             'index'     => 'entity_id'
         ]);
+        $this->addColumn(
+            'image',
+            [
+                'header' => Mage::helper('catalog')->__('Image'),
+                'type'  => 'image',
+                'index' => 'image',
+            ]
+        );
         $this->addColumn('name', [
             'header'    => Mage::helper('catalog')->__('Name'),
             'index'     => 'name'

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Product.php
@@ -124,7 +124,7 @@ class Mage_Adminhtml_Block_Catalog_Category_Tab_Product extends Mage_Adminhtml_B
             'image',
             [
                 'header' => Mage::helper('catalog')->__('Image'),
-                'type'  => 'image',
+                'type'  => 'productimage',
                 'index' => 'image',
             ]
         );

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Product.php
@@ -83,6 +83,7 @@ class Mage_Adminhtml_Block_Catalog_Category_Tab_Product extends Mage_Adminhtml_B
                 'category_id=' . (int) $this->getRequest()->getParam('id', 0),
                 'left'
             );
+
         $collection->joinAttribute('image', 'catalog_product/image', 'entity_id', null, 'left');
 
         $this->setCollection($collection);

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
@@ -139,7 +139,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Crosssell extends Mage_Admin
             'image',
             [
                 'header' => Mage::helper('catalog')->__('Image'),
-                'type'  => 'image',
+                'type'  => 'productimage',
                 'index' => 'image',
             ]
         );

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
@@ -95,6 +95,8 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Crosssell extends Mage_Admin
             $collection->addFieldToFilter('entity_id', ['in' => $productIds]);
         }
 
+        $collection->joinAttribute('image', 'catalog_product/image', 'entity_id', null, 'left');
+
         $this->setCollection($collection);
 
         return parent::_prepareCollection();
@@ -132,6 +134,15 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Crosssell extends Mage_Admin
             'width'     => 60,
             'index'     => 'entity_id'
         ]);
+
+        $this->addColumn(
+            'image',
+            [
+                'header' => Mage::helper('catalog')->__('Image'),
+                'type'  => 'image',
+                'index' => 'image',
+            ]
+        );
 
         $this->addColumn('name', [
             'header'    => Mage::helper('catalog')->__('Name'),

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
@@ -97,7 +97,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Related extends Mage_Adminht
         }
 
         $collection->joinAttribute('image', 'catalog_product/image', 'entity_id', null, 'left');
-        
+
         $this->setCollection($collection);
         return parent::_prepareCollection();
     }

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
@@ -141,7 +141,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Related extends Mage_Adminht
             'image',
             [
                 'header' => Mage::helper('catalog')->__('Image'),
-                'type'  => 'image',
+                'type'  => 'productimage',
                 'index' => 'image',
             ]
         );

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
@@ -96,6 +96,8 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Related extends Mage_Adminht
             $collection->addFieldToFilter('entity_id', ['in' => $productIds]);
         }
 
+        $collection->joinAttribute('image', 'catalog_product/image', 'entity_id', null, 'left');
+        
         $this->setCollection($collection);
         return parent::_prepareCollection();
     }
@@ -134,6 +136,15 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Related extends Mage_Adminht
             'width'     => 60,
             'index'     => 'entity_id'
         ]);
+
+        $this->addColumn(
+            'image',
+            [
+                'header' => Mage::helper('catalog')->__('Image'),
+                'type'  => 'image',
+                'index' => 'image',
+            ]
+        );
 
         $this->addColumn('name', [
             'header'    => Mage::helper('catalog')->__('Name'),

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
@@ -106,6 +106,8 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Upsell extends Mage_Adminhtm
             $collection->addFieldToFilter('entity_id', ['in' => $productIds]);
         }
 
+        $collection->joinAttribute('image', 'catalog_product/image', 'entity_id', null, 'left');
+
         $this->setCollection($collection);
         return parent::_prepareCollection();
     }
@@ -134,6 +136,16 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Upsell extends Mage_Adminhtm
             'width'     => 60,
             'index'     => 'entity_id'
         ]);
+        
+        $this->addColumn(
+            'image',
+            [
+                'header' => Mage::helper('catalog')->__('Image'),
+                'type'  => 'image',
+                'index' => 'image',
+            ]
+        );
+
         $this->addColumn('name', [
             'header'    => Mage::helper('catalog')->__('Name'),
             'index'     => 'name'

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
@@ -141,7 +141,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Upsell extends Mage_Adminhtm
             'image',
             [
                 'header' => Mage::helper('catalog')->__('Image'),
-                'type'  => 'image',
+                'type'  => 'productimage',
                 'index' => 'image',
             ]
         );

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
@@ -136,7 +136,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Upsell extends Mage_Adminhtm
             'width'     => 60,
             'index'     => 'entity_id'
         ]);
-        
+
         $this->addColumn(
             'image',
             [

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
@@ -159,7 +159,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
             'image',
             [
                 'header' => Mage::helper('catalog')->__('Image'),
-                'type'  => 'image',
+                'type'  => 'productimage',
                 'index' => 'image',
             ]
         );

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
@@ -61,7 +61,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
                 'left'
             );
         }
-        
+
         $collection->joinAttribute('image', 'catalog_product/image', 'entity_id', null, 'left');
 
         if ($store->getId()) {

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
@@ -46,11 +46,11 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
     {
         $store = $this->_getStore();
         $collection = Mage::getModel('catalog/product')->getCollection()
-            ->addAttributeToSelect('sku')
-            ->addAttributeToSelect('name')
-            ->addAttributeToSelect('attribute_set_id')
-            ->addAttributeToSelect('type_id');
-
+        ->addAttributeToSelect('sku')
+        ->addAttributeToSelect('name')
+        ->addAttributeToSelect('attribute_set_id')
+        ->addAttributeToSelect('type_id');
+        
         if (Mage::helper('catalog')->isModuleEnabled('Mage_CatalogInventory')) {
             $collection->joinField(
                 'qty',
@@ -61,6 +61,9 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
                 'left'
             );
         }
+        
+        $collection->joinAttribute('image', 'catalog_product/image', 'entity_id', null, 'left');
+
         if ($store->getId()) {
             //$collection->setStoreId($store->getId());
             $adminStore = Mage_Core_Model_App::ADMIN_STORE_ID;
@@ -151,6 +154,16 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
                 'index' => 'entity_id',
             ]
         );
+
+        $this->addColumn(
+            'image',
+            [
+                'header' => Mage::helper('catalog')->__('Image'),
+                'type'  => 'image',
+                'index' => 'image',
+            ]
+        );
+
         $this->addColumn(
             'name',
             [

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
@@ -50,7 +50,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
         ->addAttributeToSelect('name')
         ->addAttributeToSelect('attribute_set_id')
         ->addAttributeToSelect('type_id');
-        
+
         if (Mage::helper('catalog')->isModuleEnabled('Mage_CatalogInventory')) {
             $collection->joinField(
                 'qty',

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
@@ -288,6 +288,9 @@ class Mage_Adminhtml_Block_Widget_Grid_Column extends Mage_Adminhtml_Block_Widge
             case 'theme':
                 $rendererClass = 'adminhtml/widget_grid_column_renderer_theme';
                 break;
+            case 'image':
+                $rendererClass = 'adminhtml/widget_grid_column_renderer_image';
+                break;
             default:
                 $rendererClass = 'adminhtml/widget_grid_column_renderer_text';
                 break;

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
@@ -288,8 +288,8 @@ class Mage_Adminhtml_Block_Widget_Grid_Column extends Mage_Adminhtml_Block_Widge
             case 'theme':
                 $rendererClass = 'adminhtml/widget_grid_column_renderer_theme';
                 break;
-            case 'image':
-                $rendererClass = 'adminhtml/widget_grid_column_renderer_image';
+            case 'productimage':
+                $rendererClass = 'adminhtml/widget_grid_column_renderer_productimage';
                 break;
             default:
                 $rendererClass = 'adminhtml/widget_grid_column_renderer_text';

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Image.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * OpenMage
  *
@@ -24,6 +25,12 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Image extends Mage_Adminh
 
     protected $_defaultWidth = 128;
 
+    /**
+     * Renders grid column
+     *
+     * @param   Varien_Object $row
+     * @return  string
+     */
     public function render(Varien_Object $row)
     {
         $image = $this->_checkImageIsSelected($row);
@@ -32,17 +39,22 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Image extends Mage_Adminh
             //return '<img src="' . Mage::getStoreConfig('catalog/placeholder/image_placeholder') . ' " />';
         }
         $imageDimensions = $this->getColumn()->getWidth() ?: $this->_defaultWidth;
-        $imageSrc = $this->_getHelperImage($image)
-        ->resize($imageDimensions, $imageDimensions);
+        $imageSrc = $this->_getHelperImage($image)->resize($imageDimensions, $imageDimensions);
         $imageUrl = $this->_getImageUrl($image);
         $result = '';
         $result .= '<a href="' . $imageUrl . '" title="' . basename($imageUrl) . '" target="_blank">';
-            $result .= '<img src="' . $imageSrc . '" alt="' . basename($imageUrl) . '" title="' . basename($imageUrl) . '" width="' . $imageDimensions . '" height="' . $imageDimensions . '"/>';
+        $result .= '<img src="' . $imageSrc . '" alt="' . basename($imageUrl) . '" title="' . basename($imageUrl) . '" width="' . $imageDimensions . '" height="' . $imageDimensions . '"/>';
         $result .= '</a>';
         return $result;
     }
 
-    public function renderExport(Varien_Object $row) : string
+    /**
+     * Render column for export
+     *
+     * @param Varien_Object $row
+     * @return string
+     */
+    public function renderExport(Varien_Object $row): string
     {
         $image = $this->_checkImageIsSelected($row);
         if (!$image) {
@@ -51,25 +63,41 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Image extends Mage_Adminh
         return $this->_getImageUrl($image);
     }
 
+    /**
+     * @return string|null
+     */
     public function renderCss()
     {
         return parent::renderCss() . ' a-center';
     }
 
-    protected function _getHelperImage($image) : Mage_Catalog_Helper_Image
+    /**
+     * @param string $image
+     * @return Mage_Catalog_Helper_Image
+     */
+    protected function _getHelperImage($image): Mage_Catalog_Helper_Image
     {
         $dummyProduct = Mage::getModel('catalog/product');
         return Mage::helper('catalog/image')->init($dummyProduct, $this->getColumn()->getAttributeCode(), $image);
     }
 
-    protected function _getImageUrl($image) : string {
+    /**
+     * @param string $image
+     * @return string
+     */
+    protected function _getImageUrl($image): string
+    {
         if (!$image) {
             return '';
         }
         return Mage::getBaseUrl('media') . 'catalog/product/' . $image;
     }
 
-    private function _checkImageIsSelected($row) : string|null
+    /**
+     * @param Varien_Object $row
+     * @return string|false
+     */
+    private function _checkImageIsSelected($row): string|false
     {
         $value = $this->_getValue($row);
         if (!$value || $value == 'no_selection') return false;

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Image.php
@@ -53,7 +53,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Image extends Mage_Adminh
 
     public function renderCss()
     {
-        return 'a-center';
+        return parent::renderCss() . ' a-center';
     }
 
     protected function _getHelperImage($image) : Mage_Catalog_Helper_Image

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Image.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   Mage
+ * @package    Mage_Adminhtml
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
+ * @copyright  Copyright (c) 2022-2023 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Adminhtml grid item renderer product image
+ *
+ * @category   Mage
+ * @package    Mage_Adminhtml
+ */
+class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Image extends Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract
+{
+
+    protected $_defaultWidth = 128;
+    
+    protected function _getHelperImage($image)
+    {
+        $dummyProduct = Mage::getModel('catalog/product');
+        return Mage::helper('catalog/image')
+            ->init($dummyProduct, $this->getColumn()->getAttributeCode(), $image);
+    }
+
+    private function _checkImageIsSelected($row)
+    {
+        $value = $this->_getValue($row);
+        if (!$value || $value == 'no_selection') return false;
+        return $value;
+    }
+
+    public function render(Varien_Object $row)
+    {
+        $result = '';
+
+        $imageWidth = intval($this->getColumn()->getImageWidth()) > 0 ?: 128;
+        $imageHeight = intval($this->getColumn()->getImageHeight()) > 0 ?: 128;
+
+        $image = $this->_checkImageIsSelected($row);
+        if ($image) {
+            
+            $imageSrc = $this->_getHelperImage($image)
+                ->resize($imageWidth, $imageHeight);
+            $imageUrl = Mage::getBaseUrl('media') . 'catalog/product/' . $image;
+
+            $result .= '<a href="' . $imageUrl . '" title="' . basename($imageUrl) . '" target="_blank">';
+                $result .= '<img src="' . $imageSrc . '" alt="' . basename($imageUrl) . '" title="' . basename($imageUrl) . '" width="' . $imageWidth . '" height="' . $imageHeight . '"/>';
+            $result .= '</a>';
+
+        }/*  else {
+            return '<img src="' . Mage::getStoreConfig('catalog/placeholder/image_placeholder') . ' " width="' . $imageWidth . '" height="' . $imageHeight . '" />';
+        } */
+
+        return $result;
+    }
+
+    public function renderExport(Varien_Object $row)
+    {
+        $image = $this->_checkImageIsSelected($row);
+        if ($image) {
+            return Mage::getBaseUrl('media') . 'catalog/product/' . $image;
+        } else {
+            return '';
+        }
+    }
+
+    public function renderCss()
+    {
+        return 'a-center';
+    }
+}

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Image.php
@@ -26,10 +26,9 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Image extends Mage_Adminh
 
     public function render(Varien_Object $row)
     {
-        $result = '';
-
         $image = $this->_checkImageIsSelected($row);
         if ($image) {
+            $result = '';
             $imageDimensions = $this->getColumn()->getWidth() ?: $this->_defaultWidth;
             
             $imageSrc = $this->_getHelperImage($image)
@@ -39,7 +38,6 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Image extends Mage_Adminh
             $result .= '<a href="' . $imageUrl . '" title="' . basename($imageUrl) . '" target="_blank">';
                 $result .= '<img src="' . $imageSrc . '" alt="' . basename($imageUrl) . '" title="' . basename($imageUrl) . '" width="' . $imageWidth . '" height="' . $imageHeight . '"/>';
             $result .= '</a>';
-
         }/*  else {
             return '<img src="' . Mage::getStoreConfig('catalog/placeholder/image_placeholder') . ' " width="' . $imageWidth . '" height="' . $imageHeight . '" />';
         } */

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Image.php
@@ -23,33 +23,17 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Image extends Mage_Adminh
 {
 
     protected $_defaultWidth = 128;
-    
-    protected function _getHelperImage($image)
-    {
-        $dummyProduct = Mage::getModel('catalog/product');
-        return Mage::helper('catalog/image')
-            ->init($dummyProduct, $this->getColumn()->getAttributeCode(), $image);
-    }
-
-    private function _checkImageIsSelected($row)
-    {
-        $value = $this->_getValue($row);
-        if (!$value || $value == 'no_selection') return false;
-        return $value;
-    }
 
     public function render(Varien_Object $row)
     {
         $result = '';
 
-        $imageWidth = intval($this->getColumn()->getImageWidth()) > 0 ?: 128;
-        $imageHeight = intval($this->getColumn()->getImageHeight()) > 0 ?: 128;
-
         $image = $this->_checkImageIsSelected($row);
         if ($image) {
+            $imageDimensions = $this->getColumn()->getWidth() ?: $this->_defaultWidth;
             
             $imageSrc = $this->_getHelperImage($image)
-                ->resize($imageWidth, $imageHeight);
+                ->resize($imageDimensions, $imageDimensions);
             $imageUrl = Mage::getBaseUrl('media') . 'catalog/product/' . $image;
 
             $result .= '<a href="' . $imageUrl . '" title="' . basename($imageUrl) . '" target="_blank">';
@@ -76,5 +60,19 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Image extends Mage_Adminh
     public function renderCss()
     {
         return 'a-center';
+    }
+
+    protected function _getHelperImage($image)
+    {
+        $dummyProduct = Mage::getModel('catalog/product');
+        return Mage::helper('catalog/image')
+        ->init($dummyProduct, $this->getColumn()->getAttributeCode(), $image);
+    }
+
+    private function _checkImageIsSelected($row)
+    {
+        $value = $this->_getValue($row);
+        if (!$value || $value == 'no_selection') return false;
+        return $value;
     }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Image.php
@@ -27,32 +27,28 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Image extends Mage_Adminh
     public function render(Varien_Object $row)
     {
         $image = $this->_checkImageIsSelected($row);
-        if ($image) {
-            $result = '';
-            $imageDimensions = $this->getColumn()->getWidth() ?: $this->_defaultWidth;
-            
-            $imageSrc = $this->_getHelperImage($image)
-                ->resize($imageDimensions, $imageDimensions);
-            $imageUrl = Mage::getBaseUrl('media') . 'catalog/product/' . $image;
-
-            $result .= '<a href="' . $imageUrl . '" title="' . basename($imageUrl) . '" target="_blank">';
-                $result .= '<img src="' . $imageSrc . '" alt="' . basename($imageUrl) . '" title="' . basename($imageUrl) . '" width="' . $imageWidth . '" height="' . $imageHeight . '"/>';
-            $result .= '</a>';
-        }/*  else {
-            return '<img src="' . Mage::getStoreConfig('catalog/placeholder/image_placeholder') . ' " width="' . $imageWidth . '" height="' . $imageHeight . '" />';
-        } */
-
+        if (!$image) {
+            return '';
+            //return '<img src="' . Mage::getStoreConfig('catalog/placeholder/image_placeholder') . ' " />';
+        }
+        $imageDimensions = $this->getColumn()->getWidth() ?: $this->_defaultWidth;
+        $imageSrc = $this->_getHelperImage($image)
+        ->resize($imageDimensions, $imageDimensions);
+        $imageUrl = $this->_getImageUrl($image);
+        $result = '';
+        $result .= '<a href="' . $imageUrl . '" title="' . basename($imageUrl) . '" target="_blank">';
+            $result .= '<img src="' . $imageSrc . '" alt="' . basename($imageUrl) . '" title="' . basename($imageUrl) . '" width="' . $imageDimensions . '" height="' . $imageDimensions . '"/>';
+        $result .= '</a>';
         return $result;
     }
 
-    public function renderExport(Varien_Object $row)
+    public function renderExport(Varien_Object $row) : string
     {
         $image = $this->_checkImageIsSelected($row);
-        if ($image) {
-            return Mage::getBaseUrl('media') . 'catalog/product/' . $image;
-        } else {
+        if (!$image) {
             return '';
         }
+        return $this->_getImageUrl($image);
     }
 
     public function renderCss()
@@ -60,14 +56,20 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Image extends Mage_Adminh
         return 'a-center';
     }
 
-    protected function _getHelperImage($image)
+    protected function _getHelperImage($image) : Mage_Catalog_Helper_Image
     {
         $dummyProduct = Mage::getModel('catalog/product');
-        return Mage::helper('catalog/image')
-        ->init($dummyProduct, $this->getColumn()->getAttributeCode(), $image);
+        return Mage::helper('catalog/image')->init($dummyProduct, $this->getColumn()->getAttributeCode(), $image);
     }
 
-    private function _checkImageIsSelected($row)
+    protected function _getImageUrl($image) : string {
+        if (!$image) {
+            return '';
+        }
+        return Mage::getBaseUrl('media') . 'catalog/product/' . $image;
+    }
+
+    private function _checkImageIsSelected($row) : string|null
     {
         $value = $this->_getValue($row);
         if (!$value || $value == 'no_selection') return false;

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Productimage.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Productimage.php
@@ -23,7 +23,7 @@
 class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Productimage extends Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract
 {
 
-    protected $_defaultWidth = 128;
+    protected $_defaultWidth = 64;
 
     /**
      * Renders grid column

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Productimage.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Productimage.php
@@ -20,7 +20,7 @@
  * @category   Mage
  * @package    Mage_Adminhtml
  */
-class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Image extends Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract
+class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Productimage extends Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract
 {
 
     protected $_defaultWidth = 128;

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Productimage.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Productimage.php
@@ -22,7 +22,6 @@
  */
 class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Productimage extends Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract
 {
-
     protected $_defaultWidth = 64;
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Productimage.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Productimage.php
@@ -97,7 +97,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Productimage extends Mage
      * @param Varien_Object $row
      * @return string|false
      */
-    private function _checkImageIsSelected($row): string|false
+    private function _checkImageIsSelected($row)
     {
         $value = $this->_getValue($row);
         if (!$value || $value == 'no_selection') return false;

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Productimage.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Productimage.php
@@ -100,7 +100,9 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Productimage extends Mage
     private function _checkImageIsSelected($row)
     {
         $value = $this->_getValue($row);
-        if (!$value || $value == 'no_selection') return false;
+        if (!$value || $value == 'no_selection') {
+            return false;
+        }
         return $value;
     }
 }


### PR DESCRIPTION
It adds a column with the product preview image, which I believe is the most important aspect in this area:
- catalog product list
- catalog category products tab
- catalog product view in tabs upsell, related and crossell

I have added a new column renderer for product images. The images are resized to 64px by default to reduce file size, and they are generated in media/catalog/product/cache/0/64x64/ directory. 
Image previews are linked to the original url.

I think this is an important feature to add to OpenMage.

This is an initial step towards implementing advanced backend grids. The idea is to develop customizable grids where users can choose which columns to display as they prefer that display current columns by default and all additionaly is disabled to reduce possibile backward compatibility.

![catalog_product](https://github.com/OpenMage/magento-lts/assets/5071467/bcb5085b-c48d-43a9-9463-7091d5aa5ee0)
![catalog_category](https://github.com/OpenMage/magento-lts/assets/5071467/244cde02-0c1e-496f-abeb-fb14d3d85434)
![catalog_product_tabs](https://github.com/OpenMage/magento-lts/assets/5071467/9f4a22e0-29e9-4f6d-8e5a-f8f012438b23)

