### PR TITLE
Admin config: added input validation & hide disabled options

### DIFF
--- a/app/code/core/Mage/Api/etc/system.xml
+++ b/app/code/core/Mage/Api/etc/system.xml
@@ -44,6 +44,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </session_timeout>
                         <compliance_wsi translate="label">
                             <label>WS-I Compliance</label>

--- a/app/code/core/Mage/Authorizenet/etc/system.xml
+++ b/app/code/core/Mage/Authorizenet/etc/system.xml
@@ -42,6 +42,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </payment_action>
                         <title translate="label">
                             <label>Title</label>
@@ -49,6 +50,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </title>
                         <login translate="label">
                             <label>API Login ID</label>
@@ -58,6 +60,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </login>
                         <trans_key translate="label">
                             <label>Transaction Key</label>
@@ -67,6 +70,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </trans_key>
                         <signature_key translate="label">
                             <label>Signature Key</label>
@@ -76,6 +80,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </signature_key>
                         <trans_md5 translate="label">
                             <label>Merchant MD5</label>
@@ -85,6 +90,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </trans_md5>
                         <order_status translate="label">
                             <label>New Order Status</label>
@@ -94,6 +100,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </order_status>
                         <test translate="label">
                             <label>Test Mode</label>
@@ -103,6 +110,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </test>
                         <cgi_url translate="label">
                             <label>Gateway URL</label>
@@ -110,6 +118,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </cgi_url>
                         <currency translate="label">
                             <label>Accepted Currency</label>
@@ -119,6 +128,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </currency>
                         <debug translate="label">
                             <label>Debug</label>
@@ -128,6 +138,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </debug>
                         <email_customer translate="label">
                             <label>Email Customer</label>
@@ -137,6 +148,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </email_customer>
                         <merchant_email translate="label">
                             <label>Merchant's Email</label>
@@ -145,6 +157,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </merchant_email>
                         <cctypes translate="label">
                             <label>Credit Card Types</label>
@@ -154,6 +167,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </cctypes>
                         <useccv translate="label">
                             <label>Credit Card Verification</label>
@@ -163,6 +177,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </useccv>
                         <allowspecific translate="label">
                             <label>Payment from Applicable Countries</label>
@@ -172,6 +187,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </allowspecific>
                         <specificcountry translate="label">
                             <label>Payment from Specific Countries</label>
@@ -181,6 +197,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </specificcountry>
                         <min_order_total translate="label">
                             <label>Minimum Order Total</label>
@@ -188,6 +205,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </min_order_total>
                         <max_order_total translate="label">
                             <label>Maximum Order Total</label>
@@ -195,6 +213,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </max_order_total>
                         <sort_order translate="label">
                             <label>Sort Order</label>
@@ -203,6 +222,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <frontend_class>validate-number</frontend_class>
+                            <depends><active>1</active></depends>
                         </sort_order>
                     </fields>
                 </authorizenet_directpost>

--- a/app/code/core/Mage/Catalog/etc/system.xml
+++ b/app/code/core/Mage/Catalog/etc/system.xml
@@ -164,6 +164,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-greater-than-zero</validate>
                         </lines_perpage>
                     </fields>
                 </sitemap>
@@ -181,6 +182,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-greater-than-zero</validate>
                         </base_width>
                         <small_width translate="label comment">
                             <label>Small Image Width</label>
@@ -189,6 +191,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-greater-than-zero</validate>
                         </small_width>
                         <max_dimension translate="label comment">
                             <label>Maximum resolution for upload image</label>
@@ -197,6 +200,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-greater-than-zero</validate>
                         </max_dimension>
                         <progressive_threshold translate="label comment">
                             <label>Enable Progressive Images Threshold</label>
@@ -204,6 +208,7 @@
                             <validate>validate-number</validate>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
+                            <validate>validate-digits validate-greater-than-zero</validate>
                         </progressive_threshold>
                     </fields>
                 </product_image>
@@ -400,6 +405,7 @@
                             <label>Maximal Depth</label>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
+                            <frontend_class>validate-digits</frontend_class>
                         </max_depth>
                     </fields>
                 </navigation>
@@ -427,6 +433,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><use_calendar>1</use_calendar></depends>
                         </date_fields_order>
                         <time_format translate="label">
                             <label>Time Format</label>
@@ -436,6 +443,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><use_calendar>1</use_calendar></depends>
                         </time_format>
                         <year_range translate="label comment">
                             <label>Year Range</label>
@@ -445,6 +453,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><use_calendar>1</use_calendar></depends>
                         </year_range>
                     </fields>
                 </custom_options>
@@ -563,6 +572,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <comment><![CDATA[<strong style="color:red">Warning!</strong> Applying MAP by default will hide all product prices on the frontend.]]></comment>
+                            <depends><enabled>1</enabled></depends>
                         </apply_for_all>
                         <display_price_type translate="label">
                             <label>Display Actual Price</label>
@@ -572,6 +582,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </display_price_type>
                         <explanation_message translate="label">
                             <label>Default Popup Text Message</label>
@@ -580,6 +591,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </explanation_message>
                         <explanation_message_whats_this translate="label">
                             <label>Default "What's This" Text Message</label>
@@ -588,6 +600,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </explanation_message_whats_this>
                     </fields>
                 </msrp>

--- a/app/code/core/Mage/Checkout/etc/system.xml
+++ b/app/code/core/Mage/Checkout/etc/system.xml
@@ -157,6 +157,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><display>1</display></depends>
                         </count>
                     </fields>
                 </sidebar>

--- a/app/code/core/Mage/ConfigurableSwatches/etc/system.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/system.xml
@@ -50,6 +50,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><enabled>1</enabled></depends>
                         </swatch_attributes>
                         <product_list_attribute translate="label">
                             <label>Product Attribute to Use for Swatches in Product Listing</label>
@@ -59,6 +60,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </product_list_attribute>
                         <product_list_price_change translate="label" module="configurableswatches">
                             <label>Dynamic Price Change for Swatches in Product Listing</label>
@@ -68,6 +70,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </product_list_price_change>
                     </fields>
                 </general>
@@ -85,6 +88,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-greater-than-zero</validate>
                         </width>
                         <height translate="label">
                             <label>Height</label>
@@ -92,6 +96,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-greater-than-zero</validate>
                         </height>
                     </fields>
                 </product_detail_dimensions>
@@ -109,6 +114,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-greater-than-zero</validate>
                         </width>
                         <height translate="label">
                             <label>Height</label>
@@ -116,6 +122,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-greater-than-zero</validate>
                         </height>
                     </fields>
                 </product_listing_dimensions>
@@ -133,6 +140,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-greater-than-zero</validate>
                         </width>
                         <height translate="label">
                             <label>Height</label>
@@ -140,6 +148,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-greater-than-zero</validate>
                         </height>
                     </fields>
                 </layered_nav_dimensions>

--- a/app/code/core/Mage/Contacts/etc/system.xml
+++ b/app/code/core/Mage/Contacts/etc/system.xml
@@ -103,6 +103,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </email_template>
                     </fields>
                 </auto_reply>

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -74,6 +74,8 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Number of seconds between each allowed request.</comment>
+                            <depends><active>1</active></depends>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </timeframe>
                     </fields>
                 </rate_limit>
@@ -556,6 +558,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><template_hints_admin>1</template_hints_admin></depends>
                         </template_hints_blocks_admin>
                         <head_front>
                             <label>Frontend</label>
@@ -582,6 +585,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><template_hints>1</template_hints></depends>
                         </template_hints_blocks>
                     </fields>
                 </debug>
@@ -660,6 +664,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Messages with a priority lower than the selected one will not be logged. Log Levels are ordered from highest to lowest priority.</comment>
+                            <depends><active>1</active></depends>
                         </max_level>
                         <file translate="label comment">
                             <label>System Log File Name</label>
@@ -669,6 +674,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Logging from Mage::log(). File is located in {{base_dir}}/var/log. Allowed file extensions: log, txt, html, csv</comment>
+                            <depends><active>1</active></depends>
                         </file>
                         <exception_file translate="label comment">
                             <label>Exceptions Log File Name</label>
