### PR TITLE
Fixed ship-to address for UPS REST shipment API

### DIFF
--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
@@ -1859,19 +1859,6 @@ XMLAuth;
             if ($request->getShipperAddressStateOrProvinceCode()) {
                 $address['StateProvinceCode'] = $request->getShipperAddressStateOrProvinceCode();
             }
-
-            $shipToAddress = &$shipToData['Address'];
-            $shipToAddress['AddressLine'] =
-                $request->getShipperAddressStreet1() . ' ' . $request->getShipperAddressStreet2();
-            $shipToAddress['City'] = $request->getShipperAddressCity();
-            $shipToAddress['CountryCode'] = $request->getShipperAddressCountryCode();
-            $shipToAddress['PostalCode'] = $request->getShipperAddressPostalCode();
-            if ($request->getShipperAddressStateOrProvinceCode()) {
-                $shipToAddress['StateProvinceCode'] = $request->getShipperAddressStateOrProvinceCode();
-            }
-            if ($this->getConfigData('dest_type') == 'RES') {
-                $shipToAddress['ResidentialAddress'] = '';
-            }
         }
 
         $shipParams['ShipmentRequest']['Shipment']['Service']['Code'] = $request->getShippingMethod();


### PR DESCRIPTION
### Description (*)
When a shipment is a "return", only the "ShipFrom" needs to change from the store owner to the customer. The "ShipTo" will already be the store owner and does not need to be changed.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
Create a return shipment and try to get labels.

### Questions or comments
This is kind of funny, actually. If you look at the XML version of the code that creates the request object, you can see that the XML code does not REPLACE the "ShipFrom" and "ShipTo" when it's a return shipment--it actually ADDS another "ShipTo" node, which is ignored by UPS. Since UPS only looks at the first "ShipTo" node, the old XML code worked even though it was wrong. The REST code tried to mirror what the XML code does, but actually replaces the node instead of adding more.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
