### PR TITLE
Fixed stripTags() null deprecation.

### DIFF
--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -250,6 +250,9 @@ abstract class Mage_Core_Helper_Abstract
      */
     public function stripTags($data, $allowableTags = null, $escape = false)
     {
+        if ($data === null) {
+            return '';
+        }
         $result = strip_tags($data, $allowableTags);
         return $escape ? $this->escapeHtml($result, $allowableTags) : $result;
     }


### PR DESCRIPTION
    [type] => 8192:E_DEPRECATED
    [message] => strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated
    [file] => .../app/code/core/Mage/Core/Helper/Abstract.php
    [line] => 253
    [uri] => /wishlist/index/index/wishlist_id/864/