### PR TITLE
Fixed case error in some module names

### DIFF
--- a/app/design/adminhtml/default/default/template/currencysymbol/grid.phtml
+++ b/app/design/adminhtml/default/default/template/currencysymbol/grid.phtml
@@ -15,7 +15,7 @@
 ?>
 <?php
 /**
- * @var $this Mage_Currencysymbol_Block_Adminhtml_System_Currencysymbol
+ * @var $this Mage_CurrencySymbol_Block_Adminhtml_System_Currencysymbol
  */
 ?>
 <div class="content-header">

--- a/app/design/frontend/base/default/layout/catalogsearch.xml
+++ b/app/design/frontend/base/default/layout/catalogsearch.xml
@@ -65,7 +65,7 @@
 
     <catalogsearch_advanced_index translate="label">
         <label>Advanced Search Form</label>
-        <!-- Mage_Catalogsearch -->
+        <!-- Mage_CatalogSearch -->
         <reference name="root">
             <action method="setTemplate"><template>page/2columns-right.phtml</template></action>
         </reference>
@@ -88,7 +88,7 @@ Advanced search results
     <catalogsearch_advanced_result translate="label">
         <label>Advanced Search Result</label>
         <update handle="page_two_columns_right" />
-        <!-- Mage_Catalogsearch -->
+        <!-- Mage_CatalogSearch -->
         <reference name="root">
             <action method="setTemplate"><template>page/2columns-right.phtml</template></action>
         </reference>

--- a/app/design/frontend/base/default/template/catalogsearch/form.mini.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/form.mini.phtml
@@ -13,7 +13,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 /* @var $this Mage_Core_Block_Template */
-/* @var $catalogSearchHelper Mage_Catalogsearch_Helper_Data */
+/* @var $catalogSearchHelper Mage_CatalogSearch_Helper_Data */
 $catalogSearchHelper =  $this->helper('catalogsearch');
 ?>
 <form id="search_mini_form" action="<?php echo $catalogSearchHelper->getResultUrl() ?>" method="get">

--- a/app/design/frontend/rwd/default/layout/catalogsearch.xml
+++ b/app/design/frontend/rwd/default/layout/catalogsearch.xml
@@ -69,7 +69,7 @@
 
     <catalogsearch_advanced_index translate="label">
         <label>Advanced Search Form</label>
-        <!-- Mage_Catalogsearch -->
+        <!-- Mage_CatalogSearch -->
         <reference name="root">
             <action method="setTemplate"><template>page/2columns-right.phtml</template></action>
         </reference>
@@ -92,7 +92,7 @@ Advanced search results
     <catalogsearch_advanced_result translate="label">
         <label>Advanced Search Result</label>
         <update handle="page_two_columns_right" />
-        <!-- Mage_Catalogsearch -->
+        <!-- Mage_CatalogSearch -->
         <reference name="root">
             <action method="setTemplate"><template>page/2columns-right.phtml</template></action>
         </reference>

--- a/app/design/frontend/rwd/default/template/catalogsearch/form.mini.phtml
+++ b/app/design/frontend/rwd/default/template/catalogsearch/form.mini.phtml
@@ -13,7 +13,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 /* @var $this Mage_Core_Block_Template */
-/* @var $catalogSearchHelper Mage_Catalogsearch_Helper_Data */
+/* @var $catalogSearchHelper Mage_CatalogSearch_Helper_Data */
 $catalogSearchHelper =  $this->helper('catalogsearch');
 ?>
 


### PR DESCRIPTION
Because of https://github.com/OpenMage/magento-lts/pull/3821#issuecomment-1950388654 causing https://github.com/OpenMage/magento-lts/issues/3814 I searched the codebase for wrong case in module names.

This PR fixes all the mistakes I found.