### PR TITLE
Fixed strip_tags(): Passing null to parameter #1 in Catalog/Model/Product/Option/Type/File.php

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
@@ -545,7 +545,8 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
      */
     public function getPrintableOptionValue($optionValue)
     {
-        return strip_tags($this->getFormattedOptionValue($optionValue));
+        $value = $this->getFormattedOptionValue($optionValue);
+        return $value === null ? '' : strip_tags($value);
     }
 
     /**


### PR DESCRIPTION
…duct/Option/Type/File.php

    [type] => 8192:E_DEPRECATED
    [message] => strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated
    [file] => .../app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
    [line] => 548
    [uri] => /checkout/cart/configure/id/303441/