### PR TITLE
Allow an empty `content` field in a CMS Block and Page

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Edit/Form.php
@@ -116,7 +116,7 @@ class Mage_Adminhtml_Block_Cms_Block_Edit_Form extends Mage_Adminhtml_Block_Widg
             'label'     => Mage::helper('cms')->__('Content'),
             'title'     => Mage::helper('cms')->__('Content'),
             'style'     => 'height:36em',
-            'required'  => true,
+            'required'  => false,
             'config'    => Mage::getSingleton('cms/wysiwyg_config')->getConfig()
         ]);
 

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Content.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Content.php
@@ -70,7 +70,7 @@ class Mage_Adminhtml_Block_Cms_Page_Edit_Tab_Content extends Mage_Adminhtml_Bloc
         $contentField = $fieldset->addField('content', 'editor', [
             'name'      => 'content',
             'style'     => 'height:36em;',
-            'required'  => true,
+            'required'  => false,
             'disabled'  => $isElementDisabled,
             'config'    => $wysiwygConfig
         ]);


### PR DESCRIPTION
Currently, there needs to be some content in a CMS block. I propose that this restriction is removed. A HTML block can be a placeholder for future content.
