### PR TITLE
Fixed strcmp(): Passing null to parameter #1 ($string1) of type strin…

### DIFF
--- a/app/code/core/Mage/Customer/controllers/AccountController.php
+++ b/app/code/core/Mage/Customer/controllers/AccountController.php
@@ -931,8 +931,8 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
             throw Mage::exception('Mage_Core', $this->_getHelper('customer')->__('Wrong customer account specified.'));
         }
 
-        $customerToken = $customer->getRpToken();
-        if (strcmp($customerToken, $resetPasswordLinkToken) != 0 || $customer->isResetPasswordLinkTokenExpired()) {
+        $customerToken = (string) $customer->getRpToken();
+        if (strcmp($customerToken, $resetPasswordLinkToken) !== 0 || $customer->isResetPasswordLinkTokenExpired()) {
             throw Mage::exception('Mage_Core', $this->_getHelper('customer')->__('Your password reset link has expired.'));
         }
     }


### PR DESCRIPTION
…g is deprecated

### Description (*)
```
Array
(
    [type] => 8192:E_DEPRECATED
    [message] => strcmp(): Passing null to parameter #1 ($string1) of type string is deprecated
    [file] => .../app/code/core/Mage/Customer/controllers/AccountController.php
    [line] => 935
    [uri] => /customer/account/changeforgotten/
)
```
