### PR TITLE
[DDEV] n98-magerun support by default

### DIFF
--- a/.ddev/commands/web/magerun
+++ b/.ddev/commands/web/magerun
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## Description: Execute n98-magerun
+## Usage: magerun
+## Example: "ddev magerun"
+
+php -d error_reporting="E_ALL ^E_DEPRECATED" /usr/local/bin/n98-magerun.phar "$@"

--- a/.ddev/web-build/Dockerfile.magerun
+++ b/.ddev/web-build/Dockerfile.magerun
@@ -1,5 +1,5 @@
 RUN \
     curl -sS -o n98-magerun.phar https://files.magerun.net/n98-magerun.phar &&  \
-    curl -sS -o n98-magerun.phar.sha256 https://files.magerun.net/sha256.php?file=n98-mager>    shasum -a 256 -c n98-magerun.phar.sha256 && \
+    curl -sS -o n98-magerun.phar.sha256 https://files.magerun.net/sha256.php?file=n98-mager > shasum -a 256 -c n98-magerun.phar.sha256 && \
     chmod +x n98-magerun.phar && \
     mv n98-magerun.phar /usr/local/bin/n98-magerun.phar

--- a/.ddev/web-build/Dockerfile.magerun
+++ b/.ddev/web-build/Dockerfile.magerun
@@ -1,0 +1,5 @@
+RUN \
+    curl -sS -o n98-magerun.phar https://files.magerun.net/n98-magerun.phar &&  \
+    curl -sS -o n98-magerun.phar.sha256 https://files.magerun.net/sha256.php?file=n98-mager>    shasum -a 256 -c n98-magerun.phar.sha256 && \
+    chmod +x n98-magerun.phar && \
+    mv n98-magerun.phar /usr/local/bin/n98-magerun.phar

--- a/docs/DDEV.md
+++ b/docs/DDEV.md
@@ -4,7 +4,9 @@
 
 You can use the swiss army knife for Magento developers, sysadmins and devops. The tool provides a huge set of well tested command line commands which save hours of work time. 
 
-Run n98-magerun command in the terminal window, for example `ddev magerun sys:info`.
+Run any n98-magerun command in the terminal window adding **ddev** in front of it. For example `ddev magerun sys:info` prints infos about the current OpenMage system. 
+
+For more information about the available commands please visit https://n98-magerun.readthedocs.io/en/latest/commands/sys.html#sys-info.
 
 ## Using phpMyAdmin
 

--- a/docs/DDEV.md
+++ b/docs/DDEV.md
@@ -6,7 +6,7 @@ You can use the swiss army knife for Magento developers, sysadmins and devops. T
 
 Run any n98-magerun command in the terminal window adding **ddev** in front of it. For example `ddev magerun sys:info` prints infos about the current OpenMage system. 
 
-For more information about the available commands please visit https://n98-magerun.readthedocs.io/en/latest/commands/sys.html#sys-info.
+For more information about the available commands please visit https://n98-magerun.readthedocs.io/en/latest/index.html.
 
 ## Using phpMyAdmin
 

--- a/docs/DDEV.md
+++ b/docs/DDEV.md
@@ -1,5 +1,11 @@
 # OpenMage Environment Based on DDEV (https://ddev.com/)
 
+## Using n98-magerun
+
+You can use the swiss army knife for Magento developers, sysadmins and devops. The tool provides a huge set of well tested command line commands which save hours of work time. 
+
+Run n98-magerun command in the terminal window, for example `ddev magerun sys:info`.
+
 ## Using phpMyAdmin
 
 Run in the terminal window `ddev get ddev/ddev-phpmyadmin` to install the phpMyAdmin add-on then restart DDEV. 


### PR DESCRIPTION
An indispensable tool for OpenMage is **n98-magerun**, which will be updated soon to be compatible with PHP 8.3.  This CLI tool saves a lot of clicking in the Backend and offers useful commands by default or you can extend the functionality by your own. All my respect to the maintainers.

This PR allows to all DDEV users to run **n98-magerun** very simple, in the terminal window use this format ```ddev magerun sys:info```, just add ddev before your favorites command combinations. 

I created a new command **magerun**, I updated the **DDEV documentation**, I created the file to **get the latest n98-magerun version**.

I created this PR based on a great post I found it recently, https://www.vianetz.com/en/blog/2013-09-magento-development-environment/#ddev