### PR TITLE
Fixed issue #3692, fatal error on saving empty tier price.

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Tierprice.php
@@ -51,7 +51,7 @@ class Mage_Catalog_Model_Product_Attribute_Backend_Tierprice extends Mage_Catalo
     protected function _getAdditionalUniqueFields($objectArray)
     {
         $uniqueFields = parent::_getAdditionalUniqueFields($objectArray);
-        $uniqueFields['qty'] = $objectArray['price_qty'] * 1;
+        $uniqueFields['qty'] = (float) $objectArray['price_qty'];
         return $uniqueFields;
     }
 


### PR DESCRIPTION
### Description (*)
Everything is explained in issue #3692.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#3692

