### PR TITLE
Removed openmage's dev-dependencies in PHPUnit workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install OpenMage dependencies
         working-directory: ./openmage
-        run: composer install --prefer-dist --no-progress --ignore-platform-reqs
+        run: composer install --prefer-dist --no-progress --ignore-platform-reqs --no-dev
 
       - name: run phpUnit
         run: bash ./run_unit_tests.sh


### PR DESCRIPTION
in this context the dev dependencies are included in the Testfield repository, having them in both messes up phpunits class loading,