### PR TITLE
Updated the existing DDEV documentation

### DIFF
--- a/.ddev/web-build/openmage.cron
+++ b/.ddev/web-build/openmage.cron
@@ -1,0 +1,1 @@
+* * * * * /var/www/html/cron.sh

--- a/.ddev/web-build/openmage.cron
+++ b/.ddev/web-build/openmage.cron
@@ -1,1 +1,0 @@
-* * * * * /var/www/html/cron.sh

--- a/docs/DDEV.md
+++ b/docs/DDEV.md
@@ -1,12 +1,12 @@
 # OpenMage Environment Based on DDEV (https://ddev.com/)
 
-## phpMyAdmin
+## Using phpMyAdmin
 
 Run in the terminal window `ddev get ddev/ddev-phpmyadmin` to install the phpMyAdmin add-on then restart DDEV. 
 
 To launch phpMyAdmin in the browser run in the terminal window `ddev phpmyadmin`.
 
-## Mailpit
+## Using Mailpit
 
 To launch Mailpit in the browser run in the terminal window `ddev mailpit`.
 

--- a/docs/DDEV.md
+++ b/docs/DDEV.md
@@ -2,17 +2,19 @@
 
 ## phpMyAdmin
 
-Run in the terminal window this command `ddev get ddev/ddev-phpmyadmin` then restart DDEV. To launch phpMyAdmin in the browser run this command in the terminal window `ddev phpmyadmin`.
+Run in the terminal window `ddev get ddev/ddev-phpmyadmin` to install the phpMyAdmin add-on then restart DDEV. 
+
+To launch phpMyAdmin in the browser run in the terminal window `ddev phpmyadmin`.
 
 ## Mailpit
 
-To launch Mailpit in the browser run this command in the terminal window `ddev mailpit`.
+To launch Mailpit in the browser run in the terminal window `ddev mailpit`.
 
 ## Setting up cronjobs
 
-It is mandatory to run first in the terminal window this command `ddev get ddev/ddev-cron`. 
+Run in the terminal window `ddev get ddev/ddev-cron` to install the cron add-on then restart DDEV. 
 
-By default the OpenMage cronjob is running every minute. If you want to change it edit the file `.ddev/web-build/openmage.cron`.
+By default the OpenMage cronjob runs every minute. If you want to change it edit the file `.ddev/web-build/openmage.cron`.
 
 You can set the OpenMage cronjob using DDEV hooks, but you must comment all the lines in the file `.ddev/web-build/openmage.cron`. Edit the file `.ddev/config.yaml` and insert the following lines
 
