### PR TITLE
Add 'redis' option for Cm_RedisSession to make rewrite unnecessary.

### DIFF
--- a/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
@@ -67,6 +67,14 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
                 $sessionResource = Mage::getResourceSingleton('core/session');
                 $sessionResource->setSaveHandler();
                 break;
+            case 'redis':
+                /* @var Cm_RedisSession_Model_Session $sessionResource */
+                $sessionResource = Mage::getSingleton('cm_redissession/session');
+                $sessionResource->setSaveHandler();
+                if (method_exists($sessionResource, 'setDieOnError')) {
+                    $sessionResource->setDieOnError(false);
+                }
+                break;
             case 'user':
                 // getSessionSavePath represents static function for custom session handler setup
                 call_user_func($this->getSessionSavePath());


### PR DESCRIPTION
This adds the 'redis' switch case so that the redis adapter can have it's own option rather than requiring 'db' to be rewritten. This is already present in v20 as of #1513.

Fixes #3464 