### PR TITLE
Fixed `Mage_Uploader_Helper_File::getDataMaxSize()` when checking against different size units

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Image.php
@@ -240,8 +240,8 @@ class Mage_Catalog_Model_Product_Image extends Mage_Core_Model_Abstract
     }
 
     /**
+     * @return int
      * @deprecated
-     * @return float|int|string
      */
     protected function _getMemoryLimit()
     {
@@ -251,18 +251,7 @@ class Mage_Catalog_Model_Product_Image extends Mage_Core_Model_Abstract
             $memoryLimit = "128M";
         }
 
-        $value = (int)substr($memoryLimit, 0, -1);
-
-        if (substr($memoryLimit, -1) == 'K') {
-            return $value * 1024;
-        }
-        if (substr($memoryLimit, -1) == 'M') {
-            return $value * 1024 * 1024;
-        }
-        if (substr($memoryLimit, -1) == 'G') {
-            return $value * 1024 * 1024 * 1024;
-        }
-        return $memoryLimit;
+        return ini_parse_quantity($memoryLimit);
     }
 
     /**

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
@@ -801,21 +801,11 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
     {
         $_bytes = @ini_get($ini_key);
 
-        if (stristr($_bytes, 'k')) {
-            // kilobytes
-            $_bytes = (int) $_bytes * 1024;
-        } elseif (stristr($_bytes, 'm')) {
-            // megabytes
-            $_bytes = (int) $_bytes * 1024 * 1024;
-        } elseif (stristr($_bytes, 'g')) {
-            // gigabytes
-            $_bytes = (int) $_bytes * 1024 * 1024 * 1024;
-        }
-        return (int)$_bytes;
+        return ini_parse_quantity($_bytes);
     }
 
     /**
-     * Simple converrt bytes to Megabytes
+     * Simple convert bytes to Megabytes
      *
      * @param int $bytes
      * @return float

--- a/app/code/core/Mage/Uploader/Helper/File.php
+++ b/app/code/core/Mage/Uploader/Helper/File.php
@@ -707,7 +707,12 @@ class Mage_Uploader_Helper_File extends Mage_Core_Helper_Abstract
      */
     public function getDataMaxSize()
     {
-        return min($this->getPostMaxSize(), $this->getUploadMaxSize());
+        $postMaxSize = $this->getPostMaxSize();
+        $uploadMaxSize = $this->getUploadMaxSize();
+        $postMaxSizeBytes = ini_parse_quantity($postMaxSize);
+        $uploadMaxSizeBytes = ini_parse_quantity($uploadMaxSize);
+
+        return min($postMaxSizeBytes, $uploadMaxSizeBytes) === $postMaxSizeBytes ? $postMaxSize : $uploadMaxSize;
     }
 
     /**
@@ -717,27 +722,6 @@ class Mage_Uploader_Helper_File extends Mage_Core_Helper_Abstract
      */
     public function getDataMaxSizeInBytes()
     {
-        $iniSize = $this->getDataMaxSize();
-        $size = (int)substr($iniSize, 0, -1);
-        $parsedSize = 0;
-        switch (strtolower(substr($iniSize, strlen($iniSize) - 1))) {
-            case 't':
-                $parsedSize = $size * (1024 * 1024 * 1024 * 1024);
-                break;
-            case 'g':
-                $parsedSize = $size * (1024 * 1024 * 1024);
-                break;
-            case 'm':
-                $parsedSize = $size * (1024 * 1024);
-                break;
-            case 'k':
-                $parsedSize = $size * 1024;
-                break;
-            case 'b':
-            default:
-                $parsedSize = $size;
-                break;
-        }
-        return (int)$parsedSize;
+        return ini_parse_quantity($this->getDataMaxSize());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,10 @@
         "phpseclib/mcrypt_compat": "^2.0.3",
         "phpseclib/phpseclib": "^3.0.14",
         "shardj/zf1-future": "1.24.0",
-        "symfony/polyfill-php74": "^1.27",
-        "symfony/polyfill-php80": "^1.27",
-        "symfony/polyfill-php81": "^1.27"
+        "symfony/polyfill-php74": "^1.29",
+        "symfony/polyfill-php80": "^1.29",
+        "symfony/polyfill-php81": "^1.29",
+        "symfony/polyfill-php82": "^1.29"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3d728362b534d576376af960b6dc160f",
+    "content-hash": "76dfca273981ae0e9388059e1108e257",
     "packages": [
         {
             "name": "colinmollenhour/cache-backend-redis",
@@ -1952,6 +1952,82 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-php81/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php82",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php82.git",
+                "reference": "559d488c38784112c78b9bf17c5ce8366a265643"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php82/zipball/559d488c38784112c78b9bf17c5ce8366a265643",
+                "reference": "559d488c38784112c78b9bf17c5ce8366a265643",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php82\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php82/tree/v1.29.0"
             },
             "funding": [
                 {

--- a/dev/tests/unit/Mage/Uploader/Helper/FileTest.php
+++ b/dev/tests/unit/Mage/Uploader/Helper/FileTest.php
@@ -113,10 +113,6 @@ class FileTest extends TestCase
                 1024,
                 '1024'
             ],
-            'byte' => [
-                1,
-                '1B'
-            ],
             'kilobyte' => [
                 1024,
                 '1K'
@@ -128,11 +124,7 @@ class FileTest extends TestCase
             'gigabyte' => [
                 1073741824,
                 '1G'
-            ],
-            'terabyte' => [
-                1099511627776,
-                '1T'
-            ],
+            ]
         ];
     }
 }