@@ -678,6 +684,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Logging from Mage::logException(). File is located in {{base_dir}}/var/log. Allowed file extensions: log, txt, html, csv</comment>
+                            <depends><active>1</active></depends>
                         </exception_file>
                     </fields>
                 </log>
@@ -917,6 +924,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>For Windows server only.</comment>
+                            <depends><disable>0</disable></depends>
                         </host>
                         <port translate="label">
                             <label>Port (25)</label>
@@ -925,6 +933,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>For Windows server only.</comment>
+                            <depends><disable>0</disable></depends>
                         </port>
                         <!--
                         <auth translate="label">
@@ -935,6 +944,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><disable>0</disable></depends>
                         </auth>
                         <username translate="label">
                             <label>Username</label>
@@ -942,6 +952,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><disable>0</disable></depends>
                         </username>
                         <password translate="label">
                             <label>Password</label>
@@ -949,6 +960,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><disable>0</disable></depends>
                         </password>
                         -->
                         <set_return_path translate="label">
@@ -959,6 +971,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><disable>0</disable></depends>
                         </set_return_path>
                         <return_path_email translate="label">
                             <label>Return-Path Email</label>
@@ -968,7 +981,10 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
-                            <depends><set_return_path>2</set_return_path></depends>
+                            <depends>
+                                <disable>0</disable>
+                                <set_return_path>2</set_return_path>
+                            </depends>
                         </return_path_email>
                     </fields>
                 </smtp>
@@ -1016,6 +1032,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </configuration_update_time>
                     </fields>
                 </media_storage_configuration>
@@ -1111,6 +1128,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <validate>required-entry validate-digits validate-greater-than-zero</validate>
                         </password_reset_link_expiration_period>
                         <admin_notification_email_template translate="label">
                             <label>New Admin User Email Template</label>
@@ -1533,6 +1551,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <frontend_class>validate-digits</frontend_class>
                         </cookie_lifetime>
                         <cookie_path translate="label">
                             <label>Cookie Path</label>

--- a/app/code/core/Mage/Cron/etc/system.xml
+++ b/app/code/core/Mage/Cron/etc/system.xml
@@ -32,6 +32,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </schedule_generate_every>
                         <schedule_ahead_for translate="label">
                             <label>Schedule Ahead for</label>
@@ -39,6 +40,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </schedule_ahead_for>
                         <schedule_lifetime translate="label">
                             <label>Missed if Not Run Within</label>
@@ -46,6 +48,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </schedule_lifetime>
                         <history_cleanup_every translate="label">
                             <label>History Cleanup Every</label>
@@ -53,6 +56,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </history_cleanup_every>
                         <history_success_lifetime translate="label">
                             <label>Success History Lifetime</label>
@@ -60,6 +64,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </history_success_lifetime>
                         <history_failure_lifetime translate="label">
                             <label>Failure History Lifetime</label>
@@ -67,6 +72,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </history_failure_lifetime>
                     </fields>
                 </cron>

--- a/app/code/core/Mage/Customer/etc/system.xml
+++ b/app/code/core/Mage/Customer/etc/system.xml
@@ -64,6 +64,7 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                             <comment>Leave empty for default (15 minutes).</comment>
+                            <frontend_class>validate-digits</frontend_class>
                         </online_minutes_interval>
                     </fields>
                 </online_customers>
@@ -570,6 +571,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <depends><forgot_password_flow_secure separator=",">1,2</forgot_password_flow_secure></depends>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </forgot_password_ip_times>
                         <forgot_password_email_times translate="label">
                             <label>Forgot password requests to times per 24 hours from 1 e-mail</label>
@@ -578,6 +580,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <depends><forgot_password_flow_secure separator=",">1,3</forgot_password_flow_secure></depends>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </forgot_password_email_times>
                         <min_admin_password_length translate="label comment">
                             <label>Minimum admin password length</label>
@@ -588,6 +591,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </min_admin_password_length>
                     </fields>
                 </security>

--- a/app/code/core/Mage/Downloadable/etc/system.xml
+++ b/app/code/core/Mage/Downloadable/etc/system.xml
@@ -40,6 +40,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <frontend_class>validate-digits</frontend_class>
                         </downloads_number>
                         <shareable translate="label">
                             <label>Shareable</label>

--- a/app/code/core/Mage/GoogleAnalytics/etc/system.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/system.xml
@@ -46,6 +46,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </container_id>
                     </fields>
                 </gtm>
@@ -74,6 +75,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>The tracking code to use.</comment>
+                            <depends><active>1</active></depends>
                         </type>
                         <account translate="label">
                             <label>Account Number</label>
@@ -81,6 +83,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </account>
                         <user_id translate="label comment">
                             <label>User ID tracking</label>
@@ -92,7 +95,8 @@
                             <show_in_store>1</show_in_store>
                             <comment>Enable GA4 User_id tracking for logged in customers.</comment>
                             <depends>
-                              <type>analytics4</type>
+                                <active>1</active>
+                                <type>analytics4</type>
                             </depends>
                         </user_id>
                         <debug translate="label comment">
@@ -105,7 +109,8 @@
                             <show_in_store>1</show_in_store>
                             <comment>Enable GA4 Debug Real Time view for Development IP.</comment>
                             <depends>
-                              <type>analytics4</type>
+                                <active>1</active>
+                                <type>analytics4</type>
                             </depends>
                         </debug>
                     </fields>

--- a/app/code/core/Mage/Log/etc/system.xml
+++ b/app/code/core/Mage/Log/etc/system.xml
@@ -41,6 +41,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enable_log separator=",">1,2</enable_log></depends>
                         </clean_after_day>
                         <enabled translate="label">
                             <label>Enable Log Cleaning</label>
@@ -50,6 +51,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enable_log separator=",">1,2</enable_log></depends>
                         </enabled>
                         <time translate="label">
                             <label>Start Time</label>
@@ -58,6 +60,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enable_log separator=",">1,2</enable_log></depends>
                         </time>
                         <frequency translate="label">
                             <label>Frequency</label>
@@ -68,6 +71,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enable_log separator=",">1,2</enable_log></depends>
                         </frequency>
                         <error_email translate="label">
                             <label>Error Email Recipient</label>
@@ -76,6 +80,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enable_log separator=",">1,2</enable_log></depends>
                         </error_email>
                         <error_email_identity translate="label">
                             <label>Error Email Sender</label>
@@ -85,6 +90,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enable_log separator=",">1,2</enable_log></depends>
                         </error_email_identity>
                         <error_email_template translate="label">
                             <label>Error Email Template</label>
@@ -94,6 +100,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enable_log separator=",">1,2</enable_log></depends>
                         </error_email_template>
                     </fields>
                 </log>

--- a/app/code/core/Mage/Oauth/etc/system.xml
+++ b/app/code/core/Mage/Oauth/etc/system.xml
@@ -38,6 +38,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </cleanup_probability>
                         <expiration_period translate="label">
                             <label>Expiration Period</label>
@@ -46,6 +47,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </expiration_period>
                     </fields>
                 </cleanup>

--- a/app/code/core/Mage/Paygate/etc/system.xml
+++ b/app/code/core/Mage/Paygate/etc/system.xml
@@ -43,6 +43,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </cctypes>
                         <useccv translate="label">
                             <label>Credit Card Verification</label>
@@ -52,6 +53,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </useccv>
                         <email_customer translate="label">
                             <label>Email Customer</label>
@@ -61,6 +63,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </email_customer>
                         <login translate="label">
                             <label>API Login ID</label>
@@ -70,6 +73,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </login>
                         <merchant_email translate="label">
                             <label>Merchant's Email</label>
@@ -78,6 +82,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </merchant_email>
                         <order_status translate="label">
                             <label>New Order Status</label>
@@ -87,6 +92,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </order_status>
                         <sort_order translate="label">
                             <label>Sort Order</label>
@@ -94,6 +100,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sort_order>
                         <test translate="label">
                             <label>Test Mode</label>
