### PR TITLE
Fix autoincrement id fetching cache problem in import/export module

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1418,6 +1418,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "leissbua",
+      "name": "leissbua",
+      "avatar_url": "https://avatars.githubusercontent.com/u/68073221?v=4",
+      "profile": "https://github.com/leissbua",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1421,7 +1421,7 @@
     },
     {
       "login": "leissbua",
-      "name": "leissbua",
+      "name": "Michael Leiss",
       "avatar_url": "https://avatars.githubusercontent.com/u/68073221?v=4",
       "profile": "https://github.com/leissbua",
       "contributions": [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-<a href="#contributors-"><img src="https://img.shields.io/badge/all_contributors-156-orange.svg" alt="All Contributors"></a>
+<a href="#contributors-"><img src="https://img.shields.io/badge/all_contributors-157-orange.svg" alt="All Contributors"></a>
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 <a href="https://packagist.org/packages/openmage/magento-lts"><img src="https://poser.pugx.org/openmage/magento-lts/d/total.svg" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/openmage/magento-lts"><img src="https://poser.pugx.org/openmage/magento-lts/license.svg" alt="License"></a>
@@ -589,7 +589,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://juhoholsa.com/"><img src="https://avatars.githubusercontent.com/u/15036353?v=4" loading="lazy" width="100" alt=""/><br /><sub><b>Juho Hölsä</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/seifer7"><img src="https://avatars.githubusercontent.com/u/13601073?v=4" loading="lazy" width="100" alt=""/><br /><sub><b>Kane</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Sdfendor"><img src="https://avatars.githubusercontent.com/u/2728018?v=4" loading="lazy" width="100" alt=""/><br /><sub><b>Kevin Jakob</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/leissbua"><img src="https://avatars.githubusercontent.com/u/68073221?v=4" loading="lazy" width="100" alt=""/><br /><sub><b>leissbua</b></sub></a></td>
     </tr>
   </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://juhoholsa.com/"><img src="https://avatars.githubusercontent.com/u/15036353?v=4" loading="lazy" width="100" alt=""/><br /><sub><b>Juho Hölsä</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/seifer7"><img src="https://avatars.githubusercontent.com/u/13601073?v=4" loading="lazy" width="100" alt=""/><br /><sub><b>Kane</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Sdfendor"><img src="https://avatars.githubusercontent.com/u/2728018?v=4" loading="lazy" width="100" alt=""/><br /><sub><b>Kevin Jakob</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/leissbua"><img src="https://avatars.githubusercontent.com/u/68073221?v=4" loading="lazy" width="100" alt=""/><br /><sub><b>leissbua</b></sub></a></td>
     </tr>
   </tbody>

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -69,7 +69,7 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
     {
         if (!self::$instantInformationSchemaStatsExpiry) {
             // Set information_schema_stats_expiry to 0
-            $this->getReadAdapter()->query('SET information_schema_stats_expiry = 0;');
+            $this->_getReadAdapter()->query('SET information_schema_stats_expiry = 0;');
             self::$instantInformationSchemaStatsExpiry = true;
         }
     }

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -54,8 +54,6 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
         if (empty($entityStatus['Auto_increment'])) {
             Mage::throwException(Mage::helper('importexport')->__('Cannot get autoincrement value'));
         }
-	
 	return $entityStatus['Auto_increment'];
     }
-
 }

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -71,7 +71,7 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
     /**
      * Set information_schema_stats_expiry to 0 if not already set.
      */
-    public function setInformationSchemaStatsExpiry()
+    public function setInformationSchemaStatsExpiry(): void
     {
         if (!self::$instantInformationSchemaStatsExpiry) {
             $this->_getReadAdapter()->query('SET information_schema_stats_expiry = 0;');

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -54,9 +54,8 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
         if (empty($entityStatus['Auto_increment'])) {
             Mage::throwException(Mage::helper('importexport')->__('Cannot get autoincrement value'));
         }
-
-        $adapter->query('SET information_schema_stats_expiry = 1;');
-        return $entityStatus['Auto_increment'];
+	
+	return $entityStatus['Auto_increment'];
     }
 
 }

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -26,14 +26,14 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
      */
     public const DB_MAX_PACKET_SIZE        = 1048576; // Maximal packet length by default in MySQL
     public const DB_MAX_PACKET_COEFFICIENT = 0.85; // The coefficient of useful data from maximum packet length
-    
+
     /**
      * Semaphore to disable schema stats only once
      *
      * @var bool
      */
     private static $instantInformationSchemaStatsExpiry = false;
