### PR TITLE
Fixed strtr(): Passing null to parameter #1 ($string) of type string is deprecated

### DIFF
--- a/app/code/core/Mage/Catalog/Helper/Product/Url.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Url.php
@@ -115,6 +115,6 @@ class Mage_Catalog_Helper_Product_Url extends Mage_Core_Helper_Url
      */
     public function format($string)
     {
-        return strtr($string, $this->getConvertTable());
+        return $string === null ? '' : strtr($string, $this->getConvertTable());
     }
 }


### PR DESCRIPTION
…is deprecated

### Description (*)
This is in my log:
```
    [type] => 8192:E_DEPRECATED
    [message] => strtr(): Passing null to parameter #1 ($string) of type string is deprecated
    [file] => .../app/code/core/Mage/Catalog/Helper/Product/Url.php
    [line] => 118
```

It happened once only, I do not know how to replicate it.
