### PR TITLE
Show cache status info of blocks in template path hints

### DIFF
--- a/app/code/core/Mage/Core/Block/Template.php
+++ b/app/code/core/Mage/Core/Block/Template.php
@@ -215,13 +215,13 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
         if (!is_null($this->getCacheLifetime())) {
             return 'green';
         } else {
-            $_currentParentBlock = $this;
+            $currentParentBlock = $this;
             $i = 0;
-            while ($i++ < 20 && $_currentParentBlock instanceof Mage_Core_Block_Abstract) {
-                if (!is_null($_currentParentBlock->getCacheLifetime())) {
+            while ($i++ < 20 && $currentParentBlock instanceof Mage_Core_Block_Abstract) {
+                if (!is_null($currentParentBlock->getCacheLifetime())) {
                     return 'orange'; // not cached, but within cached
                 }
-                $_currentParentBlock = $_currentParentBlock->getParentBlock();
+                $currentParentBlock = $currentParentBlock->getParentBlock();
             }
         }
         return 'red';
@@ -248,17 +248,17 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
             ob_start();
         }
         if ($hints) {
-            $_isCacheEnabled = $this->_getCacheHintStatus();
+            $isCacheEnabled = $this->_getCacheHintStatus();
             echo <<<HTML
-<div style="position:relative; border:1px dotted {$_isCacheEnabled}; margin:6px 2px; padding:18px 2px 2px 2px; zoom:1;">
-<div style="position:absolute; left:0; top:0; padding:2px 5px; background:{$_isCacheEnabled}; color:white; font:normal 11px Arial;
+<div style="position:relative; border:1px dotted {$isCacheEnabled}; margin:6px 2px; padding:18px 2px 2px 2px; zoom:1;">
+<div style="position:absolute; left:0; top:0; padding:2px 5px; background:{$isCacheEnabled}; color:white; font:normal 11px Arial;
 text-align:left !important; z-index:998;text-transform: none;" onmouseover="this.style.zIndex='999'"
 onmouseout="this.style.zIndex='998'" title="{$fileName}">{$fileName}</div>
 HTML;
             if (Mage::app()->getStore()->isAdmin() ? self::$_showTemplateHintsBlocksAdmin : self::$_showTemplateHintsBlocks) {
                 $thisClass = get_class($this);
                 echo <<<HTML
-<div style="position:absolute; right:0; top:0; padding:2px 5px; background:{$_isCacheEnabled}; color:blue; font:normal 11px Arial;
+<div style="position:absolute; right:0; top:0; padding:2px 5px; background:{$isCacheEnabled}; color:blue; font:normal 11px Arial;
 text-align:left !important; z-index:998;text-transform: none;" onmouseover="this.style.zIndex='999'" onmouseout="this.style.zIndex='998'"
 title="{$thisClass}">{$thisClass}</div>
 HTML;

--- a/app/code/core/Mage/Core/Block/Template.php
+++ b/app/code/core/Mage/Core/Block/Template.php
@@ -206,9 +206,8 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
     }
 
     /**
-     * Retrieve block view from file (template)
+     * Retrieve block cache status
      *
-     * @param   string $fileName
      * @return  string
      */
     private function _getCacheHintStatus(): string

--- a/app/code/core/Mage/Core/Block/Template.php
+++ b/app/code/core/Mage/Core/Block/Template.php
@@ -211,6 +211,29 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
      * @param   string $fileName
      * @return  string
      */
+    private function _getCacheHintStatus(): string
+    {
+        if (!is_null($this->getCacheLifetime())) {
+            return 'green';
+        } else {
+            $_currentParentBlock = $this;
+            $i = 0;
+            while ($i++ < 20 && $_currentParentBlock instanceof Mage_Core_Block_Abstract) {
+                if (!is_null($_currentParentBlock->getCacheLifetime())) {
+                    return 'orange'; // not cached, but within cached
+                }
+                $_currentParentBlock = $_currentParentBlock->getParentBlock();
+            }
+        }
+        return 'red';
+    }
+
+    /**
+     * Retrieve block view from file (template)
+     *
+     * @param   string $fileName
+     * @return  string
+     */
     public function fetchView($fileName)
     {
         Varien_Profiler::start($fileName);
@@ -226,17 +249,19 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
             ob_start();
         }
         if ($hints) {
+
+            $_isCacheEnabled = $this->_getCacheHintStatus();
             echo <<<HTML
-<div style="position:relative; border:1px dotted red; margin:6px 2px; padding:18px 2px 2px 2px; zoom:1;">
-<div style="position:absolute; left:0; top:0; padding:2px 5px; background:red; color:white; font:normal 11px Arial;
-text-align:left !important; z-index:998;" onmouseover="this.style.zIndex='999'"
+<div style="position:relative; border:1px dotted {$_isCacheEnabled}; margin:6px 2px; padding:18px 2px 2px 2px; zoom:1;">
+<div style="position:absolute; left:0; top:0; padding:2px 5px; background:{$_isCacheEnabled}; color:white; font:normal 11px Arial;
+text-align:left !important; z-index:998;text-transform: none;" onmouseover="this.style.zIndex='999'"
 onmouseout="this.style.zIndex='998'" title="{$fileName}">{$fileName}</div>
 HTML;
             if (Mage::app()->getStore()->isAdmin() ? self::$_showTemplateHintsBlocksAdmin : self::$_showTemplateHintsBlocks) {
                 $thisClass = get_class($this);
                 echo <<<HTML
-<div style="position:absolute; right:0; top:0; padding:2px 5px; background:red; color:blue; font:normal 11px Arial;
-text-align:left !important; z-index:998;" onmouseover="this.style.zIndex='999'" onmouseout="this.style.zIndex='998'"
+<div style="position:absolute; right:0; top:0; padding:2px 5px; background:{$_isCacheEnabled}; color:blue; font:normal 11px Arial;
+text-align:left !important; z-index:998;text-transform: none;" onmouseover="this.style.zIndex='999'" onmouseout="this.style.zIndex='998'"
 title="{$thisClass}">{$thisClass}</div>
 HTML;
             }

--- a/app/code/core/Mage/Core/Block/Template.php
+++ b/app/code/core/Mage/Core/Block/Template.php
@@ -248,7 +248,6 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
             ob_start();
         }
         if ($hints) {
-
             $_isCacheEnabled = $this->_getCacheHintStatus();
             echo <<<HTML
 <div style="position:relative; border:1px dotted {$_isCacheEnabled}; margin:6px 2px; padding:18px 2px 2px 2px; zoom:1;">

--- a/app/code/core/Mage/Core/Block/Template.php
+++ b/app/code/core/Mage/Core/Block/Template.php
@@ -210,7 +210,7 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
      *
      * @return  string
      */
-    private function _getCacheHintStatus(): string
+    private function _getCacheHintStatusColor(): string
     {
         if (!is_null($this->getCacheLifetime())) {
             return 'green';
@@ -248,17 +248,17 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
             ob_start();
         }
         if ($hints) {
-            $isCacheEnabled = $this->_getCacheHintStatus();
+            $cacheHintStatusColor = $this->_getCacheHintStatusColor();
             echo <<<HTML
-<div style="position:relative; border:1px dotted {$isCacheEnabled}; margin:6px 2px; padding:18px 2px 2px 2px; zoom:1;">
-<div style="position:absolute; left:0; top:0; padding:2px 5px; background:{$isCacheEnabled}; color:white; font:normal 11px Arial;
+<div style="position:relative; border:1px dotted {$cacheHintStatusColor}; margin:6px 2px; padding:18px 2px 2px 2px; zoom:1;">
+<div style="position:absolute; left:0; top:0; padding:2px 5px; background:{$cacheHintStatusColor}; color:white; font:normal 11px Arial;
 text-align:left !important; z-index:998;text-transform: none;" onmouseover="this.style.zIndex='999'"
 onmouseout="this.style.zIndex='998'" title="{$fileName}">{$fileName}</div>
 HTML;
             if (Mage::app()->getStore()->isAdmin() ? self::$_showTemplateHintsBlocksAdmin : self::$_showTemplateHintsBlocks) {
                 $thisClass = get_class($this);
                 echo <<<HTML
-<div style="position:absolute; right:0; top:0; padding:2px 5px; background:{$isCacheEnabled}; color:blue; font:normal 11px Arial;
+<div style="position:absolute; right:0; top:0; padding:2px 5px; background:{$cacheHintStatusColor}; color:blue; font:normal 11px Arial;
 text-align:left !important; z-index:998;text-transform: none;" onmouseover="this.style.zIndex='999'" onmouseout="this.style.zIndex='998'"
 title="{$thisClass}">{$thisClass}</div>
 HTML;


### PR DESCRIPTION
### Description (*)
This is a small trick I usually use to debug cache blocks. I consider it useful to quickly find cache-related issues without installing other extensions.

### Manual testing scenarios (*)
1. Enable Template Path Hints
2. Frontend must show:
 - red for no cached block
 - orange for blocks nested in a cached block
 - green for cached blocks

![demo](https://github.com/OpenMage/magento-lts/assets/5071467/d8ac0a56-a63b-4cc8-a099-b2ed6899bd5a)

Inspiration from:
https://github.com/AOEpeople/Aoe_TemplateHints

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list