### PR TITLE
Recovered some lost deprecated notice in #3552

### DIFF
--- a/app/code/core/Mage/Install/Model/Installer/Filesystem.php
+++ b/app/code/core/Mage/Install/Model/Installer/Filesystem.php
@@ -25,8 +25,11 @@ class Mage_Install_Model_Installer_Filesystem extends Mage_Install_Model_Install
      * @deprecated since 1.7.1.0
      */
     public const MODE_WRITE = 'write';
+
+    /**
+     * @deprecated since 1.7.1.0
+     */
     public const MODE_READ  = 'read';
-    /**#@- */
 
     public function __construct()
     {

--- a/app/code/core/Mage/Oauth/Model/Token.php
+++ b/app/code/core/Mage/Oauth/Model/Token.php
@@ -54,7 +54,6 @@ class Mage_Oauth_Model_Token extends Mage_Core_Model_Abstract
      */
     public const TYPE_REQUEST = 'request';
     public const TYPE_ACCESS  = 'access';
-    /**#@- */
 
     /**
      * Lengths of token fields
@@ -62,14 +61,12 @@ class Mage_Oauth_Model_Token extends Mage_Core_Model_Abstract
     public const LENGTH_TOKEN    = 32;
     public const LENGTH_SECRET   = 32;
     public const LENGTH_VERIFIER = 32;
-    /**#@- */
 
     /**
      * Customer types
      */
     public const USER_TYPE_ADMIN    = 'admin';
     public const USER_TYPE_CUSTOMER = 'customer';
-    /**#@- */
 
     /**
      * Initialize resource model

--- a/app/code/core/Mage/Tax/Model/Config.php
+++ b/app/code/core/Mage/Tax/Model/Config.php
@@ -104,9 +104,25 @@ class Mage_Tax_Model_Config
      * @deprecated
      */
     public const CONFIG_XML_PATH_SHOW_IN_CATALOG = 'tax/display/show_in_catalog';
+
+    /**
+     * @deprecated
+     */
     public const CONFIG_XML_PATH_DEFAULT_PRODUCT_TAX_GROUP = 'catalog/product/default_tax_group';
+
+    /**
+     * @deprecated
+     */
     public const CONFIG_XML_PATH_DISPLAY_TAX_COLUMN = 'tax/display/column_in_summary';
+
+    /**
+     * @deprecated
+     */
     public const CONFIG_XML_PATH_DISPLAY_FULL_SUMMARY = 'tax/display/full_summary';
+
+    /**
+     * @deprecated
+     */
     public const CONFIG_XML_PATH_DISPLAY_ZERO_TAX = 'tax/display/zero_tax';
 
     /**


### PR DESCRIPTION
In https://github.com/OpenMage/magento-lts/issues/3555 it was noted that we lost some notation, this PR should recover them, without using the phpblock-template funcionality.

Notes:
- I didn't recover the tags that were just descriptions because they are extremely general and seems not useful to me
- I didn't recover (at the moment) some "type array" notation (most of them are in app/code/core/Mage/PaypalUk/Model/Api/Nvp.php) because the arrays have a clear array definition so I don't think we need to have those comments, not even for phpdoc
- same thing for some "type mixed" like in app/code/core/Mage/PaypalUk/Model/Api/Nvp.php because, sincerely, they don't even seem correct from the start

open to suggestions