### PR TITLE
404 Responses Shouldn't Be Cached

### DIFF
--- a/app/code/core/Mage/Adminhtml/Controller/Rss/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Rss/Abstract.php
@@ -47,7 +47,6 @@ class Mage_Adminhtml_Controller_Rss_Abstract extends Mage_Adminhtml_Controller_A
         } else {
             $this->getResponse()->setHeader('HTTP/1.1', '404 Not Found');
             $this->getResponse()->setHeader('Status', '404 File not found');
-
             $this->_forward('noRoute');
             return false;
         }

--- a/app/code/core/Mage/Adminhtml/Controller/Rss/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Rss/Abstract.php
@@ -47,6 +47,7 @@ class Mage_Adminhtml_Controller_Rss_Abstract extends Mage_Adminhtml_Controller_A
         } else {
             $this->getResponse()->setHeader('HTTP/1.1', '404 Not Found');
             $this->getResponse()->setHeader('Status', '404 File not found');
+
             $this->_forward('noRoute');
             return false;
         }

--- a/app/code/core/Mage/Cms/controllers/IndexController.php
+++ b/app/code/core/Mage/Cms/controllers/IndexController.php
@@ -43,6 +43,7 @@ class Mage_Cms_IndexController extends Mage_Core_Controller_Front_Action
     {
         $this->getResponse()->setHeader('HTTP/1.1', '404 Not Found');
         $this->getResponse()->setHeader('Status', '404 File not found');
+        $this->getResponse()->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0', true);
 
         $this->loadLayout();
         $this->renderLayout();
@@ -57,6 +58,7 @@ class Mage_Cms_IndexController extends Mage_Core_Controller_Front_Action
     {
         $this->getResponse()->setHeader('HTTP/1.1', '404 Not Found');
         $this->getResponse()->setHeader('Status', '404 File not found');
+        $this->getResponse()->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0', true);
 
         $pageId = Mage::getStoreConfig(Mage_Cms_Helper_Page::XML_PATH_NO_ROUTE_PAGE);
         if (!Mage::helper('cms/page')->renderPage($this, $pageId)) {
@@ -73,6 +75,7 @@ class Mage_Cms_IndexController extends Mage_Core_Controller_Front_Action
     {
         $this->getResponse()->setHeader('HTTP/1.1', '404 Not Found');
         $this->getResponse()->setHeader('Status', '404 File not found');
+        $this->getResponse()->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0', true);
 
         $this->loadLayout();
         $this->renderLayout();

--- a/app/code/core/Mage/Rss/Controller/Abstract.php
+++ b/app/code/core/Mage/Rss/Controller/Abstract.php
@@ -49,6 +49,7 @@ class Mage_Rss_Controller_Abstract extends Mage_Core_Controller_Front_Action
 
         $this->getResponse()->setHeader('HTTP/1.1', '404 Not Found');
         $this->getResponse()->setHeader('Status', '404 File not found');
+        $this->getResponse()->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0', true);
         $this->_forward('nofeed', 'index', 'rss');
         return false;
     }

--- a/app/code/core/Mage/Rss/controllers/IndexController.php
+++ b/app/code/core/Mage/Rss/controllers/IndexController.php
@@ -48,6 +48,7 @@ class Mage_Rss_IndexController extends Mage_Rss_Controller_Abstract
         } else {
             $this->getResponse()->setHeader('HTTP/1.1', '404 Not Found');
             $this->getResponse()->setHeader('Status', '404 File not found');
+            $this->getResponse()->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0', true);
             $this->_forward('defaultNoRoute');
         }
     }
@@ -59,6 +60,7 @@ class Mage_Rss_IndexController extends Mage_Rss_Controller_Abstract
     {
         $this->getResponse()->setHeader('HTTP/1.1', '404 Not Found');
         $this->getResponse()->setHeader('Status', '404 File not found');
+        $this->getResponse()->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0', true);
         $this->loadLayout(false);
         $this->renderLayout();
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
404 Responses Shouldn't Be Cached: When a resource is not found we don't want the response to be cached. Caching a 404 response could lead to incorrect behavior for users who expect to see different content when they visit a page that previously returned a 404 error.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Call noroute -action
2. The HTTP Response should now include `Cache-Control` property with following values: `no-store, no-cache, must-revalidate, max-age=0`.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [X] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->