### PR TITLE
PhpStan: bumped to 1.12.1 & renamed config files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -887,6 +887,7 @@
 'phpstan':
   - changed-files:
     - any-glob-to-any-file: [
+      .phpstan*,
       phpstan*,
       .github/workflows/phpstan.yml
     ]

--- a/.gitignore
+++ b/.gitignore
@@ -70,8 +70,11 @@
 .phpcs*.xml
 !.phpcs*.xml.dist
 
+# PhpStan
+.phpstan*.neon
 phpstan*.neon
-!phpstan.dist.*.neon
+!.phpstan.dist.neon
+!.phpstan.dist.*.neon
 
 # dev scripts loaded via composer
 /shell/update-copyright.php

--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -3966,6 +3966,11 @@ parameters:
 			path: app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Tax.php
 
 		-
+			message: "#^Negated boolean expression is always true\\.$#"
+			count: 1
+			path: app/code/core/Mage/Sales/Model/Order.php
+
+		-
 			message: "#^Variable \\$oldArea might not be defined\\.$#"
 			count: 1
 			path: app/code/core/Mage/Sales/Model/Order/Api.php

--- a/.phpstan.dist.neon
+++ b/.phpstan.dist.neon
@@ -1,6 +1,6 @@
 includes:
     - vendor/macopedia/phpstan-magento1/extension.neon
-    - phpstan.dist.baseline.neon
+    - .phpstan.dist.baseline.neon
     - phar://phpstan.phar/conf/bleedingEdge.neon
 parameters:
     magentoRootPath: %currentWorkingDirectory%

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "openmage/dev-meta-package": "^1.0",
         "phpcompatibility/php-compatibility": "^9.3",
         "phpmd/phpmd": "^2.13",
-        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan": "^1.12.1",
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.7",
         "symplify/vendor-patches": "^11.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "40e9d3cfc444bb72b7cf7754c735f694",
+    "content-hash": "59d169c9f9fd98541d9af1b1f00dc20b",
     "packages": [
         {
             "name": "colinmollenhour/cache-backend-redis",
@@ -3486,16 +3486,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "384af967d35b2162f69526c7276acadce534d0e1"
+                "reference": "d8ed7fffa66de1db0d2972267d8ed1d8fa0fe5a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/384af967d35b2162f69526c7276acadce534d0e1",
-                "reference": "384af967d35b2162f69526c7276acadce534d0e1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d8ed7fffa66de1db0d2972267d8ed1d8fa0fe5a2",
+                "reference": "d8ed7fffa66de1db0d2972267d8ed1d8fa0fe5a2",
                 "shasum": ""
             },
             "require": {
@@ -3540,7 +3540,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-27T09:18:05+00:00"
+            "time": "2024-09-03T19:55:22+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Renamed config files to have them (dot-prefixed) all together.

### Related Pull Requests
<!-- related pull request placeholder -->

- see https://github.com/OpenMage/magento-lts/pull/2831#issuecomment-1362606297
