### PR TITLE
Removed text-shadow from disabled dropdown in Admin

### DIFF
--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -355,7 +355,7 @@ select.multiselect option       { padding:3px 4px; border-bottom:1px solid #ddd;
 .field-100 input.input-text { float:left; width:100% !important; border:0 !important; padding:0 !important; }
 @media screen and (-webkit-min-device-pixel-ratio:0) {
     select option:disabled,
-    select:disabled option { color:#c9c9c9!important;color:#cacaca!important; text-shadow:2px 2px 2px #000; }
+    select:disabled option { color:#cacaca!important; }
 }
 
 /* Form List */ /* Table for default form data */


### PR DESCRIPTION
### Description (*)

Minor UX improvement to disabled dropdowns in Admin that removes `text-shadow` for better readability.

| Before | After |
| --- | --- |
| ![Screen Shot 2023-10-06 at 10 58 11 AM](https://github.com/OpenMage/magento-lts/assets/67818913/2c705dd6-c9a6-473d-a796-f146fe778875) | ![Screen Shot 2023-10-06 at 10 57 41 AM](https://github.com/OpenMage/magento-lts/assets/67818913/b67e8b17-9c4b-4db4-8f2e-1a759d326a1a) |

### Manual testing scenarios (*)

1. Go to any admin page that has a disabled dropdown, example: Configuration -> Payment Methods -> Cash On Delivery Payment.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->