### PR TITLE
Fixed unable to select "free method" in UPS backend configuration

### DIFF
--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Backend/Abstract.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Backend/Abstract.php
@@ -68,17 +68,13 @@ abstract class Mage_Usa_Model_Shipping_Carrier_Abstract_Backend_Abstract extends
         if (!method_exists($sourceModel, 'toOptionArray')) {
             Mage::throwException(Mage::helper('usa')->__('Method toOptionArray not found in source model.'));
         }
-        $hasCorrectValue = false;
         $value = $this->getValue();
         foreach ($sourceModel->toOptionArray() as $allowedValue) {
             if (isset($allowedValue['value']) && $allowedValue['value'] == $value) {
-                $hasCorrectValue = true;
-                break;
+                return $this;
             }
         }
-        if (!$hasCorrectValue) {
-            Mage::throwException(Mage::helper('usa')->__('Field "%s" has wrong value.', $this->_nameErrorField));
-        }
-        return $this;
+
+        Mage::throwException(Mage::helper('usa')->__('Field "%s" has wrong value.', $this->_nameErrorField));
     }
 }

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Method.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Method.php
@@ -23,9 +23,20 @@ class Mage_Usa_Model_Shipping_Carrier_Ups_Source_Method
     {
         $ups = Mage::getSingleton('usa/shipping_carrier_ups');
         $arr = [];
+
+        // necessary after the add of Rest API
+        $origins = $ups->getCode('originShipment');
+        foreach ($origins as $origin) {
+            foreach ($origin as $k => $v) {
+                $arr[] = ['value' => $k, 'label' => Mage::helper('usa')->__($v)];
+            }
+        }
+
+        // old XML API codes
         foreach ($ups->getCode('method') as $k => $v) {
             $arr[] = ['value' => $k, 'label' => Mage::helper('usa')->__($v)];
         }
+
         return $arr;
     }
 }

--- a/app/design/adminhtml/default/default/template/system/shipping/ups.phtml
+++ b/app/design/adminhtml/default/default/template/system/shipping/ups.phtml
@@ -17,7 +17,10 @@
 $upsModel = Mage::getSingleton('usa/shipping_carrier_ups');
 $orShipArr = $upsModel->getCode('originShipment');
 $defShipArr = $upsModel->getCode('method');
-
+$allMethodsCodes = [];
+foreach (Mage::getModel('usa/shipping_carrier_ups_source_method')->toOptionArray() as $method) {
+    $allMethodsCodes[]= $method['value'];
+}
 /** @var $this Mage_Adminhtml_Block_Template */
 $sectionCode = $this->getRequest()->getParam('section');
 $websiteCode = $this->getRequest()->getParam('website');
@@ -44,7 +47,7 @@ if (!$storeCode && $websiteCode) {
 if (!in_array($storedOriginShipment, array_keys($orShipArr))) {
     $storedOriginShipment = '';
 }
-if ($storedFreeShipment != '' && !in_array($storedFreeShipment, array_keys($defShipArr))) {
+if ($storedFreeShipment != '' && !in_array($storedFreeShipment, $allMethodsCodes)) {
     $storedFreeShipment = '';
 }
 if (!Mage::helper('usa')->validateUpsType($storedUpsType)) {


### PR DESCRIPTION
Fixes https://github.com/OpenMage/magento-lts/pull/3976#issuecomment-2125203784

It was impossible to select a "free method" for UPS shipping method

<img width="644" alt="Screenshot 2024-05-22 alle 21 43 58" src="https://github.com/OpenMage/magento-lts/assets/909743/d81d2160-deb8-4090-a5dd-b8cdebb685d5">
