### PR TITLE
Rewrote `payment.js` without prototypejs

### DIFF
--- a/js/varien/payment.js
+++ b/js/varien/payment.js
@@ -11,47 +11,39 @@
  * @copyright   Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
-var paymentForm = Class.create();
-paymentForm.prototype = {
-    initialize: function(formId){
+class paymentForm {
+    constructor(formId) {
         this.formId = formId;
         this.validator = new Validation(this.formId);
-        var elements = Form.getElements(formId);
+        const elements = document.querySelectorAll(`#${this.formId} *`);
 
-        var method = null;
-        for (var i=0; i<elements.length; i++) {
-            if (elements[i].name=='payment[method]' || elements[i].name=='form_key') {
-                if (elements[i].checked) {
-                    method = elements[i].value;
+        let method = null;
+        for (const element of elements) {
+            if (element.name === 'payment[method]' || element.name === 'form_key') {
+                if (element.checked) {
+                    method = element.value;
                 }
-            } else {
-                if((elements[i].type) && ('submit' != elements[i].type.toLowerCase())) {
-                    elements[i].disabled = true;
-                }
+            } else if (element.type && element.type.toLowerCase() !== 'submit') {
+                element.disabled = true;
             }
-            elements[i].setAttribute('autocomplete','off');
+            element.setAttribute('autocomplete', 'off');
         }
+
         if (method) this.switchMethod(method);
-    },
+    }
 
-    switchMethod: function(method){
-        if (this.currentMethod && $('payment_form_'+this.currentMethod)) {
-            var form = $('payment_form_'+this.currentMethod);
-            form.style.display = 'none';
-            var elements = form.getElementsByTagName('input');
-            for (var i=0; i<elements.length; i++) elements[i].disabled = true;
-            var elements = form.getElementsByTagName('select');
-            for (var i=0; i<elements.length; i++) elements[i].disabled = true;
-
+    switchMethod(method) {
+        const previousForm = document.getElementById(`payment_form_${this.currentMethod}`);
+        if (previousForm) {
+            previousForm.style.display = 'none';
+            Array.from(previousForm.querySelectorAll('input, select'), element => element.disabled = true);
         }
-        if ($('payment_form_'+method)){
-            var form = $('payment_form_'+method);
-            form.style.display = '';
-            var elements = form.getElementsByTagName('input');
-            for (var i=0; i<elements.length; i++) elements[i].disabled = false;
-            var elements = form.getElementsByTagName('select');
-            for (var i=0; i<elements.length; i++) elements[i].disabled = false;
+
+        const newForm = document.getElementById(`payment_form_${method}`);
+        if (newForm) {
+            newForm.style.display = '';
+            Array.from(newForm.querySelectorAll('input, select'), element => element.disabled = false);
             this.currentMethod = method;
         }
     }
-};
+}


### PR DESCRIPTION
**This PR targets `next`**

payment.js is only used in multishipping checkout, to test this PR you've to enable multishipping in the shipping settings:

<img width="722" alt="Screenshot 2024-05-27 alle 16 05 23" src="https://github.com/OpenMage/magento-lts/assets/909743/cd5f555b-9ae4-4dd6-8c34-e56affc04f51">

then add a couple of products to the cart, go to the cart page and then click the "ship to multiple addresses" button, then, in the billing section the system will load payment.js:

<img width="1509" alt="Screenshot 2024-05-27 alle 16 02 19" src="https://github.com/OpenMage/magento-lts/assets/909743/6915ab3d-07b4-4dc3-bd57-9d345b7e3f65">

I tested it and it doesn't generate any error and it seems to work ok

<img width="1326" alt="Screenshot 2024-05-27 alle 16 02 51" src="https://github.com/OpenMage/magento-lts/assets/909743/3f9c494d-1f8b-459c-bb31-194e0efdd4ab">

