### PR TITLE
Deprecated `createEntityTables()` in `Mage_Eav_Model_Entity_Setup`.

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Setup.php
@@ -1239,6 +1239,10 @@ class Mage_Eav_Model_Entity_Setup extends Mage_Core_Model_Resource_Setup
     /****************************** CREATE ENTITY TABLES ***********************************/
 
     /**
+     * @deprecated Missing unique undexes. To create custom EAV tables, refer to the core:
+     * @see app/code/core/Mage/Catalog/sql/catalog_setup/install-1.6.0.0.php
+     * @see app/code/core/Mage/Customer/sql/customer_setup/install-1.6.0.0.php
+     *
      * Create entity tables
      *
      * @param string $baseTableName

--- a/app/code/core/Mage/Eav/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Setup.php
@@ -1239,7 +1239,7 @@ class Mage_Eav_Model_Entity_Setup extends Mage_Core_Model_Resource_Setup
     /****************************** CREATE ENTITY TABLES ***********************************/
 
     /**
-     * @deprecated Missing unique undexes. To create custom EAV tables, refer to the core:
+     * @deprecated Missing unique indexes. To create custom EAV tables, refer to the core:
      * @see app/code/core/Mage/Catalog/sql/catalog_setup/install-1.6.0.0.php
      * @see app/code/core/Mage/Customer/sql/customer_setup/install-1.6.0.0.php
      *


### PR DESCRIPTION
### Description (*)
The function `createEntityTables()` isn't reference in the core, see [search result](https://github.com/search?q=repo%3AOpenMage%2Fmagento-lts+createEntityTables&type=code). As reported in issue #3626, the function does not add the required unique indexes. I propose to deprecate the function as it is not used in the core.

### Related Pull Requests
Issue #3626.

