### PR TITLE
Fixed empty exception when customer does not exist for products alerts

### DIFF
--- a/app/code/core/Mage/ProductAlert/Model/Observer.php
+++ b/app/code/core/Mage/ProductAlert/Model/Observer.php
@@ -206,7 +206,7 @@ class Mage_ProductAlert_Model_Observer
                         if ($previousCustomer) {
                             $email->send();
                         }
-                        if (!$customer || !$customer->getId()) {
+                        if (!$customer->getId()) {
                             continue;
                         }
                         $previousCustomer = $customer;

--- a/app/code/core/Mage/ProductAlert/Model/Observer.php
+++ b/app/code/core/Mage/ProductAlert/Model/Observer.php
@@ -119,7 +119,7 @@ class Mage_ProductAlert_Model_Observer
                         if ($previousCustomer) {
                             $email->send();
                         }
-                        if (!$customer || !$customer->getId()) {
+                        if (!$customer->getId()) {
                             continue;
                         }
                         $previousCustomer = $customer;

--- a/app/code/core/Mage/ProductAlert/Model/Observer.php
+++ b/app/code/core/Mage/ProductAlert/Model/Observer.php
@@ -119,7 +119,7 @@ class Mage_ProductAlert_Model_Observer
                         if ($previousCustomer) {
                             $email->send();
                         }
-                        if (!$customer) {
+                        if (!$customer || !$customer->getId()) {
                             continue;
                         }
                         $previousCustomer = $customer;
@@ -206,7 +206,7 @@ class Mage_ProductAlert_Model_Observer
                         if ($previousCustomer) {
                             $email->send();
                         }
-                        if (!$customer) {
+                        if (!$customer || !$customer->getId()) {
                             continue;
                         }
                         $previousCustomer = $customer;


### PR DESCRIPTION
### Description

When a customer does not exist, products alerts will crash with an empty error message.
We encounter that when we after importing a database from production to dev/staging/local, without customers and orders, and testing products alerts.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list