--- a/dev/tests/unit/Mage/Uploader/Helper/FileTest.php
+++ b/dev/tests/unit/Mage/Uploader/Helper/FileTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Uploader\Helper;
+
+use Mage;
+use Mage_Uploader_Helper_File;
+use PHPUnit\Framework\TestCase;
+
+class FileTest extends TestCase
+{
+    /**
+     * @var Mage_Uploader_Helper_File
+     */
+    public Mage_Uploader_Helper_File $subject;
+
+    public function setUp(): void
+    {
+        Mage::app();
+        Mage::getConfig()->setNode('global/mime/types/test-new-node', 'application/octet-stream');
+        $this->subject = Mage::helper('uploader/file');
+    }
+
+    /**
+     * @dataProvider provideGetMimeTypeFromExtensionListData
+     * @param array<int, string> $expectedResult
+     * @param string|array<int, string> $extensionsList
+     * @return void
+     */
+    public function testGetMimeTypeFromExtensionList(array $expectedResult, $extensionsList): void
+    {
+        self::assertSame($expectedResult, $this->subject->getMimeTypeFromExtensionList($extensionsList));
+    }
+
+    /**
+     * @return array<string, array<int, array<int, string>|string>>
+     */
+    public function provideGetMimeTypeFromExtensionListData(): array
+    {
+        return [
+            'string exists' => [
+                [
+                    0 => 'application/vnd.lotus-1-2-3'
+                ],
+                '123'
+            ],
+            'string not exists' => [
+                [
+                    0 => 'application/octet-stream'
+                ],
+                'not-exists'
+            ],
+            'array' => [
+                [
+                    0 => 'application/vnd.lotus-1-2-3',
+                    1 => 'application/octet-stream',
+                    2 => 'application/octet-stream',
+                ],
+                [
+                    '123',
+                    'not-exists',
+                    'test-new-node',
+                ]
+            ],
+        ];
+    }
+
+    public function testGetPostMaxSize(): void
+    {
+        self::assertIsString($this->subject->getPostMaxSize());
+    }
+
+    public function testGetUploadMaxSize(): void
+    {
+        self::assertIsString($this->subject->getUploadMaxSize());
+    }
+
+    public function testGetDataMaxSize(): void
+    {
+        $mock = $this->getMockBuilder(Mage_Uploader_Helper_File::class)
+            ->setMethods(['getPostMaxSize', 'getUploadMaxSize'])
+            ->getMock();
+
+        $mock->expects($this->once())->method('getPostMaxSize')->willReturn('1G');
+        $mock->expects($this->once())->method('getUploadMaxSize')->willReturn('1M');
+        self::assertSame('1M', $mock->getDataMaxSize());
+    }
+
+    /**
+     * @dataProvider provideGetDataMaxSizeInBytesData
+     * @param int $expectedResult
+     * @param string $maxSize
+     * @return void
+     */
+    public function testGetDataMaxSizeInBytes(int $expectedResult, string $maxSize): void
+    {
+        $mock = $this->getMockBuilder(Mage_Uploader_Helper_File::class)
+            ->setMethods(['getDataMaxSize'])
+            ->getMock();
+
+        $mock->expects($this->once())->method('getDataMaxSize')->willReturn($maxSize);
+        self::assertSame($expectedResult, $mock->getDataMaxSizeInBytes());
+    }
+
+    /**
+     * @return array<string, array<int, int|string>>
+     */
+    public function provideGetDataMaxSizeInBytesData(): array
+    {
+        return [
+            'no unit' => [
+                1024,
+                '1024'
+            ],
+            'byte' => [
+                1,
+                '1B'
+            ],
+            'kilobyte' => [
+                1024,
+                '1K'
+            ],
+            'megabyte' => [
+                1048576,
+                '1M'
+            ],
+            'gigabyte' => [
+                1073741824,
+                '1G'
+            ],
+            'terabyte' => [
+                1099511627776,
+                '1T'
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Fixes `Mage_Uploader_Helper_File::getDataMaxSize()` when different units are used.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. `min('1M', '1G')`returns `1G`