@@ -103,6 +110,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </test>
                         <debug translate="label">
                             <label>Debug</label>
@@ -112,6 +120,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </debug>
                         <title translate="label">
                             <label>Title</label>
@@ -119,6 +128,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </title>
                         <trans_key translate="label">
                             <label>Transaction Key</label>
@@ -128,6 +138,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </trans_key>
                         <payment_action translate="label">
                             <label>Payment Action</label>
@@ -137,6 +148,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </payment_action>
                         <cgi_url>
                             <label>Gateway URL</label>
@@ -144,6 +156,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </cgi_url>
                         <cgi_url_td>
                             <label>Payment Update URL</label>
@@ -151,6 +164,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </cgi_url_td>
                         <currency translate="label">
                             <label>Accepted Currency</label>
@@ -160,6 +174,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </currency>
                         <allowspecific translate="label">
                             <label>Payment from Applicable Countries</label>
@@ -169,6 +184,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </allowspecific>
                         <specificcountry translate="label">
                             <label>Payment from Specific Countries</label>
@@ -178,6 +194,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </specificcountry>
                         <min_order_total translate="label">
                             <label>Minimum Order Total</label>
@@ -185,6 +202,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </min_order_total>
                         <max_order_total translate="label">
                             <label>Maximum Order Total</label>
@@ -192,6 +210,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </max_order_total>
                         <allow_partial_authorization translate="label">
                             <label>Allow Partial Authorization</label>
@@ -201,6 +220,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </allow_partial_authorization>
                         <heading_3dsecure translate="label">
                             <label>3D Secure</label>
@@ -208,6 +228,7 @@
                             <sort_order>105</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
+                            <depends><active>1</active></depends>
                         </heading_3dsecure>
                         <centinel translate="label">
                             <label>3D Secure Card Validation</label>
@@ -216,6 +237,7 @@
                             <sort_order>125</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
+                            <depends><active>1</active></depends>
                         </centinel>
                         <centinel_is_mode_strict translate="label comment">
                             <label>Severe 3D Secure Card Validation</label>
@@ -226,6 +248,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <depends><centinel>1</centinel></depends>
+                            <depends><active>1</active></depends>
                         </centinel_is_mode_strict>
                         <centinel_api_url translate="label comment">
                             <label>Centinel API URL</label>
@@ -234,7 +257,10 @@
                             <sort_order>135</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
-                            <depends><centinel>1</centinel></depends>
+                            <depends>
+                                <active>1</active>
+                                <centinel>1</centinel>
+                            </depends>
                         </centinel_api_url>
                         <model>
                         </model>

--- a/app/code/core/Mage/Payment/etc/system.xml
+++ b/app/code/core/Mage/Payment/etc/system.xml
@@ -48,6 +48,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </order_status>
                         <sort_order translate="label">
                             <label>Sort Order</label>
@@ -56,6 +57,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <frontend_class>validate-number</frontend_class>
+                            <depends><active>1</active></depends>
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
@@ -63,6 +65,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </title>
                          <allowspecific translate="label">
                             <label>Payment from Applicable Countries</label>
@@ -72,6 +75,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                             <depends><active>1</active></depends>
                         </allowspecific>
                         <specificcountry translate="label">
                             <label>Payment from Specific Countries</label>
@@ -82,6 +86,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </specificcountry>
                         <payable_to translate="label">
                             <label>Make Check Payable to</label>
@@ -89,6 +94,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </payable_to>
                         <mailing_address translate="label">
                             <label>Send Check to</label>
@@ -97,6 +103,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </mailing_address>
                         <min_order_total translate="label">
                             <label>Minimum Order Total</label>
@@ -104,6 +111,8 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <frontend_class>validate-number</frontend_class>
+                            <depends><active>1</active></depends>
                         </min_order_total>
                         <max_order_total translate="label">
                             <label>Maximum Order Total</label>
@@ -111,6 +120,8 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <frontend_class>validate-number</frontend_class>
+                            <depends><active>1</active></depends>
                         </max_order_total>
                         <model>
                         </model>
@@ -140,6 +151,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </order_status>
                         <payment_action translate="label">
                             <label>Automatically Invoice All Items</label>
@@ -150,6 +162,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <depends>
+                                <active>1</active>
                                 <order_status separator=",">processing,processed_ogone</order_status>
                             </depends>
                         </payment_action>
@@ -160,6 +173,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <frontend_class>validate-number</frontend_class>
+                            <depends><active>1</active></depends>
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
@@ -167,6 +181,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </title>
                         <allowspecific translate="label">
                             <label>Payment from Applicable Countries</label>
@@ -176,6 +191,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </allowspecific>
                         <specificcountry translate="label">
                             <label>Payment from Specific Countries</label>
@@ -186,6 +202,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </specificcountry>
 <!--
                         <min_order_total translate="label">
@@ -194,6 +211,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </min_order_total>
                         <max_order_total translate="label">
                             <label>Maximum Order Total</label>
@@ -201,6 +219,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </max_order_total>
 -->
                         <model>
@@ -231,6 +250,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </order_status>
                         <sort_order translate="label">
                             <label>Sort Order</label>
@@ -239,6 +259,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <frontend_class>validate-number</frontend_class>
+                            <depends><active>1</active></depends>
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
@@ -246,6 +267,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </title>
                         <allowspecific translate="label">
                             <label>Payment from Applicable Countries</label>
@@ -255,6 +277,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </allowspecific>
                         <specificcountry translate="label">
                             <label>Payment from Specific Countries</label>
@@ -265,6 +288,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </specificcountry>
                         <min_order_total translate="label">
                             <label>Minimum Order Total</label>
@@ -272,6 +296,8 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <frontend_class>validate-number</frontend_class>
+                            <depends><active>1</active></depends>
                         </min_order_total>
                         <max_order_total translate="label">
                             <label>Maximum Order Total</label>
@@ -279,6 +305,8 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <frontend_class>validate-number</frontend_class>
+                            <depends><active>1</active></depends>
                         </max_order_total>
                         <model>
                         </model>
@@ -306,6 +334,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </title>
                         <order_status translate="label">
                             <label>New Order Status</label>
@@ -315,6 +344,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </order_status>
                         <allowspecific translate="label">
                             <label>Payment from Applicable Countries</label>
@@ -324,6 +354,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </allowspecific>
                         <specificcountry translate="label">
                             <label>Payment from Specific Countries</label>
@@ -334,6 +365,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </specificcountry>
                         <instructions translate="label">
                             <label>Instructions</label>
@@ -342,6 +374,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </instructions>
                         <min_order_total translate="label">
                             <label>Minimum Order Total</label>
@@ -349,6 +382,8 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <frontend_class>validate-number</frontend_class>
+                            <depends><active>1</active></depends>
                         </min_order_total>
                         <max_order_total translate="label">
                             <label>Maximum Order Total</label>
@@ -356,6 +391,8 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <frontend_class>validate-number</frontend_class>
+                            <depends><active>1</active></depends>
                         </max_order_total>
                         <sort_order translate="label">
                             <label>Sort Order</label>
@@ -363,6 +400,8 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <frontend_class>validate-number</frontend_class>
+                            <depends><active>1</active></depends>
                         </sort_order>
                     </fields>
                 </banktransfer>
@@ -388,6 +427,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </title>
                         <order_status translate="label">
                             <label>New Order Status</label>
@@ -397,6 +437,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </order_status>
                         <allowspecific translate="label">
                             <label>Payment from Applicable Countries</label>
@@ -406,6 +447,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </allowspecific>
                         <specificcountry translate="label">
                             <label>Payment from Specific Countries</label>
@@ -416,6 +458,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </specificcountry>
                         <instructions translate="label">
                             <label>Instructions</label>
@@ -424,6 +467,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </instructions>
                         <min_order_total translate="label">
                             <label>Minimum Order Total</label>
@@ -431,6 +475,8 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <frontend_class>validate-number</frontend_class>
+                            <depends><active>1</active></depends>
                         </min_order_total>
                         <max_order_total translate="label">
                             <label>Maximum Order Total</label>
