### PR TITLE
Fixed issue #4007 bug on incorrect resources added to table `admin_ru…

### DIFF
--- a/app/code/core/Mage/Admin/Model/Resource/Acl.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Acl.php
@@ -23,8 +23,6 @@ class Mage_Admin_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
 {
     public const ACL_ALL_RULES = 'all';
 
-    protected $_orphanedResources = [];
-
     /**
      * Initialize resource
      *
@@ -114,6 +112,7 @@ class Mage_Admin_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
      */
     public function loadRules(Mage_Admin_Model_Acl $acl, array $rulesArr)
     {
+        $orphanedResources = [];
         foreach ($rulesArr as $rule) {
             $role = $rule['role_type'] . $rule['role_id'];
             $resource = $rule['resource_id'];
@@ -134,8 +133,8 @@ class Mage_Admin_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
                     $acl->deny($role, $resource, $privileges, $assert);
                 }
             } catch (Zend_Acl_Exception $e) {
-                if (!in_array($resource, $this->_orphanedResources) && strpos($e->getMessage(), "Resource '$resource' not found") !== false) {
-                    $this->_orphanedResources[] = $resource;
+                if (!in_array($resource, $orphanedResources) && strpos($e->getMessage(), "Resource '$resource' not found") !== false) {
+                    $orphanedResources[] = $resource;
                 }
             } catch (Exception $e) {
                 if (Mage::getIsDeveloperMode()) {
@@ -144,11 +143,11 @@ class Mage_Admin_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
             }
         }
 
-        if ($this->_orphanedResources !== []) {
+        if ($acl->isAllowed(Mage::getSingleton('admin/session')->getUser()->getAclRole(), 'admin/system/acl/orphaned_resources') && $orphanedResources !== []) {
             Mage::getSingleton('adminhtml/session')->addNotice(
                 Mage::helper('adminhtml')->__(
                     'The following role resources are no longer available in the system: %s. You can delete them by <a href="%s">clicking here</a>.',
-                    implode(', ', $this->_orphanedResources),
+                    implode(', ', $orphanedResources),
                     Mage::helper("adminhtml")->getUrl('adminhtml/permissions_orphanedResource')
                 )
             );

--- a/app/code/core/Mage/Admin/Model/Roles.php
+++ b/app/code/core/Mage/Admin/Model/Roles.php
@@ -137,7 +137,7 @@ class Mage_Admin_Model_Roles extends Mage_Core_Model_Abstract
             $level = -1;
         } else {
             $resourceName = $parentName;
-            if (!in_array($resource->getName(), ['title', 'sort_order', 'children', 'disabled'])) {
+            if (!empty($resource->children()) && $resource->getName() !== 'children') {
                 $resourceName = (is_null($parentName) ? '' : $parentName . '/') . $resource->getName();
 
                 //assigning module for its' children nodes

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/OrphanedResource/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/OrphanedResource/Grid.php
@@ -36,9 +36,8 @@ class Mage_Adminhtml_Block_Permissions_OrphanedResource_Grid extends Mage_Adminh
      */
     protected function _prepareCollection()
     {
-        /** @var Mage_Admin_Model_Resource_Rules_Collection */
         $collection = Mage::getResourceModel('admin/rules_collection')
-            ->addFieldToFilter('resource_id', ['nin' => Mage::getModel('admin/roles')->getResourcesList2D()])
+            ->addFieldToFilter('resource_id', ['nin' => Mage::getSingleton('admin/session')->getAcl()->getResources()])
             ->addFieldToSelect('resource_id');
         $collection->getSelect()->group('resource_id');
 


### PR DESCRIPTION
…le`.

### Description (*)
This PR fixed the following:
1. Show the notice on  orphaned resources based on admin user ACL `system/acl/orphaned_resources`
2. Fixed bug on adding incorrect resources to table `admin_rule`

### Related Pull Requests
PR #3647 

### Fixed Issues (if relevant)
1. Fixes OpenMage/magento-lts#4007

### Manual testing scenarios (*)
First, replicate the conditions in issue #4007 by adding `<action>some/action</action>` node in any `adminhtml.xml` file.  and refresh the cache.

1. Check the notice is not displayed when _Orphaned Role Resources_ is unchecked in admin > System > Permissions > Roles > click to edit a role
![image](https://github.com/OpenMage/magento-lts/assets/1106470/cab0111f-0eec-4c06-82cb-1ccc971fdfaf)
2. Logout and login as user with the role from step 1. No notice should be shown.
3. Logout and login as full admin user. Notice on orphaned resources is shown.
4. Click on the link and delete the orphaned resources.
5. Check that no invalid entries are added to table `admin_rule` by navigating to admin > System > Permissions > Roles > click to edit a role > Save (there is no need to edit the role). Before this PR, the `<action>` would be added. With this PR, they are not added.


