### PR TITLE
Fixed passing null for explode is deprecated in Mage_Adminhtml_Block_System_Currency_Rate_Matrix

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Matrix.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Matrix.php
@@ -71,7 +71,7 @@ class Mage_Adminhtml_Block_System_Currency_Rate_Matrix extends Mage_Adminhtml_Bl
 
         foreach ($array as $key => $rate) {
             foreach ($rate as $code => $value) {
-                $parts = explode('.', $value);
+                $parts = explode('.', (string)$value);
                 if (count($parts) === 2) {
                     $parts[1] = str_pad(rtrim($parts[1], 0), 4, '0', STR_PAD_RIGHT);
                     $array[$key][$code] = implode('.', $parts);


### PR DESCRIPTION
### Description

This fix `passing null to parameter #2 ($string) of type string is deprecated` for `explode` with PHP 8.1/8.2/8.3.

To got it, with a multi website instance, update the currency of one website, set for example _Chilean Peso / CLP_.
Then try to import currency rates, and if there is an import error, the deprecated notice is here.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list