### PR TITLE
Backend: removed invalid "name" element, removed redundant nobr spans, added data-column-id to grids

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
@@ -124,8 +124,7 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract extends
             if ($this->getColumn()->getDir()) {
                 $className = 'sort-arrow-' . $dir;
             }
-            $out = '<a href="#" name="' . $this->getColumn()->getId() . '" title="' . $nDir
-                   . '" class="' . $className . '"><span class="sort-title">'
+            $out = '<a href="#" title="' . $nDir . '" class="' . $className . '"><span class="sort-title">'
                    . $this->escapeHtml($this->getColumn()->getHeader()) . '</span></a>';
         } else {
             $out = $this->escapeHtml($this->getColumn()->getHeader());

--- a/app/design/adminhtml/default/default/template/widget/grid.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid.phtml
@@ -114,7 +114,7 @@ $numColumns = count($this->getColumns());
                 <?php if ($this->getHeadersVisibility()): ?>
                     <tr class="headings">
                     <?php foreach ($this->getColumns() as $_column): ?>
-                        <th<?php echo $_column->getHeaderHtmlProperty() ?>><span class="nobr"><?php echo $_column->getHeaderHtml() ?></span></th>
+                        <th<?php echo $_column->getHeaderHtmlProperty() ?> data-column-id="<?php echo $_column->getId() ?>"><?php echo $_column->getHeaderHtml() ?></th>
                     <?php endforeach ?>
                     </tr>
                 <?php endif ?>

--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -159,7 +159,7 @@ table.actions td                { vertical-align:top; }
 
 /* Grid - Headings */
 .grid tr.headings { background:url(images/sort_row_bg.gif) 0 50% repeat-x; }
-.grid tr.headings th { border-width:1px; border-color:#f9f9f9 #d1cfcf #f9f9f9 #f9f9f9; border-style:solid; padding-top:1px; padding-bottom:0; font-size:.9em; }
+.grid tr.headings th { border-width:1px; border-color:#f9f9f9 #d1cfcf #f9f9f9 #f9f9f9; border-style:solid; padding-top:1px; padding-bottom:0; font-size:.9em; white-space:nowrap;}
 .grid tr.headings th.last { border-right:0; }
 .grid tr.headings th.no-link { /* Grid th with no sorting functionality */ padding-top:2px; padding-bottom:1px; color:#67767e; }
 .grid tr.headings th span.nobr { display:block; /* FF3 fix */ }

--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -162,7 +162,6 @@ table.actions td                { vertical-align:top; }
 .grid tr.headings th { border-width:1px; border-color:#f9f9f9 #d1cfcf #f9f9f9 #f9f9f9; border-style:solid; padding-top:1px; padding-bottom:0; font-size:.9em; white-space:nowrap;}
 .grid tr.headings th.last { border-right:0; }
 .grid tr.headings th.no-link { /* Grid th with no sorting functionality */ padding-top:2px; padding-bottom:1px; color:#67767e; }
-.grid tr.headings th span.nobr { display:block; /* FF3 fix */ }
 .grid tr.headings th a { display:block; padding:2px 4px 1px 0; color:#2d444f; text-decoration:none; }
 .grid tr.headings th a:hover { color:#d85909; text-decoration:none; }
 .grid tr.headings th a.sort-arrow-desc,


### PR DESCRIPTION
This PR rewrites https://github.com/OpenMage/magento-lts/pull/3923

In the process of reviewing https://github.com/OpenMage/magento-lts/pull/3923 I've seen that the `name` attribute is not valid for `span` or `a`, but the concept of the PR was interesting, so I did a clean up of the whole thing:
- removed invalid name attribute
- added data-column-id to the `th` instead
- removed the `nobr` span (there are way too many DOM nodes in OM, they need to be simplified) and added a `white-space:nowrap` to its container instead

Closes https://github.com/OpenMage/magento-lts/pull/3923