-    
+
     /**
      * Returns maximum size of packet, that we can send to DB
      *
@@ -45,7 +45,7 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
         $maxPacket = empty($maxPacketData['Value']) ? self::DB_MAX_PACKET_SIZE : $maxPacketData['Value'];
         return floor($maxPacket * self::DB_MAX_PACKET_COEFFICIENT);
     }
-    
+
     /**
      * Returns next autoincrement value for a table
      *
@@ -67,7 +67,7 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
         }
         return $entityStatus['Auto_increment'];
     }
-    
+
     /**
      * Set information_schema_stats_expiry to 0 if not already set.
      */

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -56,7 +56,11 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
     public function getNextAutoincrement($tableName)
     {
         $adapter = $this->_getReadAdapter();
-        $this->setInformationSchemaStatsExpiry();
+        try {
+            $this->setInformationSchemaStatsExpiry();    
+        } catch (Exception $e) {
+            //this will throw an exception for < mysql8
+        }
         $entityStatus = $adapter->showTableStatus($tableName);
         if (empty($entityStatus['Auto_increment'])) {
             Mage::throwException(Mage::helper('importexport')->__('Cannot get autoincrement value'));
@@ -70,7 +74,6 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
     public function setInformationSchemaStatsExpiry()
     {
         if (!self::$instantInformationSchemaStatsExpiry) {
-            // Set information_schema_stats_expiry to 0
             $this->_getReadAdapter()->query('SET information_schema_stats_expiry = 0;');
             self::$instantInformationSchemaStatsExpiry = true;
         }

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -54,6 +54,6 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
         if (empty($entityStatus['Auto_increment'])) {
             Mage::throwException(Mage::helper('importexport')->__('Cannot get autoincrement value'));
         }
-	return $entityStatus['Auto_increment'];
+        return $entityStatus['Auto_increment'];
     }
 }

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -74,7 +74,9 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
     public function setInformationSchemaStatsExpiry(): void
     {
         if (!self::$instantInformationSchemaStatsExpiry) {
-            $this->_getReadAdapter()->query('SET information_schema_stats_expiry = 0;');
+            try {
+                $this->_getReadAdapter()->query('SET information_schema_stats_expiry = 0;');
+            } catch (Exception $e) {}
             self::$instantInformationSchemaStatsExpiry = true;
         }
     }

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -72,7 +72,8 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
         if (!self::$instantInformationSchemaStatsExpiry) {
             try {
                 $this->_getReadAdapter()->query('SET information_schema_stats_expiry = 0;');
-            } catch (Exception $e) {}
+            } catch (Exception $e) {
+            }
             self::$instantInformationSchemaStatsExpiry = true;
         }
     }

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -56,11 +56,7 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
     public function getNextAutoincrement($tableName)
     {
         $adapter = $this->_getReadAdapter();
-        try {
-            $this->setInformationSchemaStatsExpiry();
-        } catch (Exception $e) {
-            //this will throw an exception for < mysql8
-        }
+        $this->setInformationSchemaStatsExpiry();
         $entityStatus = $adapter->showTableStatus($tableName);
         if (empty($entityStatus['Auto_increment'])) {
             Mage::throwException(Mage::helper('importexport')->__('Cannot get autoincrement value'));

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -57,7 +57,7 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
     {
         $adapter = $this->_getReadAdapter();
         try {
-            $this->setInformationSchemaStatsExpiry();    
+            $this->setInformationSchemaStatsExpiry();
         } catch (Exception $e) {
             //this will throw an exception for < mysql8
         }

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -26,7 +26,7 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
      */
     public const DB_MAX_PACKET_SIZE        = 1048576; // Maximal packet length by default in MySQL
     public const DB_MAX_PACKET_COEFFICIENT = 0.85; // The coefficient of useful data from maximum packet length
-
+    
     /**
      * Semaphore to disable schema stats only once
      *
@@ -45,7 +45,7 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
         $maxPacket = empty($maxPacketData['Value']) ? self::DB_MAX_PACKET_SIZE : $maxPacketData['Value'];
         return floor($maxPacket * self::DB_MAX_PACKET_COEFFICIENT);
     }
-
+    
     /**
      * Returns next autoincrement value for a table
      *
@@ -67,7 +67,7 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
         }
         return $entityStatus['Auto_increment'];
     }
-
+    
     /**
      * Set information_schema_stats_expiry to 0 if not already set.
      */

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -29,8 +29,10 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
 
     /**
      * Semaphore to disable schema stats only once
+     *
+     * @var bool
      */
-    private static boolean $instantInformationSchemaStatsExpiry = false;
+    private static $instantInformationSchemaStatsExpiry = false;
     
     /**
      * Returns maximum size of packet, that we can send to DB

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -49,11 +49,14 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Res
     public function getNextAutoincrement($tableName)
     {
         $adapter = $this->_getReadAdapter();
+        $adapter->query('SET information_schema_stats_expiry = 0;');
         $entityStatus = $adapter->showTableStatus($tableName);
-
         if (empty($entityStatus['Auto_increment'])) {
             Mage::throwException(Mage::helper('importexport')->__('Cannot get autoincrement value'));
         }
+
+        $adapter->query('SET information_schema_stats_expiry = 1;');
         return $entityStatus['Auto_increment'];
     }
+
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Import/Export fetches an autoincrement id via getNextAutoincrement($tableName) by mysql SHOW TABLE STATUS.
That table information is cached in standard mySQL and should be cached. In first place I would say, that handling of the autoincrement register of a table should only be managed by mysql, but here we are, dealing with Magento.
The change is simply to set information_schema_stats_expiry to 0 before fetching the autoincrement. This will only be valid for the connection session and does not create a performance problem for the framework in other places, where caching is absolutely wanted. In general. import/export module is the only caller to that function, so to disable the information schema cache in general would not be a good idea.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Make sure information_schema_stats_expiry is set default 86400 seconds in mysql8. Import a configurable product in replace mode, having at least one child. Go to e.g. table catalog_product_super_attribute and check the autoincremented product_super_attribute_id.
Do nothing that could trigger a mysql cache refresh. Do the same import again, and you will end up having exactly the same product_super_attribute_id from the first import.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->