### PR TITLE
Fixed implementation of SessionHandlerInterface in Mage_Core_Model_Resource_Session

### DIFF
--- a/app/code/core/Mage/Core/Model/Resource/Session.php
+++ b/app/code/core/Mage/Core/Model/Resource/Session.php
@@ -264,6 +264,6 @@ class Mage_Core_Model_Resource_Session implements SessionHandlerInterface
                 return $this->_write->delete($this->_sessionTable, $where);
             }
         }
-        return false;
+        return 0;
     }
 }

--- a/app/code/core/Mage/Core/Model/Resource/Session.php
+++ b/app/code/core/Mage/Core/Model/Resource/Session.php
@@ -19,7 +19,7 @@
  * @category   Mage
  * @package    Mage_Core
  */
-class Mage_Core_Model_Resource_Session implements Zend_Session_SaveHandler_Interface
+class Mage_Core_Model_Resource_Session implements SessionHandlerInterface
 {
     /**
      * Session maximum cookie lifetime
@@ -162,7 +162,7 @@ class Mage_Core_Model_Resource_Session implements Zend_Session_SaveHandler_Inter
      * @param string $sessName ignored
      * @return bool
      */
-    public function open($savePath, $sessName)
+    public function open($savePath, $sessName): bool
     {
         return true;
     }
@@ -172,7 +172,7 @@ class Mage_Core_Model_Resource_Session implements Zend_Session_SaveHandler_Inter
      *
      * @return bool
      */
-    public function close()
+    public function close(): bool
     {
         $this->gc($this->getLifeTime());
 
@@ -183,9 +183,9 @@ class Mage_Core_Model_Resource_Session implements Zend_Session_SaveHandler_Inter
      * Fetch session data
      *
      * @param string $sessId
-     * @return string
+     * @return string|false
      */
-    public function read($sessId)
+    public function read($sessId): string|false
     {
         $select = $this->_read->select()
                 ->from($this->_sessionTable, ['session_data'])
@@ -208,7 +208,7 @@ class Mage_Core_Model_Resource_Session implements Zend_Session_SaveHandler_Inter
      * @param string $sessData
      * @return bool
      */
-    public function write($sessId, $sessData)
+    public function write($sessId, $sessData): bool
     {
         $bindValues = [
             'session_id'      => $sessId
@@ -241,7 +241,7 @@ class Mage_Core_Model_Resource_Session implements Zend_Session_SaveHandler_Inter
      * @param string $sessId
      * @return bool
      */
-    public function destroy($sessId)
+    public function destroy($sessId): bool
     {
         $where = ['session_id = ?' => $sessId];
         $this->_write->delete($this->_sessionTable, $where);
@@ -252,18 +252,18 @@ class Mage_Core_Model_Resource_Session implements Zend_Session_SaveHandler_Inter
      * Garbage collection
      *
      * @param int $sessMaxLifeTime ignored
-     * @return bool
+     * @return int|false
      */
-    public function gc($sessMaxLifeTime)
+    public function gc($sessMaxLifeTime): int|false
     {
         if ($this->_automaticCleaningFactor > 0) {
             if ($this->_automaticCleaningFactor == 1 ||
                 rand(1, $this->_automaticCleaningFactor) == 1
             ) {
                 $where = ['session_expires < ?' => Varien_Date::toTimestamp(true)];
-                $this->_write->delete($this->_sessionTable, $where);
+                return $this->_write->delete($this->_sessionTable, $where);
             }
         }
-        return true;
+        return false;
     }
 }

--- a/app/code/core/Mage/Core/Model/Resource/Session.php
+++ b/app/code/core/Mage/Core/Model/Resource/Session.php
@@ -250,7 +250,7 @@ class Mage_Core_Model_Resource_Session implements SessionHandlerInterface
      * Garbage collection
      *
      * @param int $sessMaxLifeTime ignored
-     * @return bool
+     * @return int|false
      */
     public function gc($sessMaxLifeTime): int|false
     {
@@ -259,9 +259,9 @@ class Mage_Core_Model_Resource_Session implements SessionHandlerInterface
                 rand(1, $this->_automaticCleaningFactor) == 1
             ) {
                 $where = ['session_expires < ?' => Varien_Date::toTimestamp(true)];
-                $this->_write->delete($this->_sessionTable, $where);
+                return $this->_write->delete($this->_sessionTable, $where);
             }
         }
-        return true;
+        return 0;
     }
 }

--- a/app/code/core/Mage/Core/Model/Resource/Session.php
+++ b/app/code/core/Mage/Core/Model/Resource/Session.php
@@ -71,10 +71,6 @@ class Mage_Core_Model_Resource_Session implements SessionHandlerInterface
         $this->_write        = $resource->getConnection('core_write');
     }
 
-    /**
-     * Destrucor
-     *
-     */
     public function __destruct()
     {
         session_write_close();
@@ -255,9 +251,7 @@ class Mage_Core_Model_Resource_Session implements SessionHandlerInterface
     public function gc($sessMaxLifeTime): int|false
     {
         if ($this->_automaticCleaningFactor > 0) {
-            if ($this->_automaticCleaningFactor == 1 ||
-                rand(1, $this->_automaticCleaningFactor) == 1
-            ) {
+            if ($this->_automaticCleaningFactor == 1 || rand(1, $this->_automaticCleaningFactor) == 1) {
                 $where = ['session_expires < ?' => Varien_Date::toTimestamp(true)];
                 return $this->_write->delete($this->_sessionTable, $where);
             }

--- a/app/code/core/Mage/Core/Model/Resource/Session.php
+++ b/app/code/core/Mage/Core/Model/Resource/Session.php
@@ -162,7 +162,7 @@ class Mage_Core_Model_Resource_Session implements SessionHandlerInterface
      * @param string $sessName ignored
      * @return bool
      */
-    public function open($savePath, $sessName)
+    public function open($savePath, $sessName): bool
     {
         return true;
     }
@@ -172,7 +172,7 @@ class Mage_Core_Model_Resource_Session implements SessionHandlerInterface
      *
      * @return bool
      */
-    public function close()
+    public function close(): bool
     {
         $this->gc($this->getLifeTime());
 
@@ -185,7 +185,7 @@ class Mage_Core_Model_Resource_Session implements SessionHandlerInterface
      * @param string $sessId
      * @return string
      */
-    public function read($sessId)
+    public function read($sessId): string|false
     {
         $select = $this->_read->select()
             ->from($this->_sessionTable, ['session_data'])
@@ -206,7 +206,7 @@ class Mage_Core_Model_Resource_Session implements SessionHandlerInterface
      * @param string $sessData
      * @return bool
      */
-    public function write($sessId, $sessData)
+    public function write($sessId, $sessData): bool
     {
         $bindValues = [
             'session_id'      => $sessId
@@ -239,7 +239,7 @@ class Mage_Core_Model_Resource_Session implements SessionHandlerInterface
      * @param string $sessId
      * @return bool
      */
-    public function destroy($sessId)
+    public function destroy($sessId): bool
     {
         $where = ['session_id = ?' => $sessId];
         $this->_write->delete($this->_sessionTable, $where);
@@ -252,7 +252,7 @@ class Mage_Core_Model_Resource_Session implements SessionHandlerInterface
      * @param int $sessMaxLifeTime ignored
      * @return bool
      */
-    public function gc($sessMaxLifeTime)
+    public function gc($sessMaxLifeTime): int|false
     {
         if ($this->_automaticCleaningFactor > 0) {
             if ($this->_automaticCleaningFactor == 1 ||

--- a/app/code/core/Mage/Core/Model/Resource/Session.php
+++ b/app/code/core/Mage/Core/Model/Resource/Session.php
@@ -19,7 +19,7 @@
  * @category   Mage
  * @package    Mage_Core
  */
-class Mage_Core_Model_Resource_Session implements Zend_Session_SaveHandler_Interface
+class Mage_Core_Model_Resource_Session implements SessionHandlerInterface
 {
     /**
      * Session maximum cookie lifetime


### PR DESCRIPTION
Alternative (but actually both can be merged) version to https://github.com/OpenMage/magento-lts/pull/3497 with correct (I hope) typing, it can be merged only in `next` because it uses mixed typing which is not available in PHP7.

Should fix PHPStan errors on the `next` branch.