@@ -35,7 +37,9 @@ web_environment: [
 
 ## Using Xdebug with PhpStorm
 
-Run in the terminal window the following commands to enable or disable xDebug 
+Every DDEV project is automatically configured with Xdebug so that popular IDEs can do step debugging of PHP code. Xdebug is a server-side tool and it is installed automatically in the container so you do not have to install or configure it on your workstation. Xdebug is disabled by default for performance reasons, so you will need to enable it and configure your IDE before can start debugging. For more information, please visit https://ddev.readthedocs.io/en/latest/users/debugging-profiling/step-debugging/.
+
+Run the following commands in the terminal window to enable or disable xDebug 
 
 `ddev xdebug on`
 
@@ -49,7 +53,7 @@ xdebug.mode=debug
 xdebug.start_with_request=trigger
 ```
 
-## Accessing the Database in PhpStorm
+## Accessing the database in PhpStorm
 
 Please note that DDEV changes the port numbers on every restart. If you want to access the database in PHPStorm you must set up a fixed port. Edit the file `.ddev/config.yaml` and insert the following line
 
@@ -83,9 +87,9 @@ RUN gem install compass
 
 For more information, please visit https://stackoverflow.com/questions/61787926/how-can-i-get-sass-compass-into-the-ddev-web-container.
 
-## Creating a custom DDEV command
+## Creating a DDEV command
 
-Create a new file named `.ddev/commands/web/phpstan` and insert the following lines
+Create a new file named `phpstan` in the `.ddev/commands/web` directory and insert the following lines
 
 ```
 #!/bin/bash
@@ -97,13 +101,11 @@ Create a new file named `.ddev/commands/web/phpstan` and insert the following li
 php vendor/bin/phpstan analyze -c .github/phpstan.neon "$@"
 ```
 
-Run the custom command in the terminal window `ddev phpstan`.
+Run in the terminal window `ddev phpstan`.
 
-## OpenMage Custom DDEV commands
+## OpenMage DDEV commands
 
-**If you want to install the `Magento Sample Data` run in the terminal window this command and follow the steps**
-
-`ddev openmage-install`
+**1. If you want to install the `Magento Sample Data` run in the terminal window `ddev openmage-install` and follow the steps.**
 
 You can use flags, for example `ddev openmage-install -d -s -k -q`
 
@@ -114,13 +116,11 @@ You can use flags, for example `ddev openmage-install -d -s -k -q`
 -q (quiet mode)
 ```
 
-**By default, running the `ddev config` command does not create an administrator account. If you want to create or update one run in the terminal window this command and follow the steps**
+**2. By default, running the `ddev config` command does not create an administrator account. If you want to create or update one run in the terminal window `ddev openmage-admin` and follow the steps.**
 
-`ddev openmage-admin`
+## Useful DDEV commands (https://ddev.readthedocs.io/en/latest/users/usage/commands)
 
-## Useful DDEV Commands (https://ddev.readthedocs.io/en/latest/users/usage/commands)
-
-Run the following commands in the terminal window.
+Run in the terminal window any of the following commands for different tasks.
 
 **Create or modify a DDEV project's configuration in the current directory**
 
@@ -150,7 +150,7 @@ Run the following commands in the terminal window.
 
 `ddev npm install`, `ddev npm update`
 
-**Enable or disable XDebug**
+**Enable or disable Xdebug**
 
 `ddev xdebug on`, `ddev xdebug off`, `ddev xdebug status`
 
@@ -186,13 +186,15 @@ Run the following commands in the terminal window.
 
 `ddev clean --dry-run -all`, `ddev clean`
 
-## Using mkcert (https://github.com/FiloSottile/mkcert)
+## Using mkcert for secured connections (https://github.com/FiloSottile/mkcert)
 
-mkcert is a simple tool for making locally-trusted development certificates. If you use (Windows 10/11 + WSL + Docker), first install the mkcert package in Windows then copy the certificates files associated to the current user into the Linux distribution. For example,
+mkcert is a simple tool for making locally-trusted development certificates. If you use (Windows 10/11 + WSL + Docker), first install the mkcert package in Windows then copy the certificates files associated to the current user into the Linux distribution. 
+
+For example, copy `rootCA.pem` and `rootCA-key.pem`
 
 ```
-From: /
-To: /
+From: C:\Users\<User Name>\AppData\Local\mkcert
+To: /home/<user_name>/.local/share/mkcert
 ```
 
 ## Installing OpenMage in the browser

--- a/docs/DDEV.md
+++ b/docs/DDEV.md
@@ -57,6 +57,16 @@ Please note that DDEV changes the port numbers on every restart. If you want to 
 host_db_port: 6000
 ```
 
+## Using Browsersync (https://github.com/ddev/ddev-browsersync)
+
+Browsersync features live reloads, click mirroring, network throttling. Run the following commands in the terminal window
+
+```
+ddev get ddev/ddev-browsersync
+ddev restart
+ddev browsersync
+```
+
 ## Installing Compass (http://compass-style.org/)
 
 Compass is required for editing SCSS files.

--- a/docs/DDEV.md
+++ b/docs/DDEV.md
@@ -186,6 +186,15 @@ Run the following commands in the terminal window.
 
 `ddev clean --dry-run -all`, `ddev clean`
 
+## Using mkcert (https://github.com/FiloSottile/mkcert)
+
+mkcert is a simple tool for making locally-trusted development certificates. If you use (Windows 10/11 + WSL + Docker), first install the mkcert package in Windows then copy the certificates files associated to the current user into the Linux distribution. For example,
+
+```
+From: /
+To: /
+```
+
 ## Installing OpenMage in the browser
 
 If you want to install OpenMage in the browser rename or delete the `/app/etc/local.xml` file.

--- a/docs/DDEV.md
+++ b/docs/DDEV.md
@@ -1,12 +1,8 @@
-# OpenMage DDEV environment
+# OpenMage Environment Based on DDEV (https://ddev.com/)
 
-__This is work-in-progress.__
+## Enabling the Developer Mode
 
-## Enable developer mode
-
-Set environment variables here:
-
-`.ddev/config.yaml`
+Set environment variables editing the file `.ddev/config.yaml`. If you want to enable the Developer Mode insert the following lines
 
 ```
 web_environment: [
@@ -14,11 +10,15 @@ web_environment: [
 ]
 ```
 
-## Use xDebug with PhpStorm
+## Using xDebug with PhpStorm
 
-If xdebug works not correctly with phpstorm.
+Run in the terminal window the following commands to enable or disable xDebug 
 
-`.ddev/php/xdebug.ini`
+`ddev xdebug on`
+
+`ddev xdebug off`
+
+If xDebug does not work properly with PHPStorm edit the file `.ddev/php/xdebug.ini` and insert the following lines
 
 ```
 [xdebug]
@@ -26,23 +26,21 @@ xdebug.mode=debug
 xdebug.start_with_request=trigger
 ```
 
-## Access DB in PhpStorm
+## Accessing the Database in PhpStorm
 
-DDEV changes port numbers on every restart.
-
-If you use PhpStorms DB feature, it is helpful to use fixed port numbers. E.g. 
-
-`.ddev/config.yaml`
+Please note that DDEV changes the port numbers on every restart. If you want to access the database in PHPStorm you must set up a fixed port. Edit the file `.ddev/config.yaml` and insert the following line
 
 ```
 host_db_port: 6000
 ```
 
-## Setup cronjob
+## Setting up cronjobs
 
-Run `ddev get drud/ddev-cron` first!
+It is mandatory to run first in the terminal window this command `ddev get ddev/ddev-cron`. 
 
-`.ddev/config.cron.yaml`
+By default the OpenMage cronjob is running every minute. If you want to change it edit the file `.ddev/web-build/openmage.cron`.
+
+You can set the OpenMage cronjob using DDEV hooks, but you must comment all the lines in the file `.ddev/web-build/openmage.cron`. Edit the file `.ddev/config.yaml` and insert the following lines
 
 ```
 hooks:
@@ -51,11 +49,11 @@ hooks:
 
 ```
 
-## Install compass
+## Installing Compass (http://compass-style.org/)
 
-[Compass](http://compass-style.org/) is required for editing scss-files from RWD-theme.
+Compass is required for editing SCSS files.
 
-`.ddev/web-build/Dockerfile.ddev-compass`
+Edit the file `.ddev/web-build/Dockerfile.ddev-compass` and insert the following lines
 
 ```
 ARG BASE_IMAGE
@@ -65,11 +63,19 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--forc
 RUN gem install compass
 ```
 
-https://stackoverflow.com/questions/61787926/how-can-i-get-sass-compass-into-the-ddev-web-container
+For more information, please visit https://stackoverflow.com/questions/61787926/how-can-i-get-sass-compass-into-the-ddev-web-container
 
-## Example command shortcut
+## phpMyAdmin
 
-`.ddev/commands/web/phpstan`
+Run in the terminal windows this command `ddev get ddev/ddev-phpmyadmin` and restart DDEV. To launch phpMyAdmin in the browser window run this command `ddev phpmyadmin`.
+
+## Mailpit
+
+To launch Mailpit in the browser window run this command `ddev launch -p`.
+
+## Creating a custom DDEV command
+
+Create a new file named `.ddev/commands/web/phpstan` and insert the following lines
 
 ```
 #!/bin/bash
@@ -80,3 +86,46 @@ https://stackoverflow.com/questions/61787926/how-can-i-get-sass-compass-into-the
 
 php vendor/bin/phpstan analyze -c .github/phpstan.neon "$@"
 ```
+
+Run the custom command in the terminal window `ddev phpstan`.
+
+## OpenMage Custom DDEV commands
+
+If you want to install the Magento Sample Data run in the terminal window this command `ddev openmage-install`. You can use this command with flags, for example `ddev openmage-install -d -s -k -q`
+
+```
+-d (default values for the administrator account)
+-s (sampledata installation)
+-k (keeps the downloaded archive in the .ddev/.sampleData directory)
+-q (quiet mode)
+```
+
+If you want to change the administrator account password run in the terminal window this command `ddev openmage-admin`.
+
+## Useful DDEV Commands (https://ddev.readthedocs.io/en/latest/users/usage/commands)
+
+`ddev config`, `ddev describe`
+
+`ddev composer install`, `ddev composer update`, `ddev composer require openmage/module-mage-backup`
+
+`ddev start`, `ddev stop`, `ddev restart`, `ddev poweroff`, `ddev list`
+
+`ddev launch`, `ddev launch -m`
+
+`ddev mysql`, `ddev php`, `ddev ssh`, `ddev exec`
+
+`ddev logs`, `ddev logs -f`, `ddev logs -s db`
+
+`ddev npm install`, `ddev npm update`
+
+`ddev snapshot --name my_snapshot_name`, `ddev snapshot --list`, `ddev snapshot --cleanup`, `ddev snapshot restore`
+
+`ddev import-db --src=magento_sample_data.sql`, `ddev export-db --target-db=db --file=om_db.sql.gz`, `ddev import-files --src=om_media.tar.gz`
+
+`ddev xdebug on`, `ddev xdebug off`
+
+`ddev get --list`, `ddev get drud/ddev/cron`
+
+`ddev service enable`, `ddev service disable`
+
+`ddev delete`, `ddev delete images`, `ddev clean`

--- a/docs/DDEV.md
+++ b/docs/DDEV.md
@@ -1,38 +1,12 @@
 # OpenMage Environment Based on DDEV (https://ddev.com/)
 
-## Enabling the Developer Mode
+## phpMyAdmin
 
-Set environment variables editing the file `.ddev/config.yaml`. If you want to enable the Developer Mode insert the following lines
+Run in the terminal window this command `ddev get ddev/ddev-phpmyadmin` then restart DDEV. To launch phpMyAdmin in the browser run this command in the terminal window `ddev phpmyadmin`.
 
-```
-web_environment: [
-    MAGE_IS_DEVELOPER_MODE=1
-]
-```
+## Mailpit
 
-## Using xDebug with PhpStorm
-
-Run in the terminal window the following commands to enable or disable xDebug 
-
-`ddev xdebug on`
-
-`ddev xdebug off`
-
-If xDebug does not work properly with PHPStorm edit the file `.ddev/php/xdebug.ini` and insert the following lines
-
-```
-[xdebug]
-xdebug.mode=debug
-xdebug.start_with_request=trigger
-```
-
-## Accessing the Database in PhpStorm
-
-Please note that DDEV changes the port numbers on every restart. If you want to access the database in PHPStorm you must set up a fixed port. Edit the file `.ddev/config.yaml` and insert the following line
-
-```
-host_db_port: 6000
-```
+To launch Mailpit in the browser run this command in the terminal window `ddev mailpit`.
 
 ## Setting up cronjobs
 
@@ -49,11 +23,45 @@ hooks:
 
 ```
 
+## Enabling the Developer Mode
+
+Set environment variables editing the file `.ddev/config.yaml`. If you want to enable the Developer Mode insert the following lines
+
+```
+web_environment: [
+    MAGE_IS_DEVELOPER_MODE=1
+]
+```
+
+## Using Xdebug with PhpStorm
+
+Run in the terminal window the following commands to enable or disable xDebug 
+
+`ddev xdebug on`
+
+`ddev xdebug off`
+
+If Xdebug does not work properly with PHPStorm edit the file `.ddev/php/xdebug.ini` and insert the following lines
+
+```
+[xdebug]
+xdebug.mode=debug
+xdebug.start_with_request=trigger
+```
+
+## Accessing the Database in PhpStorm
+
+Please note that DDEV changes the port numbers on every restart. If you want to access the database in PHPStorm you must set up a fixed port. Edit the file `.ddev/config.yaml` and insert the following line
+
+```
+host_db_port: 6000
+```
+
 ## Installing Compass (http://compass-style.org/)
 
 Compass is required for editing SCSS files.
 
-Edit the file `.ddev/web-build/Dockerfile.ddev-compass` and insert the following lines
+Create a new file named `.ddev/web-build/Dockerfile.ddev-compass` and insert the following lines
 
 ```
 ARG BASE_IMAGE
@@ -63,15 +71,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--forc
 RUN gem install compass
 ```
 
-For more information, please visit https://stackoverflow.com/questions/61787926/how-can-i-get-sass-compass-into-the-ddev-web-container
-
-## phpMyAdmin
-
-Run in the terminal windows this command `ddev get ddev/ddev-phpmyadmin` and restart DDEV. To launch phpMyAdmin in the browser window run this command `ddev phpmyadmin`.
-
-## Mailpit
-
-To launch Mailpit in the browser window run this command `ddev launch -p`.
+For more information, please visit https://stackoverflow.com/questions/61787926/how-can-i-get-sass-compass-into-the-ddev-web-container.
 
 ## Creating a custom DDEV command
 
@@ -91,7 +91,11 @@ Run the custom command in the terminal window `ddev phpstan`.
 
 ## OpenMage Custom DDEV commands
 
-If you want to install the Magento Sample Data run in the terminal window this command `ddev openmage-install`. You can use this command with flags, for example `ddev openmage-install -d -s -k -q`
+**If you want to install the `Magento Sample Data` run in the terminal window this command and follow the steps**
+
+`ddev openmage-install`
+
+You can use flags, for example `ddev openmage-install -d -s -k -q`
 
 ```
 -d (default values for the administrator account)
@@ -100,32 +104,89 @@ If you want to install the Magento Sample Data run in the terminal window this c
 -q (quiet mode)
 ```
 
-If you want to change the administrator account password run in the terminal window this command `ddev openmage-admin`.
+**By default, running the `ddev config` command does not create an administrator account. If you want to create or update one run in the terminal window this command and follow the steps**
+
+`ddev openmage-admin`
 
 ## Useful DDEV Commands (https://ddev.readthedocs.io/en/latest/users/usage/commands)
 
-`ddev config`, `ddev describe`
+Run the following commands in the terminal window.
+
+**Create or modify a DDEV project's configuration in the current directory**
+
+`ddev config`
+
+**Get a detailed description of a running DDEV project**
+
+`ddev describe`
+
+**List Projects**
+
+`ddev list`
+
+**Start / Stop / Restart / Completely stop all project and containers**
+
+`ddev start`, `ddev stop`, `ddev restart`, `ddev poweroff`
+
+**Launch a browser with the current site**
+
+`ddev launch`
+
+**Execute Composer commands within a web container**
 
 `ddev composer install`, `ddev composer update`, `ddev composer require openmage/module-mage-backup`
 
-`ddev start`, `ddev stop`, `ddev restart`, `ddev poweroff`, `ddev list`
-
-`ddev launch`, `ddev launch -m`
-
-`ddev mysql`, `ddev php`, `ddev ssh`, `ddev exec`
-
-`ddev logs`, `ddev logs -f`, `ddev logs -s db`
+**Run npm inside the web container**
 
 `ddev npm install`, `ddev npm update`
 
+**Enable or disable XDebug**
+
+`ddev xdebug on`, `ddev xdebug off`, `ddev xdebug status`
+
+**Create a database snapshot for one or more projects**
+
 `ddev snapshot --name my_snapshot_name`, `ddev snapshot --list`, `ddev snapshot --cleanup`, `ddev snapshot restore`
+
+**Import or export a SQL file into the project**
 
 `ddev import-db --src=magento_sample_data.sql`, `ddev export-db --target-db=db --file=om_db.sql.gz`, `ddev import-files --src=om_media.tar.gz`
 
-`ddev xdebug on`, `ddev xdebug off`
+**Download DDEV adds-on**
 
 `ddev get --list`, `ddev get drud/ddev/cron`
 
+**Run MYSQL client in the database container / Run php inside the web container / Stars a shell session in a service container / Execute a shell command in the container**
+
+`ddev mysql`, `ddev php`, `ddev ssh`, `ddev exec`
+
+**Get the logs from your running services**
+
+`ddev logs`, `ddev logs -f`, `ddev logs -s db`
+
+**Enable or disable a service**
+
 `ddev service enable`, `ddev service disable`
 
-`ddev delete`, `ddev delete images`, `ddev clean`
+**Remove all information, including the database, from a project**
+
+`ddev delete`, `ddev delete images`
+
+**Removes items DDEV has created**
+
+`ddev clean --dry-run -all`, `ddev clean`
+
+## Installing OpenMage in the browser
+
+If you want to install OpenMage in the browser rename or delete the `/app/etc/local.xml` file.
+
+For the database connection use the following information
+
+```
+Host: db
+Database Name: db
+User Name: db
+User Password: db
+```
+
+![installation](https://github.com/ADDISON74/openmage/assets/8360474/cb6a0472-7740-4e2b-bce8-fb699ca2710c)


### PR DESCRIPTION
This PR aims to update the existing documentation in OpenMage about the DDEV test environment. Please note that this is just a small bag of elementary knowledge to be able to use it.

Those who haven't tried DDEV so far would do well to give it a chance. Since I discovered it a year and a half ago, I haven't tested OpenMage in Linux distributions. It runs quickly in Windows + WSL + Docker and it is so easy to install.