### PR TITLE
SOAP APIs: Removed all imports from schemas.xmlsoap.org

### DIFF
--- a/app/code/core/Mage/Api/etc/wsdl.xml
+++ b/app/code/core/Mage/Api/etc/wsdl.xml
@@ -4,7 +4,6 @@
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
-<!--            <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />-->
             <complexType name="FixedArray">
                 <complexContent>
                     <restriction base="soapenc:Array">

--- a/app/code/core/Mage/Api/etc/wsdl2.xml
+++ b/app/code/core/Mage/Api/etc/wsdl2.xml
@@ -4,7 +4,6 @@
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
-            <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="associativeEntity">
                 <all>
                     <element name="key" type="xsd:string" />

--- a/app/code/core/Mage/Catalog/etc/wsdl.xml
+++ b/app/code/core/Mage/Catalog/etc/wsdl.xml
@@ -6,8 +6,6 @@
              name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
-            <import namespace="http://schemas.xmlsoap.org/soap/encoding/"
-                    schemaLocation="http://schemas.xmlsoap.org/soap/encoding/"/>
             <complexType name="catalogProductEntityArray">
                 <complexContent>
                     <restriction base="soapenc:Array">

--- a/app/code/core/Mage/CatalogInventory/etc/wsdl.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/wsdl.xml
@@ -4,7 +4,6 @@
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
-            <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="catalogInventoryStockItemEntity">
                 <all>
                     <element name="product_id" type="xsd:string" minOccurs="0" />

--- a/app/code/core/Mage/Core/etc/wsdl.xml
+++ b/app/code/core/Mage/Core/etc/wsdl.xml
@@ -4,7 +4,6 @@
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
-            <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="storeEntity">
                 <all>
                     <element name="store_id" type="xsd:int" />

--- a/app/code/core/Mage/Customer/etc/wsdl.xml
+++ b/app/code/core/Mage/Customer/etc/wsdl.xml
@@ -4,7 +4,6 @@
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
-            <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="customerCustomerEntityToCreate">
                 <all>
                     <element name="customer_id" type="xsd:int" minOccurs="0" />

--- a/app/code/core/Mage/Directory/etc/wsdl.xml
+++ b/app/code/core/Mage/Directory/etc/wsdl.xml
@@ -4,7 +4,6 @@
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
-            <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="directoryCountryEntity">
                 <all>
                     <element name="country_id" type="xsd:string" />

--- a/app/code/core/Mage/Downloadable/etc/wsdl.xml
+++ b/app/code/core/Mage/Downloadable/etc/wsdl.xml
@@ -6,8 +6,6 @@
              name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
-            <import namespace="http://schemas.xmlsoap.org/soap/encoding/"
-                    schemaLocation="http://schemas.xmlsoap.org/soap/encoding/"/>
             <complexType name="catalogProductDownloadableLinkFileEntity">
                 <all>
                     <element name="name" type="xsd:string" minOccurs="0" />

--- a/app/code/core/Mage/GiftMessage/etc/wsdl.xml
+++ b/app/code/core/Mage/GiftMessage/etc/wsdl.xml
@@ -4,7 +4,6 @@
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
-            <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="giftMessageEntity">
                 <sequence>
                     <element name="from" type="xsd:string" minOccurs="0" />

--- a/app/code/core/Mage/Sales/etc/wsdl.xml
+++ b/app/code/core/Mage/Sales/etc/wsdl.xml
@@ -4,7 +4,6 @@
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
-            <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="salesOrderEntity">
                 <all>
                     <element name="increment_id" type="xsd:string" minOccurs="0" />

--- a/app/code/core/Mage/Tag/etc/wsdl.xml
+++ b/app/code/core/Mage/Tag/etc/wsdl.xml
@@ -4,7 +4,6 @@
     name="OpenMage" targetNamespace="urn:OpenMage">
     <types>
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:OpenMage">
-            <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
             <complexType name="catalogProductTagListEntity">
                 <all>
                     <element name="tag_id" type="xsd:string" minOccurs="1" />


### PR DESCRIPTION
**This PR targets `next`**

Since https://github.com/OpenMage/magento-lts/issues/3968 it seemed to be possible to remove WSDL imports from the schemas.xmlsoap.org domain, in order not to be dependent on their website to be up for every SOAP call on any store.

I did a few tests and everything seems to be working fine:
<img width="941" alt="Screenshot 2024-05-08 alle 16 46 50" src="https://github.com/OpenMage/magento-lts/assets/909743/f1cde872-9835-4a33-ad54-3b4433cf3783">

Fixes https://github.com/OpenMage/magento-lts/issues/3968