### PR TITLE
Added support for Laravel Ignition

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -965,12 +965,17 @@ final class Mage
     public static function printException(Throwable $e, $extra = '')
     {
         if (self::$_isDeveloperMode) {
-            print '<pre>';
+            if (class_exists('\Spatie\Ignition\Ignition')) {
+                \Spatie\Ignition\Ignition::make()
+                    ->applicationPath(Mage::getBaseDir())
+                    ->handleException($e);
+                die();
+            }
 
+            print '<pre>';
             if (!empty($extra)) {
                 print $extra . "\n\n";
             }
-
             print $e->getMessage() . "\n\n";
             print $e->getTraceAsString();
             print '</pre>';

--- a/app/code/core/Mage/Catalog/controllers/CategoryController.php
+++ b/app/code/core/Mage/Catalog/controllers/CategoryController.php
@@ -29,6 +29,7 @@ class Mage_Catalog_CategoryController extends Mage_Core_Controller_Front_Action
      */
     protected function _initCategory()
     {
+        Mage::throwException("pipo");
         Mage::dispatchEvent('catalog_controller_category_init_before', ['controller_action' => $this]);
         $categoryId = (int) $this->getRequest()->getParam('id', false);
         if (!$categoryId) {

--- a/app/code/core/Mage/Catalog/controllers/CategoryController.php
+++ b/app/code/core/Mage/Catalog/controllers/CategoryController.php
@@ -29,7 +29,6 @@ class Mage_Catalog_CategoryController extends Mage_Core_Controller_Front_Action
      */
     protected function _initCategory()
     {
-        Mage::throwException("pipo");
         Mage::dispatchEvent('catalog_controller_category_init_before', ['controller_action' => $this]);
         $categoryId = (int) $this->getRequest()->getParam('id', false);
         if (!$categoryId) {

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -384,7 +384,14 @@ class Mage_Core_Model_App
      */
     protected function _initEnvironment()
     {
-        $this->setErrorHandler(self::DEFAULT_ERROR_HANDLER);
+        if (Mage::getIsDeveloperMode() && class_exists('\Spatie\Ignition\Ignition')) {
+            \Spatie\Ignition\Ignition::make()
+                ->applicationPath(Mage::getBaseDir())
+                ->register();
+        } else {
+            $this->setErrorHandler(self::DEFAULT_ERROR_HANDLER);
+        }
+
         date_default_timezone_set(Mage_Core_Model_Locale::DEFAULT_TIMEZONE);
         return $this;
     }


### PR DESCRIPTION
Laravel Ignition is a pretty famous module for a better handling of error pages: https://flareapp.io/docs/ignition/introducing-ignition/overview

I thought it could be interesting for developers to have built-in, but absolutely optional (it's a pretty big package) in openmage.

**The logic is:**
- if there's a PHP error or exception
- and is in DeveloperMode
- and the spatie-ignition composer module is installed
- then the error is passed to ignition for the display

If DeveloperMode is disabled or the spatie-ignition package is not installed, OM behaves as usual.
It shouldn't introduce any performance degradation.

This is the error page for a PHP error (function doesn't exist):
<img width="1498" alt="Screenshot 2024-04-23 alle 13 25 13" src="https://github.com/OpenMage/magento-lts/assets/909743/347c256f-c98b-4132-babc-00695d901226">

This is the error page for a default PHP exception:
<img width="1489" alt="Screenshot 2024-04-23 alle 13 25 44" src="https://github.com/OpenMage/magento-lts/assets/909743/253d90cc-4ca2-426d-b152-969bebf7bcad">

And this is a Mage::throwException:
<img width="1506" alt="Screenshot 2024-04-23 alle 13 25 58" src="https://github.com/OpenMage/magento-lts/assets/909743/d5e6c3b7-544e-4c90-b69a-3e990efa5213">

**How to test**
1. `composer require "spatie/ignition"`
2. enable developer mode
3. modify one of your files in order to generate an error