### PR TITLE
Fixed cache issue in primary navigation block

### DIFF
--- a/app/code/core/Mage/Catalog/Block/Navigation.php
+++ b/app/code/core/Mage/Catalog/Block/Navigation.php
@@ -74,6 +74,7 @@ class Mage_Catalog_Block_Navigation extends Mage_Core_Block_Template
             Mage::getDesign()->getPackageName(),
             Mage::getDesign()->getTheme('template'),
             Mage::getSingleton('customer/session')->getCustomerGroupId(),
+            Mage::getBlockSingleton('page/html_header')->getIsHomePage(),
             'template' => $this->getTemplate(),
             'name' => $this->getNameInLayout(),
             $this->getCurrenCategoryKey()

--- a/app/code/core/Mage/Catalog/Block/Navigation.php
+++ b/app/code/core/Mage/Catalog/Block/Navigation.php
@@ -74,7 +74,6 @@ class Mage_Catalog_Block_Navigation extends Mage_Core_Block_Template
             Mage::getDesign()->getPackageName(),
             Mage::getDesign()->getTheme('template'),
             Mage::getSingleton('customer/session')->getCustomerGroupId(),
-            Mage::getBlockSingleton('page/html_header')->getIsHomePage(),
             'template' => $this->getTemplate(),
             'name' => $this->getNameInLayout(),
             $this->getCurrenCategoryKey()

--- a/app/code/core/Mage/Catalog/Helper/Product.php
+++ b/app/code/core/Mage/Catalog/Helper/Product.php
@@ -348,6 +348,7 @@ class Mage_Catalog_Helper_Product extends Mage_Core_Helper_Url
             $category = Mage::getModel('catalog/category')->load($categoryId);
             $product->setCategory($category);
             Mage::register('current_category', $category);
+            Mage::register('current_entity_key', $category->getPath());
         }
 
         // Register current data and dispatch final events

--- a/skin/frontend/rwd/default/css/styles.css
+++ b/skin/frontend/rwd/default/css/styles.css
@@ -3554,7 +3554,8 @@ a.skip-link {
     border-bottom: none;
   }
   .nav-primary a:hover,
-  .nav-primary li:hover > a {
+  .nav-primary li:hover,
+  .nav-primary li.active > a {
     color: #0472ad;
   }
   .nav-primary .menu-active {

--- a/skin/frontend/rwd/default/scss/layout/_header-nav.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header-nav.scss
@@ -202,7 +202,8 @@ $nav-primary-height: 30px;
         }
 
         a:hover,
-        li:hover > a {
+        li:hover,
+        li.active > a {
             color: $c-action;
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
On fresh block cache if i reload a PDP page the category of the product still marked as active in other pages if there is not a specific current category (homepage, contacts, cms page etc..)

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://github.com/OpenMage/magento-lts/issues/4041

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Flush block cache
2. Load a PDP
3. Go to homepage

The category of first PDP loaded still flagged as active.
PS: The RWD theme does not have a CSS rule to highlight the active menu, so you must inspect the HTML.
![active](https://github.com/OpenMage/magento-lts/assets/5071467/c72ea36b-b525-4774-8436-8a58ba4d8161)

This PR also adds css rule to highlight currente active category.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->