### PR TITLE
Link to NotifyStock feed only if enabled

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
@@ -290,8 +290,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
             ]
         );
 
-        if (
-            Mage::helper('catalog')->isModuleEnabled('Mage_Rss') &&
+        if (Mage::helper('catalog')->isModuleEnabled('Mage_Rss') &&
             Mage::helper('rss')->isRssEnabled() &&
             Mage::getStoreConfigFlag('rss/catalog/notifystock')
         ) {

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
@@ -290,7 +290,11 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
             ]
         );
 
-        if (Mage::helper('catalog')->isModuleEnabled('Mage_Rss')) {
+        if (
+            Mage::helper('catalog')->isModuleEnabled('Mage_Rss') &&
+            Mage::helper('rss')->isRssEnabled() &&
+            Mage::getStoreConfigFlag('rss/catalog/notifystock')
+        ) {
             $this->addRssList('rss/catalog/notifystock', Mage::helper('catalog')->__('Notify Low Stock RSS'));
         }
 


### PR DESCRIPTION
This link:
<img width="723" alt="Screenshot 2023-09-17 alle 23 47 19" src="https://github.com/OpenMage/magento-lts/assets/909743/0c7a1eb5-cf90-4459-9794-f42ed5add7f1">

should appear only if the RSS is actually enabled.

This PR should fix this.