### PR TITLE
Forced ZF1F 1.22.0 in v19

### DIFF
--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -26,4 +26,4 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Validate composer
-        run: composer validate --strict
+        run: composer validate --strict --no-check-all

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "pelago/emogrifier": "^7.0",
         "phpseclib/mcrypt_compat": "^2.0.3",
         "phpseclib/phpseclib": "^3.0.14",
-        "shardj/zf1-future": "^1.22",
+        "shardj/zf1-future": "1.22.0",
         "symfony/polyfill-php74": "^1.27",
         "symfony/polyfill-php80": "^1.27",
         "symfony/polyfill-php81": "^1.27"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "950d608bb8de1372dfcd6912b1208567",
+    "content-hash": "ef430b33b2eb14549244f5f151ea5c07",
     "packages": [
         {
             "name": "colinmollenhour/cache-backend-redis",
@@ -282,6 +282,7 @@
                 "issues": "https://github.com/eloquent/enumeration/issues",
                 "source": "https://github.com/eloquent/enumeration/tree/master"
             },
+            "abandoned": true,
             "time": "2015-11-03T22:21:38+00:00"
         },
         {
@@ -2795,7 +2796,7 @@
         },
         {
             "name": "magento-ecg/coding-standard",
-            "version": "4.5.2",
+            "version": "v4.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/magento-ecg/coding-standard.git",
@@ -2826,7 +2827,7 @@
             "homepage": "https://github.com/magento-ecg/coding-standard",
             "support": {
                 "issues": "https://github.com/magento-ecg/coding-standard/issues",
-                "source": "https://github.com/magento-ecg/coding-standard/tree/4.5.2"
+                "source": "https://github.com/magento-ecg/coding-standard/tree/v4.5.2"
             },
             "time": "2022-12-06T11:33:03+00:00"
         },


### PR DESCRIPTION
Kinda backported https://github.com/OpenMage/magento-lts/pull/3475 to v19, in order to fix composer installations for the next version.

Since v19 is frozen I didn't upgrade zf1f to 1.23 but I've kept the same version it was already in the branch.