@@ -438,6 +484,8 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <frontend_class>validate-number</frontend_class>
+                            <depends><active>1</active></depends>
                         </max_order_total>
                         <sort_order translate="label">
                             <label>Sort Order</label>
@@ -445,6 +493,8 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <frontend_class>validate-number</frontend_class>
+                            <depends><active>1</active></depends>
                         </sort_order>
                     </fields>
                 </cashondelivery>

--- a/app/code/core/Mage/ProductAlert/etc/system.xml
+++ b/app/code/core/Mage/ProductAlert/etc/system.xml
@@ -43,7 +43,6 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </allow_stock>
-
                         <email_price_template translate="label">
                             <label>Price Alert Email Template</label>
                             <frontend_type>select</frontend_type>
@@ -52,6 +51,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><allow_price>1</allow_price></depends>
                         </email_price_template>
                         <email_stock_template translate="label">
                             <label>Stock Alert Email Template</label>
@@ -61,6 +61,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><allow_stock>1</allow_stock></depends>
                         </email_stock_template>
                         <email_identity translate="label">
                             <label>Alert Email Sender</label>

--- a/app/code/core/Mage/Reports/etc/system.xml
+++ b/app/code/core/Mage/Reports/etc/system.xml
@@ -40,6 +40,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <frontend_class>validate-digits</frontend_class>
                         </viewed_count>
                         <compared_count translate="label">
                             <label>Default Recently Compared Products Count</label>
@@ -47,6 +48,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <frontend_class>validate-digits</frontend_class>
                         </compared_count>
                     </fields>
                 </recently_products>

--- a/app/code/core/Mage/Sales/etc/system.xml
+++ b/app/code/core/Mage/Sales/etc/system.xml
@@ -62,6 +62,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </discount>
                         <grand_total translate="label">
                             <label>Grand Total</label>
@@ -69,6 +70,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </grand_total>
                         <shipping translate="label">
                             <label>Shipping</label>
@@ -76,6 +78,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </shipping>
                         <subtotal translate="label">
                             <label>Subtotal</label>
@@ -83,6 +86,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </subtotal>
                         <tax translate="label">
                             <label>Tax</label>
@@ -90,6 +94,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <validate>required-entry validate-digits validate-zero-or-greater</validate>
                         </tax>
                     </fields>
                 </totals_sort>
@@ -152,7 +157,6 @@
                         </address>
                     </fields>
                 </identity>
-
                 <minimum_order translate="label">
                     <label>Minimum Order Amount</label>
                     <sort_order>50</sort_order>
@@ -176,6 +180,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <comment>Subtotal after discount.</comment>
+                            <depends><active>1</active></depends>
                             <validate>validate-number</validate>
                         </amount>
                         <description translate="label comment">
@@ -186,6 +191,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>This message will be shown in shopping cart when subtotal after discount less than minimum amount.</comment>
+                            <depends><active>1</active></depends>
                         </description>
                         <error_message translate="label">
                             <label>Error to Show in Shopping Cart</label>
@@ -194,6 +200,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </error_message>
                         <multi_address translate="label">
                             <label>Validate Each Address Separately in Multi-address Checkout</label>
@@ -203,6 +210,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </multi_address>
                         <multi_address_description translate="label comment">
                             <label>Multi-address Description Message</label>
@@ -212,6 +220,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>If empty, the default description above will be used.</comment>
+                            <depends><active>1</active></depends>
                         </multi_address_description>
                         <multi_address_error_message translate="label comment">
                             <label>Multi-address Error to Show in Shopping Cart</label>
@@ -221,6 +230,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>If empty, the default error above will be used.</comment>
+                            <depends><active>1</active></depends>
                         </multi_address_error_message>
                     </fields>
                 </minimum_order>
@@ -277,6 +287,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </identity>
                         <template translate="label">
                             <label>New Order Confirmation Template</label>
@@ -286,6 +297,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </template>
                         <guest_template translate="label">
                             <label>New Order Confirmation Template for Guest</label>
@@ -295,6 +307,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Order Email Copy To</label>
@@ -303,6 +316,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Comma-separated.</comment>
+                            <depends><enabled>1</enabled></depends>
                         </copy_to>
                         <copy_method translate="label">
                             <label>Send Order Email Copy Method</label>
@@ -312,10 +326,10 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </copy_method>
                     </fields>
                 </order>
-
                 <order_comment translate="label">
                     <label>Order Comments</label>
                     <sort_order>2</sort_order>
@@ -340,6 +354,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </identity>
                         <template translate="label">
                             <label>Order Comment Email Template</label>
@@ -349,6 +364,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </template>
                         <guest_template translate="label">
                             <label>Order Comment Email Template for Guest</label>
@@ -358,6 +374,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Order Comment Email Copy To</label>
@@ -366,6 +383,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Comma-separated.</comment>
+                            <depends><enabled>1</enabled></depends>
                         </copy_to>
                         <copy_method translate="label">
                             <label>Send Order Comments Email Copy Method</label>
@@ -375,10 +393,10 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </copy_method>
                     </fields>
                 </order_comment>
-
                 <invoice translate="label">
                     <label>Invoice</label>
                     <sort_order>3</sort_order>
@@ -403,6 +421,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </identity>
                         <template translate="label">
                             <label>Invoice Email Template</label>
@@ -412,6 +431,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </template>
                         <guest_template translate="label">
                             <label>Invoice Email Template for Guest</label>
@@ -421,6 +441,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Invoice Email Copy To</label>
@@ -429,6 +450,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Comma-separated.</comment>
+                            <depends><enabled>1</enabled></depends>
                         </copy_to>
                         <copy_method translate="label">
                             <label>Send Invoice Email Copy Method</label>
@@ -438,6 +460,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </copy_method>
                     </fields>
                 </invoice>
@@ -465,6 +488,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </identity>
                         <template translate="label">
                             <label>Invoice Comment Email Template</label>
@@ -474,6 +498,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </template>
                         <guest_template translate="label">
                             <label>Invoice Comment Email Template for Guest</label>
@@ -483,6 +508,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Invoice Comment Email Copy To</label>
@@ -491,6 +517,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Comma-separated.</comment>
+                            <depends><enabled>1</enabled></depends>
                         </copy_to>
                         <copy_method translate="label">
                             <label>Send Invoice Comments Email Copy Method</label>
@@ -500,10 +527,10 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </copy_method>
                     </fields>
                 </invoice_comment>
-
                 <shipment translate="label">
                     <label>Shipment</label>
                     <sort_order>5</sort_order>
@@ -528,6 +555,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </identity>
                         <template translate="label">
                             <label>Shipment Email Template</label>
@@ -537,6 +565,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </template>
                         <guest_template translate="label">
                             <label>Shipment Email Template for Guest</label>
@@ -546,6 +575,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Shipment Email Copy To</label>
@@ -554,6 +584,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Comma-separated.</comment>
+                            <depends><enabled>1</enabled></depends>
                         </copy_to>
                         <copy_method translate="label">
                             <label>Send Shipment Email Copy Method</label>
@@ -563,6 +594,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </copy_method>
                     </fields>
                 </shipment>
@@ -590,6 +622,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </identity>
                         <template translate="label">
                             <label>Shipment Comment Email Template</label>
@@ -599,6 +632,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </template>
                         <guest_template translate="label">
                             <label>Shipment Comment Email Template for Guest</label>
@@ -608,6 +642,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Shipment Comment Email Copy To</label>
@@ -616,6 +651,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Comma-separated.</comment>
+                            <depends><enabled>1</enabled></depends>
                         </copy_to>
                         <copy_method translate="label">
                             <label>Send Shipment Comments Email Copy Method</label>
@@ -625,10 +661,10 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </copy_method>
                     </fields>
                 </shipment_comment>
-
                 <creditmemo translate="label">
                     <label>Credit Memo</label>
                     <sort_order>7</sort_order>
@@ -653,6 +689,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </identity>
                         <template translate="label">
                             <label>Credit Memo Email Template</label>
