### PR TITLE
Fixed bug on incorrect date format for 1970-01-01 date.

### DIFF
--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -162,7 +162,7 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
         } elseif (is_int($date)) {
             $date = Mage::app()->getLocale()->date($date, null, null, $useTimezone);
         } elseif (!$date instanceof Zend_Date) {
-            if ($time = strtotime($date)) {
+            if (($time = strtotime($date)) !== false) {
                 $date = Mage::app()->getLocale()->date($time, null, null, $useTimezone);
             } else {
                 return '';

--- a/app/code/core/Mage/Core/Model/Locale.php
+++ b/app/code/core/Mage/Core/Model/Locale.php
@@ -518,7 +518,7 @@ class Mage_Core_Model_Locale
             $locale = $this->getLocale();
         }
 
-        if (empty($date)) {
+        if (!is_int($date) && empty($date)) {
             // $date may be false, but Zend_Date uses strict compare
             $date = null;
         }


### PR DESCRIPTION
### Description (*)
Test script:
```php
$result = Mage::helper('core')->formatDate('1970-01-01');
// or Mage::helper('core')->formatDate('1 Jan 1970');
Zend_Debug::dump($result);
```

Before PR:
```
string(0) ""
```
After PR, depending on your locale default format:
```
 string(10) "01/01/1970"
```

### Related Pull Requests
PR #1525 


