### PR TITLE
Removed invalid "sortcut icon" HTML element

### DIFF
--- a/app/design/adminhtml/default/default/template/forgotpassword.phtml
+++ b/app/design/adminhtml/default/default/template/forgotpassword.phtml
@@ -22,7 +22,6 @@
     <link type="text/css" rel="stylesheet" href="<?php echo $this->getSkinUrl('reset.css') ?>" media="all" />
     <link type="text/css" rel="stylesheet" href="<?php echo $this->getSkinUrl('boxes.css') ?>" media="all" />
     <link rel="icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon" />
-    <link rel="shortcut icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon" />
     <script type="text/javascript" src="<?php echo $this->getJsUrl('prototype/prototype.js') ?>"></script>
     <script type="text/javascript" src="<?php echo $this->getJsUrl('prototype/validation.js') ?>"></script>
     <script type="text/javascript" src="<?php echo $this->getJsUrl('scriptaculous/effects.js') ?>"></script>

--- a/app/design/adminhtml/default/default/template/login.phtml
+++ b/app/design/adminhtml/default/default/template/login.phtml
@@ -22,7 +22,6 @@
     <link type="text/css" rel="stylesheet" href="<?php echo $this->getSkinUrl('reset.css') ?>" media="all" />
     <link type="text/css" rel="stylesheet" href="<?php echo $this->getSkinUrl('boxes.css') ?>" media="all" />
     <link rel="icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon" />
-    <link rel="shortcut icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon" />
     <script type="text/javascript" src="<?php echo $this->getJsUrl('prototype/prototype.js') ?>"></script>
     <script type="text/javascript" src="<?php echo $this->getJsUrl('prototype/validation.js') ?>"></script>
     <script type="text/javascript" src="<?php echo $this->getJsUrl('scriptaculous/effects.js') ?>"></script>

--- a/app/design/adminhtml/default/default/template/oauth/authorize/head-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/head-simple.phtml
@@ -24,7 +24,6 @@
 <meta http-equiv="Content-Type" content="<?php echo $this->getContentType() ?>"/>
 <title><?php echo htmlspecialchars(html_entity_decode($this->getTitle())) ?></title>
 <link rel="icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon"/>
-<link rel="shortcut icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon"/>
 
 <script type="text/javascript">
 //<![CDATA[

--- a/app/design/adminhtml/default/default/template/page/head.phtml
+++ b/app/design/adminhtml/default/default/template/page/head.phtml
@@ -19,7 +19,6 @@
 <meta name="robots" content="noindex, nofollow"/>
 <title><?php echo htmlspecialchars(html_entity_decode($this->getTitle())) ?></title>
 <link rel="icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon"/>
-<link rel="shortcut icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon"/>
 
 <script type="text/javascript">
     var BLANK_URL = '<?php echo $this->getJsUrl() ?>blank.html';

--- a/app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
+++ b/app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
@@ -22,7 +22,6 @@
     <link type="text/css" rel="stylesheet" href="<?php echo $this->getSkinUrl('reset.css') ?>" media="all" />
     <link type="text/css" rel="stylesheet" href="<?php echo $this->getSkinUrl('boxes.css') ?>" media="all" />
     <link rel="icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon" />
-    <link rel="shortcut icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon" />
     <script type="text/javascript" src="<?php echo $this->getJsUrl('prototype/prototype.js') ?>"></script>
     <script type="text/javascript" src="<?php echo $this->getJsUrl('prototype/validation.js') ?>"></script>
     <script type="text/javascript" src="<?php echo $this->getJsUrl('scriptaculous/effects.js') ?>"></script>

--- a/app/design/adminhtml/default/openmage/template/forgotpassword.phtml
+++ b/app/design/adminhtml/default/openmage/template/forgotpassword.phtml
@@ -21,7 +21,6 @@
     <title><?php echo Mage::helper('adminhtml')->__('Log into OpenMage Admin Page') ?></title>
     <link type="text/css" rel="stylesheet" href="<?php echo $this->getSkinUrl('login.css') ?>" media="all" />
     <link rel="icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon" />
-    <link rel="shortcut icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon" />
     <script type="text/javascript" src="<?php echo $this->getJsUrl('prototype/prototype.js') ?>"></script>
     <script type="text/javascript" src="<?php echo $this->getJsUrl('prototype/validation.js') ?>"></script>
     <script type="text/javascript" src="<?php echo $this->getJsUrl('scriptaculous/effects.js') ?>"></script>

