### PR TITLE
Fix wrong Preview link on CMS pages grid

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid/Renderer/Action.php
@@ -26,7 +26,7 @@ class Mage_Adminhtml_Block_Cms_Page_Grid_Renderer_Action extends Mage_Adminhtml_
             $href = $row->getPreviewUrl();
         } else {
             $urlModel = Mage::getModel('core/url')->setStore($row->getData('_first_store_id'));
-            $href = $urlModel->getUrl(
+            $href = $urlModel->getDirectUrl(
                 $row->getIdentifier(),
                 [
                     '_current' => false,


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
If you have a CMS page where the identifier has 4 or more levels (e.g. `test/page/foo/bar`), the preview link on the CMS page grid will not work.

The preview link only shows the first 3 levels, where the URL key has 4 levels.

![image](https://github.com/user-attachments/assets/71e00541-dbe3-4e89-9379-973159d92032)

The preview link is generated in `Mage_Adminhtml_Block_Cms_Page_Grid_Renderer_Action`. This class uses `Mage::getModel('core/url')->getUrl(...)` to generate the link. `getUrl(...)` calls `Mage_Core_Model_Url::setReoutePath()`, which tries to parse the URL with the usual `module/controller/action` structure and cuts off the fourth level.

Using `getDirectUrl(...)` instead of `getUrl(...)` fixes this as `getDirectUrl(...)` takes the URL as is, not cutting off the fourth level.

### Manual testing scenarios (*)
1. Create a new CMS page. Set its identifier to `test/page/foo/bar` (or any other URL at least 4 levels deep).
2. Click the preview link on the CMS page grid.
3. You will get to the 404 page.
4. Check the URL of the link. It will be 'test/page/foo', not 'test/page/foo/bar' as specified in the identifier.


### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All automated tests passed successfully (all builds are green)
 - [X] Add yourself to contributors list