### PR TITLE
Fixed null deprecation in function is_empty_date().

### DIFF
--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -75,7 +75,7 @@ function now($dayOnly = false)
  */
 function is_empty_date($date)
 {
-    return preg_replace('#[ 0:-]#', '', $date) === '';
+    return $date === null || preg_replace('#[ 0:-]#', '', $date) === '';
 }
 
 /**


### PR DESCRIPTION
    [type] => 8192:E_DEPRECATED
    [message] => preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated
    [file] => .../app/code/core/Mage/Core/functions.php
    [line] => 78