### PR TITLE
Add status column to customer orders grid in Admin

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Orders.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Orders.php
@@ -45,6 +45,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_Orders extends Mage_Adminhtml_Block
             ->addFieldToSelect('created_at')
             ->addFieldToSelect('grand_total')
             ->addFieldToSelect('order_currency_code')
+            ->addFieldToSelect('status')
             ->addFieldToSelect('store_id')
             ->addFieldToSelect('billing_name')
             ->addFieldToSelect('shipping_name')
@@ -88,6 +89,14 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_Orders extends Mage_Adminhtml_Block
             'index'     => 'grand_total',
             'type'      => 'currency',
             'currency'  => 'order_currency_code',
+        ]);
+
+        $this->addColumn('status', [
+            'header' => Mage::helper('customer')->__('Status'),
+            'index' => 'status',
+            'type'  => 'options',
+            'width' => '150px',
+            'options' => Mage::getSingleton('sales/order_config')->getStatuses(),
         ]);
 
         if (!Mage::app()->isSingleStoreMode()) {


### PR DESCRIPTION
### Description (*)

A small enhancement to the customer orders grid for convenience when looking for orders with a specific status.

### Manual testing scenarios (*)

1. Go to any customer edit page in Admin and you should see the new column in the Orders tab.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->