### PR TITLE
Added whitelist to OAuth consumer callback URLs to allow custom URL scheme

### DIFF
--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit/Form.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit/Form.php
@@ -92,7 +92,6 @@ class Mage_Oauth_Block_Adminhtml_Oauth_Consumer_Edit_Form extends Mage_Adminhtml
             'title'     => Mage::helper('oauth')->__('Callback URL'),
             'required'  => false,
             'value'     => $model->getCallbackUrl(),
-            'class'     => 'validate-url',
         ]);
 
         $fieldset->addField('rejected_callback_url', 'text', [
@@ -101,7 +100,6 @@ class Mage_Oauth_Block_Adminhtml_Oauth_Consumer_Edit_Form extends Mage_Adminhtml
             'title'     => Mage::helper('oauth')->__('Rejected Callback URL'),
             'required'  => false,
             'value'     => $model->getRejectedCallbackUrl(),
-            'class'     => 'validate-url',
         ]);
 
         $fieldset->addField(

--- a/app/code/core/Mage/Oauth/Model/Consumer.php
+++ b/app/code/core/Mage/Oauth/Model/Consumer.php
@@ -65,6 +65,8 @@ class Mage_Oauth_Model_Consumer extends Mage_Core_Model_Abstract
         if (!$this->getId()) {
             $this->setUpdatedAt(time());
         }
+        $this->setCallbackUrl(trim($this->getCallbackUrl()));
+        $this->setRejectedCallbackUrl(trim($this->getRejectedCallbackUrl()));
         $this->validate();
         parent::_beforeSave();
         return $this;
@@ -73,26 +75,11 @@ class Mage_Oauth_Model_Consumer extends Mage_Core_Model_Abstract
     /**
      * Validate data
      *
-     * @return array|bool
+     * @return bool
      * @throw Mage_Core_Exception|Exception   Throw exception on fail validation
      */
     public function validate()
     {
-        if ($this->getCallbackUrl() || $this->getRejectedCallbackUrl()) {
-            $this->setCallbackUrl(trim($this->getCallbackUrl()));
-            $this->setRejectedCallbackUrl(trim($this->getRejectedCallbackUrl()));
-
-            /** @var Mage_Core_Model_Url_Validator $validatorUrl */
-            $validatorUrl = Mage::getSingleton('core/url_validator');
-
-            if ($this->getCallbackUrl() && !$validatorUrl->isValid($this->getCallbackUrl())) {
-                Mage::throwException(Mage::helper('oauth')->__('Invalid Callback URL'));
-            }
-            if ($this->getRejectedCallbackUrl() && !$validatorUrl->isValid($this->getRejectedCallbackUrl())) {
-                Mage::throwException(Mage::helper('oauth')->__('Invalid Rejected Callback URL'));
-            }
-        }
-
         /** @var Mage_Oauth_Model_Consumer_Validator_KeyLength $validatorLength */
         $validatorLength = Mage::getModel('oauth/consumer_validator_keyLength', ['length' => self::KEY_LENGTH]);
 

--- a/app/code/core/Mage/Oauth/Model/Server.php
+++ b/app/code/core/Mage/Oauth/Model/Server.php
@@ -432,7 +432,12 @@ class Mage_Oauth_Model_Server
         if (!is_string($this->_protocolParams['oauth_callback'])) {
             $this->_throwException('oauth_callback', self::ERR_PARAMETER_REJECTED);
         }
-        if (self::CALLBACK_ESTABLISHED != $this->_protocolParams['oauth_callback']
+        // Is the callback URL whitelisted?
+        $callbackUrl = $this->_consumer->getCallbackUrl();
+        if ($callbackUrl && strpos($this->_protocolParams['oauth_callback'], $callbackUrl) === 0) {
+            return;
+        }
+        if (self::CALLBACK_ESTABLISHED !== $this->_protocolParams['oauth_callback']
             && !Zend_Uri::check($this->_protocolParams['oauth_callback'])
         ) {
             $this->_throwException('oauth_callback', self::ERR_PARAMETER_REJECTED);

--- a/app/code/core/Mage/Oauth/Model/Token.php
+++ b/app/code/core/Mage/Oauth/Model/Token.php
@@ -220,18 +220,19 @@ class Mage_Oauth_Model_Token extends Mage_Core_Model_Abstract
     /**
      * Validate data
      *
-     * @return array|bool
+     * @return bool
      * @throw Mage_Core_Exception|Exception   Throw exception on fail validation
      */
     public function validate()
     {
-        /** @var Mage_Core_Model_Url_Validator $validatorUrl */
-        $validatorUrl = Mage::getSingleton('core/url_validator');
-        if (Mage_Oauth_Model_Server::CALLBACK_ESTABLISHED != $this->getCallbackUrl()
-            && !$validatorUrl->isValid($this->getCallbackUrl())
-        ) {
-            $messages = $validatorUrl->getMessages();
-            Mage::throwException(array_shift($messages));
+        if (Mage_Oauth_Model_Server::CALLBACK_ESTABLISHED !== $this->getCallbackUrl()) {
+            $callbackUrl = $this->getConsumer()->getCallbackUrl();
+            $isWhitelisted = $callbackUrl && strpos($this->getCallbackUrl(), $callbackUrl) === 0;
+            $validatorUrl = Mage::getSingleton('core/url_validator');
+            if (!$isWhitelisted && !$validatorUrl->isValid($this->getCallbackUrl())) {
+                $messages = $validatorUrl->getMessages();
+                Mage::throwException(array_shift($messages));
+            }
         }
 
         /** @var Mage_Oauth_Model_Consumer_Validator_KeyLength $validatorLength */


### PR DESCRIPTION
…eme.

### Description (*)
I need to do something similar to this [stackoverflow](https://stackoverflow.com/questions/32067812/magento-oauth-authentication-can-not-handle-custom-url-scheme), I need to provide OAuth to a mobile app, in which the callback URL looks like this `myapp://call-back`. It doesn't work without the fix in the [stackoverflow](https://stackoverflow.com/questions/32067812/magento-oauth-authentication-can-not-handle-custom-url-scheme), or this PR.

This PR does 2 things:
1. Remove the URL validation on  _Callback URL_ and _Rejected Callback URL_ when saving OAuth Consumer in backend: 
![image](https://github.com/OpenMage/magento-lts/assets/1106470/88665667-a1c1-485d-bbec-cb7d10c2bafd)
2. Use the _Callback URL_ as a whitelist for custom scheme. This code ensures that the callback URL is either whitelisted or is a valid URL, so security is not compromised for custom URL schemes.
