### PR TITLE
PHP8.1: Added getter method for `Mage_Adminhtml_Block_Widget_Grid_Column::getType()` to return string

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
@@ -38,6 +38,10 @@ class Mage_Adminhtml_Block_Widget_Grid_Column extends Mage_Adminhtml_Block_Widge
     protected $_type;
     protected $_cssClass = null;
 
+    /**
+     * @param Mage_Adminhtml_Block_Widget_Grid $grid
+     * @return $this
+     */
     public function setGrid($grid)
     {
         $this->_grid = $grid;
@@ -46,6 +50,9 @@ class Mage_Adminhtml_Block_Widget_Grid_Column extends Mage_Adminhtml_Block_Widge
         return $this;
     }
 
+    /**
+     * @return Mage_Adminhtml_Block_Widget_Grid
+     */
     public function getGrid()
     {
         return $this->_grid;
@@ -160,6 +167,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column extends Mage_Adminhtml_Block_Widge
          */
         $frameCallback = $this->getFrameCallback();
         if (is_array($frameCallback)) {
+            // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
             $renderedValue = call_user_func($frameCallback, $renderedValue, $row, $this, false);
         }
 
@@ -188,6 +196,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column extends Mage_Adminhtml_Block_Widge
          */
         $frameCallback = $this->getFrameCallback();
         if (is_array($frameCallback)) {
+            // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
             $renderedValue = call_user_func($frameCallback, $renderedValue, $row, $this, true);
         }
 
@@ -222,15 +231,22 @@ class Mage_Adminhtml_Block_Widget_Grid_Column extends Mage_Adminhtml_Block_Widge
         return $value;
     }
 
+    /**
+     * @param string $renderer
+     * @return $this
+     */
     public function setRenderer($renderer)
     {
         $this->_renderer = $renderer;
         return $this;
     }
 
+    /**
+     * @return string
+     */
     protected function _getRendererByType()
     {
-        $type = strtolower((string)$this->getType());
+        $type = strtolower($this->getType());
         $renderers = $this->getGrid()->getColumnRenderers();
 
         if (is_array($renderers) && isset($renderers[$type])) {
@@ -317,15 +333,22 @@ class Mage_Adminhtml_Block_Widget_Grid_Column extends Mage_Adminhtml_Block_Widge
         return $this->_renderer;
     }
 
+    /**
+     * @param string $filterClass
+     * @return void
+     */
     public function setFilter($filterClass)
     {
         $this->_filter = $this->getLayout()->createBlock($filterClass)
                 ->setColumn($this);
     }
 
+    /**
+     * @return string
+     */
     protected function _getFilterByType()
     {
-        $type = strtolower((string)$this->getType());
+        $type = strtolower($this->getType());
         $filters = $this->getGrid()->getColumnFilters();
         if (is_array($filters) && isset($filters[$type])) {
             return $filters[$type];
@@ -423,5 +446,10 @@ class Mage_Adminhtml_Block_Widget_Grid_Column extends Mage_Adminhtml_Block_Widge
             return $this->getHeaderExport();
         }
         return $this->getHeader();
+    }
+
+    public function getType(): string
+    {
+        return (string) $this->_getData('type');
     }
 }

--- a/rector.php
+++ b/rector.php
@@ -19,11 +19,12 @@ return RectorConfig::configure()
     ])
     ->withSkipPath(__DIR__ . '/vendor')
     ->withSkip([
+        CodeQuality\BooleanNot\SimplifyDeMorganBinaryRector::class,
+        CodeQuality\If_\SimplifyIfReturnBoolRector::class,
         __DIR__ . '/shell/translations.php',
         __DIR__ . '/shell/update-copyright.php.php'
     ])
     ->withRules([
-//        CodeQuality\BooleanNot\SimplifyDeMorganBinaryRector::class, # wait for https://github.com/rectorphp/rector/issues/8781
         CodeQuality\BooleanNot\ReplaceMultipleBooleanNotRector::class,
         CodeQuality\Foreach_\UnusedForeachValueToArrayKeysRector::class,
         CodeQuality\FuncCall\ChangeArrayPushToArrayAssignRector::class,
@@ -31,7 +32,6 @@ return RectorConfig::configure()
         CodeQuality\Identical\SimplifyArraySearchRector::class,
         CodeQuality\Identical\SimplifyConditionsRector::class,
         CodeQuality\Identical\StrlenZeroToIdenticalEmptyStringRector::class,
-//        CodeQuality\If_\SimplifyIfReturnBoolRector::class,
         CodeQuality\NotEqual\CommonNotEqualRector::class,
         CodeQuality\LogicalAnd\LogicalToBooleanRector::class,
         CodeQuality\Ternary\SimplifyTautologyTernaryRector::class,

--- a/tests/unit/Mage/Adminhtml/Block/Widget/Grid/ColumnTest.php
+++ b/tests/unit/Mage/Adminhtml/Block/Widget/Grid/ColumnTest.php
@@ -1,5 +1,18 @@
 <?php
 
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   OpenMage
+ * @package    OpenMage_Tests
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
 declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Adminhtml\Block\Widget\Grid;

--- a/tests/unit/Mage/Adminhtml/Block/Widget/Grid/ColumnTest.php
+++ b/tests/unit/Mage/Adminhtml/Block/Widget/Grid/ColumnTest.php
@@ -36,6 +36,9 @@ class ColumnTest extends TestCase
      */
     public function testGetType(): void
     {
-        $this->assertIsString($this->subject->getType());
+        $this->assertSame('', $this->subject->getType());
+
+        $this->subject->setType('text');
+        $this->assertSame('text', $this->subject->getType());
     }
 }

--- a/tests/unit/Mage/Adminhtml/Block/Widget/Grid/ColumnTest.php
+++ b/tests/unit/Mage/Adminhtml/Block/Widget/Grid/ColumnTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Adminhtml\Block\Widget\Grid;
+
+use Mage_Adminhtml_Block_Widget_Grid_Column;
+use PHPUnit\Framework\TestCase;
+
+class ColumnTest extends TestCase
+{
+    public Mage_Adminhtml_Block_Widget_Grid_Column $subject;
+
+    public function setUp(): void
+    {
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
+        $this->subject = new Mage_Adminhtml_Block_Widget_Grid_Column();
+    }
+
+    /**
+     * @group Mage_Adminhtml
+     * @group Mage_Adminhtml_Block
+     */
+    public function testGetType(): void
+    {
+        $this->assertIsString($this->subject->getType());
+    }
+}

--- a/tests/unit/Mage/Core/Model/ConfigTest.php
+++ b/tests/unit/Mage/Core/Model/ConfigTest.php
@@ -1,5 +1,18 @@
 <?php
 
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   OpenMage
+ * @package    OpenMage_Tests
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
 declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Core\Model;

--- a/tests/unit/Mage/Core/Model/UrlTest.php
+++ b/tests/unit/Mage/Core/Model/UrlTest.php
@@ -35,6 +35,15 @@ class UrlTest extends TestCase
      * @group Mage_Core
      * @group Mage_Core_Model
      */
+    public function testEscape(): void
+    {
+        $this->assertSame('%22%27%3E%3C', $this->subject->escape('"\'><'));
+    }
+
+    /**
+     * @group Mage_Core
+     * @group Mage_Core_Model
+     */
     public function testGetSecure(): void
     {
         $this->assertIsBool($this->subject->getSecure());


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Had some issue as mention in #2586 in 3rd-party-code. Added getter to return sting value for `getType()`.

### Related Pull Requests
<!-- related pull request placeholder -->

1. See OpenMage/magento-lts#2586
2. See OpenMage/magento-lts#2907

