### PR TITLE
Added support for type "label" to system.xml

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Heading.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Heading.php
@@ -29,7 +29,6 @@ class Mage_Adminhtml_Block_System_Config_Form_Field_Heading extends Mage_Adminht
      */
     public function render(Varien_Data_Form_Element_Abstract $element)
     {
-        $useContainerId = $element->getData('use_container_id');
         return sprintf(
             '<tr class="system-fieldset-sub-head" id="row_%s"><td colspan="5"><h4 id="%s">%s</h4></td></tr>',
             $element->getHtmlId(),

--- a/lib/Varien/Data/Form/Element/Info.php
+++ b/lib/Varien/Data/Form/Element/Info.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   Varien
+ * @package    Varien_Data
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * @category   Varien
+ * @package    Varien_Data
+ */
+class Varien_Data_Form_Element_Info extends Varien_Data_Form_Element_Abstract
+{
+    /**
+     * @param array $attributes
+     */
+    public function __construct($attributes = [])
+    {
+        parent::__construct($attributes);
+        $this
+            ->setType('info')
+            ->unsScope()
+            ->unsCanUseDefaultValue()
+            ->unsCanUseWebsiteValue();
+    }
+
+    public function getHtml()
+    {
+        $id = $this->getHtmlId();
+        $label = $this->getLabel();
+        $html = '<tr class="' . $id . '"><td class="label" colspan="99"><label>' . $label . '</label></td></tr>';
+        return $html;
+    }
+}

--- a/lib/Varien/Data/Form/Element/Info.php
+++ b/lib/Varien/Data/Form/Element/Info.php
@@ -31,6 +31,9 @@ class Varien_Data_Form_Element_Info extends Varien_Data_Form_Element_Abstract
             ->unsCanUseWebsiteValue();
     }
 
+    /**
+     * @return string
+     */
     public function getHtml()
     {
         $id = $this->getHtmlId();

--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -369,7 +369,7 @@ select.multiselect option       { padding:3px 4px; border-bottom:1px solid #ddd;
 .form-list td.hidden            { border:0 !important; padding:0 !important; background:0 !important; }
 .form-list td.label             { width:200px; }
 .form-list td.use-default label { display:inline-block; vertical-align:middle; padding:0 3px; }
-.form-list td.label label       { display:block; width:185px; padding-right:15px; padding-top:1px; }
+.form-list td.label label       { display:block; padding-right:15px; padding-top:1px; }
 .form-list td.value input.input-text,
 .form-list td.value textarea    { width:274px; }
 .form-list td.value textarea    { height:15em; }


### PR DESCRIPTION
Since in https://github.com/OpenMage/magento-lts/pull/3577 there wasn't much consensus I tried a different approach.

Simply add this to your system.xml:

```xml
<testlabel>
    <label><![CDATA[Innermost dimensions, <strong>not including border</strong>, in pixels.]]></label>
    <frontend_type>info</frontend_type>
    <show_in_default>1</show_in_default>
    <show_in_website>1</show_in_website>
    <show_in_store>1</show_in_store>
</testlabel>
```

and you'll get something like:

<img width="961" alt="Screenshot 2024-02-23 alle 19 06 01" src="https://github.com/OpenMage/magento-lts/assets/909743/0ffe2b4a-0cd2-4c9a-846b-2ba1b858b577">

Closes https://github.com/OpenMage/magento-lts/pull/3577