### PR TITLE
Added sharpening filter to Varien_Image_Adapter_Gd2 to fix blurry thumbnails

### DIFF
--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -409,6 +409,7 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
         );
 
         // sharpening filter to avoid blurry thumbnails
+        // https://stackoverflow.com/questions/2799159/php-gd-image-resizing-to-smaller-new-image-blurring-problem
         $sharpeningMatrix = [[-1, -1, -1], [-1, 16, -1], [-1, -1, -1]];
         $sharpeningDivisor = array_sum(array_map('array_sum', $sharpeningMatrix));
         imageconvolution($newImage, $sharpeningMatrix, $sharpeningDivisor, 0);

--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -407,6 +407,12 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
             $this->_imageSrcWidth,
             $this->_imageSrcHeight
         );
+
+        // sharpening filter to avoid blurry thumbnails
+        $sharpeningMatrix = [[-1, -1, -1], [-1, 16, -1], [-1, -1, -1]];
+        $sharpeningDivisor = array_sum(array_map('array_sum', $sharpeningMatrix));
+        imageconvolution($newImage, $sharpeningMatrix, $sharpeningDivisor, 0);
+
         $this->_imageHandler = $newImage;
         $this->refreshImageDimensions();
         $this->_resized = true;


### PR DESCRIPTION
With GD2, we've had the "blurry thumbnails" problems for many years now, some have created 3rd party modules based on image-magick but today I was wondering around the internet and found [this stackoverflow page](https://stackoverflow.com/questions/2799159/php-gd-image-resizing-to-smaller-new-image-blurring-problem) and thought to give it a try and it seems to work really nicely to me!

before:
<img width="351" alt="Screenshot 2023-09-15 alle 11 21 21" src="https://github.com/OpenMage/magento-lts/assets/909743/502b9a07-172f-416d-9986-336fad6f0153">

after:
<img width="359" alt="Screenshot 2023-09-15 alle 11 20 23" src="https://github.com/OpenMage/magento-lts/assets/909743/2e1e95b8-9121-4da0-8390-21bd25e15ea3">

It seems a really good improvement so I thought to create a PR for it.

UPDATE 1: tested on a customer's website, didn't like the result, on desktop/mobile-preview looks ok but on real mobile device looked a bit jaggy