### PR TITLE
Fixed PHPStan workflows not running on the correct PHP version

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -12,9 +12,14 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4', '8.2']
+        php-versions: ['7.4', '8.2', '8.3']
 
     steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+    
       - uses: actions/checkout@v4
 
       - name: Check PHP version

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -8,10 +8,18 @@ on:
 jobs:
   phpstan:
     name: Analyze
-    runs-on: [ubuntu-latest]
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['7.4', '8.2']
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Check PHP version
+        id: check-php-version
+        run: echo "php -v" >> $GITHUB_OUTPUT
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -22,10 +22,6 @@ jobs:
     
       - uses: actions/checkout@v4
 
-      - name: Check PHP version
-        id: check-php-version
-        run: php -v
-
       - name: Get composer cache directory
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
@@ -38,7 +34,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
-        run: php -v && composer install --prefer-dist --no-progress --ignore-platform-req=ext-*
+        run: composer install --prefer-dist --no-progress --ignore-platform-req=ext-*
 
       - name: PHPStan Static Analysis
         run: XDEBUG_MODE=off php vendor/bin/phpstan.phar analyze

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -38,7 +38,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --ignore-platform-req=ext-*
+        run: php -v && composer install --prefer-dist --no-progress --ignore-platform-req=ext-*
 
       - name: PHPStan Static Analysis
         run: XDEBUG_MODE=off php vendor/bin/phpstan.phar analyze

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Check PHP version
         id: check-php-version
-        run: echo "php -v" >> $GITHUB_OUTPUT
+        run: php -v
 
       - name: Get composer cache directory
         id: composer-cache


### PR DESCRIPTION
Without the `setup-php` step workflows are not running with the correct PHP version, this PR fixes it for PHPStan, I'll check more workflows later.

Also, this PR makes PHPStan run on php7.4, 8.2 and 8.3 for futureproofing.