### PR TITLE
Deprecated functionality: strlen() in the Tablerate.php file

### DIFF
--- a/app/code/core/Mage/Shipping/Model/Resource/Carrier/Tablerate.php
+++ b/app/code/core/Mage/Shipping/Model/Resource/Carrier/Tablerate.php
@@ -128,7 +128,7 @@ class Mage_Shipping_Model_Resource_Carrier_Tablerate extends Mage_Core_Model_Res
 
         $i = 0;
         $postcode = $request->getDestPostcode();
-        while (strlen($postcode) > 1) {
+        while (strlen($postcode ?? '') > 1) {
             $i++;
             $postcode = substr($postcode, 0, -1);
             $bind[':wildcard_postcode_' . $i] = "{$postcode}*";


### PR DESCRIPTION
In order to reproduce this issue use a table rate (uploading a CSV file in the Backend) in your test environment then follow the checkout steps to the end. 

Starting with PHP 8.1 to 8.3 you will get this error in the OM log file.

```
Deprecated functionality: strlen(): Passing null to parameter #1 ($string) of type string is deprecated  in /var/www/html/app/code/core/Mage/Shipping/Model/Resource/Carrier/Tablerate.php on line 131
```

My approach is using **strlen($variable ?? '')** but it could be **strlen((string) $variabile)** too. Please feel free to share your opinion for the best implementation.