--- a/app/design/adminhtml/default/openmage/template/login.phtml
+++ b/app/design/adminhtml/default/openmage/template/login.phtml
@@ -21,7 +21,6 @@
     <title><?php echo Mage::helper('adminhtml')->__('Log into OpenMage Admin Page') ?></title>
     <link type="text/css" rel="stylesheet" href="<?php echo $this->getSkinUrl('login.css') ?>" media="all" />
     <link rel="icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon" />
-    <link rel="shortcut icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon" />
     <script type="text/javascript" src="<?php echo $this->getJsUrl('prototype/prototype.js') ?>"></script>
     <script type="text/javascript" src="<?php echo $this->getJsUrl('prototype/validation.js') ?>"></script>
     <script type="text/javascript" src="<?php echo $this->getJsUrl('scriptaculous/effects.js') ?>"></script>

--- a/app/design/adminhtml/default/openmage/template/resetforgottenpassword.phtml
+++ b/app/design/adminhtml/default/openmage/template/resetforgottenpassword.phtml
@@ -21,7 +21,6 @@
     <title><?php echo Mage::helper('adminhtml')->__('Reset a Password') ?></title>
     <link type="text/css" rel="stylesheet" href="<?php echo $this->getSkinUrl('login.css') ?>" media="all" />
     <link rel="icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon" />
-    <link rel="shortcut icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon" />
     <script type="text/javascript" src="<?php echo $this->getJsUrl('prototype/prototype.js') ?>"></script>
     <script type="text/javascript" src="<?php echo $this->getJsUrl('prototype/validation.js') ?>"></script>
     <script type="text/javascript" src="<?php echo $this->getJsUrl('scriptaculous/effects.js') ?>"></script>

--- a/app/design/frontend/base/default/template/oauth/authorize/head-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/head-simple.phtml
@@ -22,6 +22,5 @@
 <meta http-equiv="Content-Type" content="<?php echo $this->getContentType() ?>" />
 <title><?php echo $this->getTitle() ?></title>
 <link rel="icon" href="<?php echo $this->getFaviconFile(); ?>" type="image/x-icon" />
-<link rel="shortcut icon" href="<?php echo $this->getFaviconFile(); ?>" type="image/x-icon" />
 
 <?php echo $this->getCssJsHtml() ?>

--- a/app/design/frontend/base/default/template/page/html/head.phtml
+++ b/app/design/frontend/base/default/template/page/html/head.phtml
@@ -24,7 +24,6 @@
 <meta name="keywords" content="<?php echo htmlspecialchars($this->getKeywords()) ?>" />
 <meta name="robots" content="<?php echo htmlspecialchars($this->getRobots()) ?>" />
 <link rel="icon" href="<?php echo $this->getFaviconFile(); ?>" type="image/x-icon" />
-<link rel="shortcut icon" href="<?php echo $this->getFaviconFile(); ?>" type="image/x-icon" />
 <?php echo $this->getCssJsHtml() ?>
 <?php echo $this->getChildHtml() ?>
 <?php echo $this->helper('core/js')->getTranslatorScript() ?>

--- a/app/design/install/default/default/template/page.phtml
+++ b/app/design/install/default/default/template/page.phtml
@@ -23,10 +23,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title><?php echo Mage::helper('install')->__('OpenMage Installation Wizard') ?></title>
-
 <link rel="icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon" />
-<link rel="shortcut icon" href="<?php echo $this->getSkinUrl('favicon.ico') ?>" type="image/x-icon" />
-
 <script type="text/javascript" src="<?php echo $this->getJsUrl() ?>prototype/prototype.js"></script>
 <script type="text/javascript" src="<?php echo $this->getJsUrl() ?>prototype/validation.js"></script>
 <script type="text/javascript" src="<?php echo $this->getJsUrl() ?>scriptaculous/effects.js"></script>

--- a/errors/default/page.phtml
+++ b/errors/default/page.phtml
@@ -24,7 +24,6 @@
 <meta name="robots" content="*" />
 <link rel="stylesheet" href="css/styles.css" type="text/css" />
 <link rel="icon" href="images/favicon.ico" type="image/x-icon" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
 </head>
 <body>
     <div class="wrapper">


### PR DESCRIPTION
Many templates have this "shortcut icon" element (which is just the favicon btw) but shortcut icon is not a valid "rel" type, as explained here: https://www.w3schools.com/tags/att_link_rel.asp

Also, in [this page](https://stackoverflow.com/questions/13211206/html5-link-rel-shortcut-icon) we find:
<img width="737" alt="Screenshot 2024-04-13 alle 13 15 41" src="https://github.com/OpenMage/magento-lts/assets/909743/0a59fb4c-e6f0-4f91-b0b0-1831aa65bef3">

That's why this PR removes it.

Note that all templates also have a "icon" link so "shortcut" should be double useless
