### PR TITLE
Fixed branch names in code-ql workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,7 @@ on:
     branches: [ "main", "next", "v19" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main", "v20", "v19" ]
+    branches: [ "main", "next", "v19" ]
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'


### PR DESCRIPTION
Although I approved PR #3789, I did not notice that another change was mandatory regarding the new v20 branch name. 

This PR fixes this omission. My apologies for that.