### PR TITLE
Fixed regression introduced in #2993 where attributes are not correctly pre-filtered for the layered navigation

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Layer.php
+++ b/app/code/core/Mage/Catalog/Model/Layer.php
@@ -255,10 +255,8 @@ class Mage_Catalog_Model_Layer extends Varien_Object
     /**
      * Filter which attributes are included in getFilterableAttributes
      *
-     * @param Mage_Catalog_Model_Resource_Eav_Attribute $attribute
-     * @return  bool
      */
-    protected function _filterFilterableAttributes($attribute)
+    protected function _filterFilterableAttributes(Mage_Catalog_Model_Resource_Eav_Attribute $attribute): bool
     {
         return $attribute->getIsFilterable() > 0;
     }

--- a/app/code/core/Mage/Catalog/Model/Layer.php
+++ b/app/code/core/Mage/Catalog/Model/Layer.php
@@ -212,6 +212,9 @@ class Mage_Catalog_Model_Layer extends Varien_Object
             foreach ($setAttributeIds as $attributeId) {
                 if (!isset($attributes[$attributeId])) {
                     $attribute = $eavConfig->getAttribute(Mage_Catalog_Model_Product::ENTITY, $attributeId);
+                    if (!$this->_filterFilterableAttributes($attribute)) {
+                        continue;
+                    }
                     if ($attribute instanceof Mage_Catalog_Model_Resource_Eav_Attribute && $attribute->getIsFilterable()) {
                         $attributes[$attributeId] = $attribute;
                     }
@@ -247,6 +250,17 @@ class Mage_Catalog_Model_Layer extends Varien_Object
     {
         $collection->addIsFilterableFilter();
         return $collection;
+    }
+
+    /**
+     * Filter which attributes are included in getFilterableAttributes
+     *
+     * @param Mage_Catalog_Model_Resource_Eav_Attribute $attribute
+     * @return  bool
+     */
+    protected function _filterFilterableAttributes($attribute)
+    {
+        return $attribute->getIsFilterable() > 0;
     }
 
     /**

--- a/app/code/core/Mage/CatalogSearch/Model/Layer.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Layer.php
@@ -100,6 +100,17 @@ class Mage_CatalogSearch_Model_Layer extends Mage_Catalog_Model_Layer
     }
 
     /**
+     * Filter which attributes are included in getFilterableAttributes
+     *
+     * @param Mage_Catalog_Model_Resource_Eav_Attribute $attribute
+     * @return  bool
+     */
+    protected function _filterFilterableAttributes($attribute)
+    {
+        return $attribute->getIsVisible() && $attribute->getIsFilterableInSearch() > 0;
+    }
+
+    /**
      * Prepare attribute for use in layered navigation
      *
      * @param   Mage_Eav_Model_Entity_Attribute $attribute

--- a/app/code/core/Mage/CatalogSearch/Model/Layer.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Layer.php
@@ -102,10 +102,8 @@ class Mage_CatalogSearch_Model_Layer extends Mage_Catalog_Model_Layer
     /**
      * Filter which attributes are included in getFilterableAttributes
      *
-     * @param Mage_Catalog_Model_Resource_Eav_Attribute $attribute
-     * @return  bool
      */
-    protected function _filterFilterableAttributes($attribute)
+    protected function _filterFilterableAttributes(Mage_Catalog_Model_Resource_Eav_Attribute  $attribute): bool
     {
         return $attribute->getIsVisible() && $attribute->getIsFilterableInSearch() > 0;
     }


### PR DESCRIPTION
### Description (*)
Fix a regression introduced with the EAV overhaul where the filterable and filterable in search attribute options are not honored correctly.

Notes: For some reason the `Mage_CatalogSearch_Model_Layer::_prepareAttributeCollection` used to include a `is_visible` condition but not the parent for regular catalog layered nav. I've reproduced this behavior in the interest of having a usable fix quickly but I think it might cause the other issues found during the debugging of #4055

### Related Pull Requests
- introduced by https://github.com/OpenMage/magento-lts/pull/2993

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
- fixes https://github.com/OpenMage/magento-lts/issues/4055

### Manual testing scenarios (*)
See issue #4055
