### PR TITLE
Updated cron shell script to call php binary with php.ini config argument

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -33,10 +33,10 @@ INSTALLDIR=`echo $0 | sed 's/cron\.sh//g'`
 # prepend the installation path if not given an absolute path
 if [ "$INSTALLDIR" != "" -a "`expr index $CRONSCRIPT /`" != "1" ];then
     if ! ps auxwww | grep "$INSTALLDIR$CRONSCRIPT$MODE" | grep -v grep 1>/dev/null 2>/dev/null ; then
-    	$PHP_BIN $INSTALLDIR$CRONSCRIPT$MODE &
+    	$PHP_BIN -c ${INSTALLDIR}php.ini $INSTALLDIR$CRONSCRIPT$MODE &
     fi
 else
     if  ! ps auxwww | grep "$CRONSCRIPT$MODE" | grep -v grep | grep -v cron.sh 1>/dev/null 2>/dev/null ; then
-        $PHP_BIN $CRONSCRIPT$MODE &
+        $PHP_BIN -c ${INSTALLDIR}php.ini $CRONSCRIPT$MODE &
     fi
 fi


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Running PHP from CLI does not load the `php.ini` configuration file from the current directory [(confirmed here.)](https://www.php.net/manual/en/configuration.file.php)
This can result in unexpected behaviour.
Simply adding the `-c` parameter to the `php` binary call and specifying the Magento install directory will mean that the CLI php will more accurately reflect the environment that the HTTP server is using.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Apply the change to your `cron.sh` file
2. Allow your cron to run
3. Examine the results and ensure no new errors occurred

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->