### PR TITLE
DDEV: added cronjob

### DIFF
--- a/.ddev/web-build/Dockerfile.ddev-cron
+++ b/.ddev/web-build/Dockerfile.ddev-cron
@@ -1,0 +1,18 @@
+#ddev-generated
+# Install cron package; this can be done in webimage_extra_packages, but put it here for now.
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests cron
+
+# Copy our custom config
+COPY ./cron.conf /etc/supervisor/conf.d/cron.conf
+
+# Make it so you can add to cron.d without root privileges
+RUN chmod 777 /etc/cron.d /var/run
+
+# Copy over our custom jobs
+COPY ./*.cron /etc/cron.d/
+
+# Give execution rights on the cron jobs
+RUN chmod -f 0644 /etc/cron.d/*.cron || true
+
+# Concatenate files
+RUN { cat /etc/cron.d/*.cron; } | crontab -u ${username} -

--- a/.ddev/web-build/cron.conf
+++ b/.ddev/web-build/cron.conf
@@ -1,0 +1,8 @@
+#ddev-generated
+[program:cron]
+command=sudo /usr/sbin/cron -f -L7
+autorestart=true
+startretries=10
+stdout_logfile=/proc/self/fd/2
+stdout_logfile_maxbytes=0
+redirect_stderr=true

--- a/.ddev/web-build/openmage.cron
+++ b/.ddev/web-build/openmage.cron
@@ -1,0 +1,1 @@
+* * * * * /var/www/html/cron.sh


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Adds ddev cronjob ...

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. See OpenMage/magento-lts#3780

(have to run `ddev poweroff` or `ddev restart`)

@ADDISON74 pls test without `ddev get ddev/ddev-cron`! Files in place should work.