### PR TITLE
Highlight popular countries in country select

### DIFF
--- a/app/code/core/Mage/Checkout/Block/Onepage/Abstract.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Abstract.php
@@ -18,6 +18,7 @@
  *
  * @category   Mage
  * @package    Mage_Checkout
+ * @phpstan-type Option array{label: string, value: non-falsy-string}
  *
  * @method \Mage_Sales_Model_Quote_Address getAddress()
  */
@@ -213,6 +214,7 @@ abstract class Mage_Checkout_Block_Onepage_Abstract extends Mage_Core_Block_Temp
 
         if ($options == false) {
             $options = $this->getCountryCollection()->toOptionArray();
+            $options = $this->sortCountryOptions($options);
             if ($useCache) {
                 Mage::app()->saveCache(serialize($options), $cacheId, $cacheTags);
             }
@@ -239,5 +241,29 @@ abstract class Mage_Checkout_Block_Onepage_Abstract extends Mage_Core_Block_Temp
     {
         return true;
     }
-    /* */
+
+    /**
+     * @template T of Option[]
+     * @param T $countryOptions
+     * @return array{0: array{label: string, value: Option[]}, 1: array{label: string, value: Option[]}}|T
+     */
+    private function sortCountryOptions(array $countryOptions): array
+    {
+        $topCountryCodes = $this->helper('directory')->getTopCountryCodes();
+        $headOptions = $tailOptions = [];
+
+        foreach ($countryOptions as $countryOption) {
+            if (in_array($countryOption['value'], $topCountryCodes)) {
+                $headOptions[] = $countryOption;
+            } else {
+                $tailOptions[] = $countryOption;
+            }
+        }
+
+        if (empty($headOptions)) {
+            return $countryOptions;
+        }
+
+        return [['label' => $this->__('Popular'), 'value' => $headOptions], ['label' => $this->__('Others'), 'value' => $tailOptions]];
+    }
 }

--- a/app/code/core/Mage/Directory/Helper/Data.php
+++ b/app/code/core/Mage/Directory/Helper/Data.php
@@ -307,4 +307,16 @@ class Mage_Directory_Helper_Data extends Mage_Core_Helper_Abstract
         }
         return in_array($countryId, $countyList);
     }
+
+    /** @return list<string> */
+    public function getTopCountryCodes(): array
+    {
+        $topCountries = array_filter(explode(',', (string)Mage::getStoreConfig('general/country/top_countries')));
+
+        $transportObject = new Varien_Object();
+        $transportObject->setData('top_countries', $topCountries);
+        Mage::dispatchEvent('directory_get_top_countries', ['topCountries' => $transportObject]);
+
+        return $transportObject->getData('top_countries');
+    }
 }

--- a/app/code/core/Mage/Directory/etc/system.xml
+++ b/app/code/core/Mage/Directory/etc/system.xml
@@ -279,6 +279,16 @@
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
                         </optional_zip_countries>
+                        <top_countries translate="label">
+                            <label>Top Countries</label>
+                            <frontend_type>multiselect</frontend_type>
+                            <sort_order>40</sort_order>
+                            <source_model>adminhtml/system_config_source_country</source_model>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <can_be_empty>1</can_be_empty>
+                        </top_countries>
                     </fields>
                 </country>
                 <region translate="label">

--- a/skin/frontend/base/default/js/opcheckout.js
+++ b/skin/frontend/base/default/js/opcheckout.js
@@ -408,7 +408,7 @@ Shipping.prototype = {
         this.form = form;
         if ($(this.form)) {
             $(this.form).observe('submit', function(event){this.save();Event.stop(event);}.bind(this));
-            $(this.form).select('#shipping\\:country_id').first().addEventListener('change', () => { if (window.shipping) shipping.setSameAsBilling(false) });
+            $(this.form).select('#shipping\\:country_id').first()?.addEventListener('change', () => { if (window.shipping) shipping.setSameAsBilling(false) });
         }
         this.addressUrl = addressUrl;
         this.saveUrl = saveUrl;

--- a/skin/frontend/base/default/js/opcheckout.js
+++ b/skin/frontend/base/default/js/opcheckout.js
@@ -408,6 +408,7 @@ Shipping.prototype = {
         this.form = form;
         if ($(this.form)) {
             $(this.form).observe('submit', function(event){this.save();Event.stop(event);}.bind(this));
+            $(this.form).select('#shipping\\:country_id').first().addEventListener('change', () => { if (window.shipping) shipping.setSameAsBilling(false) });
         }
         this.addressUrl = addressUrl;
         this.saveUrl = saveUrl;


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR backports a feature from Magento 2 (in a nicer way with option groups) that allows to configure countries that will be shown on top of the country list ("popular countries").

Also the code duplication for `Mage_Checkout_Block_Onepage_Abstract::getCountryHtmlSelect()` and `Mage_Directory_Block_Data::getCountryHtmlSelect()` is removed.

In addition a new event `directory_get_top_countries` is added, that allows to customize the logic (e.g. to determine top countries automatically from quotes/orders).

<img width="423" alt="Bildschirmfoto 2024-07-07 um 11 15 54" src="https://github.com/OpenMage/magento-lts/assets/26252058/8b4ccb65-9172-4e0b-aa6e-e1daa49f7b57">

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Repeat the following tests for 
- country dropdown in cart estimate shipping
- checkout billing
- checkout shipping
- customer account address edit
- customer account register

1. Without any configuration the country dropdown looks the same as before
2. Configure one top country in _System > Configuration > General > Countries Options > Top Countries_ and verify the country dropdown
3. Configure multiple top countries in _System > Configuration > General > Countries Options > Top Countries_ and verify the country dropdown

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->