### PR TITLE
Fixing warning about providing null instead of an expected string

### DIFF
--- a/lib/Unserialize/Reader/Str.php
+++ b/lib/Unserialize/Reader/Str.php
@@ -66,7 +66,7 @@ class Unserialize_Reader_Str
         }
 
         if ($this->_status == self::READING_VALUE) {
-            $val = is_null($this->_value) ? "" : $this->value;
+            $val = is_null($this->_value) ? "" : $this->_value;
             if (strlen($val) < $this->_length) {
                 $this->_value .= $char;
                 return null;

--- a/lib/Unserialize/Reader/Str.php
+++ b/lib/Unserialize/Reader/Str.php
@@ -66,14 +66,15 @@ class Unserialize_Reader_Str
         }
 
         if ($this->_status == self::READING_VALUE) {
-            if (strlen($this->_value) < $this->_length) {
+            $val = is_null($this->_value) ? "" : $this->value;
+            if (strlen($val) < $this->_length) {
                 $this->_value .= $char;
                 return null;
             }
 
-            if (strlen($this->_value) == $this->_length) {
+            if (strlen($val) == $this->_length) {
                 if ($char == Unserialize_Parser::SYMBOL_SEMICOLON && $prevChar == Unserialize_Parser::SYMBOL_QUOTE) {
-                    return (string)$this->_value;
+                    return (string)$val;
                 }
             }
         }

--- a/lib/Unserialize/Reader/Str.php
+++ b/lib/Unserialize/Reader/Str.php
@@ -66,15 +66,19 @@ class Unserialize_Reader_Str
         }
 
         if ($this->_status == self::READING_VALUE) {
-            $val = is_null($this->_value) ? "" : $this->_value;
-            if (strlen($val) < $this->_length) {
+            if (is_null($this->_value)) {
+                $this->_value = $char;
+                return null;
+            }
+
+            if (strlen($this->_value) < $this->_length) {
                 $this->_value .= $char;
                 return null;
             }
 
-            if (strlen($val) == $this->_length) {
+            if (strlen($this->_value) == $this->_length) {
                 if ($char == Unserialize_Parser::SYMBOL_SEMICOLON && $prevChar == Unserialize_Parser::SYMBOL_QUOTE) {
-                    return (string)$val;
+                    return (string)$this->_value;
                 }
             }
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Fixing  a null-vs-string deprecation:
2023-11-18T17:14:09+00:00 ERR (3): strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /..../lib/Unserialize/Reader/Str.php on line 69

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->