### PR TITLE
PHPStan (and PHP syntax) workflows now only run on PHP 7.4 and 8.3

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4', '8.2', '8.3']
+        php-versions: ['7.4', '8.3']
 
     steps:
       - name: Setup PHP

--- a/.github/workflows/syntax-php.yml
+++ b/.github/workflows/syntax-php.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.4', '8.1', '8.2']
+        php: ['7.4', '8.3']
 
     name: PHP Syntax ${{ matrix.php }}
 


### PR DESCRIPTION
This PR removes the workflow that runs PHPStan on PHP 8.2, leaving only 7.4 and 8.3 running, because they're the first and last versions of PHP supported by us.

Why? Our workflows are heavy and slow, we're burning a lot of resources and time, which IMHO we should try to optimize.

I think we can remove 8.2 because 8.2 and 8.3 always give more or less the same results, so we kinda don't need to run both (but for sure we need the later one).

Note: we introduced 8.3 when 8.3 was still in beta, and at that point it made total sense.