@@ -662,6 +699,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </template>
                         <guest_template translate="label">
                             <label>Credit Memo Email Template for Guest</label>
@@ -671,6 +709,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Credit Memo Email Copy To</label>
@@ -679,6 +718,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Comma-separated.</comment>
+                            <depends><enabled>1</enabled></depends>
                         </copy_to>
                         <copy_method translate="label">
                             <label>Send Credit Memo Email Copy Method</label>
@@ -688,6 +728,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </copy_method>
                     </fields>
                 </creditmemo>
@@ -715,6 +756,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </identity>
                         <template translate="label">
                             <label>Credit Memo Comment Email Template</label>
@@ -724,6 +766,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </template>
                         <guest_template translate="label">
                             <label>Credit Memo Comment Email Template for Guest</label>
@@ -733,6 +776,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </guest_template>
                         <copy_to translate="label comment">
                             <label>Send Credit Memo Comment Email Copy To</label>
@@ -741,6 +785,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Comma-separated.</comment>
+                            <depends><enabled>1</enabled></depends>
                         </copy_to>
                         <copy_method translate="label">
                             <label>Send Credit Memo Comments Email Copy Method</label>
@@ -750,6 +795,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </copy_method>
                     </fields>
                 </creditmemo_comment>

--- a/app/code/core/Mage/Sendfriend/etc/system.xml
+++ b/app/code/core/Mage/Sendfriend/etc/system.xml
@@ -49,6 +49,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </template>
                         <allow_guest translate="label">
                             <label>Allow for Guests</label>
@@ -58,6 +59,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </allow_guest>
                         <max_recipients translate="label">
                             <label>Max Recipients</label>
@@ -66,6 +68,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <frontend_class>validate-digits</frontend_class>
+                            <depends><enabled>1</enabled></depends>
                         </max_recipients>
                         <max_per_hour translate="label">
                             <label>Max Products Sent in 1 Hour</label>
@@ -74,6 +77,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <frontend_class>validate-digits</frontend_class>
+                            <depends><enabled>1</enabled></depends>
                         </max_per_hour>
                         <check_by translate="label">
                             <label>Limit Sending By</label>
@@ -83,6 +87,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </check_by>
                     </fields>
                 </email>

--- a/app/code/core/Mage/Shipping/etc/system.xml
+++ b/app/code/core/Mage/Shipping/etc/system.xml
@@ -47,6 +47,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><checkout_multiple>1</checkout_multiple></depends>
                         </checkout_multiple_maximum_qty>
                     </fields>
                 </option>
@@ -136,6 +137,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </name>
                         <price translate="label">
                             <label>Price</label>
@@ -144,6 +146,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </price>
                         <handling_type translate="label">
                             <label>Calculate Handling Fee</label>
@@ -153,6 +156,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_type>
                         <handling_fee translate="label">
                             <label>Handling Fee</label>
@@ -161,6 +165,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_fee>
                         <sort_order translate="label">
                             <label>Sort Order</label>
@@ -168,6 +173,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
@@ -175,6 +181,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </title>
                         <type translate="label">
                             <label>Type</label>
@@ -184,6 +191,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </type>
                         <sallowspecific translate="label">
                             <label>Ship to Applicable Countries</label>
@@ -194,6 +202,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sallowspecific>
                         <specificcountry translate="label">
                             <label>Ship to Specific Countries</label>
@@ -204,6 +213,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </specificcountry>
                         <showmethod translate="label">
                             <label>Show Method if Not Applicable</label>
@@ -213,6 +223,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </showmethod>
                         <specificerrmsg translate="label">
                             <label>Displayed Error Message</label>
@@ -221,6 +232,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </specificerrmsg>
                     </fields>
                 </flatrate>
@@ -247,6 +259,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </free_shipping_subtotal>
                         <name translate="label">
                             <label>Method Name</label>
@@ -254,6 +267,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </name>
                         <sort_order translate="label">
                             <label>Sort Order</label>
@@ -261,6 +275,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
@@ -268,6 +283,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </title>
                         <sallowspecific translate="label">
                             <label>Ship to Applicable Countries</label>
@@ -278,6 +294,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sallowspecific>
                         <specificcountry translate="label">
                             <label>Ship to Specific Countries</label>
@@ -288,6 +305,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </specificcountry>
                         <showmethod translate="label">
                             <label>Show Method if Not Applicable</label>
@@ -297,6 +315,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </showmethod>
                         <specificerrmsg translate="label">
                             <label>Displayed Error Message</label>
@@ -305,6 +324,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </specificerrmsg>
                     </fields>
                 </freeshipping>
@@ -323,7 +343,8 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
-                        </handling_type>
+                             <depends><active>1</active></depends>
+                         </handling_type>
                         <handling_fee translate="label">
                             <label>Handling Fee</label>
                             <validate>validate-number validate-zero-or-greater</validate>
@@ -331,6 +352,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_fee>
                         <active translate="label">
                             <label>Enabled</label>
@@ -349,6 +371,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </condition_name>
                         <include_virtual_price translate="label">
                             <label>Include Virtual Products in Price Calculation</label>
@@ -358,6 +381,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </include_virtual_price>
                         <export translate="label">
                             <label>Export</label>
@@ -366,6 +390,7 @@
                             <show_in_default>0</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </export>
                         <import translate="label">
                             <label>Import</label>
@@ -375,6 +400,7 @@
                             <show_in_default>0</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </import>
                         <name translate="label">
                             <label>Method Name</label>
@@ -382,6 +408,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </name>
                         <sort_order translate="label">
                             <label>Sort Order</label>
@@ -389,6 +416,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
@@ -396,6 +424,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </title>
                         <sallowspecific translate="label">
                             <label>Ship to Applicable Countries</label>
@@ -406,6 +435,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sallowspecific>
                         <specificcountry translate="label">
                             <label>Ship to Specific Countries</label>
@@ -416,6 +446,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </specificcountry>
                         <showmethod translate="label">
                             <label>Show Method if Not Applicable</label>
@@ -426,6 +457,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </showmethod>
                         <specificerrmsg translate="label">
                             <label>Displayed Error Message</label>
@@ -434,6 +466,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </specificerrmsg>
                     </fields>
                 </tablerate>

--- a/app/code/core/Mage/Sitemap/etc/system.xml
+++ b/app/code/core/Mage/Sitemap/etc/system.xml
@@ -48,6 +48,8 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Valid values range: from 0.0 to 1.0.</comment>
+                            <frontend_class>validate-number</frontend_class>
+                            <depends><changefreq separator=",">always,hourly,daily,weekly,monthly,yearly,never</changefreq></depends>
                         </priority>
                         <lastmod translate="label">
                             <label>Show lastmod</label>
@@ -57,6 +59,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><changefreq separator=",">always,hourly,daily,weekly,monthly,yearly,never</changefreq></depends>
                         </lastmod>
                     </fields>
                 </category>
@@ -84,6 +87,8 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Valid values range: from 0.0 to 1.0.</comment>
+                            <frontend_class>validate-number</frontend_class>
+                            <depends><changefreq separator=",">always,hourly,daily,weekly,monthly,yearly,never</changefreq></depends>
                         </priority>
                         <lastmod translate="label">
                             <label>Show lastmod</label>
@@ -93,6 +98,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><changefreq separator=",">always,hourly,daily,weekly,monthly,yearly,never</changefreq></depends>
                         </lastmod>
                     </fields>
                 </product>
@@ -120,6 +126,8 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Valid values range: from 0.0 to 1.0.</comment>
+                            <frontend_class>validate-number</frontend_class>
+                            <depends><changefreq separator=",">always,hourly,daily,weekly,monthly,yearly,never</changefreq></depends>
                         </priority>
                         <lastmod translate="label">
                             <label>Show lastmod</label>
@@ -129,6 +137,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><changefreq separator=",">always,hourly,daily,weekly,monthly,yearly,never</changefreq></depends>
                         </lastmod>
                     </fields>
                 </page>
