### PR TITLE
Fixed null parameter warning in Mage_Wishlist_Block_Abstract

### DIFF
--- a/app/code/core/Mage/Wishlist/Block/Abstract.php
+++ b/app/code/core/Mage/Wishlist/Block/Abstract.php
@@ -232,7 +232,7 @@ abstract class Mage_Wishlist_Block_Abstract extends Mage_Catalog_Block_Product_A
      */
     public function hasDescription($item)
     {
-        return ($item->getDescription() ?? '') != '';
+        return trim($item->getDescription() ?? '') != '';
     }
 
     /**

--- a/app/code/core/Mage/Wishlist/Block/Abstract.php
+++ b/app/code/core/Mage/Wishlist/Block/Abstract.php
@@ -232,7 +232,7 @@ abstract class Mage_Wishlist_Block_Abstract extends Mage_Catalog_Block_Product_A
      */
     public function hasDescription($item)
     {
-        return trim($item->getDescription()) != '';
+        return ($item->getDescription() ?? '') != '';
     }
 
     /**


### PR DESCRIPTION
**Steps to reproduce this issue**

1. Log into a customer account
2. Add any product to Favorites
3. Once you are redirected to the Favorites page send the Favorites list to an email address

Take a look in this file **/var/log/system.log**. You will see this error, in my test with PHP version 8.3.8.

```Deprecated functionality: trim(): Passing null to parameter #1 ($string) of type string is deprecated  in /var/www/html/app/code/core/Mage/Wishlist/Block/Abstract.php on line 235```
