### PR TITLE
Fixed phpstan on Mage_Customer_Model_Customer

### DIFF
--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -2711,11 +2711,6 @@ parameters:
 			path: app/code/core/Mage/Customer/Model/Convert/Parser/Customer.php
 
 		-
-			message: "#^Method Mage_Directory_Model_Region\\:\\:loadByName\\(\\) invoked with 1 parameter, 2 required\\.$#"
-			count: 1
-			path: app/code/core/Mage/Customer/Model/Customer.php
-
-		-
 			message: "#^Parameter \\#1 \\$data \\(stdClass\\) of method Mage_Customer_Model_Customer_Api_V2\\:\\:_prepareData\\(\\) should be compatible with parameter \\$data \\(array\\) of method Mage_Customer_Model_Customer_Api\\:\\:_prepareData\\(\\)$#"
 			count: 1
 			path: app/code/core/Mage/Customer/Model/Customer/Api/V2.php

--- a/app/code/core/Mage/Customer/Model/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Customer.php
@@ -1416,7 +1416,7 @@ class Mage_Customer_Model_Customer extends Mage_Core_Model_Abstract
                         return false;
                     }
 
-                    $region = Mage::getModel('directory/region')->loadByName($data[$prefix . 'region']);
+                    $region = Mage::getModel('directory/region')->loadByName($data[$prefix . 'region'], 'US');
                     if (!$region->getId()) {
                         return false;
                     }


### PR DESCRIPTION
### Description (*)
Line 1419 in app\code\core\Mage\Customer\Model\Customer.php
```php
    $region = Mage::getModel('directory/region')->loadByName($data[$prefix . 'region']);
```
will result in 
> Fatal error:  Uncaught ArgumentCountError: Too few arguments to function Mage_Directory_Model_Region::loadByName()

However, the function `validateAddress()` is not reference in the core. Removing it is a potential BC, but should we remove it anyway?