### PR TITLE
Fix PHPStan on next branch

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,7 +17,20 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
-          tools: phpstan
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --ignore-platform-req=ext-*
 
       - name: PHPStan Static Analysis
-        run: phpstan analyze
+        run: XDEBUG_MODE=off php vendor/bin/phpstan.phar analyze

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,19 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v3
+      - name: Setup PHP 8.2
+        uses: shivammathur/setup-php@v2
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --ignore-platform-req=ext-*
+          php-version: '8.2'
+          tools: phpstan
 
       - name: PHPStan Static Analysis
-        run: XDEBUG_MODE=off php vendor/bin/phpstan.phar analyze
+        run: phpstan analyze

--- a/phpstan.dist.baseline.neon
+++ b/phpstan.dist.baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Return type mixed of method Mage_Core_Model_Resource_Session\\:\\:\\w+\\(\\) is not covariant with tentative return type \\w+ of method SessionHandlerInterface\\:\\:\\w+\\(\\)\\.$#"
+			message: "#^Return type mixed of method Mage_Core_Model_Resource_Session::\\w+\\(\\) is not covariant with tentative return type [\\w\\|]+ of method SessionHandlerInterface::\\w+\\(\\)\\.$#"
 			count: 6
 			path: app/code/core/Mage/Core/Model/Resource/Session.php
 

--- a/phpstan.dist.baseline.neon
+++ b/phpstan.dist.baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Return type mixed of method Mage_Core_Model_Resource_Session\\:\\:\\w+\\(\\) is not covariant with tentative return type \\w+ of method SessionHandlerInterface\\:\\:\\w+\\(\\)\\.$#"
+			count: 6
+			path: app/code/core/Mage/Core/Model/Resource/Session.php
+
+		-
 			message: "#^Call to an undefined method Mage_Core_Model_Abstract\\:\\:addError\\(\\)\\.$#"
 			count: 1
 			path: app/Mage.php

--- a/phpstan.dist.baseline.neon
+++ b/phpstan.dist.baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Return type mixed of method Mage_Core_Model_Resource_Session::\\w+\\(\\) is not covariant with tentative return type [\\w\\|]+ of method SessionHandlerInterface::\\w+\\(\\)\\.$#"
+			message: "#^Return type mixed of method Mage_Core_Model_Resource_Session\\:\\:\\w+\\(\\) is not covariant with tentative return type [\\w\\|]+ of method SessionHandlerInterface\\:\\:\\w+\\(\\)\\.$#"
 			count: 6
 			path: app/code/core/Mage/Core/Model/Resource/Session.php
 


### PR DESCRIPTION
Attempt to fix this:
![image](https://github.com/OpenMage/magento-lts/assets/38738/14137122-256c-4f70-8779-b15be2af7519)

Cannot use union static return types since we still support PHP 7.4 so this just has to be disabled..