### PR TITLE
Added a new event 'adminhtml_helper_catalog_product_edit_action_attri…

### DIFF
--- a/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Edit/Action/Attribute.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Edit/Action/Attribute.php
@@ -116,8 +116,8 @@ class Mage_Adminhtml_Helper_Catalog_Product_Edit_Action_Attribute extends Mage_C
                 ->addIsNotUniqueFilter()
                 ->setInAllAttributeSetsFilter($this->getProductsSetIds());
 
-            if ($this->_excludedAttributes) {
-                $this->_attributes->addFieldToFilter('attribute_code', ['nin' => $this->_excludedAttributes]);
+            if ($exludedAttributes = $this->_getExcludedAttributes()) {
+                $this->_attributes->addFieldToFilter('attribute_code', ['nin' => $exludedAttributes]);
             }
 
             // check product type apply to limitation and remove attributes that impossible to change in mass-update
@@ -135,6 +135,23 @@ class Mage_Adminhtml_Helper_Catalog_Product_Edit_Action_Attribute extends Mage_C
         }
 
         return $this->_attributes;
+    }
+
+    /**
+     * Dispatch event to update $_excludedAttributes.
+     *
+     * @return string[]
+     */
+    protected function _getExcludedAttributes()
+    {
+        $excludedAttributes = new ArrayObject($this->_excludedAttributes);
+        Mage::dispatchEvent(
+            'adminhtml_helper_catalog_product_edit_action_attribute_exclude',
+            ['excluded_attributes' => $excludedAttributes]
+
+        );
+
+        return $excludedAttributes->getArrayCopy();
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Edit/Action/Attribute.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Edit/Action/Attribute.php
@@ -148,7 +148,6 @@ class Mage_Adminhtml_Helper_Catalog_Product_Edit_Action_Attribute extends Mage_C
         Mage::dispatchEvent(
             'adminhtml_helper_catalog_product_edit_action_attribute_exclude',
             ['excluded_attributes' => $excludedAttributes]
-
         );
 
         return $excludedAttributes->getArrayCopy();

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -67,6 +67,7 @@
 | adminhtml_customer_orders_add_action_renderer | 1.9.4.5 |
 | adminhtml_customer_prepare_save | 1.9.4.5 |
 | adminhtml_customer_save_after | 1.9.4.5 |
+| adminhtml_helper_catalog_product_edit_action_attribute_exclude | 20.1.2 |
 | adminhtml_init_system_config | 1.9.4.5 |
 | adminhtml_promo_catalog_edit_tab_main_prepare_form | 1.9.4.5 |
 | adminhtml_promo_quote_edit_tab_coupons_form_prepare_form | 1.9.4.5 |


### PR DESCRIPTION
### Description (*)
This PR added a new event to have the possibility to customize what attributes to exclude when doing a mass action on the product grid.

Observer script:
```php
    public function excludeProductAttribute($observer)
    {
        /** @var ArrayObject $excludedAttributes*/
        $excludedAttributes = $observer->getExcludedAttributes();
        /** @var string[] $additional */
        $additional = Mage::getResourceSingleton('catalog/attribute')->getAttributeCodesByFrontendType('label');
        // add $additional to $excludedAttributes
        $excludedAttributes->exchangeArray(array_merge($excludedAttributes->getArrayCopy(), $additional));
    }
```

### Related Pull Requests
PR #3540 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#<3534>



