### PR TITLE
Fixed bug on incorrect join in addAttributeToSelect() when the second parameter is true

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -1332,7 +1332,11 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
         /**
          * process join type
          */
-        $joinMethod = $joinType === true || $joinType === 'left' ? 'joinLeft' : 'join';
+        if ($joinType === true || $joinType === 'left') {
+            $joinMethod = 'joinLeft';
+        } else {
+            $joinMethod = 'join';
+        }
 
         $this->_joinAttributeToSelect($joinMethod, $attribute, $attrTable, $condArr, $attributeCode, $attrFieldName);
 

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -1332,11 +1332,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
         /**
          * process join type
          */
-        if ($joinType === true || $joinType === 'left') {
-            $joinMethod = 'joinLeft';
-        } else {
-            $joinMethod = 'join';
-        }
+        $joinMethod = ($joinType === true || $joinType === 'left') ? 'joinLeft' : $joinMethod = 'join';
 
         $this->_joinAttributeToSelect($joinMethod, $attribute, $attrTable, $condArr, $attributeCode, $attrFieldName);
 

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -1332,7 +1332,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
         /**
          * process join type
          */
-        $joinMethod = ($joinType === true || $joinType === 'left') ? 'joinLeft' : $joinMethod = 'join';
+        $joinMethod = ($joinType === true || $joinType === 'left') ? 'joinLeft' : 'join';
 
         $this->_joinAttributeToSelect($joinMethod, $attribute, $attrTable, $condArr, $attributeCode, $attrFieldName);
 

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -1332,7 +1332,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
         /**
          * process join type
          */
-        $joinMethod = $joinType == 'left' ? 'joinLeft' : 'join';
+        $joinMethod = $joinType === true || $joinType === 'left' ? 'joinLeft' : 'join';
 
         $this->_joinAttributeToSelect($joinMethod, $attribute, $attrTable, $condArr, $attributeCode, $attrFieldName);
 

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -1268,7 +1268,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
      * Add attribute value table to the join if it wasn't added previously
      *
      * @param   string $attributeCode
-     * @param   string $joinType inner|left
+     * @param   bool|string $joinType inner|left
      * @throws  Mage_Eav_Exception
      * @return  $this
      */
@@ -1332,7 +1332,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
         /**
          * process join type
          */
-        $joinMethod = $joinType === 'left' ? 'joinLeft' : 'join';
+        $joinMethod = $joinType == 'left' ? 'joinLeft' : 'join';
 
         $this->_joinAttributeToSelect($joinMethod, $attribute, $attrTable, $condArr, $attributeCode, $attrFieldName);
 


### PR DESCRIPTION
… parameter is true.

### Description (*)
Ref issue #2664, when the second parameter in `addAttributeToSelect()` is true, the expected join is a left join, but this behavior was changed in PR #2494

![image](https://github.com/OpenMage/magento-lts/assets/1106470/32fb78a7-f7cd-46db-bbd4-4a73dde42da9)

This PR revert the change.

### Related Pull Requests
PR #2494 

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#2664

### Manual testing scenarios (*)
1. See https://onlinephp.io/c/0eb9f on comparison  between `===` and `==`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

