### PR TITLE
Added composer patch to get.php, ref. #3453

### DIFF
--- a/get.php
+++ b/get.php
@@ -28,7 +28,7 @@ require $bp . '/app/bootstrap.php';
 /**
  * Set include path
  */
-
+$paths = [];
 $paths[] = $bp . $ds . 'app' . $ds . 'code' . $ds . 'local';
 $paths[] = $bp . $ds . 'app' . $ds . 'code' . $ds . 'community';
 $paths[] = $bp . $ds . 'app' . $ds . 'code' . $ds . 'core';
@@ -36,11 +36,21 @@ $paths[] = $bp . $ds . 'lib';
 
 $appPath = implode($ps, $paths);
 set_include_path($appPath . $ps . get_include_path());
-
 include_once 'Mage/Core/functions.php';
 include_once 'Varien/Autoload.php';
 
 Varien_Autoload::register();
+
+/** AUTOLOADER PATCH **/
+$autoloaderPath = getenv('COMPOSER_VENDOR_PATH');
+if (!$autoloaderPath) {
+    $autoloaderPath = dirname($bp) . $ds .  'vendor';
+    if (!is_dir($autoloaderPath)) {
+        $autoloaderPath = $bp . $ds . 'vendor';
+    }
+}
+require $autoloaderPath . $ds . 'autoload.php';
+/** AUTOLOADER PATCH **/
 
 $varDirectory = $bp . $ds . Mage_Core_Model_Config_Options::VAR_DIRECTORY;
 


### PR DESCRIPTION
If you've a webserver supporting rewrites (apache), and you try to access a /media/nonexisting.jpg file you don't get a 404, but you get an error 500.
The rewrite goes to /get.php, which was not patched for composer autoload, which fails to load some classes.

More explanations at https://github.com/OpenMage/magento-lts/issues/3453

Fixes https://github.com/OpenMage/magento-lts/issues/3453