### PR TITLE
Revert "Added support for Laravel Ignition"

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -966,17 +966,12 @@ final class Mage
     public static function printException(Throwable $e, $extra = '')
     {
         if (self::$_isDeveloperMode) {
-            if (class_exists('\Spatie\Ignition\Ignition')) {
-                \Spatie\Ignition\Ignition::make()
-                    ->applicationPath(Mage::getBaseDir())
-                    ->handleException($e);
-                die();
-            }
-
             print '<pre>';
+
             if (!empty($extra)) {
                 print $extra . "\n\n";
             }
+
             print $e->getMessage() . "\n\n";
             print $e->getTraceAsString();
             print '</pre>';

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -384,14 +384,7 @@ class Mage_Core_Model_App
      */
     protected function _initEnvironment()
     {
-        if (Mage::getIsDeveloperMode() && class_exists('\Spatie\Ignition\Ignition')) {
-            \Spatie\Ignition\Ignition::make()
-                ->applicationPath(Mage::getBaseDir())
-                ->register();
-        } else {
-            $this->setErrorHandler(self::DEFAULT_ERROR_HANDLER);
-        }
-
+        $this->setErrorHandler(self::DEFAULT_ERROR_HANDLER);
         date_default_timezone_set(Mage_Core_Model_Locale::DEFAULT_TIMEZONE);
         return $this;
     }


### PR DESCRIPTION
Since @empiricompany worked on creating a much more complete [support for Ignition in an external module](https://github.com/empiricompany/openmage_ignition) (which is always the preferred way) it's probably better to remove the support from the core in favor of his module.

What do you think?

Notes:
- it seems the https://github.com/empiricompany/openmage_ignition works also with our patch in the core so it could be possible to have a "basic" support for Ignition in the core, more feature from the module (but is it worth it?)