### PR TITLE
Fixed ZF1F version in composer.json to avoid conflicts with our patches

### DIFF
--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -26,4 +26,4 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Validate composer
-        run: composer validate --strict
+        run: composer validate --strict --no-check-all

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "pelago/emogrifier": "^7.0",
         "phpseclib/mcrypt_compat": "^2.0.3",
         "phpseclib/phpseclib": "^3.0.14",
-        "shardj/zf1-future": "^1.22",
+        "shardj/zf1-future": "1.23.5",
         "symfony/polyfill-php74": "^1.27",
         "symfony/polyfill-php80": "^1.27",
         "symfony/polyfill-php81": "^1.27"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "902e142809dc8d50b1e628dad67320a2",
+    "content-hash": "d2c7d1ef752587a200077be1ef2a74de",
     "packages": [
         {
             "name": "colinmollenhour/cache-backend-redis",


### PR DESCRIPTION
when implementing our composer patches for ZF1F we didn't consider that our 20.1.0 tagged release can't now run a `composer install` because ZF1F is now been updated and the patches can't be applied anymore.

Explanation at https://github.com/OpenMage/magento-lts/issues/3474

Thus we have to specify the exact version number of ZF1F in the composer.json.

Fixes https://github.com/OpenMage/magento-lts/issues/3474