### PR TITLE
Removed useless config in Mage/CatalogRule/etc/config.xml

### DIFF
--- a/app/code/core/Mage/CatalogRule/etc/config.xml
+++ b/app/code/core/Mage/CatalogRule/etc/config.xml
@@ -212,15 +212,5 @@
                 </run>
             </catalogrule_apply_all>
         </jobs>
-        <events>
-            <catalog_product_get_final_price>
-                <observers>
-                    <catalogrule>
-                        <class>catalogrule/observer</class>
-                        <method>processAdminFinalPrice</method>
-                    </catalogrule>
-                </observers>
-            </catalog_product_get_final_price>
-        </events>
     </crontab>
 </config>


### PR DESCRIPTION
### Description (*)
Found this useless config while investigating discussion #4065. 

Ref https://github.com/OpenMage/magento-lts/blob/68a5ec5fe00dca6b094d6a148a766acf74156728/cron.php#L67-L67

Call https://github.com/OpenMage/magento-lts/blob/68a5ec5fe00dca6b094d6a148a766acf74156728/app/code/core/Mage/Core/Model/Config.php#L1274-L1276

Where `$events = Mage::getConfig()->getNode('crontab/events')` is
```php
 object(Mage_Core_Model_Config_Element)#147 (3) {
  ["default"] => object(Mage_Core_Model_Config_Element)#146 (1) {
    ["observers"] => object(Mage_Core_Model_Config_Element)#155 (1) {
      ["cron_observer"] => object(Mage_Core_Model_Config_Element)#158 (2) {
        ["class"] => string(13) "cron/observer"
        ["method"] => string(8) "dispatch"
      }
    }
  }
  ["always"] => object(Mage_Core_Model_Config_Element)#141 (1) {
    ["observers"] => object(Mage_Core_Model_Config_Element)#155 (1) {
      ["cron_observer"] => object(Mage_Core_Model_Config_Element)#158 (2) {
        ["class"] => string(13) "cron/observer"
        ["method"] => string(14) "dispatchAlways"
      }
    }
  }
  ["catalog_product_get_final_price"] => object(Mage_Core_Model_Config_Element)#117 (1) {
    ["observers"] => object(Mage_Core_Model_Config_Element)#155 (1) {
      ["catalogrule"] => object(Mage_Core_Model_Config_Element)#158 (2) {
        ["class"] => string(20) "catalogrule/observer"
        ["method"] => string(22) "processAdminFinalPrice"
      }
    }
  }
}
```

The last element `catalog_product_get_final_price` has nothing to do with cron, it is not supposed to be there. 


