### PR TITLE
Fix ACL Resource "admin/sales/order/actions/use" not found

### DIFF
--- a/app/code/core/Mage/Sales/Model/Observer.php
+++ b/app/code/core/Mage/Sales/Model/Observer.php
@@ -290,7 +290,7 @@ class Mage_Sales_Model_Observer
         if (!($methodInstance instanceof Mage_Sales_Model_Payment_Method_Billing_AgreementAbstract)) {
             return;
         }
-        if (!Mage::getSingleton('admin/session')->isAllowed('sales/order/actions/use')) {
+        if (!Mage::getSingleton('admin/session')->isAllowed('sales/billing_agreement/actions/use')) {
             $observer->getEvent()->getResult()->isAvailable = false;
         }
     }


### PR DESCRIPTION

<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The observer `restrictAdminBillingAgreementUsage` just get's triggered from admin area, so we use some existing adminhtml ACL rule which seems to cover exactly this case. <br><br>Replace non-existent ACL  `admin/sales/order/actions/use` with available `admin/sales/billing_agreement/actions/use`. 


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#4192

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Went to "Catalog" -> "Manage Products" and clicked on "Edit" at some product
 - A URL like https://test.shop.com/index.php/rmdadmin/catalog_product/edit/id/28/key/3ebcfb6842bac53c8778eec32d224ce4/ would raise the issue without patch
 -  The ACL was checked and no Exception got thrown anymore in the Mage Developer Mode. It looks fine now.