### PR TITLE
Switched DOCTYPE to HTML5 for adminhtml themes

### DIFF
--- a/app/design/adminhtml/default/default/template/empty.phtml
+++ b/app/design/adminhtml/default/default/template/empty.phtml
@@ -13,8 +13,8 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->getLang() ?>" lang="<?php echo $this->getLang() ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->getLang() ?>">
 <head>
 <?php $this->getChild('head')->unsetChildren(); ?>
 <?php echo $this->getChildHtml('head'); ?>

--- a/app/design/adminhtml/default/default/template/forgotpassword.phtml
+++ b/app/design/adminhtml/default/default/template/forgotpassword.phtml
@@ -13,8 +13,8 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="noindex, nofollow" />

--- a/app/design/adminhtml/default/default/template/login.phtml
+++ b/app/design/adminhtml/default/default/template/login.phtml
@@ -13,8 +13,8 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="noindex, nofollow" />

--- a/app/design/adminhtml/default/default/template/newsletter/preview/iframeswitcher.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/preview/iframeswitcher.phtml
@@ -16,8 +16,8 @@
 <?php
 /* @var $this Mage_Core_Block_Template */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->getLang() ?>" lang="<?php echo $this->getLang() ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->getLang() ?>">
 <head>
 <?php echo $this->getChildHtml('head') ?>
 <style type="text/css">

--- a/app/design/adminhtml/default/default/template/newsletter/queue/preview.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/queue/preview.phtml
@@ -13,7 +13,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/app/design/adminhtml/default/default/template/newsletter/template/preview.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/template/preview.phtml
@@ -13,7 +13,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/app/design/adminhtml/default/default/template/page.phtml
+++ b/app/design/adminhtml/default/default/template/page.phtml
@@ -26,8 +26,8 @@
     },
     "vars":{}
 }*/ ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->getLang() ?>" lang="<?php echo $this->getLang() ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->getLang() ?>">
 <head>
     <?php echo $this->getChildHtml('head') ?>
 </head>

--- a/app/design/adminhtml/default/default/template/popup.phtml
+++ b/app/design/adminhtml/default/default/template/popup.phtml
@@ -26,8 +26,8 @@
     },
     "vars":{}
 }*/ ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->getLang() ?>" lang="<?php echo $this->getLang() ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->getLang() ?>">
 <head>
 <?php echo $this->getChildHtml('head') ?>
 </head>

--- a/app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
+++ b/app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
@@ -13,8 +13,8 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="noindex, nofollow" />

--- a/app/design/adminhtml/default/default/template/widget/form/element.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/element.phtml
@@ -88,7 +88,7 @@
             apply_source_formatting : 'true',
             convert_urls : 'false',
             force_br_newlines : 'true',
-            doctype : '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">'
+            doctype : '<!DOCTYPE html>'
 
         });
         //]]>

--- a/app/design/adminhtml/default/openmage/template/forgotpassword.phtml
+++ b/app/design/adminhtml/default/openmage/template/forgotpassword.phtml
@@ -13,8 +13,8 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="noindex, nofollow" />

--- a/app/design/adminhtml/default/openmage/template/login.phtml
+++ b/app/design/adminhtml/default/openmage/template/login.phtml
@@ -13,8 +13,8 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="noindex, nofollow" />

--- a/app/design/adminhtml/default/openmage/template/resetforgottenpassword.phtml
+++ b/app/design/adminhtml/default/openmage/template/resetforgottenpassword.phtml
@@ -13,8 +13,8 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="noindex, nofollow" />

--- a/app/design/install/default/default/template/page.phtml
+++ b/app/design/install/default/default/template/page.phtml
@@ -18,8 +18,8 @@
  * Template for Mage_Page_Block_Html
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title><?php echo Mage::helper('install')->__('OpenMage Installation Wizard') ?></title>

--- a/app/locale/en_US/template/email/html/header.html
+++ b/app/locale/en_US/template/email/html/header.html
@@ -1,6 +1,6 @@
 <!--@subject Email - Header @-->
-<!DOCTYPE html>
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="initial-scale=1.0, width=device-width" />

--- a/app/locale/en_US/template/email/html/header.html
+++ b/app/locale/en_US/template/email/html/header.html
@@ -1,6 +1,6 @@
 <!--@subject Email - Header @-->
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="initial-scale=1.0, width=device-width" />

--- a/errors/default/page.phtml
+++ b/errors/default/page.phtml
@@ -13,8 +13,8 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
 <title><?php echo $this->pageTitle?></title>
 <base href="<?php echo $this->getSkinUrl()?>" />


### PR DESCRIPTION
In https://github.com/OpenMage/magento-lts/pull/3574 @m-overlund suggested to check also the adminhtml templates, this PR is for that reason.