@@ -155,6 +164,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </error_email>
                         <error_email_identity translate="label">
                             <label>Error Email Sender</label>
@@ -164,6 +174,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </error_email_identity>
                         <error_email_template translate="label">
                             <label>Error Email Template</label>
@@ -173,6 +184,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </error_email_template>
                         <frequency translate="label">
                             <label>Frequency</label>
@@ -183,6 +195,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </frequency>
                         <time translate="label">
                             <label>Start Time</label>
@@ -191,6 +204,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
                         </time>
                     </fields>
                 </generate>

--- a/app/code/core/Mage/Usa/etc/system.xml
+++ b/app/code/core/Mage/Usa/etc/system.xml
@@ -31,6 +31,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </account>
                         <active translate="label">
                             <label>Enabled for Checkout</label>
@@ -50,6 +51,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </allowed_methods>
                         <contentdesc translate="label">
                             <label>Package Description</label>
@@ -57,6 +59,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </contentdesc>
                         <!--
                         If the free_shipping_enable flag enable, the system will check free_shipping_subtotal to give free shipping
@@ -70,6 +73,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </free_shipping_enable>
                         <free_shipping_subtotal translate="label">
                             <label>Minimum Order Amount for Free Shipping</label>
@@ -78,6 +82,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </free_shipping_subtotal>
                         <dutiable translate="label">
                             <label>Shipment Dutiable</label>
@@ -87,6 +92,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </dutiable>
                         <dutypaymenttype translate="label">
                             <label>Shipment Duty Payment Type</label>
@@ -96,6 +102,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </dutypaymenttype>
                         <free_method translate="label">
                             <label>Free Method</label>
@@ -106,6 +113,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </free_method>
                         <gateway_url translate="label">
                             <label>Gateway URL</label>
@@ -114,6 +122,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </gateway_url>
                         <verify_peer translate="label">
                             <label>Enable SSL Verification</label>
@@ -123,6 +132,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </verify_peer>
                         <handling_type translate="label">
                             <label>Calculate Handling Fee</label>
@@ -132,6 +142,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_type>
                         <handling_action translate="label">
                             <label>Handling Applied</label>
@@ -141,6 +152,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_action>
                         <handling_fee translate="label">
                             <label>Handling Fee</label>
@@ -149,6 +161,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_fee>
                         <max_package_weight translate="label">
                             <label>Maximum Package Weight (Please consult your shipping carrier for maximum supported shipping weight)</label>
@@ -157,6 +170,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </max_package_weight>
                         <id translate="label">
                             <label>Access ID</label>
@@ -166,6 +180,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </id>
                         <password translate="label">
                             <label>Password</label>
@@ -175,6 +190,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </password>
                         <shipment_requesttype translate="label">
                             <label>Packages Request Type</label>
@@ -184,6 +200,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </shipment_requesttype>
                         <shipment_type translate="label">
                             <label>Shipment Type</label>
@@ -193,6 +210,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </shipment_type>
                         <shipping_intlkey translate="label">
                             <label>Shipping Key (International)</label>
@@ -202,6 +220,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </shipping_intlkey>
                         <shipping_key translate="label">
                             <label>Shipping Key</label>
@@ -211,6 +230,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </shipping_key>
                         <sort_order translate="label">
                             <label>Sort Order</label>
@@ -218,6 +238,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
@@ -225,6 +246,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </title>
                         <sallowspecific translate="label">
                             <label>Ship to Applicable Countries</label>
@@ -235,6 +257,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sallowspecific>
                         <specificcountry translate="label">
                             <label>Ship to Specific Countries</label>
@@ -245,6 +268,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </specificcountry>
                         <showmethod translate="label">
                             <label>Show Method if Not Applicable</label>
@@ -255,6 +279,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </showmethod>
                         <specificerrmsg translate="label">
                             <label>Displayed Error Message</label>
@@ -263,6 +288,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </specificerrmsg>
 
                         <additional_protection_enabled translate="label">
@@ -273,6 +299,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </additional_protection_enabled>
                         <additional_protection_min_value translate="label">
                             <label>Additional Protection Min Subtotal</label>
@@ -281,6 +308,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </additional_protection_min_value>
                         <additional_protection_use_subtotal translate="label">
                             <label>Additional Protection Value</label>
@@ -290,6 +318,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </additional_protection_use_subtotal>
                         <additional_protection_value translate="label comment">
                             <label>Additional Protection Configuration Value</label>
@@ -298,6 +327,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </additional_protection_value>
 
                         <additional_protection_rounding translate="label">
@@ -308,6 +338,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </additional_protection_rounding>
 
                         <hazardous_materials translate="label">
@@ -318,6 +349,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </hazardous_materials>
 
                         <default_length translate="label">
@@ -326,6 +358,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </default_length>
                         <default_width translate="label">
                             <label>Default Package Width</label>
@@ -333,6 +366,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </default_width>
                         <default_height translate="label">
                             <label>Default Package Height</label>
@@ -340,6 +374,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </default_height>
 
                         <shipment_days translate="label">
@@ -351,6 +386,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </shipment_days>
 
                         <intl_shipment_days translate="label">
@@ -362,6 +398,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </intl_shipment_days>
                         <debug translate="label">
                             <label>Debug</label>
@@ -371,6 +408,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </debug>
                     </fields>
                 </dhl>
@@ -396,6 +434,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </title>
                         <account translate="label comment">
                             <label>Account ID</label>
@@ -406,6 +445,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <comment>Please make sure to use only digits here. No dashes are allowed.</comment>
+                            <depends><active>1</active></depends>
                         </account>
                         <meter_number translate="label">
                             <label>Meter Number</label>
@@ -415,6 +455,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </meter_number>
                         <key translate="label">
                             <label>Key</label>
@@ -424,6 +465,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </key>
                         <password translate="label">
                             <label>Password</label>
@@ -433,6 +475,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </password>
                         <sandbox_mode translate="label">
                             <label>Sandbox Mode</label>
@@ -442,6 +485,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sandbox_mode>
                         <shipment_requesttype translate="label">
                             <label>Packages Request Type</label>
@@ -451,6 +495,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </shipment_requesttype>
                         <packaging translate="label">
                             <label>Packaging</label>
@@ -460,6 +505,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </packaging>
                         <dropoff translate="label">
                             <label>Dropoff</label>
@@ -469,6 +515,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </dropoff>
                         <unit_of_measure translate="label">
                             <label>Weight Unit</label>
@@ -478,6 +525,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </unit_of_measure>
                         <max_package_weight translate="label">
                             <label>Maximum Package Weight (Please consult your shipping carrier for maximum supported shipping weight)</label>
@@ -486,6 +534,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </max_package_weight>
                         <handling_type translate="label">
                             <label>Calculate Handling Fee</label>
@@ -495,6 +544,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_type>
                         <handling_action translate="label">
                             <label>Handling Applied</label>
@@ -504,6 +554,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_action>
                         <handling_fee translate="label">
                             <label>Handling Fee</label>
@@ -512,6 +563,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_fee>
                         <residence_delivery translate="label">
                             <label>Residential Delivery</label>
@@ -521,6 +573,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </residence_delivery>
                         <allowed_methods translate="label">
                             <label>Allowed Methods</label>
@@ -531,6 +584,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </allowed_methods>
                         <smartpost_hubid translate="label comment">
                             <label>Hub ID</label>
@@ -539,6 +593,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <comment>The field is applicable if the Smart Post method is selected.</comment>
+                            <depends><active>1</active></depends>
                         </smartpost_hubid>
                         <free_method translate="label">
                             <label>Free Method</label>
@@ -549,6 +604,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </free_method>
                         <free_shipping_enable translate="label">
                             <label>Free Shipping with Minimum Order Amount</label>
@@ -558,6 +614,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </free_shipping_enable>
                         <free_shipping_subtotal translate="label">
                             <label>Minimum Order Amount for Free Shipping</label>
@@ -566,6 +623,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </free_shipping_subtotal>
                         <specificerrmsg translate="label">
                             <label>Displayed Error Message</label>
