### PR TITLE
Cast store config image opacity to int (#3727)

### DIFF
--- a/app/code/core/Mage/Catalog/Helper/Image.php
+++ b/app/code/core/Mage/Catalog/Helper/Image.php
@@ -143,7 +143,7 @@ class Mage_Catalog_Helper_Image extends Mage_Core_Helper_Abstract
             Mage::getStoreConfig("design/watermark/{$this->_getModel()->getDestinationSubdir()}_image")
         );
         $this->setWatermarkImageOpacity(
-            Mage::getStoreConfig("design/watermark/{$this->_getModel()->getDestinationSubdir()}_imageOpacity")
+            (int) Mage::getStoreConfig("design/watermark/{$this->_getModel()->getDestinationSubdir()}_imageOpacity")
         );
         $this->setWatermarkPosition(
             Mage::getStoreConfig("design/watermark/{$this->_getModel()->getDestinationSubdir()}_position")

--- a/app/code/core/Mage/Catalog/Helper/Image.php
+++ b/app/code/core/Mage/Catalog/Helper/Image.php
@@ -143,7 +143,7 @@ class Mage_Catalog_Helper_Image extends Mage_Core_Helper_Abstract
             Mage::getStoreConfig("design/watermark/{$this->_getModel()->getDestinationSubdir()}_image")
         );
         $this->setWatermarkImageOpacity(
-            (int) Mage::getStoreConfig("design/watermark/{$this->_getModel()->getDestinationSubdir()}_imageOpacity")
+            Mage::getStoreConfig("design/watermark/{$this->_getModel()->getDestinationSubdir()}_imageOpacity")
         );
         $this->setWatermarkPosition(
             Mage::getStoreConfig("design/watermark/{$this->_getModel()->getDestinationSubdir()}_position")
@@ -488,12 +488,12 @@ class Mage_Catalog_Helper_Image extends Mage_Core_Helper_Abstract
     /**
      * Set watermark image opacity
      *
-     * @param int $imageOpacity
+     * @param int|string $imageOpacity
      * @return $this
      */
     public function setWatermarkImageOpacity($imageOpacity)
     {
-        $this->_watermarkImageOpacity = $imageOpacity;
+        $this->_watermarkImageOpacity = (int) $imageOpacity;
         $this->_getModel()->setWatermarkImageOpacity($imageOpacity);
         return $this;
     }

--- a/app/code/core/Mage/Catalog/Model/Product/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Image.php
@@ -693,12 +693,12 @@ class Mage_Catalog_Model_Product_Image extends Mage_Core_Model_Abstract
     /**
      * Set watermark image opacity
      *
-     * @param int $imageOpacity
+     * @param int|string $imageOpacity
      * @return $this
      */
     public function setWatermarkImageOpacity($imageOpacity)
     {
-        $this->_watermarkImageOpacity = $imageOpacity;
+        $this->_watermarkImageOpacity = (int) $imageOpacity;
         return $this;
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixes PHP 8.1 exception `Argument #9 ($pct) must be of type int, string given in lib/Varien/Image/Adapter/Gd2.php:504` thrown when custom image opacity is set in admin configuration.


### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#3727

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Ensure that you are working with PHP 8.1 or newer.
2. Go to System -> Configuration -> Product Image Watermarks.
3. Add watermark images and set every opacity field to any value.
4. Check if PDP works properly images are properly rendered with or without the adjustment.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All automated tests passed successfully (all builds are green)
 - [X] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->