### PR TITLE
Fixed: Fixer.io endpoint for currency updates

### DIFF
--- a/app/code/core/Mage/Directory/Model/Currency/Import/Fixerio.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Import/Fixerio.php
@@ -36,7 +36,7 @@ class Mage_Directory_Model_Currency_Import_Fixerio extends Mage_Directory_Model_
      *
      * @var string
      */
-    protected $_url = 'https://api.apilayer.com/fixer/latest?apikey={{ACCESS_KEY}}&base={{CURRENCY_FROM}}&symbols={{CURRENCY_TO}}';
+    protected $_url = 'http://data.fixer.io/api/latest?access_key={{ACCESS_KEY}}&base={{CURRENCY_FROM}}&symbols={{CURRENCY_TO}}&format=1';
 
     /**
      * Information messages stack


### PR DESCRIPTION

I tested it, and it works, in our own project I used an overwrite to make sure we can keep collecting data.

### Description (*)
Recently there were some changes, this is the new endpoint if anyone is also using it 💸
The platform had a few changes over the years, but I think recently an endpoint was deprecated, resulting in no more updating our currency information.

The format is the same, just the url is changed and apiKey was renamed to access_key in the params.


### Related Pull Requests

I believe this solves: https://github.com/OpenMage/magento-lts/issues/3071


### Fixed Issues (if relevant)
I believe this solves: https://github.com/OpenMage/magento-lts/issues/3071


### Manual testing scenarios (*)
1. set up a free account on fixer.io
2. add 2 or more currencies
3. go to System -> Manage Currencies -> Rates
4. Press import
5. Success

![image](https://github.com/OpenMage/magento-lts/assets/10960505/951067bf-f803-4735-aa5a-fbdef6ec05ef)


### Questions or comments
First PR for Open Mage, keep it up!