### PR TITLE
Fixed null parameter warning in Mage_Wishlist_Controller_Abstract::allcartAction()

### DIFF
--- a/app/code/core/Mage/Wishlist/Controller/Abstract.php
+++ b/app/code/core/Mage/Wishlist/Controller/Abstract.php
@@ -85,8 +85,9 @@ abstract class Mage_Wishlist_Controller_Abstract extends Mage_Core_Controller_Fr
 
         $qtysString = $this->getRequest()->getParam('qty');
         if (isset($qtysString)) {
-            $qtys = array_filter(json_decode($qtysString), fn($qtysString) => strlen($qtysString ?? ''));
-            // $qtys = array_filter(json_decode($qtysString), function ($qtysString) { return strlen($qtysString ?? ''); });
+            $qtys = array_filter(json_decode($qtysString), fn($tmpString) => strlen($tmpString ?? ''));
+            // $qtys = array_filter(json_decode($qtysString), function ($tmpString) { return strlen($tmpString ?? ''); });
+            // $qtys = array_filter(json_decode($qtysString), function ($tmpString) { return $tmpString !== NULL && strlen($tmpString); }); => From Drupal Community
             // $qtys = @array_filter(json_decode($qtysString), '\strlen');
         }
 

--- a/app/code/core/Mage/Wishlist/Controller/Abstract.php
+++ b/app/code/core/Mage/Wishlist/Controller/Abstract.php
@@ -85,7 +85,9 @@ abstract class Mage_Wishlist_Controller_Abstract extends Mage_Core_Controller_Fr
 
         $qtysString = $this->getRequest()->getParam('qty');
         if (isset($qtysString)) {
-            $qtys = array_filter(json_decode($qtysString), '\strlen');
+            $qtys = array_filter(json_decode($qtysString), fn($qtysString) => strlen($qtysString ?? ''));
+            // $qtys = array_filter(json_decode($qtysString), function ($qtysString) { return strlen($qtysString ?? ''); });
+            // $qtys = @array_filter(json_decode($qtysString), '\strlen');
         }
 
         /** @var Mage_Wishlist_Model_Item $item */

--- a/app/code/core/Mage/Wishlist/Controller/Abstract.php
+++ b/app/code/core/Mage/Wishlist/Controller/Abstract.php
@@ -85,10 +85,7 @@ abstract class Mage_Wishlist_Controller_Abstract extends Mage_Core_Controller_Fr
 
         $qtysString = $this->getRequest()->getParam('qty');
         if (isset($qtysString)) {
-            $qtys = array_filter(json_decode($qtysString), fn($tmpString) => strlen($tmpString ?? ''));
-            // $qtys = array_filter(json_decode($qtysString), function ($tmpString) { return strlen($tmpString ?? ''); });
-            // $qtys = array_filter(json_decode($qtysString), function ($tmpString) { return $tmpString !== NULL && strlen($tmpString); }); => From Drupal Community
-            // $qtys = @array_filter(json_decode($qtysString), '\strlen');
+            $qtys = array_filter(json_decode($qtysString), fn ($tmpString) => strlen($tmpString ?? ''));
         }
 
         /** @var Mage_Wishlist_Model_Item $item */


### PR DESCRIPTION
This PR is related to the issue #4076.

I am getting this error with PHP > 8.1 in the system.log file:

```Deprecated functionality: strlen(): Passing null to parameter #1 ($string) of type string is deprecated  in /var/www/html/app/code/core/Mage/Wishlist/Controller/Abstract.php on line 88```

**/app/code/core/Mage/Wishlist/Controller/Abstract.php on line 88**

In order to reproduce this issue log into a customer account in the Frontend then add any product to the Wishlist. You will be redirected to the customer account. A part of the URL is **wishlist/index/index/wishlist_id/[PRODUCT_ID]/**. Press the [Add All to the Cart] button. In my case I am getting an error message because the product has custom options and I have to choose them. If you take a look into the /var/log directory you will see a nice system.log file, having 374 kB as size and inside the same line 1745 times. Every line is for a product which is not in the wishlist. With a script someone could make the system.log file as big as he wants, an pretty fast.

**IMPORTANT NOTE**
This PR has 4 implementations inside (4 lines - 1 my choice, 3 commented), there may be others. Please share your opinions, at the end there will be only one line left. Once it is merged I will fix the same issue in the Import/Export module.

```php
array_filter($VARIABLE, fn ($tmpString) => strlen($tmpString ?? ''))
// $qtys = array_filter($VARIABLE, function ($tmpString) { return strlen($tmpString ?? ''); });
// $qtys = array_filter($VARIABLE, function ($tmpString) { return $tmpString !== NULL && strlen($tmpString); }); => From Drupal Community
// $qtys = @array_filter($VARIABLE, '\strlen');
```