### PR TITLE
Fixed some PHP8.1 warnings about null parameters

### DIFF
--- a/app/code/core/Mage/Customer/Block/Widget/Name.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Name.php
@@ -74,7 +74,7 @@ class Mage_Customer_Block_Widget_Name extends Mage_Customer_Block_Widget_Abstrac
         $helper = $this->helper('customer');
         $prefixOptions = $helper->getNamePrefixOptions();
         if ($this->getObject() && !empty($prefixOptions)) {
-            $oldPrefix = $this->escapeHtml(trim($this->getObject()->getPrefix()));
+            $oldPrefix = $this->escapeHtml(trim($this->getObject()->getPrefix() ?? ''));
             $prefixOptions[$oldPrefix] = $oldPrefix;
         }
         return $prefixOptions;
@@ -131,7 +131,7 @@ class Mage_Customer_Block_Widget_Name extends Mage_Customer_Block_Widget_Abstrac
         $helper = $this->helper('customer');
         $suffixOptions = $helper->getNameSuffixOptions();
         if ($this->getObject() && !empty($suffixOptions)) {
-            $oldSuffix = $this->escapeHtml(trim($this->getObject()->getSuffix()));
+            $oldSuffix = $this->escapeHtml(trim($this->getObject()->getSuffix() ?? ''));
             $suffixOptions[$oldSuffix] = $oldSuffix;
         }
         return $suffixOptions;

--- a/app/code/core/Mage/Customer/Helper/Data.php
+++ b/app/code/core/Mage/Customer/Helper/Data.php
@@ -417,10 +417,7 @@ class Mage_Customer_Helper_Data extends Mage_Core_Helper_Abstract
         $result = [];
         $options = explode(';', $options);
         foreach ($options as $value) {
-            if ($value !== null && strlen($value) > 0) {
-                $value = $this->escapeHtml(trim($value));
-            }
-            $result[$value] = $value;
+            $result[$value] = $this->escapeHtml(trim($value));
         }
         return $result;
     }

--- a/app/code/core/Mage/Customer/Helper/Data.php
+++ b/app/code/core/Mage/Customer/Helper/Data.php
@@ -417,7 +417,8 @@ class Mage_Customer_Helper_Data extends Mage_Core_Helper_Abstract
         $result = [];
         $options = explode(';', $options);
         foreach ($options as $value) {
-            $result[$value] = $this->escapeHtml(trim($value));
+            $value = $this->escapeHtml(trim($value));
+            $result[$value] = $value;
         }
         return $result;
     }

--- a/app/code/core/Mage/Customer/Helper/Data.php
+++ b/app/code/core/Mage/Customer/Helper/Data.php
@@ -417,7 +417,9 @@ class Mage_Customer_Helper_Data extends Mage_Core_Helper_Abstract
         $result = [];
         $options = explode(';', $options);
         foreach ($options as $value) {
-            $value = $this->escapeHtml(trim($value));
+            if ($value !== null && strlen($value) > 0) {
+                $value = $this->escapeHtml(trim($value));
+            }
             $result[$value] = $value;
         }
         return $result;

--- a/app/code/core/Mage/GiftMessage/Block/Message/Inline.php
+++ b/app/code/core/Mage/GiftMessage/Block/Message/Inline.php
@@ -242,7 +242,10 @@ class Mage_GiftMessage_Block_Message_Inline extends Mage_Core_Block_Template
      */
     public function getEscaped($value, $defaultValue = '')
     {
-        return $this->escapeHtml(trim($value) != '' ? $value : $defaultValue);
+        if ($value === null || strlen($value) == 0) {
+            return $defaultValue;
+        }
+        return $this->escapeHtml(trim($value));
     }
 
     /**


### PR DESCRIPTION
in https://github.com/OpenMage/magento-lts/issues/3796 @ADDISON74 (which will have to be marked as coauthor when merging) pointed out that there were multiple `escapeHtml(trim(` in the code, this PR fixes php8.1 warning about null parameters on all of them.

The fixes are all slightly different, depending on the case.

### Fixed Issues (if relevant)

1. Fixes https://github.com/OpenMage/magento-lts/issues/3796
