### PR TITLE
Fix a Type Error when converting an Order with no Coupon to a Quote

### DIFF
--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -2096,10 +2096,10 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
     }
 
     /**
-     * @param string $couponCode
+     * @param string|null $couponCode
      * @return $this
      */
-    public function setCouponCode(string $couponCode)
+    public function setCouponCode(?string $couponCode)
     {
         return $this->setData('coupon_code', $couponCode);
     }


### PR DESCRIPTION
### Description (*)

A small for a Type Error that occurs when converting an Order to a Quote, the `coupon_code` setter should accept `null` since the database field is nullable.

### Related Pull Requests

- See OpenMage/magento-lts#2825

### Fixed Issues (if relevant)

1. Fixes OpenMage/magento-lts#3472

### Manual testing scenarios (*)

```php
$orderId = XXXXX;
$order = Mage::getModel('sales/order')->load($orderId);
$quote = Mage::getSingleton('sales/convert_order')->toQuote($order);
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->