@@ -574,6 +632,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </specificerrmsg>
                         <sallowspecific translate="label">
                             <label>Ship to Applicable Countries</label>
@@ -584,6 +643,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sallowspecific>
                         <specificcountry translate="label">
                             <label>Ship to Specific Countries</label>
@@ -594,6 +654,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </specificcountry>
                         <debug translate="label">
                             <label>Debug</label>
@@ -603,6 +664,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </debug>
                         <showmethod translate="label">
                             <label>Show Method if Not Applicable</label>
@@ -613,6 +675,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </showmethod>
                         <sort_order translate="label">
                             <label>Sort Order</label>
@@ -620,7 +683,8 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
-                        0</sort_order>
+                            <depends><active>1</active></depends>
+                        </sort_order>
                     </fields>
                 </fedex>
                 <ups translate="label" module="usa">
@@ -638,6 +702,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </access_license_number>
                         <active translate="label">
                             <label>Enabled for Checkout</label>
@@ -657,6 +722,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </allowed_methods>
                         <shipment_requesttype translate="label">
                             <label>Packages Request Type</label>
@@ -666,6 +732,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </shipment_requesttype>
                         <container translate="label">
                             <label>Container</label>
@@ -675,6 +742,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </container>
                         <free_shipping_enable translate="label">
                             <label>Free Shipping with Minimum Order Amount</label>
@@ -684,6 +752,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </free_shipping_enable>
                         <free_shipping_subtotal translate="label">
                             <label>Minimum Order Amount for Free Shipping</label>
@@ -692,6 +761,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </free_shipping_subtotal>
                         <dest_type translate="label">
                             <label>Destination Type</label>
@@ -701,6 +771,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </dest_type>
                         <free_method translate="label">
                             <label>Free Method</label>
@@ -712,6 +783,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </free_method>
                         <verify_peer translate="label">
                             <label>Enable SSL Verification</label>
@@ -721,6 +793,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </verify_peer>
                         <gateway_xml_url translate="label">
                             <label>Gateway XML URL</label>
@@ -729,6 +802,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </gateway_xml_url>
                         <gateway_rest_url translate="label">
                             <label>Gateway REST URL</label>
@@ -737,6 +811,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </gateway_rest_url>
                         <tracking_xml_url translate="label">
                             <label>Tracking XML URL</label>
@@ -745,6 +820,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </tracking_xml_url>
                         <tracking_rest_url translate="label">
                             <label>Tracking REST URL</label>
@@ -753,6 +829,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </tracking_rest_url>
                         <shipconfirm_xml_url translate="label">
                             <label>Shipping Confirm XML URL</label>
@@ -761,6 +838,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </shipconfirm_xml_url>
                         <shipconfirm_rest_url translate="label">
                             <label>Shipping Confirm REST URL</label>
@@ -769,6 +847,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </shipconfirm_rest_url>
                         <shipaccept_xml_url translate="label">
                             <label>Shipping Accept XML URL</label>
@@ -777,6 +856,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </shipaccept_xml_url>
                         <handling_type translate="label">
                             <label>Calculate Handling Fee</label>
@@ -786,6 +866,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_type>
                         <handling_action translate="label">
                             <label>Handling Applied</label>
@@ -795,6 +876,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_action>
                         <handling_fee translate="label">
                             <label>Handling Fee</label>
@@ -803,6 +885,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_fee>
                         <max_package_weight translate="label">
                             <label>Maximum Package Weight (Please consult your shipping carrier for maximum supported shipping weight)</label>
@@ -811,6 +894,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </max_package_weight>
                         <min_package_weight translate="label">
                             <label>Minimum Package Weight (Please consult your shipping carrier for minimum supported shipping weight)</label>
@@ -819,6 +903,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </min_package_weight>
                         <origin_shipment translate="label">
                             <label>Origin of the Shipment</label>
@@ -829,6 +914,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </origin_shipment>
                         <client_id translate="label comment">
                             <label>Client ID</label>
@@ -839,6 +925,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </client_id>
                         <client_secret translate="label">
                             <label>Client Secret</label>
@@ -848,6 +935,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </client_secret>
                         <password translate="label">
                             <label>Password</label>
@@ -857,6 +945,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </password>
                         <pickup translate="label">
                             <label>Pickup Method</label>
@@ -866,6 +955,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </pickup>
                         <sort_order translate="label">
                             <label>Sort Order</label>
@@ -873,6 +963,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sort_order>
                         <title translate="label">
                             <label>Title</label>
@@ -880,6 +971,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </title>
                         <type translate="label">
                             <label>UPS Type</label>
@@ -890,6 +982,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </type>
                         <unit_of_measure translate="label comment">
                             <label>Weight Unit</label>
@@ -899,6 +992,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </unit_of_measure>
                         <username translate="label">
                             <label>User ID</label>
@@ -908,6 +1002,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </username>
                         <negotiated_active translate="label">
                             <label>Enable Negotiated Rates</label>
@@ -917,6 +1012,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </negotiated_active>
                         <shipper_number translate="label comment">
                             <label>Shipper Number</label>
@@ -925,6 +1021,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <comment>Required for negotiated rates; 6-character UPS.</comment>
+                            <depends><active>1</active></depends>
                         </shipper_number>
                         <sallowspecific translate="label">
                             <label>Ship to Applicable Countries</label>
@@ -935,6 +1032,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sallowspecific>
                         <specificcountry translate="label">
                             <label>Ship to Specific Countries</label>
@@ -945,6 +1043,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </specificcountry>
                         <showmethod translate="label">
                             <label>Show Method if Not Applicable</label>
@@ -955,6 +1054,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </showmethod>
                         <specificerrmsg translate="label">
                             <label>Displayed Error Message</label>
@@ -963,6 +1063,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </specificerrmsg>
                         <mode_xml translate="label comment">
                             <label>Mode</label>
@@ -973,6 +1074,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </mode_xml>
                         <debug translate="label">
                             <label>Debug</label>
@@ -982,6 +1084,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </debug>
                     </fields>
                 </ups>
@@ -1007,6 +1110,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </gateway_url>
                         <gateway_secure_url translate="label">
                             <label>Secure Gateway URL</label>
@@ -1014,6 +1118,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </gateway_secure_url>
                         <title translate="label">
                             <label>Title</label>
@@ -1021,6 +1126,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </title>
                         <userid translate="label">
                             <label>User ID</label>
@@ -1030,6 +1136,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </userid>
                         <password translate="label">
                             <label>Password</label>
@@ -1039,6 +1146,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </password>
                         <mode translate="label">
                             <label>Mode</label>
@@ -1048,6 +1156,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </mode>
                         <shipment_requesttype translate="label">
                             <label>Packages Request Type</label>
@@ -1057,6 +1166,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </shipment_requesttype>
                         <container translate="label">
                             <label>Container</label>
@@ -1066,6 +1176,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </container>
                         <size translate="label">
                             <label>Size</label>
@@ -1075,6 +1186,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </size>
                         <width translate="label">
                             <label>Width</label>
@@ -1083,6 +1195,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <depends><size>LARGE</size></depends>
+                            <depends><active>1</active></depends>
                         </width>
                         <length translate="label">
                             <label>Length</label>
@@ -1091,6 +1204,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <depends><size>LARGE</size></depends>
+                            <depends><active>1</active></depends>
                         </length>
                         <height translate="label">
                             <label>Height</label>
@@ -1099,6 +1213,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <depends><size>LARGE</size></depends>
+                            <depends><active>1</active></depends>
                         </height>
                         <girth translate="label">
                             <label>Girth</label>
@@ -1107,6 +1222,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <depends><size>LARGE</size></depends>
+                            <depends><active>1</active></depends>
                         </girth>
                         <machinable translate="label">
                             <label>Machinable</label>
@@ -1116,6 +1232,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </machinable>
                         <max_package_weight translate="label">
                             <label>Maximum Package Weight (Please consult your shipping carrier for maximum supported shipping weight)</label>
@@ -1124,6 +1241,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </max_package_weight>
                         <handling_type translate="label">
                             <label>Calculate Handling Fee</label>
