### PR TITLE
Updated `Mage_Core_Model_File_Uploader` instantiation to use Mage::getModel()

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/File.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/File.php
@@ -45,7 +45,7 @@ class Mage_Adminhtml_Model_System_Config_Backend_File extends Mage_Core_Model_Co
                 $file['tmp_name'] = $tmpName[$this->getGroupId()]['fields'][$this->getField()]['value'];
                 $name = $_FILES['groups']['name'];
                 $file['name'] = $name[$this->getGroupId()]['fields'][$this->getField()]['value'];
-                $uploader = new Mage_Core_Model_File_Uploader($file);
+                $uploader = Mage::getModel('core/file_uploader', $file);
                 $uploader->setAllowedExtensions($this->_getAllowedExtensions());
                 $uploader->setAllowRenameFiles(true);
                 $this->addValidators($uploader);

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GalleryController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GalleryController.php
@@ -30,7 +30,7 @@ class Mage_Adminhtml_Catalog_Product_GalleryController extends Mage_Adminhtml_Co
     public function uploadAction()
     {
         try {
-            $uploader = new Mage_Core_Model_File_Uploader('image');
+            $uploader = Mage::getModel('core/file_uploader', 'image');
             $uploader->setAllowedExtensions(Varien_Io_File::ALLOWED_IMAGES_EXTENSIONS);
             $uploader->addValidateCallback(
                 'catalog_product_image',

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
@@ -274,7 +274,7 @@ class Mage_Cms_Model_Wysiwyg_Images_Storage extends Varien_Object
      */
     public function uploadFile($targetPath, $type = null)
     {
-        $uploader = new Mage_Core_Model_File_Uploader('image');
+        $uploader = Mage::getModel('core/file_uploader', 'image');
         if ($allowed = $this->getAllowedExtensions($type)) {
             $uploader->setAllowedExtensions($allowed);
         }

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Http.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Http.php
@@ -24,11 +24,9 @@ class Mage_Dataflow_Model_Convert_Adapter_Http extends Mage_Dataflow_Model_Conve
     public function load()
     {
         if (!$_FILES) {
-            ?>
-<form method="POST" enctype="multipart/form-data">
-File to upload: <input type="file" name="io_file"/> <input type="submit" value="Upload"/>
-</form>
-            <?php
+            echo '<form method="POST" enctype="multipart/form-data">';
+            echo 'File to upload: <input type="file" name="io_file"/> <input type="submit" value="Upload"/>';
+            echo '</form>';
             exit;
         }
         if (!empty($_FILES['io_file']['tmp_name'])) {
@@ -52,15 +50,13 @@ File to upload: <input type="file" name="io_file"/> <input type="submit" value="
     public function loadFile()
     {
         if (!$_FILES) {
-            ?>
-<form method="POST" enctype="multipart/form-data">
-File to upload: <input type="file" name="io_file"/> <input type="submit" value="Upload"/>
-</form>
-            <?php
+            echo '<form method="POST" enctype="multipart/form-data">';
+            echo 'File to upload: <input type="file" name="io_file"/> <input type="submit" value="Upload"/>';
+            echo '</form>';
             exit;
         }
         if (!empty($_FILES['io_file']['tmp_name'])) {
-            $uploader = new Mage_Core_Model_File_Uploader('io_file');
+            $uploader = Mage::getModel('core/file_uploader', 'io_file');
             $uploader->setAllowedExtensions(['csv','xml']);
             $path = Mage::app()->getConfig()->getTempVarDir() . '/import/';
             $uploader->save($path);

--- a/app/code/core/Mage/Dataflow/Model/Convert/Iterator/Http.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Iterator/Http.php
@@ -24,21 +24,20 @@ class Mage_Dataflow_Model_Convert_Iterator_Http extends Mage_Dataflow_Model_Conv
     public function load()
     {
         if (!$_FILES) {
-            ?>
-<form method="POST" enctype="multipart/form-data">
-File to upload: <input type="file" name="io_file"/> <input type="submit" value="Upload"/>
-</form>
-            <?php
+            echo '<form method="post" enctype="multipart/form-data">';
+            echo 'File to upload: <input type="file" name="io_file"/> <input type="submit" value="Upload"/>';
+            echo '</form>';
             exit;
         }
         if (!empty($_FILES['io_file']['tmp_name'])) {
-            $uploader = new Mage_Core_Model_File_Uploader('io_file');
+            $uploader = Mage::getModel('core/file_uploader', 'io_file');
             $uploader->setAllowedExtensions(['csv','xml']);
             $path = Mage::app()->getConfig()->getTempVarDir() . '/import/';
             $uploader->save($path);
             if ($uploadFile = $uploader->getUploadedFileName()) {
                 $fp = fopen($uploadFile, 'rb');
                 while ($row = fgetcsv($fp)) {
+                    // check csv
                 }
                 fclose($fp);
             }

--- a/app/code/core/Mage/Dataflow/Model/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Profile.php
@@ -171,7 +171,7 @@ class Mage_Dataflow_Model_Profile extends Mage_Core_Model_Abstract
         ) {
             for ($index = 0; $index < 3; $index++) {
                 if ($file = $_FILES['file_' . ($index + 1)]['tmp_name']) {
-                    $uploader = new Mage_Core_Model_File_Uploader('file_' . ($index + 1));
+                    $uploader = Mage::getModel('core/file_uploader', 'file_' . ($index + 1));
                     $uploader->setAllowedExtensions(['csv','xml']);
                     $path = Mage::app()->getConfig()->getTempVarDir() . '/import/';
                     $uploader->save($path);

--- a/app/code/core/Mage/Dataflow/Model/Session/Adapter/Http.php
+++ b/app/code/core/Mage/Dataflow/Model/Session/Adapter/Http.php
@@ -24,16 +24,14 @@ class Mage_Dataflow_Model_Session_Adapter_Http extends Mage_Dataflow_Model_Conve
     public function load()
     {
         if (!$_FILES) {
-            ?>
-<form method="POST" enctype="multipart/form-data">
-File to upload: <input type="file" name="io_file"/> <input type="submit" value="Upload"/>
-</form>
-            <?php
+            echo '<form method="POST" enctype="multipart/form-data">';
+            echo 'File to upload: <input type="file" name="io_file"/> <input type="submit" value="Upload"/>';
+            echo '</form>';
             exit;
         }
 
         if (!empty($_FILES['io_file']['tmp_name'])) {
-            $uploader = new Mage_Core_Model_File_Uploader('io_file');
+            $uploader = Mage::getModel('core/file_uploader', 'io_file');
             $uploader->setAllowedExtensions(['csv', 'xml']);
             $path = Mage::app()->getConfig()->getTempVarDir() . '/import/';
             $uploader->save($path);

--- a/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/FileController.php
+++ b/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/FileController.php
@@ -43,7 +43,7 @@ class Mage_Downloadable_Adminhtml_Downloadable_FileController extends Mage_Admin
         }
         $result = [];
         try {
-            $uploader = new Mage_Core_Model_File_Uploader($type);
+            $uploader = Mage::getModel('core/file_uploader', $type);
             $uploader->setAllowRenameFiles(true);
             $uploader->setFilesDispersion(true);
             $result = $uploader->save($tmpPath);


### PR DESCRIPTION
### Description

Replace `Mage_Core_Model_File_Uploader` with `core/file_uploader`, like in #3301, everywhere.

Only tested for _app/code/core/Mage/Adminhtml/Model/System/Config/Backend/File.php_.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list