### PR TITLE
Removed deprecated `escape()` from `cookies.js`

### DIFF
--- a/js/mage/cookies.js
+++ b/js/mage/cookies.js
@@ -11,7 +11,6 @@
  * @copyright   Copyright (c) 2018-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
-// old school cookie functions grabbed off the web
 
 if (!window.Mage) var Mage = {};
 
@@ -27,7 +26,7 @@ Mage.Cookies.set = function(name, value){
      var path = (argc > 3) ? argv[3] : Mage.Cookies.path;
      var domain = (argc > 4) ? argv[4] : Mage.Cookies.domain;
      var secure = (argc > 5) ? argv[5] : Mage.Cookies.secure;
-     document.cookie = name + "=" + escape (value) +
+     document.cookie = name + "=" + encodeURIComponent(value) +
        ((expires == null) ? "" : ("; expires=" + expires.toUTCString())) +
        ((path == null) ? "" : ("; path=" + path)) +
        ((domain == null) ? "" : ("; domain=" + domain)) +
@@ -62,5 +61,5 @@ Mage.Cookies.getCookieVal = function(offset){
    if(endstr == -1){
        endstr = document.cookie.length;
    }
-   return unescape(document.cookie.substring(offset, endstr));
+   return decodeURIComponent(document.cookie.substring(offset, endstr));
 };


### PR DESCRIPTION
This escape javascript function is deprecated, I think the correct replacement in this case should be encodeURIComponent