### PR TITLE
Change initStatements to charset option when create db connection.

### DIFF
--- a/app/etc/config.xml
+++ b/app/etc/config.xml
@@ -27,7 +27,7 @@
                     <password/>
                     <dbname>openmage_lts</dbname>
                     <model>mysql4</model>
-                    <initStatements>SET NAMES utf8</initStatements>
+                    <charset>utf8</charset>
                     <type>pdo_mysql</type>
                     <active>0</active>
                     <persistent>0</persistent>


### PR DESCRIPTION
 - This option pass to Zend_Db_Adapter_Pdo_Abstract (parent of Mage_Core_Model_Resource_Type_Db_Pdo_Mysql) when init new PDO
 - `SET NAMES utf8` might be there as a workaround for php < 5.3.6 but should not be a case anymore.
 - Ref
   - https://stackoverflow.com/questions/4361459/php-pdo-charset-set-names
   - https://stackoverflow.com/questions/1650591/whether-to-use-set-names
   
*When Openmage start. It seems to merge every `etc/*.xml` config including this file. So before this commit, end-user who want to remove `initStatements` must explicitly set empty to `<initStatements />` in later file. Otherwise it still be there.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->