### PR TITLE
Use a core/flag to store tax notification ignored flag rather than co…

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/TaxController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/TaxController.php
@@ -28,7 +28,7 @@ class Mage_Adminhtml_TaxController extends Mage_Adminhtml_Controller_Action
     {
         $section = $this->getRequest()->getParam('section');
         if ($section) {
-            Mage::helper('tax')->setIsIgnored('tax/ignore_notification/' . $section, 1);
+            Mage::helper('tax')->setIsIgnored('tax/ignore_notification/' . $section, true);
         }
         $this->_redirectReferer();
     }

--- a/app/code/core/Mage/Adminhtml/controllers/TaxController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/TaxController.php
@@ -28,13 +28,7 @@ class Mage_Adminhtml_TaxController extends Mage_Adminhtml_Controller_Action
     {
         $section = $this->getRequest()->getParam('section');
         if ($section) {
-            try {
-                $path = 'tax/ignore_notification/' . $section;
-                Mage::getModel('core/config')->saveConfig($path, 1);
-                Mage::getConfig()->reinit();
-            } catch (Exception $e) {
-                Mage::getSingleton('adminhtml/session')->addError($e->getMessage());
-            }
+            Mage::helper('tax')->setIsIgnored('tax/ignore_notification/' . $section, 1);
         }
         $this->_redirectReferer();
     }

--- a/app/code/core/Mage/Tax/Helper/Data.php
+++ b/app/code/core/Mage/Tax/Helper/Data.php
@@ -1173,7 +1173,7 @@ class Mage_Tax_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function isWrongDisplaySettingsIgnored()
     {
-        return (bool)$this->_app->getStore()->getConfig(Mage_Tax_Model_Config::XML_PATH_TAX_NOTIFICATION_PRICE_DISPLAY);
+        return $this->_isIgnored(Mage_Tax_Model_Config::XML_PATH_TAX_NOTIFICATION_PRICE_DISPLAY);
     }
 
     /**
@@ -1183,7 +1183,7 @@ class Mage_Tax_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function isWrongDiscountSettingsIgnored()
     {
-        return (bool)$this->_app->getStore()->getConfig(Mage_Tax_Model_Config::XML_PATH_TAX_NOTIFICATION_DISCOUNT);
+        return $this->_isIgnored(Mage_Tax_Model_Config::XML_PATH_TAX_NOTIFICATION_DISCOUNT);
     }
 
     /**
@@ -1193,8 +1193,7 @@ class Mage_Tax_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function isConflictingFptTaxConfigurationSettingsIgnored()
     {
-        return (bool) $this->_app->getStore()
-            ->getConfig(Mage_Tax_Model_Config::XML_PATH_TAX_NOTIFICATION_FPT_CONFIGURATION);
+        return $this->_isIgnored(Mage_Tax_Model_Config::XML_PATH_TAX_NOTIFICATION_FPT_CONFIGURATION);
     }
 
     /**
@@ -1206,5 +1205,40 @@ class Mage_Tax_Helper_Data extends Mage_Core_Helper_Abstract
     public function isCrossBorderTradeEnabled($store = null)
     {
         return (bool)$this->_config->crossBorderTradeEnabled($store);
+    }
+
+    /**
+     * Use flag to store ignore setting rather than config to avoid config reinit/save
+     * Read config value for backwards compatibility.
+     *
+     * @param string $key
+     * @return bool
+     * @throws Mage_Core_Model_Store_Exception
+     * @throws Throwable
+     */
+    protected function _isIgnored(string $key)
+    {
+        $flag = Mage::getModel('core/flag', ['flag_code' => $key])->loadSelf();
+        if ($flag->getId()) {
+            return (bool) $flag->getFlagData();
+        }
+        $configValue = $this->_app->getStore()->getConfig($key);
+        if ($configValue !== null) {
+            $flag->setFlagData((bool) $configValue)->save();
+            return (bool) $configValue;
+        }
+        return false;
+    }
+
+    /**
+     * @param string $key
+     * @param bool $value
+     * @return void
+     * @throws Throwable
+     */
+    public function setIsIgnored(string $key, bool $value)
+    {
+        $flag = Mage::getModel('core/flag', ['flag_code' => $key])->loadSelf();
+        $flag->setFlagData($value)->save();
     }
 }

--- a/app/code/core/Mage/Tax/Model/Config/Notification.php
+++ b/app/code/core/Mage/Tax/Model/Config/Notification.php
@@ -75,11 +75,7 @@ class Mage_Tax_Model_Config_Notification extends Mage_Core_Model_Config_Data
      */
     protected function _resetNotificationFlag($path)
     {
-        $this->_getConfig()
-            ->load($path, 'path')
-            ->setValue(0)
-            ->setPath($path)
-            ->save();
+        Mage::helper('tax')->setIsIgnored($path, 0);
         return $this;
     }
 }

--- a/app/code/core/Mage/Tax/Model/Config/Notification.php
+++ b/app/code/core/Mage/Tax/Model/Config/Notification.php
@@ -75,7 +75,7 @@ class Mage_Tax_Model_Config_Notification extends Mage_Core_Model_Config_Data
      */
     protected function _resetNotificationFlag($path)
     {
-        Mage::helper('tax')->setIsIgnored($path, 0);
+        Mage::helper('tax')->setIsIgnored($path, false);
         return $this;
     }
 }


### PR DESCRIPTION
Config is not meant to store state data, the core/flag table is more appropriate for this purpose. This patch eliminates one possible way that a user action can cause a config cache `reinit()` buy storing the "ignore this notification" flag in the core/flag table instead of config.

How to reproduce:
Change the tax config so that the warning appears. Clicking "Ignore this notification" should not cause config to be updated.

![image](https://github.com/OpenMage/magento-lts/assets/38738/c8b8401f-0ff2-4444-a4e4-261ee08d3e24)
