### PR TITLE
Fixed cannot save Category/Custom Design on store level

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
@@ -116,7 +116,8 @@ abstract class Mage_Catalog_Model_Resource_Abstract extends Mage_Eav_Model_Entit
         $select = $this->_getReadAdapter()->select()
             ->from(['attr_table' => $table], [])
             ->where("attr_table.{$this->getEntityIdField()} = ?", $object->getId())
-            ->where('attr_table.store_id IN (?)', $storeIds);
+            ->where('attr_table.store_id IN (?)', $storeIds)
+            ->order('attr_table.store_id ASC');
         if (count($storeIds) > 1) {
             $select->order('attr_table.store_id ASC');
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

When I debug why some data I just save didn't show on Catalog -> Manage Categories -> (Choose _non-default_ Store View) -> Custom Design -> (Some custom EAV attrs)

I found that the text actually save on db. But when it query back, it query for both default store (store_id is 0) and target store and later cause issue.

Magento logic seems to rely on order of values query from db, like first match item will be a value for default store while second item will be a value for target store.

Here is example table `catalog_category_entity_text` produce by query of `_getLoadAttributesSelect` function
|value_id|entity_type_id|attribute_id|store_id|entity_id|value|
|--------|--------------|------------|--------|---------|-----|
|76494|3|244|1|837|targetStoreValueIJustSave|
|76549|3|244|0|837|NULL _<- It show this value instead of `targetStoreValueIJustSave`_|
|*|3|*|*|837|*|

Then on Magento admin page, It just show _nothing_ on field I just save.

This PR will make sure if value_id mixed up, Magento still can show a correct value for the store.

### Related Pull Requests
<!-- related pull request placeholder -->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->



### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->