### PR TITLE
Fix placeholder image in WYSIWYG editor when using a different admin theme

### DIFF
--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Config.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Config.php
@@ -127,8 +127,7 @@ class Mage_Cms_Model_Wysiwyg_Config extends Varien_Object
      */
     public function getSkinImagePlaceholderPath()
     {
-        return Mage::getModel('core/design_package')->getSkinBaseDir(['_area' => 'adminhtml']) . DS .
-            self::WYSIWYG_SKIN_IMAGE_PLACEHOLDER_FILE;
+        return Mage::getDesign()->getFilename(self::WYSIWYG_SKIN_IMAGE_PLACEHOLDER_FILE, ['_type' => 'skin']);
     }
 
     /**


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

A very long description for a very specific use case 😄.

If you insert an image into your content, but later you delete the image from the disk, the WYSIWYG editor shows a placeholder image:

![image](https://github.com/user-attachments/assets/13278563-c67e-46aa-95f6-73476ece4e9b)

If you have set a different admin theme, a broken image will be shown instead:

![image](https://github.com/user-attachments/assets/bed877c2-2910-441c-93de-0dd9537fddb4)

Or worse, if no width and height is set in the generated <img ...> tag, nothing will be shown at all:

![image](https://github.com/user-attachments/assets/a3385a90-4813-4020-868e-b6a9e0c0838f)

I would expect the placeholder image to always be shown, no matter which admin theme is used

---

This is caused as follows:

The WYSIWYG editor generates the HTML code like this:

```html
<p><img src="{{media url="wysiwyg/test.jpg"}}" alt=""></p>
```

To resolve the {{media}} tag, the editor sends a request to the server:

![image](https://github.com/user-attachments/assets/27fe7c54-4039-4002-8935-7c96bbdaff5c)

The request will be handled in Mage_Adminhtml_Cms_WysiwygController::directiveAction(). There, the placeholder image will be used if the original image cannot be found. The path to the placeholder image is generated like this:

```php
public function getSkinImagePlaceholderPath()
{
    return Mage::getModel('core/design_package')->getSkinBaseDir(['_area' => 'adminhtml']) . DS .
        self::WYSIWYG_SKIN_IMAGE_PLACEHOLDER_FILE;
}
```

This is the problem. It takes the skin directory **of the current theme** (`skin/adminhtml/default/mytheme/`) and concatenates the path to the placeholder image. This works fine for the `default` admin theme. But to correctly support other admin themes, is has to take fallbacks to the default theme into account. Using `getFilename()`, as in this PR, fixes that.


### Manual testing scenarios (*)

1. On a CMS page, product or anywhere else where you can use the WYSIWYG editor, add an image to the content and save.

![image](https://github.com/user-attachments/assets/055fa99c-ff1d-4f55-a6e5-77fc712bc7dd)

2. Delete the newly uploaded image from the folder media/wysiwyg/.

3. Refresh the admin page. You will see the placeholder image as expected (as we have not yet set an admin theme)

![image](https://github.com/user-attachments/assets/5ba4cd98-b6ed-4954-9e2b-0e3d35e4d6e6)

4. Set a different admin theme by setting this in your app/etc/local.xml:

```xml
<config>
    <stores>
        <admin>
            <design>
                <theme>
                    <default>mytheme</default>
                </theme>
            </design>
        </admin>
    </stores>
</config>
```

You don't need to create any directories. All file requests will transparently fall back to the default theme (well, almost all).

5. Clear the config cache.

6. Reload the admin page where you added the image. You will see a broken image.

![image](https://github.com/user-attachments/assets/e9d61e1f-cf8b-4b95-a50a-fc91f895f771)

7. Apply my PR. The placeholder image is back.
 
(for extra fun, subscribe to exception mails in errors/local.xml and get email bombed whenever somebody edits a page with broken images)


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
