### PR TITLE
[DDEV] Adding n98-magerun support for the test environment

### DIFF
--- a/.ddev/commands/web/magerun
+++ b/.ddev/commands/web/magerun
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+## Description: Execute n98-magerun
+## Usage: magerun
+## Example: "ddev magerun"
+
+if [ ! -f vendor/bin/n98-magerun ]; then
+  read -r -p "n98-magerun is not installed. Do you want to install it? [y/N] " INSTALL_MAGE>  INSTALL_MAGERUN=${INSTALL_MAGERUN,,} # to lower
+  if [[ "${INSTALL_MAGERUN}" =~ ^(yes|y) ]]; then
+    composer require --dev n98/magerun:dev-develop
+  else
+    exit 1
+  fi
+fi
+
+php -d error_reporting="E_ALL ^E_DEPRECATED" vendor/bin/n98-magerun "$@"

--- a/.ddev/commands/web/magerun
+++ b/.ddev/commands/web/magerun
@@ -5,7 +5,8 @@
 ## Example: "ddev magerun"
 
 if [ ! -f vendor/bin/n98-magerun ]; then
-  read -r -p "n98-magerun is not installed. Do you want to install it? [y/N] " INSTALL_MAGE>  INSTALL_MAGERUN=${INSTALL_MAGERUN,,} # to lower
+  read -r -p "n98-magerun is not installed. Do you want to install it? [y/N] " INSTALL_MAGE
+  INSTALL_MAGERUN=${INSTALL_MAGERUN,,} # to lower
   if [[ "${INSTALL_MAGERUN}" =~ ^(yes|y) ]]; then
     composer require --dev n98/magerun:dev-develop
   else

--- a/docs/DDEV.md
+++ b/docs/DDEV.md
@@ -1,5 +1,13 @@
 # OpenMage Environment Based on DDEV (https://ddev.com/)
 
+## Using n98-magerun
+
+You can use the swiss army knife for Magento developers, sysadmins and devops. The tool provides a huge set of well tested command line commands which save hours of work time. 
+
+Run any n98-magerun command in the terminal window by adding **ddev** in front of it. For example `ddev magerun sys:info` prints infos about the current OpenMage system. 
+
+For more information about the available commands please visit https://n98-magerun.readthedocs.io/en/latest/index.html.
+
 ## Using phpMyAdmin
 
 Run in the terminal window `ddev get ddev/ddev-phpmyadmin` to install the phpMyAdmin add-on then restart DDEV. 


### PR DESCRIPTION
An indispensable tool for Magento 1 / OpenMage is **n98-magerun**, which will be updated soon to be compatible with PHP 8.3.  This CLI tool saves a lot of clicking in the Backend and offers useful commands by default or you can extend the functionality by your own.

This PR allows to all DDEV users to run **n98-magerun** very simple in the terminal window, using this format ```ddev magerun sys:info```. Just add **ddev** before your favorites commands.

Informative, this PR adds a new command **magerun** for DDEV and it updates the existing **DDEV documentation**.  n98-magerun development version is installed using Composer. Initially I chose to use a Docker container , but the version that was proposed to me later is more elegant. updating OpenMage packages will also update n98-magerun too.

The PR was inspired by a great information source I found it recently here https://www.vianetz.com/en/blog/2013-09-magento-development-environment/#ddev

Those who want a testing environment can choose DDEV. For more information please visit this link https://github.com/OpenMage/magento-lts/discussions/3839.