### PR TITLE
Fixed out-of-range column `lognum` in the table `api_user`

### DIFF
--- a/app/code/core/Mage/Api/etc/config.xml
+++ b/app/code/core/Mage/Api/etc/config.xml
@@ -17,7 +17,7 @@
 <config>
     <modules>
         <Mage_Api>
-            <version>1.6.0.2</version>
+            <version>1.6.0.3</version>
         </Mage_Api>
     </modules>
     <global>

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.2-1.6.0.3.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   Mage
+ * @package    Mage_Api
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
+ * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Core_Model_Resource_Setup $this */
+$this->startSetup();
+
+$this->getConnection()->changeColumn(
+    $this->getTable('api/user'),
+    'lognum',
+    'lognum',
+    [
+        'type' => Varien_Db_Ddl_Table::TYPE_INTEGER,
+        'unsigned' => true,
+        'nullable' => false,
+        'default' => '0',
+        'comment' => 'Quantity of log ins'
+    ]
+);
+
+$this->endSetup();

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.2-1.6.0.3.php
@@ -8,8 +8,7 @@
  *
  * @category   Mage
  * @package    Mage_Api
- * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
- * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @copyright  Copyright (c) 2023 The OpenMage Contributors (https://www.openmage.org)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 


### PR DESCRIPTION
### Description (*)
The column `lognum` was type `smallint`, which has a limit of 65,535.
https://github.com/OpenMage/magento-lts/blob/2a2a2fb504247e8966f8ffc2e17d614be5d43128/app/code/core/Mage/Api/sql/api_setup/install-1.6.0.0.php#L160-L160

Production:
![image](https://github.com/OpenMage/magento-lts/assets/1106470/67aaea51-d2a4-40c1-989d-e6b1a4b5129e)

### Questions or comments
I'm not sure what's the use of lognum, especially when it hits the limit, it's useless. Nonetheless,  it needs fixing.