### PR TITLE
Fixed null parameter warning in Mage_ImportExport_Model_Import_Entity_Product::_filterRowData()

### DIFF
--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
@@ -1972,7 +1972,7 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
      */
     protected function _filterRowData(&$rowData)
     {
-        $rowData = array_filter($rowData, '\strlen');
+        $rowData = array_filter($rowData, fn ($tmpString) => strlen($tmpString ?? ''));
         // Exceptions - for sku - put them back in
         if (!isset($rowData[self::COL_SKU])) {
             $rowData[self::COL_SKU] = null;


### PR DESCRIPTION
This PR is similar to #4083. 

It replaces the callback function **'\strlen'** with an arrow function (introduced in PHP 7.4) to avoid the error message bellow starting with PHP >8.1

**Deprecated functionality: strlen(): Passing null to parameter #1**

Initially there were 4 variants, but considering the opinions from PR #4083 I chose the same implementation.

```php
array_filter($VARIABLE, fn ($tmpString) => strlen($tmpString ?? ''))
// $qtys = array_filter($VARIABLE, function ($tmpString) { return strlen($tmpString ?? ''); });
// $qtys = array_filter($VARIABLE, function ($tmpString) { return $tmpString !== NULL && strlen($tmpString); }); => From Drupal Community
// $qtys = @array_filter($VARIABLE, '\strlen');
```