### PR TITLE
Fixed regression introduced in #2993 where attributes are no longer sorted correctly by attribute group order in attribute comparison

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Compare/Item/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Compare/Item/Collection.php
@@ -215,15 +215,23 @@ class Mage_Catalog_Model_Resource_Product_Compare_Item_Collection extends Mage_C
                 $eavConfig = Mage::getSingleton('eav/config');
                 $attributeIds = $eavConfig->getAttributeSetAttributeIds($setIds);
                 $this->_comparableAttributes = [];
+                $attributeSortInfo = [];
                 foreach ($attributeIds as $attributeId) {
                     $attribute = $eavConfig->getAttribute(Mage_Catalog_Model_Product::ENTITY, $attributeId);
                     if ($attribute->getData('is_comparable')) {
                         $this->_comparableAttributes[$attribute->getAttributeCode()] = $attribute;
+                        $attributeSortInfo[$attribute->getAttributeCode()] = $eavConfig->getAttributeSetGroupInfo($attributeId, $setIds);
                     }
                 }
 
-                usort($this->_comparableAttributes, function ($a, $b) {
-                    return $a->getPosition() - $b->getPosition();
+                uasort($this->_comparableAttributes, function ($a, $b) use ($attributeSortInfo) {
+                    /** @var Mage_Eav_Model_Entity_Attribute_Abstract $a */
+                    /** @var Mage_Eav_Model_Entity_Attribute_Abstract $b */
+
+                    $aSort = $attributeSortInfo[$a->getAttributeCode()]; // contains group_id, group_sort, sort
+                    $bSort = $attributeSortInfo[$b->getAttributeCode()]; // contains group_id, group_sort, sort
+
+                    return $aSort['group_sort'] <=> $bSort['group_sort'] ?: $aSort['sort'] <=> $bSort['sort'];
                 });
             }
         }

--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -599,6 +599,27 @@ class Mage_Eav_Model_Config
     }
 
     /**
+     * Return first attribute sorting information found for a given list of attribute sets
+     * @param int $attributeId
+     * @param int|int[] $attributeSetIds
+     * @return false|array
+     */
+    public function getAttributeSetGroupInfo($attributeId, $attributeSetIds)
+    {
+        if (!is_array($attributeSetIds)) {
+            $attributeSetIds = [$attributeSetIds];
+        }
+
+        foreach ($attributeSetIds as $attributeSetId) {
+            if (isset($this->_attributeSetInfo[$attributeId][$attributeSetId])) {
+                return $this->_attributeSetInfo[$attributeId][$attributeSetId];
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @param mixed $entityType
      * @param string $attribute
      * @return  Mage_Eav_Model_Entity_Attribute_Abstract|null


### PR DESCRIPTION
### Description (*)
Fix a regression introduced with the EAV overhaul where the product comparison in the frontend does not sort the attributes by group anymore.

### Related Pull Requests
- introduced by https://github.com/OpenMage/magento-lts/pull/2993

### Fixed Issues (if relevant)
- #4062

### Manual testing scenarios (*)
1. Compare 2 products
2. Move attributes in attribute sets around and observe the frontend order