@@ -1133,6 +1251,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_type>
                         <handling_action translate="label">
                             <label>Handling Applied</label>
@@ -1142,6 +1261,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_action>
                         <handling_fee translate="label">
                             <label>Handling Fee</label>
@@ -1150,6 +1270,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_fee>
                         <allowed_methods translate="label">
                             <label>Allowed Methods</label>
@@ -1160,6 +1281,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </allowed_methods>
                         <free_method translate="label">
                             <label>Free Method</label>
@@ -1170,6 +1292,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </free_method>
                         <free_shipping_enable translate="label">
                             <label>Free Shipping with Minimum Order Amount</label>
@@ -1179,6 +1302,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </free_shipping_enable>
                         <free_shipping_subtotal translate="label">
                             <label>Minimum Order Amount for Free Shipping</label>
@@ -1187,6 +1311,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </free_shipping_subtotal>
                         <specificerrmsg translate="label">
                             <label>Displayed Error Message</label>
@@ -1195,6 +1320,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </specificerrmsg>
                         <sallowspecific translate="label">
                             <label>Ship to Applicable Countries</label>
@@ -1205,6 +1331,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sallowspecific>
                         <specificcountry translate="label">
                             <label>Ship to Specific Countries</label>
@@ -1215,6 +1342,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </specificcountry>
                         <debug translate="label">
                             <label>Debug</label>
@@ -1224,6 +1352,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </debug>
                         <showmethod translate="label">
                             <label>Show Method if Not Applicable</label>
@@ -1234,6 +1363,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </showmethod>
                         <sort_order translate="label">
                             <label>Sort Order</label>
@@ -1241,7 +1371,8 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
-                        0</sort_order>
+                            <depends><active>1</active></depends>
+                        </sort_order>
                     </fields>
                 </usps>
                 <dhlint translate="label" module="usa">
@@ -1266,6 +1397,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </gateway_url>
                         <verify_peer translate="label">
                             <label>Enable SSL Verification</label>
@@ -1275,6 +1407,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </verify_peer>
                         <title translate="label">
                             <label>Title</label>
@@ -1282,6 +1415,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </title>
                         <id translate="label">
                             <label>Access ID</label>
@@ -1291,6 +1425,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </id>
                         <password translate="label">
                             <label>Password</label>
@@ -1300,6 +1435,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </password>
                         <account translate="label">
                             <label>Account Number</label>
@@ -1307,6 +1443,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </account>
                         <content_type translate="label">
                             <label>Content Type</label>
@@ -1316,6 +1453,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </content_type>
                         <handling_type translate="label">
                             <label>Calculate Handling Fee</label>
@@ -1325,6 +1463,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_type>
                         <handling_action translate="label comment">
                             <label>Handling Applied</label>
@@ -1335,6 +1474,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_action>
                         <handling_fee translate="label">
                             <label>Handling Fee</label>
@@ -1343,6 +1483,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </handling_fee>
                         <divide_order_weight translate="label comment">
                             <label>Divide Order Weight</label>
@@ -1353,6 +1494,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </divide_order_weight>
                         <unit_of_measure translate="label">
                             <label>Weight Unit</label>
@@ -1363,6 +1505,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </unit_of_measure>
                         <size translate="label">
                             <label>Size</label>
@@ -1372,6 +1515,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </size>
                         <height translate="label">
                             <label>Height</label>
@@ -1379,7 +1523,10 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <depends><size>1</size></depends>
+                            <depends>
+                                <active>1</active>
+                                <size>1</size>
+                            </depends>
                         </height>
                         <depth translate="label">
                             <label>Depth</label>
@@ -1387,7 +1534,10 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <depends><size>1</size></depends>
+                            <depends>
+                                <active>1</active>
+                                <size>1</size>
+                            </depends>
                         </depth>
                         <width translate="label">
                             <label>Width</label>
@@ -1395,7 +1545,10 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <depends><size>1</size></depends>
+                            <depends>
+                                <active>1</active>
+                                <size>1</size>
+                            </depends>
                         </width>
                         <doc_methods translate="label">
                             <label>Allowed Methods</label>
@@ -1405,7 +1558,10 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
-                            <depends><content_type>D</content_type></depends>
+                            <depends>
+                                <active>1</active>
+                                <content_type>D</content_type>
+                            </depends>
                         </doc_methods>
                         <nondoc_methods translate="label">
                             <label>Allowed Methods</label>
@@ -1415,7 +1571,10 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
-                            <depends><content_type>N</content_type></depends>
+                            <depends>
+                                <active>1</active>
+                                <content_type>N</content_type>
+                            </depends>
                         </nondoc_methods>
                         <ready_time>
                             <label>Ready time</label>
@@ -1424,6 +1583,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </ready_time>
                         <specificerrmsg translate="label">
                             <label>Displayed Error Message</label>
@@ -1432,6 +1592,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </specificerrmsg>
                         <!--
                         If the free_shipping_enable flag enable, the system will check free_shipping_subtotal to give free shipping
@@ -1446,7 +1607,10 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
-                            <depends><content_type>D</content_type></depends>
+                            <depends>
+                                <active>1</active>
+                                <content_type>D</content_type>
+                            </depends>
                         </free_method_doc>
                         <free_method_nondoc translate="label">
                             <label>Free Method</label>
@@ -1457,7 +1621,10 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
-                            <depends><content_type>N</content_type></depends>
+                            <depends>
+                                <active>1</active>
+                                <content_type>N</content_type>
+                            </depends>
                         </free_method_nondoc>
                         <free_shipping_enable translate="label">
                             <label>Free Shipping with Minimum Order Amount</label>
@@ -1467,6 +1634,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </free_shipping_enable>
                         <free_shipping_subtotal translate="label">
                             <label>Minimum Order Amount for Free Shipping</label>
@@ -1475,6 +1643,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </free_shipping_subtotal>
                         <sallowspecific translate="label">
                             <label>Ship to Applicable Countries</label>
@@ -1485,6 +1654,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sallowspecific>
                         <specificcountry translate="label">
                             <label>Ship to Specific Countries</label>
@@ -1495,6 +1665,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <can_be_empty>1</can_be_empty>
+                            <depends><active>1</active></depends>
                         </specificcountry>
                         <showmethod translate="label">
                             <label>Show Method if Not Applicable</label>
@@ -1505,6 +1676,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </showmethod>
                         <sort_order translate="label">
                             <label>Sort Order</label>
@@ -1512,6 +1684,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </sort_order>
                         <debug translate="label">
                             <label>Debug</label>
@@ -1521,6 +1694,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
                         </debug>
                     </fields>
                 </dhlint>

--- a/app/code/core/Mage/Weee/etc/system.xml
+++ b/app/code/core/Mage/Weee/etc/system.xml
@@ -42,6 +42,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enable>1</enable></depends>
                         </display_list>
                         <display translate="label">
                             <label>Display Prices On Product View Page</label>
@@ -51,6 +52,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enable>1</enable></depends>
                         </display>
                         <display_sales translate="label">
                             <label>Display Prices In Sales Modules</label>
@@ -60,6 +62,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enable>1</enable></depends>
                         </display_sales>
                         <display_email translate="label">
                             <label>Display Prices In Emails</label>
@@ -69,6 +72,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enable>1</enable></depends>
                         </display_email>
                         <discount translate="label">
                             <label>Apply Discounts To FPT</label>
@@ -78,6 +82,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enable>1</enable></depends>
                         </discount>
                         <apply_vat translate="label">
                             <label>FPT Tax Configuration</label>
@@ -87,6 +92,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enable>1</enable></depends>
                         </apply_vat>
                         <include_in_subtotal translate="label">
                             <label>Include FPT In Subtotal</label>
@@ -96,6 +102,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends><enable>1</enable></depends>
                         </include_in_subtotal>
                     </fields>
                 </weee>


### PR DESCRIPTION
Do not render options for disabled sections (e.g. disabled payment methods).

Added some input-validation to enforce number/digit imput.