### PR TITLE
Updated allcontributors badge to new format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-<p align="center">
 [![All Contributors](https://img.shields.io/github/all-contributors/openmage/magento-lts?color=ee8449)](#contributors)
 <a href="https://packagist.org/packages/openmage/magento-lts"><img src="https://poser.pugx.org/openmage/magento-lts/d/total.svg" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/openmage/magento-lts"><img src="https://poser.pugx.org/openmage/magento-lts/license.svg" alt="License"></a>
 <a href="https://github.com/openmage/magento-lts/actions/workflows/security-php.yml"><img src="https://github.com/openmage/magento-lts/actions/workflows/security-php.yml/badge.svg" alt="PHP Security workflow Badge" /></a>
 <a href="https://github.com/OpenMage/magento-lts/actions/workflows/workflow.yml"><img src="https://github.com/OpenMage/magento-lts/actions/workflows/workflow.yml/badge.svg" alt="CI workflow Badge" /></a>
-</p>
 
 # Magento - Long Term Support
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <p align="center">
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-<a href="#contributors-"><img src="https://img.shields.io/badge/all_contributors-157-orange.svg" alt="All Contributors"></a>
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
+[![All Contributors](https://img.shields.io/github/all-contributors/openmage/magento-lts?color=ee8449)](#contributors)
 <a href="https://packagist.org/packages/openmage/magento-lts"><img src="https://poser.pugx.org/openmage/magento-lts/d/total.svg" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/openmage/magento-lts"><img src="https://poser.pugx.org/openmage/magento-lts/license.svg" alt="License"></a>
 <a href="https://github.com/openmage/magento-lts/actions/workflows/security-php.yml"><img src="https://github.com/openmage/magento-lts/actions/workflows/security-php.yml/badge.svg" alt="PHP Security workflow Badge" /></a>


### PR DESCRIPTION
As stated in [allcontributors faq](https://allcontributors.org/docs/en/bot/faq) there's a new format for the number-of-contributors badge, which is actually much better cause we don't have to update the number every time.

you can notice I've removed the "align center" because it was breaking the badge (for some weird github reason), the only way to fix it was to add an empty line but... these weird hack are forgotten in 2 seconds and then we'd break it at the next update to the readme.

result of this PR is:
<img width="939" alt="Screenshot 2024-02-02 alle 22 32 03" src="https://github.com/OpenMage/magento-lts/assets/909743/770d85a0-e00f-46e5-9a52-35e1d9af27c9">
