### PR TITLE
Fixed row click issue in Category Products tab

### DIFF
--- a/app/design/adminhtml/default/default/template/catalog/category/edit/form.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/edit/form.phtml
@@ -198,10 +198,10 @@
         grid.reloadParams = {'selected_products[]':categoryProducts.keys()};
     }
     function categoryProductRowClick(grid, event){
-        var trElement = Event.findElement(event, 'tr');
+        var tdElement = Event.findElement(event, 'td');
         var isInput   = Event.element(event).tagName == 'INPUT';
-        if(trElement){
-            var checkbox = Element.getElementsBySelector(trElement, 'input');
+        if(tdElement){
+            var checkbox = Element.getElementsBySelector(tdElement, 'input');
             if(checkbox[0]){
                 var checked = isInput ? checkbox[0].checked : !checkbox[0].checked;
                 <?php echo $_gridJsObject ?>.setCheckboxChecked(checkbox[0], checked);


### PR DESCRIPTION
When you use the **Category Products** tab in the **Categories** page, you may face an important issue without realizing it. As the grid functionality was thought by the Magento team, when you click on a row, regardless of the position where the mouse pointer is, the row will be checked or unchecked. As soon as you press the **[Save Category]** button, products may appear or disappear in the grid by mistake. I faced this issue many times when I was editing the position and I didn't click exactly in the box but a little next to it.

This PR solves the issue and limits the row click strictly to the grid cell where the checkbox is (the first column).

![rowclick](https://github.com/OpenMage/magento-lts/assets/8360474/38d34a25-afd4-4211-8f67-139251cb6bdd)