### PR TITLE
Fix syntax in Mage_Adminhtml.csv

### DIFF
--- a/app/locale/en_US/Mage_Adminhtml.csv
+++ b/app/locale/en_US/Mage_Adminhtml.csv
@@ -1031,7 +1031,7 @@
 "The Layered Navigation indexing queue has been canceled.","The Layered Navigation indexing queue has been canceled."
 "The Layered Navigation indices were refreshed.","The Layered Navigation indices were refreshed."
 "The Layered Navigation process has been queued to be killed.","The Layered Navigation process has been queued to be killed."
-"The OpenMage cache has been flushed and updates applied.":"The OpenMage cache has been flushed and updates applied."
+"The OpenMage cache has been flushed and updates applied.","The OpenMage cache has been flushed and updates applied."
 "The Special Price is active only when lower than the Actual Price.","The Special Price is active only when lower than the Actual Price."
 "The URL Rewrite has been deleted.","The URL Rewrite has been deleted."
 "The URL Rewrite has been saved.","The URL Rewrite has been saved."


### PR DESCRIPTION
### Description (*)
Fixes a tiny syntax error in `Mage_Adminhtml.csv`.

### Related Pull Requests

- https://github.com/OpenMage/magento-lts/pull/3533

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->