### PR TITLE
Fixed incompatible interface deprecations in DB Session Adapter

### DIFF
--- a/app/code/core/Mage/Core/Model/Resource/Session.php
+++ b/app/code/core/Mage/Core/Model/Resource/Session.php
@@ -162,6 +162,7 @@ class Mage_Core_Model_Resource_Session implements Zend_Session_SaveHandler_Inter
      * @param string $sessName ignored
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function open($savePath, $sessName)
     {
         return true;
@@ -172,6 +173,7 @@ class Mage_Core_Model_Resource_Session implements Zend_Session_SaveHandler_Inter
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function close()
     {
         $this->gc($this->getLifeTime());
@@ -185,6 +187,7 @@ class Mage_Core_Model_Resource_Session implements Zend_Session_SaveHandler_Inter
      * @param string $sessId
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function read($sessId)
     {
         $select = $this->_read->select()
@@ -208,6 +211,7 @@ class Mage_Core_Model_Resource_Session implements Zend_Session_SaveHandler_Inter
      * @param string $sessData
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function write($sessId, $sessData)
     {
         $bindValues = [
@@ -241,6 +245,7 @@ class Mage_Core_Model_Resource_Session implements Zend_Session_SaveHandler_Inter
      * @param string $sessId
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function destroy($sessId)
     {
         $where = ['session_id = ?' => $sessId];
@@ -254,6 +259,7 @@ class Mage_Core_Model_Resource_Session implements Zend_Session_SaveHandler_Inter
      * @param int $sessMaxLifeTime ignored
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function gc($sessMaxLifeTime)
     {
         if ($this->_automaticCleaningFactor > 0) {

--- a/app/code/core/Mage/Core/Model/Resource/Session.php
+++ b/app/code/core/Mage/Core/Model/Resource/Session.php
@@ -19,7 +19,7 @@
  * @category   Mage
  * @package    Mage_Core
  */
-class Mage_Core_Model_Resource_Session implements Zend_Session_SaveHandler_Interface
+class Mage_Core_Model_Resource_Session implements SessionHandlerInterface
 {
     /**
      * Session maximum cookie lifetime


### PR DESCRIPTION

### Description (*)

Small fix to make the methods in DB session adapter compatible with `SessionHandlerInterface`.

### Fixed Issues (if relevant)

1. Fixes OpenMage/magento-lts#3496

### Manual testing scenarios (*)

1. Switch `<session_save>` in `local.xml` to `db`.
2. Clean the cache and check `system.log`.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->