### PR TITLE
Fixed null deprecation in Zend_Pdf

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
@@ -444,6 +444,7 @@ abstract class Mage_Sales_Model_Order_Pdf_Abstract extends Varien_Object
 
             $tracks = [];
             if ($shipment) {
+                /** @var Mage_Sales_Model_Order_Shipment $shipment */
                 $tracks = $shipment->getAllTracks();
             }
             if (count($tracks)) {
@@ -474,7 +475,7 @@ abstract class Mage_Sales_Model_Order_Pdf_Abstract extends Varien_Object
                     $truncatedTitle = substr($track->getTitle(), 0, $maxTitleLen) . $endOfTitle;
                     //$page->drawText($truncatedCarrierTitle, 285, $yShipments , 'UTF-8');
                     $page->drawText($truncatedTitle, 292, $yShipments, 'UTF-8');
-                    $page->drawText($track->getNumber(), 410, $yShipments, 'UTF-8');
+                    $page->drawText($track->getNumber() ?? '', 410, $yShipments, 'UTF-8');
                     $yShipments -= $topMargin - 5;
                 }
             } else {

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/PageBuilder.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/PageBuilder.php
@@ -258,7 +258,7 @@ class Mage_Usa_Model_Shipping_Carrier_Dhl_Label_Pdf_PageBuilder
 
         $phoneNumber = implode(' ', array_filter([(string)$sender->Contact->PhoneNumber,
             (string)$sender->Contact->PhoneExtension]));
-        $phoneNumber = $phoneNumber ? "Phone: " . $phoneNumber : null;
+        $phoneNumber = $phoneNumber ? "Phone: " . $phoneNumber : '';
         $pageY = $this->_drawSenderAddress($sender->AddressLine, $phoneNumber);
 
         $divisionCode = (string)(strlen($sender->DivisionCode) ? $sender->DivisionCode . ' ' : null);


### PR DESCRIPTION
See https://github.com/Shardj/zf1-future/issues/398:
```
[type] => 8192:E_DEPRECATED
[message] => iconv(): Passing null to parameter #3 ($string) of type string is deprecated
[file] => .../shardj/zf1-future/library/Zend/Pdf/Resource/Font/Simple.php
```

When we try to draw a null with `drawText()` on a pdf page: `$page->drawText(null)`, the deprecation notice is thrown.