### PR TITLE
Fixed no data shown for products with recurring profiles

### DIFF
--- a/lib/Unserialize/Reader/Str.php
+++ b/lib/Unserialize/Reader/Str.php
@@ -44,7 +44,6 @@ class Unserialize_Reader_Str
      */
     public function read($char, $prevChar)
     {
-
         if (is_null($this->_status) && $prevChar == Unserialize_Parser::SYMBOL_COLON) {
             $this->_status = self::READING_LENGTH;
         }
@@ -67,8 +66,7 @@ class Unserialize_Reader_Str
 
         if ($this->_status == self::READING_VALUE) {
             if (is_null($this->_value)) {
-                $this->_value = $char;
-                return null;
+                $this->_value = '';
             }
 
             if (strlen($this->_value) < $this->_length) {


### PR DESCRIPTION
This issue was explained by @f1-outsourcing in https://github.com/OpenMage/magento-lts/discussions/3908

I debugged it and found out that https://github.com/OpenMage/magento-lts/pull/3663 was the cause.

I rewrote https://github.com/OpenMage/magento-lts/pull/3663 and it seems to be solving both the object of https://github.com/OpenMage/magento-lts/pull/3663 and the problem in https://github.com/OpenMage/magento-lts/discussions/3908

To test:
- checkout the main branch
- create a product with a recurring profile
- refresh the product page in the backend (the recurring profile data will be empty)
- apply the patch in this PR
- refresh the same product page, the data will show (and there's no null parameter warning in the logs)

tagging @alexh-swdev @kiatng @elidrissidev since they worked on https://github.com/OpenMage/magento-lts/pull/3663, please also check this