### PR TITLE
Fixed customer can't login after registering through PayPal Express Checkout

### DIFF
--- a/app/code/core/Mage/Paypal/Model/Express/Checkout.php
+++ b/app/code/core/Mage/Paypal/Model/Express/Checkout.php
@@ -986,6 +986,7 @@ class Mage_Paypal_Model_Express_Checkout
         $customer->setSuffix($quote->getCustomerSuffix());
         $customer->setPassword($customer->decryptPassword($quote->getPasswordHash()));
         $customer->setPasswordHash($customer->hashPassword($customer->getPassword()));
+        $customer->setPasswordCreatedAt(time());
         $customer->save();
         $quote->setCustomer($customer);
         $quote->setPasswordHash('');


### PR DESCRIPTION
If a customer registers through the checkout and pays with paypal, then he can't login.

Fixes https://github.com/OpenMage/magento-lts/issues/2023