### PR TITLE
Fixed available currencies filtering in UPS _parseRestResponse() method

### DIFF
--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
@@ -2348,7 +2348,7 @@ XMLAuth;
             if (@$rateResponseData['RateResponse']['Response']['ResponseStatus']['Description'] === 'Success') {
                 $arr = $rateResponseData['RateResponse']['RatedShipment'] ?? [];
                 $allowedMethods = explode(",", $this->getConfigData('allowed_methods') ?? '');
-                $allowedCurrencies = Mage::app()->getStore()->getAvailableCurrencyCodes();
+                $allowedCurrencies = Mage::getModel('directory/currency')->getConfigAllowCurrencies();
                 foreach ($arr as $shipElement) {
                     $negotiatedArr = $shipElement['NegotiatedRateCharges'] ?? [] ;
                     $negotiatedActive = $this->getConfigFlag('negotiated_active')


### PR DESCRIPTION
Mage::getModel('directory/currency')->getConfigAllowCurrencies() was already used on line 860 for the _parseXmlResponse and it has to be used for the Rest response too.

Suggested by https://github.com/OpenMage/magento-lts/pull/3878#issuecomment-2133622080