### PR TITLE
Fixed deprecated functionality strtr() in widget controller

### DIFF
--- a/app/code/core/Mage/Widget/controllers/Adminhtml/WidgetController.php
+++ b/app/code/core/Mage/Widget/controllers/Adminhtml/WidgetController.php
@@ -33,7 +33,7 @@ class Mage_Widget_Adminhtml_WidgetController extends Mage_Adminhtml_Controller_A
     public function indexAction()
     {
         // save extra params for widgets insertion form
-        $skipped = $this->getRequest()->getParam('skip_widgets');
+        $skipped = (string)$this->getRequest()->getParam('skip_widgets');
         $skipped = Mage::getSingleton('widget/widget_config')->decodeWidgetsFromQuery($skipped);
 
         Mage::register('skip_widgets', $skipped);


### PR DESCRIPTION
### Description (*)
This small PR fixes a deprecation warning when adding a new widget in admin cms page:

```
Deprecated functionality: strtr(): Passing null to parameter #1 ($string) of type string is deprecated  in /var/www/htdocs/app/code/core/Mage/Core/Helper/Abstract.php on line 408

#0 [internal function]: mageCoreErrorHandler(8192, 'strtr(): Passin...', '/var/www/htdocs...', 408)
#1 /var/www/htdocs/app/code/core/Mage/Core/Helper/Abstract.php(408): strtr(NULL, '-_,', '+/=')
#2 /var/www/htdocs/app/code/core/Mage/Widget/Model/Widget/Config.php(132): Mage_Core_Helper_Abstract->urlDecode(NULL)
#3 /var/www/htdocs/app/code/core/Mage/Widget/controllers/Adminhtml/WidgetController.php(37): Mage_Widget_Model_Widget_Config->decodeWidgetsFromQuery(NULL)
#4 /var/www/htdocs/app/code/core/Mage/Core/Controller/Varien/Action.php(421): Mage_Widget_Adminhtml_WidgetController->indexAction()
#5 /var/www/htdocs/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(255): Mage_Core_Controller_Varien_Action->dispatch('index')
#6 /var/www/htdocs/app/code/core/Mage/Core/Controller/Varien/Front.php(181): Mage_Core_Controller_Varien_Router_Standard->match(Object(Mage_Core_Controller_Request_Http))
#7 /var/www/htdocs/app/code/core/Mage/Core/Model/App.php(358): Mage_Core_Controller_Varien_Front->dispatch()
#8 /var/www/htdocs/app/Mage.php(743): Mage_Core_Model_App->run(Array)
#9 /var/www/src/zzz/master/src/index.php(60): Mage::run('', 'store')
#10 {main}
```

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. `error_reporting=E_ALL`
2. Edit a CMS page in Magento admin
3. Click button "Insert Widget"
4. The error is shown

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
