### PR TITLE
Add the column ID name to the <span> in absence of a link

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
@@ -115,7 +115,7 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract extends
     /**
      * @return string
      */
-    public function renderHeader(): string
+    public function renderHeader()
     {
         if ($this->getColumn()->getGrid()->getSortable() !== false && $this->getColumn()->getSortable() !== false) {
             $className = 'not-sort';

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
@@ -128,7 +128,7 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract extends
                    . '" class="' . $className . '"><span class="sort-title">'
                    . $this->escapeHtml($this->getColumn()->getHeader()) . '</span></a>';
         } else {
-            $out = '<span name="' . $this->getColumn()->getId() . '">'.$this->escapeHtml($this->getColumn()->getHeader()) . '</span>';
+            $out = '<span name="' . $this->getColumn()->getId() . '">' . $this->escapeHtml($this->getColumn()->getHeader()) . '</span>';
         }
         return $out;
     }

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
@@ -115,7 +115,7 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract extends
     /**
      * @return string
      */
-    public function renderHeader()
+    public function renderHeader(): string
     {
         if ($this->getColumn()->getGrid()->getSortable() !== false && $this->getColumn()->getSortable() !== false) {
             $className = 'not-sort';
@@ -128,7 +128,7 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract extends
                    . '" class="' . $className . '"><span class="sort-title">'
                    . $this->escapeHtml($this->getColumn()->getHeader()) . '</span></a>';
         } else {
-            $out = $this->escapeHtml($this->getColumn()->getHeader());
+            $out = '<span name="' . $this->getColumn()->getId() . '">'.$this->escapeHtml($this->getColumn()->getHeader()) . '</span>';
         }
         return $out;
     }


### PR DESCRIPTION
It's possible to determine the column name for admin grids, but not if they are not sortable. I propose to add this.
