### PR TITLE
Custom option null deprecation

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
@@ -567,7 +567,7 @@ abstract class Mage_Catalog_Model_Product_Type_Abstract
                 if ($option->getIsRequire()) {
                     $customOption = $this->getProduct($product)
                         ->getCustomOption(self::OPTION_PREFIX . $option->getId());
-                    if (!$customOption || strlen($customOption->getValue()) == 0) {
+                    if (!$customOption || $customOption->getValue() === null || strlen($customOption->getValue()) == 0) {
                         $this->getProduct($product)->setSkipCheckRequiredOption(true);
                         Mage::throwException(
                             Mage::helper('catalog')->__('The product has required options')

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
@@ -567,7 +567,7 @@ abstract class Mage_Catalog_Model_Product_Type_Abstract
                 if ($option->getIsRequire()) {
                     $customOption = $this->getProduct($product)
                         ->getCustomOption(self::OPTION_PREFIX . $option->getId());
-                    if (!$customOption || $customOption->getValue() === null || strlen($customOption->getValue()) == 0) {
+                    if (!$customOption || $customOption->getValue() === null || strlen($customOption->getValue()) === 0) {
                         $this->getProduct($product)->setSkipCheckRequiredOption(true);
                         Mage::throwException(
                             Mage::helper('catalog')->__('The product has required options')


### PR DESCRIPTION
```
    [type] => 8192:E_DEPRECATED
    [message] => strlen(): Passing null to parameter #1 ($string) of type string is deprecated
    [file] => .../app/code/Mage/Catalog/Model/Product/Type/Abstract.php
    [line] => 570
    [uri] => /checkout/cart/configure/id/296927/
```