### PR TITLE
Disable composer autoloader prepending

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,6 +121,7 @@
         "platform": {
             "php": "7.4"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "prepend-autoloader": false
     }
 }


### PR DESCRIPTION
### Description (*)

The `spl_autoload_register` function takes a third parameter called `$prepend`, this parameter was being used by Composer for its autoloader to take priority over any other registered autoloaders. Disabling this flag should make it possible to override Zend classes again just like before the introduction of zf1-future.

### Related Pull Requests

Discussion #3462

### Manual testing scenarios (*)

1. Run `composer dump`
2. Should be possible to override any Zend_* classes now by copying them to `app/code/{community,core,local}`.

### Questions or comments

See https://getcomposer.org/doc/06-config.md#prepend-autoloader

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->