### PR TITLE
RWD: enhanced contrast on a few colors to fix accessibility issues

### DIFF
--- a/skin/frontend/rwd/default/css/madisonisland.css
+++ b/skin/frontend/rwd/default/css/madisonisland.css
@@ -177,7 +177,7 @@ body .promos > li {
 .cms-index-index h2.subtitle {
   padding: 6px 0;
   text-align: center;
-  color: #3399cc;
+  color: #0472ad;
   font-weight: 600;
   border-bottom: 1px solid #cccccc;
   border-top: 1px solid #cccccc;
@@ -216,7 +216,7 @@ body .promos > li {
 }
 
 .catblocks li:hover {
-  border-color: #3399cc;
+  border-color: #0472ad;
 }
 
 @media only screen and (max-width: 770px) {
@@ -285,7 +285,7 @@ body .promos > li {
 }
 
 .catalog-category-view div.categoryland-caption span.blue-big-text {
-  color: #3399CC;
+  color: #0472ad;
   font-size: 50px;
   font-weight: 800;
   padding: 0 0 0 8px;
@@ -314,7 +314,7 @@ body .promos > li {
 
 .cms-home #homepage-main-slides div.slides_control div div.slideshow-caption span.blue-big-text,
 .catalog-category-view div.categoryland-caption span.blue-big-text {
-  color: #3399CC;
+  color: #0472ad;
   font-size: 50px;
   font-weight: 800;
   padding: 0 0 0 8px;

--- a/skin/frontend/rwd/default/css/styles.css
+++ b/skin/frontend/rwd/default/css/styles.css
@@ -485,7 +485,7 @@ textarea {
 }
 
 a {
-  color: #3399cc;
+  color: #0472ad;
   text-decoration: none;
 }
 
@@ -512,7 +512,7 @@ ul {
 h1, .h1 {
   margin: 0;
   margin-bottom: 0.7em;
-  color: #3399cc;
+  color: #0472ad;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
   font-size: 28px;
   font-weight: 400;
@@ -605,7 +605,7 @@ h6, .h6 {
 }
 
 .availability.in-stock {
-  color: #11b400;
+  color: #0f8900;
 }
 
 .availability.available-soon,
@@ -664,7 +664,7 @@ h6, .h6 {
   line-height: 1.4;
   text-rendering: optimizeSpeed;
   text-transform: uppercase;
-  color: #3399cc;
+  color: #0472ad;
   margin-bottom: 0;
   text-transform: uppercase;
   font-weight: 600;
@@ -770,7 +770,7 @@ body:not(.customer-account) .block:first-child .block-title {
     display: block;
     border-top: 4px solid transparent;
     border-bottom: 4px solid transparent;
-    border-left: 4px solid #3399cc;
+    border-left: 4px solid #0472ad;
     border-right: none;
     left: 10px;
     top: 50%;
@@ -812,7 +812,7 @@ body:not(.customer-account) .block:first-child .block-title {
     display: block;
     border-right: 4px solid transparent;
     border-left: 4px solid transparent;
-    border-top: 4px solid #3399cc;
+    border-top: 4px solid #0472ad;
     border-bottom: none;
     left: 10px;
     top: 50%;
@@ -849,7 +849,7 @@ body:not(.customer-account) .block:first-child .block-title {
 .block-account li strong,
 .block-cms-menu li strong {
   font-weight: 400;
-  color: #3399cc;
+  color: #0472ad;
 }
 .block-account li a,
 .block-cms-menu li a {
@@ -857,7 +857,7 @@ body:not(.customer-account) .block:first-child .block-title {
 }
 .block-account li a:hover,
 .block-cms-menu li a:hover {
-  color: #3399cc;
+  color: #0472ad;
 }
 
 /* ============================================ *
@@ -904,7 +904,7 @@ body:not(.customer-account) .block:first-child .block-title {
 .cart-table .product-cart-actions .button,
 #co-shipping-method-form .buttons-set .button,
 .footer .button {
-  background: #3399cc;
+  background: #0472ad;
   display: inline-block;
   padding: 7px 15px;
   border: 0;
@@ -982,7 +982,7 @@ a.button:hover {
   text-decoration: underline;
   text-transform: uppercase;
   display: inline-block;
-  color: #3399cc;
+  color: #0472ad;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
 }
 .button2 span:hover,
@@ -1140,7 +1140,7 @@ a.button:hover {
 }
 
 .breadcrumbs a:hover {
-  color: #3399cc;
+  color: #0472ad;
 }
 
 .breadcrumbs strong {
@@ -1176,13 +1176,13 @@ a.button:hover {
 }
 .btn-remove:hover,
 .btn-previous:hover {
-  background-color: #3399cc;
-  border-color: #3399cc;
+  background-color: #0472ad;
+  border-color: #0472ad;
 }
 
 .btn-remove:after {
   content: 'X';
-  color: #3399cc;
+  color: #0472ad;
   height: 20px;
   line-height: 20px;
   width: 100%;
@@ -1216,7 +1216,7 @@ a.button:hover {
   display: block;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
-  border-right: 4px solid #3399cc;
+  border-right: 4px solid #0472ad;
   border-left: none;
   position: absolute;
   top: 50%;
@@ -1513,7 +1513,7 @@ a.button:hover {
  * Promotional Message Banner
  */
 .promo-msg {
-  color: #3399cc;
+  color: #0472ad;
   text-align: center;
   margin: 10px;
   text-transform: uppercase;
@@ -1533,7 +1533,7 @@ a.button:hover {
  * Messages
  */
 .success {
-  color: #11b400;
+  color: #0f8900;
 }
 
 .error {
@@ -1605,7 +1605,7 @@ a.button:hover {
 
 .messages .success-msg li {
   color: black;
-  border-left: 5px solid #11b400;
+  border-left: 5px solid #0f8900;
   background-color: #eff5ea;
 }
 
@@ -1617,7 +1617,7 @@ a.button:hover {
   display: block;
   border-top: 6px solid transparent;
   border-bottom: 6px solid transparent;
-  border-left: 6px solid #11b400;
+  border-left: 6px solid #0f8900;
   border-right: none;
 }
 
@@ -1743,7 +1743,7 @@ a.button:hover {
 }
 
 .price-box .price {
-  color: #3399cc;
+  color: #0472ad;
   font-size: 16px;
 }
 
@@ -1760,7 +1760,7 @@ a.button:hover {
 
 .price-box .minimal-price-link {
   padding-left: 1em;
-  color: #3399cc;
+  color: #0472ad;
   display: block;
   /* We want this to show on its own line, otherwise the layout looks funky */
 }
@@ -1790,7 +1790,7 @@ a.button:hover {
 }
 
 .price-box .special-price {
-  color: #3399cc;
+  color: #0472ad;
   padding-left: 1em;
 }
 .price-box .special-price .price-label {
@@ -1890,7 +1890,7 @@ span.weee {
   z-index: 300;
   width: 200px;
   padding: 8px;
-  border: 1px solid #3399cc;
+  border: 1px solid #0472ad;
   background-color: #F6F6F6;
   top: 21px;
   left: -100px;
@@ -1903,7 +1903,7 @@ span.weee {
   display: block;
   border-right: 7px solid transparent;
   border-left: 7px solid transparent;
-  border-bottom: 7px solid #3399cc;
+  border-bottom: 7px solid #0472ad;
   border-top: none;
   left: 97px;
   top: -7px;
@@ -1981,7 +1981,7 @@ span.weee {
   }
 }
 .no-touch .product-image:hover {
-  border-color: #3399cc;
+  border-color: #0472ad;
 }
 
 /* -------------------------------------------- *
@@ -2208,7 +2208,7 @@ span.weee {
   width: 25px;
   height: 30px;
   padding: 0;
-  color: #3399cc;
+  color: #0472ad;
   font-family: "Helvetica Neue", Verdana, Arial, sans-serif;
 }
 
@@ -2231,7 +2231,7 @@ span.weee {
 }
 .pages .next:hover,
 .pages .previous:hover {
-  border: 1px solid #3399cc;
+  border: 1px solid #0472ad;
 }
 
 .pages .next:before {
@@ -2242,7 +2242,7 @@ span.weee {
   display: block;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
-  border-left: 4px solid #3399cc;
+  border-left: 4px solid #0472ad;
   border-right: none;
   top: 50%;
   margin-top: -3px;
@@ -2269,7 +2269,7 @@ span.weee {
   display: block;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
-  border-right: 4px solid #3399cc;
+  border-right: 4px solid #0472ad;
   border-left: none;
   top: 50%;
   margin-top: -3px;
@@ -2369,7 +2369,7 @@ body.customer-account .data-table .summary-collapse:before {
   display: block;
   border-right: 7px solid transparent;
   border-left: 7px solid transparent;
-  border-top: 7px solid #3399cc;
+  border-top: 7px solid #0472ad;
   border-bottom: none;
   position: static;
   display: inline-block;
@@ -2401,7 +2401,7 @@ body.customer-account .data-table .show-details .summary-collapse:before {
   display: block;
   border-right: 7px solid transparent;
   border-left: 7px solid transparent;
-  border-bottom: 7px solid #3399cc;
+  border-bottom: 7px solid #0472ad;
   border-top: none;
   position: static;
   display: inline-block;
@@ -2618,7 +2618,7 @@ textarea {
   font-size: 15px;
 }
 .input-text:focus {
-  border: 1px solid #3399cc;
+  border: 1px solid #0472ad;
 }
 
 .input-text.validation-failed {
@@ -3163,7 +3163,7 @@ body {
  * ============================================ */
 .header-language-background {
   padding: 10px;
-  background-color: #3399cc;
+  background-color: #0472ad;
   text-transform: uppercase;
 }
 .header-language-background .header-language-container {
@@ -3529,7 +3529,7 @@ a.skip-link {
   }
   .nav-primary li.menu-active > a,
   .nav-primary li.sub-menu-active > a {
-    color: #3399cc;
+    color: #0472ad;
   }
 }
 /* ============================================ *
@@ -3555,7 +3555,7 @@ a.skip-link {
   }
   .nav-primary a:hover,
   .nav-primary li:hover > a {
-    color: #3399cc;
+    color: #0472ad;
   }
   .nav-primary .menu-active {
     z-index: 200;
@@ -3738,7 +3738,7 @@ a.skip-link {
   }
 
   #header-account a:hover {
-    color: #3399cc;
+    color: #0472ad;
   }
 }
 /* -------------------------------------------- *
@@ -3757,7 +3757,7 @@ a.skip-link {
 }
 
 #header-account a:hover {
-  color: #3399cc;
+  color: #0472ad;
 }
 
 /* ============================================ *
@@ -3829,7 +3829,7 @@ a.skip-link {
 }
 @media only screen and (min-width: 771px) {
   .skip-cart {
-    color: #3399cc;
+    color: #0472ad;
     text-transform: uppercase;
   }
   .skip-cart:hover {
@@ -3856,7 +3856,7 @@ a.skip-link {
 
   .skip-cart .count,
   .skip-link.skip-active .count {
-    color: #3399cc;
+    color: #0472ad;
   }
 }
 .skip-cart .count.empty {
@@ -3973,7 +3973,7 @@ a.skip-link {
 }
 .footer .block-title,
 .footer address {
-  color: #3399cc;
+  color: #0472ad;
 }
 .footer .links {
   float: left;
@@ -3990,7 +3990,7 @@ a.skip-link {
   color: #636363;
 }
 .footer .links a:hover {
-  color: #3399cc;
+  color: #0472ad;
 }
 .footer .block-subscribe {
   float: right;
@@ -4203,7 +4203,7 @@ h3.product-name a:hover,
 h4.product-name a:hover,
 h5.product-name a:hover,
 p.product-name a:hover {
-  color: #3399cc;
+  color: #0472ad;
   text-decoration: none;
 }
 
@@ -4665,7 +4665,7 @@ p.product-name a:hover {
   display: block;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
-  border-top: 4px solid #3399cc;
+  border-top: 4px solid #0472ad;
   border-bottom: none;
   left: 10px;
   top: 50%;
@@ -4712,7 +4712,7 @@ p.product-name a:hover {
   display: block;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
-  border-top: 4px solid #3399cc;
+  border-top: 4px solid #0472ad;
   border-bottom: none;
   left: 10px;
   top: 50%;
@@ -4770,7 +4770,7 @@ p.product-name a:hover {
     border-bottom-width: 0;
   }
   .block-layered-nav .block-content > dl > dt:hover {
-    color: #3399cc;
+    color: #0472ad;
   }
   .block-layered-nav .block-content > dl > dt:after {
     content: '';
@@ -4780,7 +4780,7 @@ p.product-name a:hover {
     display: block;
     border-top: 4px solid transparent;
     border-bottom: 4px solid transparent;
-    border-left: 4px solid #3399cc;
+    border-left: 4px solid #0472ad;
     border-right: none;
   }
   .block-layered-nav .block-content > dl > dt.last {
@@ -4800,7 +4800,7 @@ p.product-name a:hover {
     display: block;
     border-right: 4px solid transparent;
     border-left: 4px solid transparent;
-    border-top: 4px solid #3399cc;
+    border-top: 4px solid #0472ad;
     border-bottom: none;
     left: 6px;
     top: 50%;
@@ -4811,7 +4811,7 @@ p.product-name a:hover {
   }
 
   .block-layered-nav .block-subtitle--filter {
-    background-color: #3399cc;
+    background-color: #0472ad;
     border: 0;
     margin-bottom: 0;
     display: block;
@@ -4930,7 +4930,7 @@ p.product-name a:hover {
 }
 .product-view .product-shop .product-name .h1,
 .product-view .product-img-box .product-name h1 {
-  color: #3399cc;
+  color: #0472ad;
   margin-bottom: 10px;
   border: 0;
 }
@@ -4984,7 +4984,7 @@ p.product-name a:hover {
 .product-view .product-shop .price-box .regular-price .price,
 .product-view .product-shop .price-box .special-price .price,
 .product-view .product-shop .price-box .full-product-price .price {
-  color: #3399cc;
+  color: #0472ad;
   font-size: 24px;
 }
 .product-view .product-shop .price-box .special-price .price-label {
@@ -5377,7 +5377,7 @@ p.product-name a:hover {
   }
   .product-collateral .toggle-tabs li.current span,
   .product-collateral .toggle-tabs li:hover span {
-    color: #3399cc;
+    color: #0472ad;
   }
   .product-collateral .toggle-tabs li:first-child {
     border-left: none;
@@ -5442,7 +5442,7 @@ p.product-name a:hover {
     display: block;
     border-right: 4px solid transparent;
     border-left: 4px solid transparent;
-    border-top: 4px solid #3399cc;
+    border-top: 4px solid #0472ad;
     border-bottom: none;
     left: 10px;
     top: 50%;
@@ -5466,7 +5466,7 @@ p.product-name a:hover {
     border-bottom-width: 0;
   }
   .product-collateral > dl > dt:hover {
-    color: #3399cc;
+    color: #0472ad;
   }
   .product-collateral > dl > dt:after {
     content: '';
@@ -5476,7 +5476,7 @@ p.product-name a:hover {
     display: block;
     border-top: 4px solid transparent;
     border-bottom: 4px solid transparent;
-    border-left: 4px solid #3399cc;
+    border-left: 4px solid #0472ad;
     border-right: none;
   }
   .product-collateral > dl > dt.last {
@@ -5496,7 +5496,7 @@ p.product-name a:hover {
     display: block;
     border-right: 4px solid transparent;
     border-left: 4px solid transparent;
-    border-top: 4px solid #3399cc;
+    border-top: 4px solid #0472ad;
     border-bottom: none;
     left: 6px;
     top: 50%;
@@ -5570,7 +5570,7 @@ p.product-name a:hover {
 }
 
 .grouped-items-table .name-wrapper {
-  color: #3399cc;
+  color: #0472ad;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
 }
 .grouped-items-table .qty-wrapper {
@@ -6369,7 +6369,7 @@ p.product-name a:hover {
   display: block;
   border-top: 6px solid transparent;
   border-bottom: 6px solid transparent;
-  border-right: 6px solid #3399cc;
+  border-right: 6px solid #0472ad;
   border-left: none;
   position: absolute;
   top: 3px;
@@ -6383,7 +6383,7 @@ p.product-name a:hover {
   display: block;
   border-right: 6px solid transparent;
   border-left: 6px solid transparent;
-  border-top: 6px solid #3399cc;
+  border-top: 6px solid #0472ad;
   border-bottom: none;
   right: -15px;
   top: 6px;
@@ -6802,7 +6802,7 @@ p.product-name a:hover {
  * Checkout - Cart Cross sell
  * ============================================ */
 .crosssell h2 {
-  color: #3399cc;
+  color: #0472ad;
 }
 .crosssell .item a.product-image {
   width: auto;
@@ -6934,7 +6934,7 @@ p.product-name a:hover {
   text-align: center;
   color: #FFFFFF;
   line-height: 26px;
-  background-color: #3399cc;
+  background-color: #0472ad;
   display: block;
   position: absolute;
   top: 50%;
@@ -6952,7 +6952,7 @@ p.product-name a:hover {
 
 .opc .section.allow .step-title:hover h2,
 .opc .section.active .step-title h2 {
-  color: #3399cc;
+  color: #0472ad;
 }
 
 .opc .section .step-title h2 {
@@ -7536,7 +7536,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   line-height: inherit;
 }
 #narrow-by-list dd .swatch-link:hover .swatch-label {
-  border-color: #3399cc;
+  border-color: #0472ad;
 }
 #narrow-by-list dd .swatch-label {
   background: #f4f4f4;
@@ -7589,7 +7589,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 .configurable-swatch-list .hover .swatch-link,
 .configurable-swatch-list .selected .swatch-link,
 .swatch-link:hover {
-  border-color: #3399cc;
+  border-color: #0472ad;
 }
 
 .configurable-swatch-box {
@@ -7631,7 +7631,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 .product-view .product-options .swatch-attr .select-label {
   display: inline;
   font-weight: normal;
-  color: #3399cc;
+  color: #0472ad;
   padding-left: 5px;
 }
 .product-view .product-options dd .input-box {
@@ -8512,7 +8512,7 @@ div.paypal-logo span > img {
   display: none;
 }
 #customer-reviews h2 {
-  color: #3399cc;
+  color: #0472ad;
   font-size: 12px;
   text-transform: uppercase;
 }
@@ -8526,7 +8526,7 @@ div.paypal-logo span > img {
   text-transform: uppercase;
 }
 #customer-reviews h3 span {
-  color: #3399cc;
+  color: #0472ad;
 }
 #customer-reviews .fieldset {
   padding-top: 25px;
@@ -8609,7 +8609,7 @@ div.paypal-logo span > img {
   margin: 15px 0;
 }
 #customer-reviews dl dd .review-meta {
-  color: #3399cc;
+  color: #0472ad;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
   font-size: 10px;
   font-weight: normal;
@@ -8970,7 +8970,7 @@ div.paypal-logo span > img {
   text-transform: uppercase;
 }
 #wishlist-table .product-name a {
-  color: #3399cc;
+  color: #0472ad;
 }
 #wishlist-table .wishlist-sku {
   font-size: 11px;
@@ -8997,7 +8997,7 @@ div.paypal-logo span > img {
   text-transform: uppercase;
 }
 #wishlist-table textarea:focus {
-  border: 1px solid #3399cc;
+  border: 1px solid #0472ad;
 }
 #wishlist-table .item-manage {
   text-align: right;
@@ -9064,12 +9064,12 @@ div.paypal-logo span > img {
 }
 #wishlist-table .giftregisty-add li {
   cursor: pointer;
-  color: #3399cc;
+  color: #0472ad;
   margin-bottom: 3px;
 }
 #wishlist-table .truncated .details {
   background: none;
-  color: #3399cc;
+  color: #0472ad;
 }
 #wishlist-table td[data-rwd-label]:before {
   font-weight: 600;
@@ -9326,7 +9326,7 @@ div.paypal-logo span > img {
   font-weight: bold;
 }
 .header-minicart .product-details .product-name a {
-  color: #3399cc;
+  color: #0472ad;
 }
 .header-minicart .info-wrapper {
   margin-bottom: 0.5em;
@@ -9336,7 +9336,7 @@ div.paypal-logo span > img {
   padding-right: 10px;
 }
 .header-minicart .info-wrapper td {
-  color: #3399cc;
+  color: #0472ad;
   clear: right;
 }
 .header-minicart .info-wrapper .qty-wrapper td {
@@ -9378,7 +9378,7 @@ div.paypal-logo span > img {
   text-transform: uppercase;
 }
 .header-minicart .subtotal .price {
-  color: #3399cc;
+  color: #0472ad;
 }
 .header-minicart .minicart-actions {
   padding: 10px;
@@ -9512,7 +9512,7 @@ div.paypal-logo span > img {
   -o-border-radius: 2px;
   border-radius: 2px;
   background-color: #FFFFFF;
-  border: 1px solid #3399cc;
+  border: 1px solid #0472ad;
   left: 0;
   padding-left: 0;
   position: absolute;
@@ -9521,7 +9521,7 @@ div.paypal-logo span > img {
 }
 .search-autocomplete ul li {
   border-bottom: 1px solid #f4f4f4;
-  color: #3399cc;
+  color: #0472ad;
   cursor: pointer;
   font-size: 12px;
   padding: 4px 6px;
@@ -9531,7 +9531,7 @@ div.paypal-logo span > img {
   color: #2e8ab8;
 }
 .search-autocomplete ul li.selected {
-  background-color: #3399cc;
+  background-color: #0472ad;
   color: white;
 }
 .search-autocomplete ul li .amount {
@@ -9549,7 +9549,7 @@ div.paypal-logo span > img {
   display: block;
   border-right: 7px solid transparent;
   border-left: 7px solid transparent;
-  border-bottom: 7px solid #3399cc;
+  border-bottom: 7px solid #0472ad;
   border-top: none;
   left: 50%;
   top: -7px;
@@ -9589,7 +9589,7 @@ div.paypal-logo span > img {
 }
 .product-review .product-details h2 {
   border-bottom: 1px solid #cccccc;
-  color: #3399CC;
+  color: #0472ad;
   font-size: 16px;
   font-weight: 600;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
@@ -9665,11 +9665,11 @@ div.paypal-logo span > img {
 }
 .cms-page-view .std h1,
 .cms-no-route .std h1 {
-  color: #3399cc;
+  color: #0472ad;
 }
 .cms-page-view .std h2,
 .cms-no-route .std h2 {
-  color: #3399cc;
+  color: #0472ad;
 }
 .cms-page-view .std li,
 .cms-no-route .std li {
@@ -9746,7 +9746,7 @@ div.paypal-logo span > img {
   display: block;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
-  border-top: 4px solid #3399cc;
+  border-top: 4px solid #0472ad;
   border-bottom: none;
   left: 10px;
   top: 50%;

--- a/skin/frontend/rwd/default/css/styles.css
+++ b/skin/frontend/rwd/default/css/styles.css
@@ -672,7 +672,7 @@ h6, .h6 {
 .block-title small {
   font-size: 100%;
   font-weight: normal;
-  color: #a0a0a0;
+  color: #767676;
 }
 
 body:not(.customer-account) .block:first-child .block-title {
@@ -1739,7 +1739,7 @@ a.button:hover {
 }
 
 .price-notice {
-  color: #a0a0a0;
+  color: #767676;
 }
 
 .price-box .price {
@@ -1753,7 +1753,7 @@ a.button:hover {
 }
 
 .price-box .price-label {
-  color: #a0a0a0;
+  color: #767676;
   white-space: nowrap;
   font-family: "Raleway", "Helvetica Neue", Verdana, Arial, sans-serif;
 }
@@ -1765,7 +1765,7 @@ a.button:hover {
   /* We want this to show on its own line, otherwise the layout looks funky */
 }
 .price-box .minimal-price-link .label {
-  color: #a0a0a0;
+  color: #767676;
 }
 
 /* -------------------------------------------- *
@@ -1785,7 +1785,7 @@ a.button:hover {
 }
 
 .price-box .old-price .price {
-  color: #a0a0a0;
+  color: #767676;
   text-decoration: line-through;
 }
 
@@ -2041,7 +2041,7 @@ span.weee {
 }
 
 .std .note {
-  color: #a0a0a0;
+  color: #767676;
   font-size: 13px;
 }
 
@@ -2567,7 +2567,7 @@ span.required em {
  * Hints
  */
 .input-hint {
-  color: #a0a0a0;
+  color: #767676;
   font-size: 12px;
 }
 
@@ -2677,11 +2677,11 @@ input[type=text].qty {
  * Placeholder
  */
 ::-webkit-input-placeholder {
-  color: #a0a0a0;
+  color: #767676;
 }
 
 input:-moz-placeholder {
-  color: #a0a0a0;
+  color: #767676;
 }
 
 /* -------------------------------------------- *
@@ -2844,7 +2844,7 @@ form .form-instructions {
   font-style: italic;
   font-family: Georgia, Times, "Times New Roman", serif;
   font-size: 13px;
-  color: #a0a0a0;
+  color: #767676;
 }
 
 /* ============================================ *
@@ -3928,7 +3928,7 @@ a.skip-link {
 
 .mini-cart-list .has-options {
   margin-bottom: 0;
-  color: #a0a0a0;
+  color: #767676;
   font-size: 12px;
 }
 
@@ -4284,7 +4284,7 @@ p.product-name a:hover {
 }
 
 .products-grid .price-box {
-  color: #a0a0a0;
+  color: #767676;
   font-size: 13px;
   margin: 0 0 5px;
 }
@@ -4741,7 +4741,7 @@ p.product-name a:hover {
   display: block;
 }
 .block-layered-nav dl dd ol > li > a .count {
-  color: #a0a0a0;
+  color: #767676;
 }
 
 @media only screen and (min-width: 771px) {
@@ -6947,7 +6947,7 @@ p.product-name a:hover {
 }
 
 .opc .section.allow .step-title h2 {
-  color: #a0a0a0;
+  color: #767676;
 }
 
 .opc .section.allow .step-title:hover h2,
@@ -7185,7 +7185,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   margin-bottom: 6px;
   text-transform: uppercase;
   font-weight: normal;
-  color: #a0a0a0;
+  color: #767676;
 }
 .block-progress dt.complete {
   color: #636363;
@@ -7611,7 +7611,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
 
 /* CUSTOM */
 .availability.out-of-stock span {
-  color: #a0a0a0;
+  color: #767676;
 }
 
 .product-view .product-options .swatch-attr {
@@ -7713,7 +7713,7 @@ body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-l
   font-style: italic;
   font-family: Georgia, Times, "Times New Roman", serif;
   font-size: 13px;
-  color: #a0a0a0;
+  color: #767676;
 }
 
 .remember-me-box a.hide {

--- a/skin/frontend/rwd/default/scss/_var.scss
+++ b/skin/frontend/rwd/default/scss/_var.scss
@@ -91,7 +91,7 @@ $c-gray: #333333;
 // Text
 
 $c-text: #636363;
-$c-text-gray: #A0A0A0;
+$c-text-gray: #767676;
 $c-text-white: #E6E6E6;
 // Primary font color for headings and other non-link text
 $c-text-primary: $c-blue;
@@ -101,7 +101,7 @@ $c-text-primary: $c-blue;
 
 $c-action: $c-blue;
 $c-stimulus: darken($c-blue, 15%);
-$c-subtle: #A0A0A0;
+$c-subtle: #767676;
 
 // Notifications
 

--- a/skin/frontend/rwd/default/scss/_var.scss
+++ b/skin/frontend/rwd/default/scss/_var.scss
@@ -75,8 +75,8 @@ $max-std-formatted-width: 50em;
 // Usually not used directly in Sass partials.
 // Only used to define context-based color vars in this file.
 
-$c-blue: #3399CC;
-$c-green: #11B400;
+$c-blue: #0472ad;
+$c-green: #0f8900;
 $c-pink: #D85378;
 $c-orange: #F3793B;
 $c-red: #CF5050;

--- a/skin/frontend/rwd/default/scss/content/_category.scss
+++ b/skin/frontend/rwd/default/scss/content/_category.scss
@@ -113,7 +113,7 @@
 }
 
 .catalog-category-view div.categoryland-caption span.blue-big-text {
-    color: #3399CC;
+    color: #0472ad;
     font-size: 50px;
     font-weight: 800;
     padding: 0 0 0 8px;
@@ -142,7 +142,7 @@
 
 .cms-home #homepage-main-slides div.slides_control div div.slideshow-caption span.blue-big-text,
 .catalog-category-view div.categoryland-caption span.blue-big-text {
-    color: #3399CC;
+    color: #0472ad;
     font-size: 50px;
     font-weight: 800;
     padding: 0 0 0 8px;

--- a/skin/frontend/rwd/default/scss/module/_account-reviews.scss
+++ b/skin/frontend/rwd/default/scss/module/_account-reviews.scss
@@ -35,7 +35,7 @@
     .product-details {
         h2 {
             border-bottom: 1px solid $c-module-border;
-            color: #3399CC;
+            color: #0472ad;
             font-size: $f-size-xl;
             font-weight: 600;
             font-family: $f-stack-special;


### PR DESCRIPTION
Default RWD theme has some color contrast problems as reported by lighthouse:

<img width="1486" alt="Screenshot 2024-03-28 alle 00 04 45" src="https://github.com/OpenMage/magento-lts/assets/909743/831a47d7-6257-4d18-ae36-30aa2c0b213f">

<img width="1461" alt="Screenshot 2024-03-28 alle 00 05 41" src="https://github.com/OpenMage/magento-lts/assets/909743/08e93bac-3a60-4bb8-acaf-ebdcfac15e70">

This PR slightly changes the colors that are creating this problems, it is very important that our default theme respect accessibility, more important if the fixes are so easy.

After the PR:
<img width="1408" alt="Screenshot 2024-03-28 alle 00 10 14" src="https://github.com/OpenMage/magento-lts/assets/909743/8d3ab254-9c52-4849-8bc7-5e22c9ba65f4">

<img width="1446" alt="Screenshot 2024-03-28 alle 00 09 56" src="https://github.com/OpenMage/magento-lts/assets/909743/9f7d9cf5-579a-4cf2-a9cc-0c20722e6aa9">
