### PR TITLE
Fixed null error on hash_equal in Mage_Oauth_Model_Server

### DIFF
--- a/app/code/core/Mage/Oauth/Model/Server.php
+++ b/app/code/core/Mage/Oauth/Model/Server.php
@@ -309,7 +309,7 @@ class Mage_Oauth_Model_Server
             if (self::REQUEST_TOKEN == $this->_requestType) {
                 $this->_validateVerifierParam();
 
-                if (!hash_equals($this->_token->getVerifier(), $this->_protocolParams['oauth_verifier'])) {
+                if (!hash_equals((string)$this->_token->getVerifier(), $this->_protocolParams['oauth_verifier'])) {
                     $this->_throwException('', self::ERR_VERIFIER_INVALID);
                 }
                 if (!hash_equals((string)$this->_token->getConsumerId(), (string)$this->_consumer->getId())) {


### PR DESCRIPTION
```
Array
(
    [type] => 1:E_ERROR
    [message] => Uncaught TypeError: hash_equals(): Argument #1 ($known_string) must be of type string, null given in .../app/code/core/Mage/Oauth/Model/Server.php:312
Stack trace:
#0 .../app/code/core/Mage/Oauth/Model/Server.php(312): hash_equals(NULL, '9d5d6e009e9c427...')
#1 .../app/code/core/Mage/Oauth/Model/Server.php(382): Mage_Oauth_Model_Server->_initToken()
#2 .../app/code/core/Mage/Oauth/Model/Server.php(573): Mage_Oauth_Model_Server->_processRequest('token')
#3 .../app/code/core/Mage/Oauth/controllers/TokenController.php(47): Mage_Oauth_Model_Server->accessToken()
#4 .../app/code/core/Mage/Core/Controller/Varien/Action.php(421): Mage_Oauth_TokenController->indexAction()
#5 .../app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(255): Mage_Core_Controller_Varien_Action->dispatch('index')
#6 .../app/code/core/Mage/Core/Controller/Varien/Front.php(181): Mage_Core_Controller_Varien_Router_Standard->match(Object(Mage_Core_Controller_Request_Http))
#7 .../app/code/core/Mage/Core/Model/App.php(358): Mage_Core_Controller_Varien_Front->dispatch()
#8 .../app/Mage.php(763): Mage_Core_Model_App->run(Array)
#9 .../index.php(67): Mage::run('api', 'website')
#10 {main}
  thrown
    [file] => .../app/code/core/Mage/Oauth/Model/Server.php
    [line] => 312
    [uri] => /oauth/token?oauth_consumer_key=6c06f6774b377d597b6f7a1a64fa5758&oauth_token=db79f67c97c749cc8ccb0874d814aecc&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1709539181&oauth_nonce=tR5cbPVUIIZ&oauth_version=1.0&oauth_callback=https%3A%2F%2Fexample.com%2Fcallback&oauth_verifier=9d5d6e009e9c427eca31f6eb8b5aef2e&oauth_signature=yh%2B9zkh4Hj8txL5K2TnI1YXEWY4%3D
)
```