### PR TITLE
Fixed bug in Mage_Usa_Model_Shipping_Carrier_Ups->_doShipmentRequestRest()

### DIFF
--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
@@ -1692,14 +1692,14 @@ XMLAuth;
 
         // PackageResults is always an array for API version v2403, but could be an object for other versions.
         // The UPS API docs don't mark it required and don't say if it is always set, so let's be cautious.
-        if (!isset($responseData->ShipmentResults->PackageResults)) {
+        if (!isset($responseData->ShipmentResponse->ShipmentResults->PackageResults)) {
             $package = null;
-        } elseif (is_array($responseData->ShipmentResults->PackageResults)) {
+        } elseif (is_array($responseData->ShipmentResponse->ShipmentResults->PackageResults)) {
             /** @var null|object{TrackingNumber: string, ShippingLabel: object{GraphicImage: string}} $package */
-            $package = $responseData->ShipmentResults->PackageResults[0] ?? null;
-        } elseif (is_object($responseData->ShipmentResults->PackageResults)) {
+            $package = $responseData->ShipmentResponse->ShipmentResults->PackageResults[0] ?? null;
+        } elseif (is_object($responseData->ShipmentResponse->ShipmentResults->PackageResults)) {
             /** @var object{TrackingNumber: string, ShippingLabel: object{GraphicImage: string}} $package */
-            $package = $responseData->ShipmentResults->PackageResults;
+            $package = $responseData->ShipmentResponse->ShipmentResults->PackageResults;
         } else {
             Mage::log(
                 'Unexpected response shape from UPS REST API /shipments endpoint for .ShipmentResults.PackageResults',


### PR DESCRIPTION
### Description (*)
The _doShipmentRequest method has a mistake in parsing the JSON response from UPS. Each successful response has a ShipmentResponse object under the root object.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
Should I make an issue first for this kind of thing?

### Manual testing scenarios (*)
Do anything that requires getting shipping labels from UPS

### Questions or comments
The Magento2 code for UPS has this right. When I implemented the OpenMage version, my brain just skipped over the ShipmentResponse key- probably because it looks so similar to the next key, "ShipmentResults". Here's the Magento2 part for reference:

```
            $responseShipment = json_decode($response, true);
            $result = new DataObject();
            $shippingLabelContent =
                (string)$responseShipment['ShipmentResponse']['ShipmentResults']['PackageResults']['ShippingLabel']
                ['GraphicImage'];
            $trackingNumber =
                (string)$responseShipment['ShipmentResponse']['ShipmentResults']['PackageResults']['TrackingNumber'];
            // phpcs:ignore Magento2.Functions.DiscouragedFunction
            $result->setLabelContent(base64_decode($shippingLabelContent));
            $result->setTrackingNumber($trackingNumber)
```

We've been running this in production after encountering errors with generating shipping labels.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list