### PR TITLE
Fixed implicit conversion to int is deprecated in Mage_Shell_Indexer

### DIFF
--- a/shell/indexer.php
+++ b/shell/indexer.php
@@ -160,7 +160,7 @@ class Mage_Shell_Indexer extends Mage_Shell_Abstract
                         $resultTime = microtime(true) - $startTime;
                         Mage::dispatchEvent($process->getIndexerCode() . '_shell_reindex_after');
                         echo $process->getIndexer()->getName()
-                            . " index was rebuilt successfully in " . gmdate('H:i:s', $resultTime) . "\n";
+                            . " index was rebuilt successfully in " . gmdate('H:i:s', ceil($resultTime)) . "\n";
                     } catch (Mage_Core_Exception $e) {
                         echo $e->getMessage() . "\n";
                     } catch (Exception $e) {


### PR DESCRIPTION
### Description

This fix `Implicit conversion from float 0.9833660125732422 to int loses precision` for `gmdate` with PHP 8.1.
To test with PHP 8.0 / 8.1 / 8.2 / 8.3: `MAGE_IS_DEVELOPER_MODE=1 php8.x .../shell/indexer.php reindexall`

See also this [discussion comment](https://github.com/OpenMage/magento-lts/discussions/3025#discussioncomment-5195497).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list