### PR TITLE
Added DDEV cronjob file

### DIFF
--- a/.ddev/web-build/openmage.cron
+++ b/.ddev/web-build/openmage.cron
@@ -1,0 +1,1 @@
+* * * * * /var/www/html/cron.sh


### PR DESCRIPTION
Without this change the OpenMage cronjob cannot be run in the DDEV test environment.

The original PR comes from here https://github.com/sreichel/openmage-future/pull/2 with the permission of its author.

In this PR https://github.com/OpenMage/magento-lts/pull/3830 I updated the DDEV documentation related to the cronjobs because it was no longer valid.