### PR TITLE
Forced PHP version to 7.4 for PHPCS related workflows

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: [ubuntu-latest]
 
     steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -21,6 +21,11 @@ jobs:
             path: .phpcs.php.xml.dist
 
     steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
On the `next` branch the PHPCS worklows fail because the PHP version is not the right one (on `next` it should be 8.1).

This PR is propedeutic to fix the PHP version for to 8.1 in the `next` branch but have the workflows definition files more similar possible, this is why this PR runs the setup-php action to 7.4 for the `main` branch, so that I can be changed easily on `next` without incompatibilities.