### PR TITLE
Fixed deprecation warning if downloadable sample is a url

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1445,6 +1445,15 @@
       "contributions": [
         "code"
       ]
+  },
+  {
+      "login": "ma4nn",
+      "name": "Christoph Massmann",
+      "avatar_url": "https://avatars.githubusercontent.com/u/26252058?v=4",
+      "profile": "https://www.vianetz.com/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/leissbua"><img src="https://avatars.githubusercontent.com/u/68073221?v=4" loading="lazy" width="100" alt=""/><br /><sub><b>Michael Leiss</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://www.riseart.com/"><img src="https://avatars.githubusercontent.com/u/26821235?v=4" loading="lazy" width="100" alt=""/><br /><sub><b>Marcos Steverlynck</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/ahudock"><img src="https://avatars.githubusercontent.com/u/33500977?v=4" loading="lazy" width="100" alt=""/><br /><sub><b>Andy Hudock</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://www.vianetz.com/"><img src="https://avatars.githubusercontent.com/u/26252058?v=4" loading="lazy" width="100" alt=""/><br /><sub><b>Christoph Massmann</b></sub></a></td>
     </tr>
   </tbody>
 </table>

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
@@ -88,7 +88,7 @@ class Mage_Downloadable_Block_Adminhtml_Catalog_Product_Edit_Tab_Downloadable_Sa
             ];
             $file = Mage::helper('downloadable/file')->getFilePath(
                 Mage_Downloadable_Model_Sample::getBasePath(),
-                $item->getSampleFile()
+                (string)$item->getSampleFile()
             );
             if ($item->getSampleFile() && !is_file($file)) {
                 Mage::helper('core/file_storage_database')->saveFileToFilesystem($file);

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
@@ -88,7 +88,7 @@ class Mage_Downloadable_Block_Adminhtml_Catalog_Product_Edit_Tab_Downloadable_Sa
             ];
             $file = Mage::helper('downloadable/file')->getFilePath(
                 Mage_Downloadable_Model_Sample::getBasePath(),
-                (string)$item->getSampleFile()
+                $item->getSampleFile()
             );
             if ($item->getSampleFile() && !is_file($file)) {
                 Mage::helper('core/file_storage_database')->saveFileToFilesystem($file);

--- a/app/code/core/Mage/Downloadable/Helper/File.php
+++ b/app/code/core/Mage/Downloadable/Helper/File.php
@@ -124,11 +124,15 @@ class Mage_Downloadable_Helper_File extends Mage_Core_Helper_Abstract
      * Return full path to file
      *
      * @param string $path
-     * @param string $file
+     * @param string|null $file
      * @return string
      */
     public function getFilePath($path, $file)
     {
+        if ($file === null) {
+            return $path . DS;
+        }
+
         $file = $this->_prepareFileForPath($file);
 
         if (substr($file, 0, 1) == DS) {

--- a/app/code/core/Mage/Downloadable/Helper/File.php
+++ b/app/code/core/Mage/Downloadable/Helper/File.php
@@ -129,7 +129,7 @@ class Mage_Downloadable_Helper_File extends Mage_Core_Helper_Abstract
      */
     public function getFilePath($path, $file)
     {
-        if ($file === null) {
+        if ($file === null || $file === '') {
             return $path . DS;
         }
 

--- a/app/code/core/Mage/Downloadable/Model/Sample.php
+++ b/app/code/core/Mage/Downloadable/Model/Sample.php
@@ -27,7 +27,7 @@
  * @method $this setProductId(int $value)
  * @method string getSampleUrl()
  * @method $this setSampleUrl(string $value)
- * @method string getSampleFile()
+ * @method string|null getSampleFile()
  * @method $this setSampleFile(string $value)
  * @method string getSampleType()
  * @method $this setSampleType(string $value)


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fixes the error `Deprecated functionality: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated  in /app/htdocs/app/code/core/Mage/Downloadable/Helper/File.php on line 149`.
It occurs when a downloadable product is edited in backend that uses urls for the samples (as opposed to files).

### Manual testing scenarios (*)
1. Create a new downloadable product in backend
2. In tab "Downloadable Information" add a sample row with a URL

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
