### PR TITLE
Fixed null deprecation in lib/Varien/Filter/Template.php

### DIFF
--- a/lib/Varien/Filter/Template.php
+++ b/lib/Varien/Filter/Template.php
@@ -118,6 +118,10 @@ class Varien_Filter_Template implements Zend_Filter_Interface
      */
     public function filter($value)
     {
+        if ($value === null) {
+            return '';
+        }
+
         // "depend" and "if" operands should be first
         $directives = [
             self::CONSTRUCTION_DEPEND_PATTERN => 'dependDirective',


### PR DESCRIPTION
```
Array
(
    [type] => 8192:E_DEPRECATED
    [message] => preg_match_all(): Passing null to parameter #2 ($subject) of type string is deprecated
    [file] => .../lib/Varien/Filter/Template.php
    [line] => 141
    [uri] => /index.php/catalogsearch/advanced/result/?name=e
)
```