### PR TITLE
Fixed strip_tags(): Passing null to parameter #1 in Fulltext.php

### DIFF
--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
@@ -761,7 +761,9 @@ class Mage_CatalogSearch_Model_Resource_Fulltext extends Mage_Core_Model_Resourc
             }
         }
 
-        $value = preg_replace("#\s+#siu", ' ', trim(strip_tags($value)));
+        if ($value !== null) {
+            $value = preg_replace("#\s+#siu", ' ', trim(strip_tags($value)));
+        }
 
         return $value;
     }

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
@@ -761,9 +761,7 @@ class Mage_CatalogSearch_Model_Resource_Fulltext extends Mage_Core_Model_Resourc
             }
         }
 
-        if ($value !== null) {
-            $value = preg_replace("#\s+#siu", ' ', trim(strip_tags($value)));
-        }
+        $value = $value === null ? '' : preg_replace("#\s+#siu", ' ', trim(strip_tags($value)));
 
         return $value;
     }


### PR DESCRIPTION
### Description (*)
In the process of updating a couple of sites to PHP8.1. This was logged:

```
    [type] => 8192:E_DEPRECATED
    [message] => strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated
    [file] => .../app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
    [line] => 764
    [uri] => /index.php/admin/catalog_product/save/back/edit/tab/product_info_tabs_group_30/store/0/id/13641/key/debdde05d306ac8c1ac92215807e895d/
```

