### PR TITLE
fix some 'undefined array key' warnings

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
@@ -83,7 +83,7 @@ class Mage_Adminhtml_Block_System_Config_Form_Field extends Mage_Adminhtml_Block
                 $defTextArr = [];
                 foreach ($options as $k => $v) {
                     if ($isMultiple) {
-                        if (is_array($v['value']) && in_array($k, $v['value'])) {
+                        if (isset($v['value']) && is_array($v['value']) && in_array($k, $v['value'])) {
                             $defTextArr[] = $v['label'];
                         }
                     } elseif (isset($v['value'])) {

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Select.php
@@ -54,7 +54,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Select extends Mage_Adminht
      */
     protected function _renderOption($option, $value)
     {
-        $selected = (($option['value'] == $value && (!is_null($value))) ? ' selected="selected"' : '');
+        $selected = (isset($option['value']) && ($option['value'] == $value && (!is_null($value))) ? ' selected="selected"' : '');
         return '<option value="' . $this->escapeHtml($option['value']) . '"' . $selected . '>' . $this->escapeHtml($option['label']) . '</option>';
     }
 
@@ -66,7 +66,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Select extends Mage_Adminht
         $html = '<select name="' . $this->_getHtmlName() . '" id="' . $this->_getHtmlId() . '" class="no-changes">';
         $value = $this->getValue();
         foreach ($this->_getOptions() as $option) {
-            if (is_array($option['value'])) {
+            if (isset($option['value']) is_array($option['value'])) {
                 $html .= '<optgroup label="' . $this->escapeHtml($option['label']) . '">';
                 foreach ($option['value'] as $subOption) {
                     $html .= $this->_renderOption($subOption, $value);


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Sometimes, the array key "value" is not available, showing warnings in the logfile. This PR adds some isset-checks to avoid them.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
See for example
`Warning: Undefined array key "value"  in /var/www/XXX/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php on line 86`

### Manual testing scenarios (*)

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->