### PR TITLE
Fixed `array_keys(null)` and call to undefined method in `Mage_Eav_Model_Config`

### DIFF
--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -201,9 +201,7 @@ class Mage_Eav_Model_Config
             $fqEntityModelClass = Mage::getConfig()->getModelClassName($entityModelClass);
             if (!class_exists($fqEntityModelClass)) {
                 if (Mage::getIsDeveloperMode()) {
-                    throw new Exception(
-                        'Failed loading of eav entity type because it does not exist: ' . $entityModelClass
-                    );
+                    throw new Exception('Failed loading of eav entity type because it does not exist: ' . $entityModelClass);
                 } else {
                     Mage::log('Skipped loading of eav entity type because it does not exist: ' . $entityModelClass);
                 }

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
@@ -33,7 +33,7 @@
  * @method bool getIsConfigurable()
  * @method bool getIsFilterable()
  * @method bool getIsFilterableInSearch()
- * @method bool setIsGlobal()
+ * @method $this setIsGlobal(int $value)
  * @method bool getIsRequired()
  * @method bool getIsSearchable()
  * @method bool getIsUnique()

--- a/phpstan.dist.baseline.neon
+++ b/phpstan.dist.baseline.neon
@@ -3011,11 +3011,6 @@ parameters:
 			path: app/code/core/Mage/Eav/Model/Attribute/Data/File.php
 
 		-
-			message: "#^Call to an undefined method Mage_Core_Model_Resource_Abstract\\:\\:getDefaultAttributes\\(\\)\\.$#"
-			count: 1
-			path: app/code/core/Mage/Eav/Model/Config.php
-
-		-
 			message: "#^Method Mage_Eav_Model_Config\\:\\:getAttribute\\(\\) should return Mage_Eav_Model_Entity_Attribute_Abstract\\|false but returns Mage_Eav_Model_Entity_Attribute_Interface\\.$#"
 			count: 1
 			path: app/code/core/Mage/Eav/Model/Config.php


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Issue 1: `array_keys(null)` fixed arround line 573.

Issue 2: undifiened method `getDefaultAttributes()` for invoice, creditmemo, ... fixed arround line 372

### Related Pull Requests
<!-- related pull request placeholder -->

1. See OpenMage/magento-lts#2993

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. See OpenMage/magento-lts#4034

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. install `n98/magerun:dev-develop` (v3.0.0)
2. add custom attributes to all entity types

<details>
  <summary>Test script</summary>
   
  ```php
<?php

require_once('app/Mage.php');
umask(0);
Mage::app();

class Test4034
{
    public function prepare()
    {
        $attributeCode = 'crazyCoolAttribute';
        $data = ['type'  => 'text', 'input' => 'text', 'label' => 'Test Attribute'];

        foreach (self::entityTypeProvider() as $entityType) {
            $this->createAttribute(array_values($entityType)[0], $attributeCode, $data);
        }
    }

    /**
     * From N98-magerun unit test
     */
    public static function entityTypeProvider()
    {
        return [['catalog_category'], ['catalog_product'], ['creditmemo'], ['customer'], ['customer_address'], ['invoice'], ['order'], ['shipment']];
    }

    /**
     * From N98-magerun unit test
     *
     * @param string $entityType
     * @param string $attributeCode
     * @param array $data
     */
    protected function createAttribute($entityType, $attributeCode, $data)
    {
        $setup = Mage::getModel('eav/entity_setup', 'core_setup');
        $setup->addAttribute($entityType, $attributeCode, $data);
    }
}

$test = new Test4034();
$test->prepare();
  ```
  
</details>

3. test `eav:attribute:view creditmemo crazyCoolAttribute` and `eav:attribute:remove creditmemo crazyCoolAttribute`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

After adding/removing EAV cache has to be cleaned, but this should be done in N98-magerun. (???) Not sure if it fixes all errors in unit tests, but these two issues should be easy to reproduce.

Todo: add `Mage::app()->getCacheInstance()->cleanType('eav');`
