### PR TITLE
Fixed unnecessary entries in table `api-session` when using insta-login in API calls

### DIFF
--- a/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
@@ -116,16 +116,6 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
     }
 
     /**
-     *  Check session expiration
-     *
-     *  @return  bool
-     */
-    protected function _isSessionExpired()
-    {
-        return $this->_getSession()->isSessionExpired();
-    }
-
-    /**
      * Dispatch webservice fault
      *
      * @param string $faultName

--- a/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
@@ -88,6 +88,21 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
     }
 
     /**
+     * Allow insta-login via HTTP Basic Auth
+     *
+     * @param string $sessionId
+     * @return $this
+     */
+    protected function _instaLogin(&$sessionId)
+    {
+        if ($sessionId === NULL && !empty($_SERVER['PHP_AUTH_USER']) && !empty($_SERVER['PHP_AUTH_PW'])) {
+            $this->_getSession()->setIsInstaLogin();
+            $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+        }
+        return $this;
+    }
+
+    /**
      * Check current user permission on resource and privilege
      *
      *
@@ -225,11 +240,8 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
      */
     public function call($sessionId, $apiPath, $args = [])
     {
-        // Allow insta-login via HTTP Basic Auth
-        if ($sessionId === null && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
-            $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
-        }
-        $this->_startSession($sessionId);
+        $this->_instaLogin($sessionId)
+            ->_startSession($sessionId);
 
         if (!$this->_getSession()->isLoggedIn($sessionId)) {
             return $this->_fault('session_expired');
@@ -313,11 +325,8 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
      */
     public function multiCall($sessionId, array $calls = [], $options = [])
     {
-        // Allow insta-login via HTTP Basic Auth
-        if ($sessionId === null && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
-            $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
-        }
-        $this->_startSession($sessionId);
+        $this->_instaLogin($sessionId)
+            ->_startSession($sessionId);
 
         if (!$this->_getSession()->isLoggedIn($sessionId)) {
             return $this->_fault('session_expired');
@@ -445,11 +454,8 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
      */
     public function resources($sessionId)
     {
-        // Allow insta-login via HTTP Basic Auth
-        if ($sessionId === null && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
-            $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
-        }
-        $this->_startSession($sessionId);
+        $this->_instaLogin($sessionId)
+            ->_startSession($sessionId);
 
         if (!$this->_getSession()->isLoggedIn($sessionId)) {
             return $this->_fault('session_expired');
@@ -513,11 +519,8 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
      */
     public function resourceFaults($sessionId, $resourceName)
     {
-        // Allow insta-login via HTTP Basic Auth
-        if ($sessionId === null && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
-            $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
-        }
-        $this->_startSession($sessionId);
+        $this->_instaLogin($sessionId)
+            ->_startSession($sessionId);
 
         if (!$this->_getSession()->isLoggedIn($sessionId)) {
             return $this->_fault('session_expired');
@@ -553,10 +556,8 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
      */
     public function globalFaults($sessionId)
     {
-        // Allow insta-login via HTTP Basic Auth
-        if ($sessionId === null && ! empty($_SERVER['PHP_AUTH_USER']) && ! empty($_SERVER['PHP_AUTH_PW'])) {
-            $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
-        }
+        $this->_instaLogin($sessionId)
+            ->_startSession($sessionId);
         $this->_startSession($sessionId);
         return array_values($this->_getConfig()->getFaults());
     }

--- a/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
@@ -95,7 +95,7 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
      */
     protected function _instaLogin(&$sessionId)
     {
-        if ($sessionId === NULL && !empty($_SERVER['PHP_AUTH_USER']) && !empty($_SERVER['PHP_AUTH_PW'])) {
+        if ($sessionId === null && !empty($_SERVER['PHP_AUTH_USER']) && !empty($_SERVER['PHP_AUTH_PW'])) {
             $this->_getSession()->setIsInstaLogin();
             $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
         }

--- a/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
@@ -548,7 +548,6 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
     {
         $this->_instaLogin($sessionId)
             ->_startSession($sessionId);
-        $this->_startSession($sessionId);
         return array_values($this->_getConfig()->getFaults());
     }
 

--- a/app/code/core/Mage/Api/Model/Session.php
+++ b/app/code/core/Mage/Api/Model/Session.php
@@ -113,7 +113,7 @@ class Mage_Api_Model_Session extends Mage_Core_Model_Session_Abstract
      *
      * @return bool
      */
-    public function getIsInstaLogin()
+    public function getIsInstaLogin(): bool
     {
         return (bool) $this->getData('is_insta_login');
     }

--- a/app/code/core/Mage/Api/Model/Session.php
+++ b/app/code/core/Mage/Api/Model/Session.php
@@ -97,6 +97,28 @@ class Mage_Api_Model_Session extends Mage_Core_Model_Session_Abstract
     }
 
     /**
+     * Flag login as HTTP Basic Auth.
+     *
+     * @param bool $isInstaLogin
+     * @return $this
+     */
+    public function setIsInstaLogin(bool $isInstaLogin = true)
+    {
+        $this->setData('is_insta_login', $isInstaLogin);
+        return $this;
+    }
+
+    /**
+     * Is insta-login?
+     *
+     * @return bool
+     */
+    public function getIsInstaLogin()
+    {
+        return (bool) $this->getData('is_insta_login');
+    }
+
+    /**
      * @param string $username
      * @param string $apiKey
      * @return mixed
@@ -105,8 +127,15 @@ class Mage_Api_Model_Session extends Mage_Core_Model_Session_Abstract
     public function login($username, $apiKey)
     {
         $user = Mage::getModel('api/user')
-            ->setSessid($this->getSessionId())
-            ->login($username, $apiKey);
+            ->setSessid($this->getSessionId());
+        if ($this->getIsInstaLogin() && $user->authenticate($username, $apiKey)) {
+            Mage::dispatchEvent('api_user_authenticated', [
+                'model'    => $user,
+                'api_key'  => $apiKey,
+            ]);
+        } else {
+            $user->login($username, $apiKey);
+        }
 
         if ($user->getId() && $user->getIsActive() != '1') {
             Mage::throwException(Mage::helper('api')->__('Your account has been deactivated.'));

--- a/phpstan.dist.baseline.neon
+++ b/phpstan.dist.baseline.neon
@@ -766,11 +766,6 @@ parameters:
 			path: app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
 
 		-
-			message: "#^Method Mage_Api_Model_Session\\:\\:isSessionExpired\\(\\) invoked with 0 parameters, 1 required\\.$#"
-			count: 1
-			path: app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
-
-		-
 			message: "#^Result of method SoapServer\\:\\:handle\\(\\) \\(void\\) is used\\.$#"
 			count: 1
 			path: app/code/core/Mage/Api/Model/Server/V2/Adapter/Soap.php


### PR DESCRIPTION
…in in API calls.


### Description (*)
The API session has default expiry of 3600 secs from the time of the last API call. This expiry is managed in the table `api_asession`.  With the introduction of insta-login in PR #3443, the session expiry become irrelevant. This PR bypassed adding entries to the various api tables. In my test, this saves 10 to 20 mini-seconds to insta-login.

### Related Pull Requests
PR #3443 

### Fixed Issues (if relevant)
Partially fixed issue #3449.

### Manual testing scenarios (*)
1. No new entries are added in the table `api_asession` with insta-login.
2. Normal entries are added in the table `api_asession` with "normal" login.


