### PR TITLE
Excluded Varien_Data_Form_Element_Label from "edit attributes" mass action

### DIFF
--- a/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Edit/Action/Attribute.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Edit/Action/Attribute.php
@@ -114,6 +114,7 @@ class Mage_Adminhtml_Helper_Catalog_Product_Edit_Action_Attribute extends Mage_C
                 ->getEntityType(Mage_Catalog_Model_Product::ENTITY)
                 ->getAttributeCollection()
                 ->addIsNotUniqueFilter()
+                ->addFieldToFilter('frontend_input', ['neq' => 'label'])
                 ->setInAllAttributeSetsFilter($this->getProductsSetIds());
 
             if ($this->_excludedAttributes) {

--- a/js/mage/adminhtml/product.js
+++ b/js/mage/adminhtml/product.js
@@ -1001,14 +1001,18 @@ function toogleFieldEditMode(toogleIdentifier, fieldContainer) {
 }
 
 function disableFieldEditMode(fieldContainer) {
-    $(fieldContainer).disabled = true;
+    if ($(fieldContainer)) {
+        $(fieldContainer).disabled = true;
+    }
     if ($(fieldContainer + '_hidden')) {
         $(fieldContainer + '_hidden').disabled = true;
     }
 }
 
 function enableFieldEditMode(fieldContainer) {
-    $(fieldContainer).disabled = false;
+    if ($(fieldContainer)) {
+        $(fieldContainer).disabled = false;
+    }
     if ($(fieldContainer + '_hidden')) {
         $(fieldContainer + '_hidden').disabled = false;
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

- Label Attribute made with `Varien_Data_Form_Element_Label` doesn't have an HTML element for `disableFieldEditMode` or `enableFieldEditMode` to disable or enable
- first i excluded all attributes that are labels.
- i added a check in JS to prevent it from crashing even if the attributes are added to the Form.


### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#3534 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. have an EAV Attribute for `frontend_input` = `label`
2. go to the Product Grid and use the `Update Attributes` mass action
3. JS does crash, because `disableFieldEditMode` can't find an element with the given id.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list (i should already be added)
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->