### PR TITLE
Fix deprecated functionality str_contains() in Design/Package.php

### DIFF
--- a/app/code/core/Mage/Core/Block/Template.php
+++ b/app/code/core/Mage/Core/Block/Template.php
@@ -86,7 +86,7 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
     /**
      * Get relevant path to template
      *
-     * @return string
+     * @return string|null
      */
     public function getTemplate()
     {
@@ -117,7 +117,7 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
         if ($area) {
             $params['_area'] = $area;
         }
-        return Mage::getDesign()->getTemplateFilename($this->getTemplate(), $params);
+        return Mage::getDesign()->getTemplateFilename((string)$this->getTemplate(), $params);
     }
 
     /**


### PR DESCRIPTION
### Description (*)
This small PR fixes a deprecation warning if e.g. `getCacheKey()` is called on a `Mage_Core_Block_Template` block instance without a template assigned (which may happen because the `template` attribute in that class is of type `string|null`):
```
Deprecated functionality: str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated  in /var/www/htdocs/app/code/core/Mage/Core/Model/Design/Package.php on line 459

#0 [internal function]: mageCoreErrorHandler(8192, 'str_contains():...', '/var/www/htdocs...', 459)
#1 /var/www/htdocs/app/code/core/Mage/Core/Model/Design/Package.php(459): str_contains(NULL, '..')
#2 /var/www/htdocs/app/code/core/Mage/Core/Model/Design/Package.php(497): Mage_Core_Model_Design_Package->getFilename(NULL, Array)
#3 /var/www/htdocs/app/code/core/Mage/Core/Block/Template.php(120): Mage_Core_Model_Design_Package->getTemplateFilename(NULL, Array)
#4 /var/www/htdocs/app/code/core/Mage/Core/Block/Template.php(352): Mage_Core_Block_Template->getTemplateFile()
#5 /var/www/htdocs/app/code/core/Mage/Core/Block/Abstract.php(1341): Mage_Core_Block_Template->getCacheKeyInfo()
```

In addition it corrects the return type for `getTemplate()`.

### Manual testing scenarios (*)
1. Output the cache key of a new block instance somewhere: 
`<?= $this->getLayout()->createBlock('core/template', 'test')->getCacheKey() ?>`

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
