### PR TITLE
Remove Deprecated Global Translate Function "__()"

### DIFF
--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -29,17 +29,6 @@ function destruct($object)
 }
 
 /**
- * Translator function
- *
- * @return string
- * @deprecated 1.3
- */
-function __()
-{
-    return Mage::app()->getTranslator()->translate(func_get_args());
-}
-
-/**
  * Tiny function to enhance functionality of ucwords
  *
  * Will capitalize first letters and convert separators if needed

--- a/lib/Varien/Io/Sftp.php
+++ b/lib/Varien/Io/Sftp.php
@@ -38,7 +38,7 @@ class Varien_Io_Sftp extends Varien_Io_Abstract implements Varien_Io_Interface
      * @param string $args[username] Remote username
      * @param string $args[password] Connection password
      * @param int $args[timeout] Connection timeout [=10]
-     *
+     * @throws Exception
      */
     public function open(array $args = [])
     {
@@ -53,7 +53,7 @@ class Varien_Io_Sftp extends Varien_Io_Abstract implements Varien_Io_Interface
         }
         $this->_connection = new \phpseclib3\Net\SFTP($host, $port, $args['timeout']);
         if (!$this->_connection->login($args['username'], $args['password'])) {
-            throw new Exception(sprintf(__("Unable to open SFTP connection as %s@%s", $args['username'], $args['host'])));
+            throw new Exception(sprintf('Unable to open SFTP connection as %s@%s', $args['username'], $args['host']));
         }
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Original PR #2333 has accidentally been deleted a while ago but the changes are still relevant. 
PR now targets `next` branch.

Removes the global translation function being deprecated since 1.3 (March 2009). found one remnant usage in **lib/Varien** which has no corresponding translation string thus in my understanding doesn't work anyways. This ancient artifact shouldn't have a place in 21.x. 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
