### PR TITLE
Fixed some PHPStan errors in lib/Varien

### DIFF
--- a/lib/Varien/Db/Tree.php
+++ b/lib/Varien/Db/Tree.php
@@ -26,6 +26,9 @@ Zend_Loader::loadClass('Zend_Db_Select');
 Zend_Loader::loadClass('Varien_Db_Tree_Node');
 Zend_Loader::loadClass('Varien_Db_Tree_NodeSet');
 
+/**
+ * @deprecated
+ */
 class Varien_Db_Tree
 {
     private $_id;
@@ -398,39 +401,33 @@ class Varien_Db_Tree
     public function __moveNode($eId, $pId, $aId = 0)
     {
         $eInfo = $this->getNodeInfo($eId);
+        $level = $eInfo[$this->_level];
+        $left_key = $eInfo[$this->_left];
+        $right_key = $eInfo[$this->_right];
+        $right_key_near = 0;
+        $left_key_near = 0;
+        $skew_level = 0;
+        
         if ($pId != 0) {
             $pInfo = $this->getNodeInfo($pId);
+            $skew_level = $pInfo[$this->_level] - $eInfo[$this->_level] + 1;
         }
         if ($aId != 0) {
             $aInfo = $this->getNodeInfo($aId);
         }
 
-        $level = $eInfo[$this->_level];
-        $left_key = $eInfo[$this->_left];
-        $right_key = $eInfo[$this->_right];
-        if ($pId == 0) {
-            $level_up = 0;
-        } else {
-            $level_up = $pInfo[$this->_level];
-        }
-
-        $right_key_near = 0;
-        $left_key_near = 0;
-
         if ($pId == 0) { //move to root
             $right_key_near = $this->_db->fetchOne('SELECT MAX(' . $this->_right . ') FROM ' . $this->_table);
-        } elseif ($aId != 0 && $pId == $eInfo[$this->_pid]) { // if we have after ID
+        } elseif (isset($aInfo) && $aId != 0 && $pId == $eInfo[$this->_pid]) { // if we have after ID
             $right_key_near = $aInfo[$this->_right];
             $left_key_near = $aInfo[$this->_left];
-        } elseif ($aId == 0 && $pId == $eInfo[$this->_pid]) { // if we do not have after ID
+        } elseif (isset($pInfo) && $aId == 0 && $pId == $eInfo[$this->_pid]) { // if we do not have after ID
             $right_key_near = $pInfo[$this->_left];
-        } elseif ($pId != $eInfo[$this->_pid]) {
+        } elseif (isset($pInfo) && $pId != $eInfo[$this->_pid]) {
             $right_key_near = $pInfo[$this->_right] - 1;
         }
 
-        $skew_level = $pInfo[$this->_level] - $eInfo[$this->_level] + 1;
         $skew_tree = $eInfo[$this->_right] - $eInfo[$this->_left] + 1;
-
         echo "alert('" . $right_key_near . "');";
 
         if ($right_key_near > $right_key) { // up
@@ -454,19 +451,22 @@ class Varien_Db_Tree
                     ' . $this->_right . ' > ' . $left_key . ' AND ' . $this->_left . ' <= ' . $right_key_near;
         }
 
-        $this->_db->beginTransaction();
-        try {
-            $this->_db->query($sql);
-            //$afrows = $this->_db->get
-            $this->_db->commit();
-        } catch (Exception $e) {
-            $this->_db->rollBack();
-            echo $e->getMessage();
-            echo "<br>\r\n";
-            echo $sql;
-            echo "<br>\r\n";
-            exit();
+        if (isset($sql)) {
+            $this->_db->beginTransaction();
+            try {
+                $this->_db->query($sql);
+                //$afrows = $this->_db->get
+                $this->_db->commit();
+            } catch (Exception $e) {
+                $this->_db->rollBack();
+                echo $e->getMessage();
+                echo "<br>\r\n";
+                echo $sql;
+                echo "<br>\r\n";
+                exit();
+            }
         }
+
         echo "alert('node added')";
     }
 

--- a/lib/Varien/Debug.php
+++ b/lib/Varien/Debug.php
@@ -91,6 +91,7 @@ class Varien_Debug
             }
 
             // prepare method's name
+            $methodName = '';
             if (isset($data['class']) && isset($data['function'])) {
                 if (isset($data['object']) && get_class($data['object']) != $data['class']) {
                     $className = get_class($data['object']) . '[' . $data['class'] . ']';

--- a/phpstan.dist.baseline.neon
+++ b/phpstan.dist.baseline.neon
@@ -5619,22 +5619,3 @@ parameters:
 			message: "#^Strict comparison using \\=\\=\\= between mixed and false will always evaluate to false\\.$#"
 			count: 1
 			path: lib/Varien/Simplexml/Config.php
-		-
-			message: "#^Variable \\$aInfo might not be defined\\.$#"
-			count: 2
-			path: lib/Varien/Db/Tree.php
-
-		-
-			message: "#^Variable \\$pInfo might not be defined\\.$#"
-			count: 4
-			path: lib/Varien/Db/Tree.php
-
-		-
-			message: "#^Variable \\$sql might not be defined\\.$#"
-			count: 2
-			path: lib/Varien/Db/Tree.php
-
-		-
-			message: "#^Variable \\$methodName might not be defined\\.$#"
-			count: 2
-			path: lib/Varien/Debug.php


### PR DESCRIPTION
I couldn't find any usage of `Varien_Db_Tree` in any way and since it doesn't seem to be very well written I marked it as deprecated and, if this is confirmed, I'd remove it from `next`.