### PR TITLE
Updated PHPCS packagist name to their new organization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "phpmd/phpmd": "^2.13",
         "phpstan/phpstan": "^1.9.13",
         "phpunit/phpunit": "^9.5",
-        "squizlabs/php_codesniffer": "^3.7",
+        "phpcsstandards/php_codesniffer": "^3.7",
         "symplify/vendor-patches": "^11.1"
     },
     "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7fa4970f47693e04c0b769ceb76a9a9c",
+    "content-hash": "bd67349b55c03159ab1ca47844c267bc",
     "packages": [
         {
             "name": "colinmollenhour/cache-backend-redis",
@@ -4729,12 +4729,12 @@
             "version": "3.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
@@ -4779,6 +4779,20 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
             "time": "2023-02-22T23:07:41+00:00"
         },
         {


### PR DESCRIPTION
PHPCS is migrating to a new organization: https://twitter.com/jrf_nl/status/1730583893537898786 so I thought about updating the package name in our composer.json reflecting this new change.