### PR TITLE
Fixed missing layout parameter when choosing widget page group

### DIFF
--- a/app/design/adminhtml/default/default/template/widget/instance/edit/layout.phtml
+++ b/app/design/adminhtml/default/default/template/widget/instance/edit/layout.phtml
@@ -123,6 +123,7 @@ var pageGroupTemplate = '<div class="options-box page_group_container" id="page_
 '<div class="no-display ignore-validate pages group_container" id="pages_{{id}}">'+
     '<input type="hidden" class="container_name" name="__[container_name]" value="widget_instance[{{id}}][pages]" />'+
     '<input type="hidden" name="widget_instance[{{id}}][pages][page_id]" value="{{page_id}}" />'+
+    '<input type="hidden" class="layout_handle_pattern" name="widget_instance[{{id}}][all_pages][layout_handle]" value="default" />'+
     '<input type="hidden" class="for_all" name="widget_instance[{{id}}][pages][for]" value="all" />'+
     '<table cellspacing="0" class="option-header">'+
         '<col width="200" />'+
@@ -280,7 +281,7 @@ var WidgetInstance = {
         blockContainer = container.down('div.block_reference');
         if (blockContainer && blockContainer.innerHTML == '') {
             layoutHandle = '';
-            if (layoutHandleField = container.down('select#layout_handle')) {
+            if (layoutHandleField = container.down('input.layout_handle_pattern')) {
                 layoutHandle = layoutHandleField.value;
             }
             this.loadSelectBoxByType('block_reference', container, layoutHandle, additional);


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixes the issue that the layout parameter is missing in some cases when choosing the page group on the widget instance page in backend.
As a result not all available block references will be shown in the select field.

This has already been tried to fix in https://github.com/OpenMage/magento-lts/pull/802, but the implementation does only work when choosing "Specified Page" in the page group select. For all other options like category or product pages (where no additional "Page" select is available) only the `default` layout handle will be used (instead of e.g. `catalog_product_view`) and therewith not all available blocks will be shown in "Block Reference".

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. In Backend go to _CMS > Widgets_ and create a new Widget instance
2. In the form section "Layout Updates" verify that all combinations of "Display On", "Page" and "Block Reference" produce the correct behaviour, i.e. the contents of the "Block Reference" select matches the chosen page
3. Verify step 2. especially for product pages vs. home page (as mentioned in https://github.com/OpenMage/magento-lts/pull/802)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->