### PR TITLE
Fixed deprecated functionality str_contains() in Design/Package.php

### DIFF
--- a/app/code/core/Mage/Core/Block/Template.php
+++ b/app/code/core/Mage/Core/Block/Template.php
@@ -60,9 +60,9 @@ class Mage_Core_Block_Template extends Mage_Core_Block_Abstract
     /**
      * Path to template file in theme.
      *
-     * @var string|null
+     * @var string
      */
-    protected $_template;
+    protected $_template = '';
 
     /**
      * Internal constructor, that is called from real constructor

--- a/app/code/core/Mage/Payment/Block/Catalog/Product/View/Profile.php
+++ b/app/code/core/Mage/Payment/Block/Catalog/Product/View/Profile.php
@@ -92,7 +92,7 @@ class Mage_Payment_Block_Catalog_Product_View_Profile extends Mage_Core_Block_Te
     protected function _toHtml()
     {
         if (!$this->_profile) {
-            $this->_template = null;
+            $this->_template = '';
         }
         return parent::_toHtml();
     }


### PR DESCRIPTION
This small PR fixes a deprecation warning if e.g. `getCacheKey()` is called on a `Mage_Core_Block_Template` block instance without a template assigned (which may happen because the `template` attribute in that class is of type `string|null`)

Everything is described in https://github.com/OpenMage/magento-lts/pull/3473

Closes https://github.com/OpenMage/magento-lts/pull/3473