### PR TITLE
Fixed configuration name typo

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
@@ -151,7 +151,7 @@ class Mage_Adminhtml_Permissions_UserController extends Mage_Adminhtml_Controlle
             try {
                 $model->save();
                 // Send notification to General and additional contacts (if declared) that a new admin user was created.
-                if (Mage::getStoreConfigFlag('admin/security/crate_admin_user_notification') && $isNew) {
+                if (Mage::getStoreConfigFlag('admin/security/create_admin_user_notification') && $isNew) {
                     Mage::getModel('admin/user')->sendAdminNotification($model);
                 }
                 if ($uRoles = $this->getRequest()->getParam('roles', false)) {

--- a/app/code/core/Mage/Core/etc/config.xml
+++ b/app/code/core/Mage/Core/etc/config.xml
@@ -17,7 +17,7 @@
 <config>
     <modules>
         <Mage_Core>
-            <version>1.6.0.10</version>
+            <version>1.6.0.11</version>
         </Mage_Core>
     </modules>
     <global>

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -1256,7 +1256,7 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </extensions_compatibility_mode>
-                        <crate_admin_user_notification translate="label comment">
+                        <create_admin_user_notification translate="label comment">
                             <label>New Admin User Create Notification</label>
                             <comment>This setting enable notification when new admin user created.</comment>
                             <frontend_type>select</frontend_type>
@@ -1265,7 +1265,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
-                        </crate_admin_user_notification>
+                        </create_admin_user_notification>
                         <reprocess_image_quality translate="label comment">
                             <label>Image Reprocess Quality</label>
                             <comment>The recommended value is 85, a higher value will increase the file size. You can set the value to 0 to disable image processing, but it may cause security risks.</comment>

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.10-1.6.0.11.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.10-1.6.0.11.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   Mage
+ * @package    Mage_Core
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
+ * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Core_Model_Resource_Setup $installer */
+$installer = $this;
+$installer->startSetup();
+
+$table = $installer->getTable('core/config_data');
+
+if ($installer->getConnection()->isTableExists($table)) {
+    $oldPath = 'admin/security/crate_admin_user_notification';
+    $newPath = 'admin/security/create_admin_user_notification';
+
+    $select = $installer->getConnection()->select()
+        ->from($table, ['config_id', 'path'])
+        ->where('path = ?', $oldPath);
+
+    $rows = $installer->getConnection()->fetchAll($select);
+
+    foreach ($rows as $row) {
+        $installer->getConnection()->update(
+            $table,
+            ['path' => $newPath],
+            ['config_id = ?' => $row['config_id']]
+        );
+    }
+}
+
+$installer->endSetup();

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.10-1.6.0.11.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.10-1.6.0.11.php
@@ -8,8 +8,7 @@
  *
  * @category   Mage
  * @package    Mage_Core
- * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
- * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixes a typo in a configuration name in the system XML. The incorrect configuration name `crate_admin_user_notification` has been corrected to `create_admin_user_notification`.

### Related Pull Requests
<!-- related pull request placeholder -->
https://github.com/OpenMage/magento-lts/pull/3722

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
No.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Navigate to the admin configuration: System -> Admin -> Security -> New Admin User Create Notification
2. Check the updated configuration name is `create_admin_user_notification`.
3. Test saving the configuration to ensure it works with the corrected name.
4. Optionally make sure email is sent to general store email when creating a new admin user and option "New Admin User Create Notification" is enabled.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
As part of this change, I would like to discuss on how to handle the transfer of the existing configuration values when users upgrade to the new version. The goal is to migrate the values from the old configuration name (crate_admin_user_notification) to the new one (create_admin_user_notification) seamlessly during the upgrade process. 
We could do core_setup script that copies the value but that would need that we upgrade the module version that has not been done before. Any insights or recommended approaches for this would be greatly appreciated. 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->