### PR TITLE
Fixed null parameter warning on Mage_Core_Model_Input_Filter_MaliciousCode::filter()

### DIFF
--- a/app/code/core/Mage/Core/Model/Input/Filter/MaliciousCode.php
+++ b/app/code/core/Mage/Core/Model/Input/Filter/MaliciousCode.php
@@ -50,13 +50,15 @@ class Mage_Core_Model_Input_Filter_MaliciousCode implements Zend_Filter_Interfac
     ];
 
     /**
-     * Filter value
-     *
-     * @param string|array $value
+     * @param string|array|null $value
      * @return string|array
      */
     public function filter($value)
     {
+        if ($value === null) {
+            return '';
+        }
+
         do {
             $value = preg_replace($this->_expressions, '', $value, -1, $count);
         } while ($count !== 0);


### PR DESCRIPTION
Fixes https://github.com/OpenMage/magento-lts/issues/3812