### PR TITLE
DDEV - Removing the sample archive from the root directory

### DIFF
--- a/.ddev/commands/web/openmage-install
+++ b/.ddev/commands/web/openmage-install
@@ -70,7 +70,7 @@ fi
 
 if [[ $INSTALL_SAMPLE_DATA =~ ^(yes|y) ]]; then
   SAMPLE_DATA_URL=https://github.com/Vinai/compressed-magento-sample-data/raw/master/compressed-magento-sample-data-1.9.2.4.tgz
-  SAMPLE_DATA_DIRECTORY="${ROOT}/.sampleData"
+  SAMPLE_DATA_DIRECTORY="${ROOT}/.ddev/.sampleData"
   SAMPLE_DATA_FILE=sample_data.tgz
 
   if [[ ! -d "${SAMPLE_DATA_DIRECTORY}" ]]; then
@@ -88,7 +88,8 @@ if [[ $INSTALL_SAMPLE_DATA =~ ^(yes|y) ]]; then
   tar xf "${SAMPLE_DATA_FILE}"
 
   echo "Copying Sample Data into the OpenMage directory..."
-  cp -r magento-sample-data-1.9.2.4/* "${ROOT}/"
+  cp -r magento-sample-data-1.9.2.4/media/* "${ROOT}/media/"
+  cp -r magento-sample-data-1.9.2.4/skin/* "${ROOT}/skin/"
 
   echo "Clearing var/cache..."
   rm -rf "${ROOT}/var/cache/"*
@@ -99,8 +100,7 @@ if [[ $INSTALL_SAMPLE_DATA =~ ^(yes|y) ]]; then
   # remove sample data
   if [[ "${SAMPLE_DATA_KEEP_FLAG}" ]]; then
     # shellcheck disable=SC2046
-    rm -rf $(
-      find . -maxdepth 1 -type f -name "*" ! -name "${SAMPLE_DATA_FILE}")
+    rm -rf magento-sample-data-1.9.2.4/
   else
     cd "${ROOT}" || exit
     rm -rf "${SAMPLE_DATA_DIRECTORY}"

--- a/.gitignore
+++ b/.gitignore
@@ -55,9 +55,6 @@
 # composer
 /vendor
 
-# ddev
-.ddev/config.yaml
-
 # scss-cache
 /skin/*/*/*/scss/.sass-cache
 
@@ -80,3 +77,6 @@ phpstan*.neon
 # dev scripts loaded via composer
 /shell/update-copyright.php
 /shell/translations.php
+
+# DDEV
+.ddev/.sampleData


### PR DESCRIPTION
### Important Notice
This is PR #3793 deleted by the author. For me this PR was important to install the Magento Sample Pack.

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

The sample database was initially saved in the root directory. This PR deletes it or keeps it for a later install.

The **-k** flag is for keeping the downloaded archive to be used with new installations. The archive will be stored in the **.ddev/.sampleData** directory. This one must be ignored by git.

### Related Pull Requests
<!-- related pull request placeholder -->

See OpenMage/magento-lts#3788

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ```ddev openmage-install -q``` 
2. ```ddev openmage-install -q -k```

Thank you @sreichel for your contribution. I would have preferred to merge the PR created by you instead of wasting time to create it again.