### PR TITLE
Added stopPropagation to "copy text" buttons in backend

### DIFF
--- a/js/varien/js.js
+++ b/js/varien/js.js
@@ -737,6 +737,8 @@ function createCopyIconElement() {
  * @param {Event} event - The event object triggered by the click event
  */
 function copyText(event) {
+    event.stopPropagation();
+    event.preventDefault();
     const copyIcon = event.currentTarget;
     const copyText = copyIcon.previousElementSibling.getAttribute('data-copy-text');
     navigator.clipboard.writeText(copyText);


### PR DESCRIPTION
### Description (*)
This PR adds `event.stopPropagation()` and `event.preventDefault()` to the new copyText() function.

The copy function is a very nice feature, which we already added to several other locations. Now our editors wanted to be able to copy values from backend grids, like this:

![image](https://github.com/OpenMage/magento-lts/assets/2081806/22e89f93-9e42-4aab-8567-1517d619ae31)

Adding the copy button can be done using a renderer. But the copy button is clicked, the event propagates up the DOM and triggers the row click, which navigates to the details page.

This is not what we wanted. I think, clicking the copy button should just do the copying and not do anything else. Therefore, calling `event.stopPropagation()` and `event.preventDefault()` to prevent all other actions should have no negative side effects.


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. A dirty way to add a copy button to a grid would be to edit Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Datetime::render() and add the line \
   `$data = '<span data-copy-text="' . $data . '">' . $data . '</span>';`
  right before the `return $data;`, like this \
   \
   ![image](https://github.com/OpenMage/magento-lts/assets/2081806/f459df90-93d6-4b51-894e-5137fc792c9a)
   This adds a copy button to the date column in the orders grid
   ![image](https://github.com/OpenMage/magento-lts/assets/2081806/911dc9dc-da38-49e5-b816-7ad615deb8a1)

2. Clicking the copy button copies the date. But it also navigates to the order details. With this PR applied, it only copies the date.

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All automated tests passed successfully (all builds are green)
 - [X] Add yourself to contributors list
