### PR TITLE
Exception is now printed on Mage_Catalog_ProductController::viewAction() in developer mode

### DIFF
--- a/app/code/core/Mage/Catalog/controllers/ProductController.php
+++ b/app/code/core/Mage/Catalog/controllers/ProductController.php
@@ -126,7 +126,7 @@ class Mage_Catalog_ProductController extends Mage_Core_Controller_Front_Action
                 } elseif (!$this->getResponse()->isRedirect()) {
                     $this->_forward('noRoute');
                 }
-            } else if (Mage::getIsDeveloperMode()) {
+            } elseif (Mage::getIsDeveloperMode()) {
                 Mage::printException($e);
             } else {
                 Mage::logException($e);

--- a/app/code/core/Mage/Catalog/controllers/ProductController.php
+++ b/app/code/core/Mage/Catalog/controllers/ProductController.php
@@ -126,6 +126,8 @@ class Mage_Catalog_ProductController extends Mage_Core_Controller_Front_Action
                 } elseif (!$this->getResponse()->isRedirect()) {
                     $this->_forward('noRoute');
                 }
+            } else if (Mage::getIsDeveloperMode()) {
+                Mage::printException($e);
             } else {
                 Mage::logException($e);
                 $this->_forward('noRoute');


### PR DESCRIPTION
### Description

When there is an error in `$viewHelper->prepareAndRender($productId, $this, $params);`, when developer mode is enabled, error is only logged, not displayed. This PR display the error to the user.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list