### PR TITLE
Replaced `=== null` with `is_null()`

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -673,7 +673,7 @@ final class Mage
      */
     public static function app($code = '', $type = 'store', $options = [])
     {
-        if (self::$_app === null) {
+        if (is_null(self::$_app)) {
             self::$_app = new Mage_Core_Model_App();
             self::setRoot();
             self::$_events = new Varien_Event_Collection();
@@ -818,7 +818,7 @@ final class Mage
      */
     public static function isInstalled($options = [])
     {
-        if (self::$_isInstalled === null) {
+        if (is_null(self::$_isInstalled)) {
             self::setRoot();
 
             if (is_string($options)) {

--- a/app/code/core/Mage/Admin/Model/Acl.php
+++ b/app/code/core/Mage/Admin/Model/Acl.php
@@ -63,7 +63,7 @@ class Mage_Admin_Model_Acl extends Zend_Acl
      */
     protected function _getRoleRegistry()
     {
-        if ($this->_roleRegistry === null) {
+        if (is_null($this->_roleRegistry)) {
             $this->_roleRegistry = Mage::getModel('admin/acl_role_registry');
         }
         return $this->_roleRegistry;

--- a/app/code/core/Mage/Admin/Model/User.php
+++ b/app/code/core/Mage/Admin/Model/User.php
@@ -232,7 +232,7 @@ class Mage_Admin_Model_User extends Mage_Core_Model_Abstract
      */
     public function getRole()
     {
-        if ($this->_role === null) {
+        if (is_null($this->_role)) {
             $this->_role = Mage::getModel('admin/roles');
             $roles = $this->getRoles();
             if ($roles && isset($roles[0]) && $roles[0]) {

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Abstract.php
@@ -119,7 +119,7 @@ class Mage_Adminhtml_Block_Catalog_Category_Abstract extends Mage_Adminhtml_Bloc
     public function getRootByIds($ids)
     {
         $root = Mage::registry('root');
-        if ($root === null) {
+        if (is_null($root)) {
             $categoryTreeResource = Mage::getResourceSingleton('catalog/category_tree');
             $ids    = $categoryTreeResource->getExistingCategoryIdsBySpecifiedIds($ids);
             $tree   = $categoryTreeResource->loadByIds($ids);

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Categories.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Categories.php
@@ -190,7 +190,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Categories extends Mage_Admi
      */
     protected function _getSelectedNodes()
     {
-        if ($this->_selectedNodes === null) {
+        if (is_null($this->_selectedNodes)) {
             $this->_selectedNodes = [];
             $root = $this->getRoot();
             foreach ($this->getCategoryIds() as $categoryId) {

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group/Abstract.php
@@ -139,7 +139,7 @@ abstract class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Price_Group_Abstrac
             }
         }
 
-        if ($groupId !== null) {
+        if (!is_null($groupId)) {
             return $this->_customerGroups[$groupId] ?? [];
         }
 

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group/Abstract.php
@@ -126,7 +126,7 @@ abstract class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Price_Group_Abstrac
      */
     public function getCustomerGroups($groupId = null)
     {
-        if ($this->_customerGroups === null) {
+        if (is_null($this->_customerGroups)) {
             if (!Mage::helper('catalog')->isModuleEnabled('Mage_Customer')) {
                 return [];
             }

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist/Grid/Renderer/Description.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist/Grid/Renderer/Description.php
@@ -24,6 +24,6 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_Wishlist_Grid_Renderer_Description 
     public function render(Varien_Object $row)
     {
         $value = $row->getData($this->getColumn()->getIndex());
-        return $value !== null ? nl2br(htmlspecialchars($value)) : '';
+        return !is_null($value) ? nl2br(htmlspecialchars($value)) : '';
     }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit.php
@@ -266,7 +266,7 @@ class Mage_Adminhtml_Block_Newsletter_Template_Edit extends Mage_Adminhtml_Block
     public function getJsTemplateName()
     {
         $templateCode = $this->getModel()->getTemplateCode();
-        if ($templateCode === null) {
+        if (is_null($templateCode)) {
             return '';
         }
         return addcslashes($this->escapeHtml($templateCode), "\"\r\n\\");

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit/Form.php
@@ -82,7 +82,7 @@ class Mage_Adminhtml_Block_Newsletter_Template_Edit_Form extends Mage_Adminhtml_
             'label'     => Mage::helper('newsletter')->__('Sender Name'),
             'title'     => Mage::helper('newsletter')->__('Sender Name'),
             'required'  => true,
-            'value'     => $model->getId() !== null
+            'value'     => !is_null($model->getId())
                 ? $model->getTemplateSenderName()
                 : $identityName,
         ]);
@@ -93,7 +93,7 @@ class Mage_Adminhtml_Block_Newsletter_Template_Edit_Form extends Mage_Adminhtml_
             'title'     => Mage::helper('newsletter')->__('Sender Email'),
             'class'     => 'validate-email',
             'required'  => true,
-            'value'     => $model->getId() !== null
+            'value'     => !is_null($model->getId())
                 ? $model->getTemplateSenderEmail()
                 : $identityEmail
         ]);

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid.php
@@ -187,7 +187,7 @@ class Mage_Adminhtml_Block_Report_Grid extends Mage_Adminhtml_Block_Widget_Grid
 
         $collection->setStoreIds($storeIds);
 
-        if ($this->getSubReportSize() !== null) {
+        if (!is_null($this->getSubReportSize())) {
             $collection->setPageSize($this->getSubReportSize());
         }
 

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Totals.php
@@ -25,7 +25,7 @@ class Mage_Adminhtml_Block_Sales_Order_Creditmemo_Totals extends Mage_Adminhtml_
 
     public function getCreditmemo()
     {
-        if ($this->_creditmemo === null) {
+        if (is_null($this->_creditmemo)) {
             if ($this->hasData('creditmemo')) {
                 $this->_creditmemo = $this->_getData('creditmemo');
             } elseif (Mage::registry('current_creditmemo')) {

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Totals.php
@@ -25,7 +25,7 @@ class Mage_Adminhtml_Block_Sales_Order_Invoice_Totals extends Mage_Adminhtml_Blo
 
     public function getInvoice()
     {
-        if ($this->_invoice === null) {
+        if (is_null($this->_invoice)) {
             if ($this->hasData('invoice')) {
                 $this->_invoice = $this->_getData('invoice');
             } elseif (Mage::registry('current_invoice')) {

--- a/app/code/core/Mage/Adminhtml/Block/Store/Switcher.php
+++ b/app/code/core/Mage/Adminhtml/Block/Store/Switcher.php
@@ -224,7 +224,7 @@ class Mage_Adminhtml_Block_Store_Switcher extends Mage_Adminhtml_Block_Template
      */
     public function hasDefaultOption($hasDefaultOption = null)
     {
-        if ($hasDefaultOption !== null) {
+        if (!is_null($hasDefaultOption)) {
             $this->_hasDefaultOption = $hasDefaultOption;
         }
         return $this->_hasDefaultOption;

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Array/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Array/Abstract.php
@@ -121,7 +121,7 @@ abstract class Mage_Adminhtml_Block_System_Config_Form_Field_Array_Abstract exte
      */
     public function getArrayRows()
     {
-        if ($this->_arrayRowsCache !== null) {
+        if (!is_null($this->_arrayRowsCache)) {
             return $this->_arrayRowsCache;
         }
         $result = [];

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset.php
@@ -186,7 +186,7 @@ class Mage_Adminhtml_Block_System_Config_Form_Fieldset extends Mage_Adminhtml_Bl
      */
     protected function _getCollapseState($element)
     {
-        if ($element->getExpanded() !== null) {
+        if (!is_null($element->getExpanded())) {
             return 1;
         }
         $extra = Mage::getSingleton('admin/session')->getUser()->getExtra();

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Wizard.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Wizard.php
@@ -85,14 +85,14 @@ class Mage_Adminhtml_Block_System_Convert_Gui_Edit_Tab_Wizard extends Mage_Admin
      */
     public function getValue($key, $default = '', $defaultNew = null)
     {
-        if ($defaultNew !== null) {
+        if (!is_null($defaultNew)) {
             if ($this->getProfileId() == 0) {
                 $default = $defaultNew;
             }
         }
 
         $value = $this->getData($key);
-        return $this->escapeHtml($value !== null && strlen($value) > 0 ? $value : $default);
+        return $this->escapeHtml(!is_null($value) && strlen($value) > 0 ? $value : $default);
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Template.php
+++ b/app/code/core/Mage/Adminhtml/Block/Template.php
@@ -50,7 +50,7 @@ class Mage_Adminhtml_Block_Template extends Mage_Core_Block_Template
      */
     public function isOutputEnabled($moduleName = null)
     {
-        if ($moduleName === null) {
+        if (is_null($moduleName)) {
             $moduleName = $this->getModuleName();
         }
         return !Mage::getStoreConfigFlag('advanced/modules_disable_output/' . $moduleName);

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit.php
@@ -192,7 +192,7 @@ class Mage_Adminhtml_Block_Urlrewrite_Edit extends Mage_Adminhtml_Block_Widget_C
      */
     public function getButtonsHtml($area = null)
     {
-        if ($this->_buttonsHtml === null) {
+        if (is_null($this->_buttonsHtml)) {
             $this->_buttonsHtml = parent::getButtonsHtml();
             foreach (array_keys($this->_children) as $alias) {
                 if (str_contains($alias, '_button')) {

--- a/app/code/core/Mage/Adminhtml/Block/Widget.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget.php
@@ -26,7 +26,7 @@ class Mage_Adminhtml_Block_Widget extends Mage_Adminhtml_Block_Template
 {
     public function getId()
     {
-        if ($this->getData('id') === null) {
+        if (is_null($this->getData('id'))) {
             $this->setData('id', Mage::helper('core')->uniqHash('id_'));
         }
         return $this->getData('id');

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -509,7 +509,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
                 call_user_func($column->getFilterConditionCallback(), $this->getCollection(), $column);
             } else {
                 $cond = $column->getFilter()->getCondition();
-                if ($field && $cond !== null) {
+                if ($field && !is_null($cond)) {
                     $filtered = array_map(static function ($value) {
                         return is_object($value) ? $value->__toString() : $value;
                     }, is_array($cond) ? array_values($cond) : [$cond]);

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -1761,7 +1761,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
      */
     public function isColumnGrouped($column, $value = null)
     {
-        if ($value === null) {
+        if (is_null($value)) {
             if (is_object($column)) {
                 return in_array($column->getIndex(), $this->_groupedColumn);
             }

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
@@ -144,7 +144,7 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract extends
             }
         }
 
-        if ($width !== null) {
+        if (!is_null($width)) {
             $out .= ' width="' . $width . '"';
         }
 

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
@@ -137,7 +137,7 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract extends
 
         if ($this->getColumn()->hasData('width')) {
             $customWidth = $this->getColumn()->getData('width');
-            if (($customWidth === null) || (preg_match('/^[0-9]+%?$/', (string)$customWidth))) {
+            if ((is_null($customWidth)) || (preg_match('/^[0-9]+%?$/', (string)$customWidth))) {
                 $width = $customWidth;
             } elseif (preg_match('/^([0-9]+)px$/', $customWidth, $matches)) {
                 $width = (int)$matches[1];

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
@@ -316,7 +316,7 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract extends Mage
      */
     public function getUseSelectAll()
     {
-        return $this->_getData('use_select_all') === null || $this->_getData('use_select_all');
+        return is_null($this->_getData('use_select_all')) || $this->_getData('use_select_all');
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
@@ -209,7 +209,7 @@ class Mage_Adminhtml_Block_Widget_Tabs extends Mage_Adminhtml_Block_Widget
             $this->_setActiveTab($activeTabId);
         }
 
-        if ($this->_activeTab === null && !empty($this->_tabs)) {
+        if (is_null($this->_activeTab) && !empty($this->_tabs)) {
             $this->_activeTab = (reset($this->_tabs))->getId();
         }
 

--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
@@ -925,7 +925,7 @@ class Mage_Adminhtml_Model_Sales_Order_Create extends Varien_Object implements M
 
                     $parsedValue = $group->parseOptionValue($value, $productOptions[$label]['values']);
 
-                    if ($parsedValue !== null) {
+                    if (!is_null($parsedValue)) {
                         $newOptions[$optionId] = $parsedValue;
                     } else {
                         $newAdditionalOptions[] = [
@@ -1408,7 +1408,7 @@ class Mage_Adminhtml_Model_Sales_Order_Create extends Varien_Object implements M
                 if ($customerAddressId && $customer->getId()) {
                     $customer->getAddressItemById($customerAddressId)->addData($customerShippingAddress->getData());
                 } elseif (!empty($customerAddressId)
-                    && $customerBillingAddress !== null
+                    && !is_null($customerBillingAddress)
                     && $this->getBillingAddress()->getCustomerAddressId() == $customerAddressId
                 ) {
                     $customerBillingAddress->setIsDefaultShipping(true);

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
@@ -636,7 +636,7 @@ class Mage_Adminhtml_Catalog_ProductController extends Mage_Adminhtml_Controller
          * Initialize product categories
          */
         $categoryIds = $this->getRequest()->getPost('category_ids');
-        if ($categoryIds !== null) {
+        if (!is_null($categoryIds)) {
             if (empty($categoryIds)) {
                 $categoryIds = [];
             }

--- a/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
@@ -136,7 +136,7 @@ class Mage_Adminhtml_System_StoreController extends Mage_Adminhtml_Controller_Ac
                 $codeBase   = Mage::helper('core')->__('Before modifying the store view code please make sure that it is not used in index.php.');
                 break;
         }
-        if ($itemId !== null) {
+        if (!is_null($itemId)) {
             $model->load($itemId);
         }
 

--- a/app/code/core/Mage/Api/Model/Acl.php
+++ b/app/code/core/Mage/Api/Model/Acl.php
@@ -69,7 +69,7 @@ class Mage_Api_Model_Acl extends Zend_Acl
      */
     protected function _getRoleRegistry()
     {
-        if ($this->_roleRegistry === null) {
+        if (is_null($this->_roleRegistry)) {
             $this->_roleRegistry = Mage::getModel('api/acl_role_registry');
         }
         return $this->_roleRegistry;

--- a/app/code/core/Mage/Api/Model/Server.php
+++ b/app/code/core/Mage/Api/Model/Server.php
@@ -98,7 +98,7 @@ class Mage_Api_Model_Server
             $this->_api     = $adapterCode;
 
             // get handler code from config if no handler passed as argument
-            if ($handler === null && !empty($adapters[$adapterCode]->handler)) {
+            if (is_null($handler) && !empty($adapters[$adapterCode]->handler)) {
                 $handler = (string) $adapters[$adapterCode]->handler;
             }
             $handlers = $helper->getHandlers();

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
@@ -104,7 +104,7 @@ class Mage_Api_Model_Server_Adapter_Soap extends Varien_Object implements Mage_A
     {
         $controller = $this->getData('controller');
 
-        if ($controller === null) {
+        if (is_null($controller)) {
             $controller = new Varien_Object(
                 ['request' => Mage::app()->getRequest(), 'response' => Mage::app()->getResponse()]
             );

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
@@ -124,7 +124,7 @@ class Mage_Api_Model_Server_Adapter_Soap extends Varien_Object implements Mage_A
     {
         $apiConfigCharset = Mage::getStoreConfig('api/config/charset');
 
-        if ($this->getController()->getRequest()->getParam('wsdl') !== null) {
+        if (!is_null($this->getController()->getRequest()->getParam('wsdl'))) {
             // Generating wsdl content from template
             $io = new Varien_Io_File();
             $io->open(['path' => Mage::getModuleDir('etc', 'Mage_Api')]);
@@ -214,7 +214,7 @@ class Mage_Api_Model_Server_Adapter_Soap extends Varien_Object implements Mage_A
         $urlModel = Mage::getModel('core/url')
             ->setUseSession(false);
 
-        $wsdlUrl = $params !== null
+        $wsdlUrl = !is_null($params)
             ? Mage::helper('api')->getServiceUrl('*/*/*', ['_current' => true, '_query' => $params])
             : Mage::helper('api')->getServiceUrl('*/*/*');
 

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Xmlrpc.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Xmlrpc.php
@@ -70,7 +70,7 @@ class Mage_Api_Model_Server_Adapter_Xmlrpc extends Varien_Object implements Mage
     {
         $controller = $this->getData('controller');
 
-        if ($controller === null) {
+        if (is_null($controller)) {
             $controller = new Varien_Object(
                 ['request' => Mage::app()->getRequest(), 'response' => Mage::app()->getResponse()]
             );

--- a/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
@@ -192,7 +192,7 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
      */
     protected function _prepareResourceModelName($resource)
     {
-        if ($this->_resourceSuffix !== null) {
+        if (!is_null($this->_resourceSuffix)) {
             return $resource . $this->_resourceSuffix;
         }
         return $resource;

--- a/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
@@ -95,7 +95,7 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
      */
     protected function _instaLogin(&$sessionId)
     {
-        if ($sessionId === null && !empty($_SERVER['PHP_AUTH_USER']) && !empty($_SERVER['PHP_AUTH_PW'])) {
+        if (is_null($sessionId) && !empty($_SERVER['PHP_AUTH_USER']) && !empty($_SERVER['PHP_AUTH_PW'])) {
             $this->_getSession()->setIsInstaLogin();
             $sessionId = $this->login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
         }

--- a/app/code/core/Mage/Api/Model/Server/V2/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/V2/Adapter/Soap.php
@@ -41,7 +41,7 @@ class Mage_Api_Model_Server_V2_Adapter_Soap extends Mage_Api_Model_Server_Adapte
     {
         $apiConfigCharset = Mage::getStoreConfig('api/config/charset');
 
-        if ($this->getController()->getRequest()->getParam('wsdl') !== null) {
+        if (!is_null($this->getController()->getRequest()->getParam('wsdl'))) {
             $this->wsdlConfig->setHandler($this->getHandler())
                 ->init();
 

--- a/app/code/core/Mage/Api/Model/Server/Wsi/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/Wsi/Adapter/Soap.php
@@ -44,7 +44,7 @@ class Mage_Api_Model_Server_Wsi_Adapter_Soap extends Mage_Api_Model_Server_Adapt
     {
         $apiConfigCharset = Mage::getStoreConfig('api/config/charset');
 
-        if ($this->getController()->getRequest()->getParam('wsdl') !== null) {
+        if (!is_null($this->getController()->getRequest()->getParam('wsdl'))) {
             $this->getController()->getResponse()
                 ->clearHeaders()
                 ->setHeader('Content-Type', 'text/xml; charset=' . $apiConfigCharset)

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Permissions/User/Edit/Tab/Roles.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Permissions/User/Edit/Tab/Roles.php
@@ -111,7 +111,7 @@ class Mage_Api2_Block_Adminhtml_Permissions_User_Edit_Tab_Roles extends Mage_Adm
      */
     protected function _getSelectedRoles()
     {
-        if ($this->_selectedRoles === null) {
+        if (is_null($this->_selectedRoles)) {
             $userRoles = [];
 
             /** @var Mage_Admin_Model_User $user */

--- a/app/code/core/Mage/Api2/Helper/Data.php
+++ b/app/code/core/Mage/Api2/Helper/Data.php
@@ -148,7 +148,7 @@ class Mage_Api2_Helper_Data extends Mage_Core_Helper_Abstract
 
         $attributes = $resource->getAllowedAttributes($userType, $resourceId, $operation);
 
-        return ($attributes === false || $attributes === null ? [] : explode(',', $attributes));
+        return ($attributes === false || is_null($attributes) ? [] : explode(',', $attributes));
     }
 
     /**

--- a/app/code/core/Mage/Api2/Model/Acl.php
+++ b/app/code/core/Mage/Api2/Model/Acl.php
@@ -75,7 +75,7 @@ class Mage_Api2_Model_Acl extends Zend_Acl
      */
     protected function _getRolesCollection()
     {
-        if ($this->_rolesCollection === null) {
+        if (is_null($this->_rolesCollection)) {
             $this->_rolesCollection = Mage::getResourceModel('api2/acl_global_role_collection');
         }
         return $this->_rolesCollection;
@@ -88,7 +88,7 @@ class Mage_Api2_Model_Acl extends Zend_Acl
      */
     protected function _getConfig()
     {
-        if ($this->_config === null) {
+        if (is_null($this->_config)) {
             $this->_config = Mage::getModel('api2/config');
         }
         return $this->_config;

--- a/app/code/core/Mage/Api2/Model/Acl/Filter.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter.php
@@ -103,11 +103,11 @@ class Mage_Api2_Model_Acl_Filter
      */
     public function getAllowedAttributes($operationType = null)
     {
-        if ($this->_allowedAttributes === null) {
+        if (is_null($this->_allowedAttributes)) {
             /** @var Mage_Api2_Helper_Data $helper */
             $helper = Mage::helper('api2/data');
 
-            if ($operationType === null) {
+            if (is_null($operationType)) {
                 $operationType = $helper->getTypeOfOperation($this->_resource->getOperation());
             }
             if ($helper->isAllAttributesAllowed($this->_resource->getUserType())) {
@@ -139,7 +139,7 @@ class Mage_Api2_Model_Acl_Filter
      */
     public function getAttributesToInclude()
     {
-        if ($this->_attributesToInclude === null) {
+        if (is_null($this->_attributesToInclude)) {
             $allowedAttrs   = $this->getAllowedAttributes(Mage_Api2_Model_Resource::OPERATION_ATTRIBUTE_READ);
             $requestedAttrs = $this->_resource->getRequest()->getRequestedAttributes();
 

--- a/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/ResourcePermission.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/ResourcePermission.php
@@ -63,7 +63,7 @@ class Mage_Api2_Model_Acl_Filter_Attribute_ResourcePermission implements Mage_Ap
                     }
 
                     /** @var Mage_Api2_Model_Acl_Filter_Attribute $rule */
-                    if ($rule->getAllowedAttributes() !== null) {
+                    if (!is_null($rule->getAllowedAttributes())) {
                         $allowedAttributes[$rule->getResourceId()][$rule->getOperation()] = explode(
                             ',',
                             $rule->getAllowedAttributes()

--- a/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/ResourcePermission.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/ResourcePermission.php
@@ -47,7 +47,7 @@ class Mage_Api2_Model_Acl_Filter_Attribute_ResourcePermission implements Mage_Ap
      */
     public function getResourcesPermissions()
     {
-        if ($this->_resourcesPermissions === null) {
+        if (is_null($this->_resourcesPermissions)) {
             $rulesPairs = [];
 
             if ($this->_userType) {

--- a/app/code/core/Mage/Api2/Model/Acl/Global.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global.php
@@ -32,7 +32,7 @@ class Mage_Api2_Model_Acl_Global
     public function isAllowed(Mage_Api2_Model_Auth_User_Abstract $apiUser, $resourceType, $operation)
     {
         // skip user without role, e.g. Customer
-        if ($apiUser->getRole() === null) {
+        if (is_null($apiUser->getRole())) {
             return true;
         }
         /** @var Mage_Api2_Model_Acl $aclInstance */

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Role.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Role.php
@@ -64,7 +64,7 @@ class Mage_Api2_Model_Acl_Global_Role extends Mage_Core_Model_Abstract
      */
     protected function _beforeSave()
     {
-        if ($this->isObjectNew() && $this->getCreatedAt() === null) {
+        if ($this->isObjectNew() && is_null($this->getCreatedAt())) {
             $this->setCreatedAt(Varien_Date::now());
         } else {
             $this->setUpdatedAt(Varien_Date::now());

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/ResourcePermission.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/ResourcePermission.php
@@ -40,7 +40,7 @@ class Mage_Api2_Model_Acl_Global_Rule_ResourcePermission implements Mage_Api2_Mo
      */
     public function getResourcesPermissions()
     {
-        if ($this->_resourcesPermissions === null) {
+        if (is_null($this->_resourcesPermissions)) {
             $roleConfigNodeName = $this->_role->getConfigNodeName();
             $rulesPairs = [];
             $allowedType = Mage_Api2_Model_Acl_Global_Rule_Permission::TYPE_ALLOW;

--- a/app/code/core/Mage/Api2/Model/Auth/Adapter.php
+++ b/app/code/core/Mage/Api2/Model/Auth/Adapter.php
@@ -69,7 +69,7 @@ class Mage_Api2_Model_Auth_Adapter
             if ($adapterModel->isApplicableToRequest($request)) {
                 $userParams = $adapterModel->getUserParams($request);
 
-                if ($userParams->type !== null) {
+                if (!is_null($userParams->type)) {
                     return $userParams;
                 }
                 throw new Mage_Api2_Exception('Can not determine user type', Mage_Api2_Model_Server::HTTP_UNAUTHORIZED);

--- a/app/code/core/Mage/Api2/Model/Config.php
+++ b/app/code/core/Mage/Api2/Model/Config.php
@@ -411,7 +411,7 @@ class Mage_Api2_Model_Config extends Varien_Simplexml_Config
         $availVersions = $this->getVersions($resourceType); // already ordered in reverse order
         $useVersion    = reset($availVersions);
 
-        if ($lowerOrEqualsTo !== null) {
+        if (!is_null($lowerOrEqualsTo)) {
             foreach ($availVersions as $availVersion) {
                 if ($availVersion <= $lowerOrEqualsTo) {
                     $useVersion = $availVersion;

--- a/app/code/core/Mage/Api2/Model/Multicall.php
+++ b/app/code/core/Mage/Api2/Model/Multicall.php
@@ -179,7 +179,7 @@ class Mage_Api2_Model_Multicall
         );
         $params = [];
         $params['api_type'] = 'rest';
-        if ($parentResourceIdFieldName !== null) {
+        if (!is_null($parentResourceIdFieldName)) {
             $params[$parentResourceIdFieldName] = $this->_parentResourceId;
         }
         $uri = $chain->assemble($params);

--- a/app/code/core/Mage/Api2/Model/Renderer.php
+++ b/app/code/core/Mage/Api2/Model/Renderer.php
@@ -53,7 +53,7 @@ abstract class Mage_Api2_Model_Renderer
         }
 
         //if server can't respond in any of accepted types it SHOULD send 406(not acceptable)
-        if ($adapterPath === null) {
+        if (is_null($adapterPath)) {
             throw new Mage_Api2_Exception(
                 'Server can not understand Accept HTTP header media type.',
                 Mage_Api2_Model_Server::HTTP_NOT_ACCEPTABLE

--- a/app/code/core/Mage/Api2/Model/Request.php
+++ b/app/code/core/Mage/Api2/Model/Request.php
@@ -71,7 +71,7 @@ class Mage_Api2_Model_Request extends Zend_Controller_Request_Http
      */
     protected function _getInterpreter()
     {
-        if ($this->_interpreter === null) {
+        if (is_null($this->_interpreter)) {
             $this->_interpreter = Mage_Api2_Model_Request_Interpreter::factory($this->getContentType());
         }
         return $this->_interpreter;

--- a/app/code/core/Mage/Api2/Model/Request/Internal.php
+++ b/app/code/core/Mage/Api2/Model/Request/Internal.php
@@ -42,7 +42,7 @@ class Mage_Api2_Model_Request_Internal extends Mage_Api2_Model_Request
      */
     public function getBodyParams()
     {
-        if ($this->_bodyParams === null) {
+        if (is_null($this->_bodyParams)) {
             $this->_bodyParams = $this->_getInterpreter()->interpret((string) $this->getRawBody());
         }
         return $this->_bodyParams;

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter.php
@@ -47,7 +47,7 @@ abstract class Mage_Api2_Model_Request_Interpreter
             }
         }
 
-        if ($adapterModel === null) {
+        if (is_null($adapterModel)) {
             throw new Mage_Api2_Exception(
                 sprintf('Server can not understand Content-Type HTTP header media type "%s"', $type),
                 Mage_Api2_Model_Server::HTTP_BAD_REQUEST

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Json.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Json.php
@@ -40,7 +40,7 @@ class Mage_Api2_Model_Request_Interpreter_Json implements Mage_Api2_Model_Reques
             throw new Mage_Api2_Exception('Decoding error.', Mage_Api2_Model_Server::HTTP_BAD_REQUEST);
         }
 
-        if ($body != 'null' && $decoded === null) {
+        if ($body != 'null' && is_null($decoded)) {
             throw new Mage_Api2_Exception('Decoding error.', Mage_Api2_Model_Server::HTTP_BAD_REQUEST);
         }
 

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Xml.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Xml.php
@@ -132,7 +132,7 @@ class Mage_Api2_Model_Request_Interpreter_Xml implements Mage_Api2_Model_Request
      */
     protected function _loadErrorHandler($errno, $errstr, $errfile, $errline)
     {
-        if ($this->_loadErrorStr === null) {
+        if (is_null($this->_loadErrorStr)) {
             $this->_loadErrorStr = $errstr;
         } else {
             $this->_loadErrorStr .= (PHP_EOL . $errstr);

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Xml.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Xml.php
@@ -58,7 +58,7 @@ class Mage_Api2_Model_Request_Interpreter_Xml implements Mage_Api2_Model_Request
         libxml_disable_entity_loader(false);
 
         // Check if there was a error while loading file
-        if ($this->_loadErrorStr !== null) {
+        if (!is_null($this->_loadErrorStr)) {
             throw new Mage_Api2_Exception('Decoding error.', Mage_Api2_Model_Server::HTTP_BAD_REQUEST);
         }
 

--- a/app/code/core/Mage/Api2/Model/Resource.php
+++ b/app/code/core/Mage/Api2/Model/Resource.php
@@ -712,7 +712,7 @@ abstract class Mage_Api2_Model_Resource
 
         $orderField = $this->getRequest()->getOrderField();
 
-        if ($orderField !== null) {
+        if (!is_null($orderField)) {
             $operation = self::OPERATION_ATTRIBUTE_READ;
             if (!is_string($orderField)
                 || !array_key_exists($orderField, $this->getAvailableAttributes($this->getUserType(), $operation))

--- a/app/code/core/Mage/Api2/Model/Resource.php
+++ b/app/code/core/Mage/Api2/Model/Resource.php
@@ -381,7 +381,7 @@ abstract class Mage_Api2_Model_Resource
      */
     public function getVersion()
     {
-        if ($this->_version === null) {
+        if (is_null($this->_version)) {
             if (preg_match('/^.+([1-9]\d*)$/', get_class($this), $matches)) {
                 $this->setVersion($matches[1]);
             } else {
@@ -611,7 +611,7 @@ abstract class Mage_Api2_Model_Resource
      */
     protected function _critical($message, $code = null)
     {
-        if ($code === null) {
+        if (is_null($code)) {
             $errors = $this->_getCriticalErrors();
             if (!isset($errors[$message])) {
                 throw new Exception(

--- a/app/code/core/Mage/Api2/Model/Resource/Validator/Eav.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Validator/Eav.php
@@ -119,7 +119,7 @@ class Mage_Api2_Model_Resource_Validator_Eav extends Mage_Api2_Model_Resource_Va
         $errors = [];
 
         // validate attributes with source models
-        if ($attrValue !== null && $attribute->getSourceModel()) {
+        if (!is_null($attrValue) && $attribute->getSourceModel()) {
             if ($attribute->getFrontendInput() !== 'multiselect' && is_array($attrValue)) {
                 return ['Invalid value type for ' . $attribute->getAttributeCode()];
             }

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View.php
@@ -30,7 +30,7 @@ class Mage_Bundle_Block_Catalog_Product_View extends Mage_Catalog_Block_Product_
      */
     public function getTierPrices($product = null)
     {
-        if ($product === null) {
+        if (is_null($product)) {
             $product = $this->getProduct();
         }
 

--- a/app/code/core/Mage/Bundle/Model/Product/Price.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Price.php
@@ -934,7 +934,7 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
                 ->getRulePrice(Mage::app()->getLocale()->storeTimeStamp($store), $wId, $gId, $productId);
         }
 
-        if ($rulePrice !== null && $rulePrice !== false) {
+        if (!is_null($rulePrice) && $rulePrice !== false) {
             $finalPrice = min($finalPrice, $rulePrice);
         }
 

--- a/app/code/core/Mage/Bundle/Model/Product/Type.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Type.php
@@ -1041,14 +1041,14 @@ class Mage_Bundle_Model_Product_Type extends Mage_Catalog_Model_Product_Type_Abs
 
         $result = null;
         $parentVisibility = $product->getMsrpDisplayActualPriceType();
-        if ($parentVisibility === null) {
+        if (is_null($parentVisibility)) {
             $parentVisibility = $helper->getMsrpDisplayActualPriceType();
         }
         $visibilities = array($parentVisibility);
         foreach ($collection as $item) {
             if ($helper->canApplyMsrp($item)) {
                 $productVisibility = $item->getMsrpDisplayActualPriceType();
-                if ($productVisibility === null) {
+                if (is_null($productVisibility)) {
                     $productVisibility = $helper->getMsrpDisplayActualPriceType();
                 }
                 $visibilities[] = $productVisibility;

--- a/app/code/core/Mage/Bundle/Model/Product/Type.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Type.php
@@ -1056,7 +1056,7 @@ class Mage_Bundle_Model_Product_Type extends Mage_Catalog_Model_Product_Type_Abs
             }
         }
 
-        if ($result && $visibility !== null) {
+        if ($result && !is_null($visibility)) {
             if ($visibilities) {
                 $maxVisibility = max($visibilities);
                 $result = $result && $maxVisibility == $visibility;

--- a/app/code/core/Mage/Bundle/Model/Resource/Option/Collection.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Option/Collection.php
@@ -68,7 +68,7 @@ class Mage_Bundle_Model_Resource_Option_Collection extends Mage_Core_Model_Resou
             'option_value.title',
             'option_value_default.title'
         );
-        if ($storeId !== null) {
+        if (!is_null($storeId)) {
             $this->getSelect()
                 ->columns(['title' => $title])
                 ->joinLeft(

--- a/app/code/core/Mage/Bundle/Model/Resource/Price/Index.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Price/Index.php
@@ -517,7 +517,7 @@ class Mage_Bundle_Model_Resource_Price_Index extends Mage_Core_Model_Resource_Db
         $rulePrice = Mage::getResourceModel('catalogrule/rule')
             ->getRulePrice($storeTimeStamp, $website->getId(), $customerGroup->getId(), $productId);
 
-        if ($rulePrice !== null && $rulePrice !== false) {
+        if (!is_null($rulePrice) && $rulePrice !== false) {
             $finalPrice = min($finalPrice, $rulePrice);
         }
 

--- a/app/code/core/Mage/Captcha/Model/Observer.php
+++ b/app/code/core/Mage/Captcha/Model/Observer.php
@@ -320,7 +320,7 @@ class Mage_Captcha_Model_Observer
                 Mage::getSingleton('catalog/session')->setFormData($request->getPost());
                 $id = (int)$request->getParam('id');
                 $catId = $request->getParam('cat_id');
-                if ($catId !== null) {
+                if (!is_null($catId)) {
                     $id .= '/cat_id/' . (int)$catId;
                 }
                 $controller->getResponse()->setRedirect(Mage::getUrl('*/*/send/id/' . $id));

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Abstract.php
@@ -128,7 +128,7 @@ abstract class Mage_Catalog_Block_Layer_Filter_Abstract extends Mage_Core_Block_
      */
     public function shouldDisplayProductCount()
     {
-        if ($this->_displayProductCount === null) {
+        if (is_null($this->_displayProductCount)) {
             $this->_displayProductCount = Mage::helper('catalog')->shouldDisplayProductCountOnLayer();
         }
         return $this->_displayProductCount;

--- a/app/code/core/Mage/Catalog/Block/Navigation.php
+++ b/app/code/core/Mage/Catalog/Block/Navigation.php
@@ -127,7 +127,7 @@ class Mage_Catalog_Block_Navigation extends Mage_Core_Block_Template
      */
     public function getCurrentChildCategories()
     {
-        if ($this->_currentChildCategories === null) {
+        if (is_null($this->_currentChildCategories)) {
             $layer = Mage::getSingleton('catalog/layer');
             $category = $layer->getCurrentCategory();
             $this->_currentChildCategories = $category->getChildrenCategories();

--- a/app/code/core/Mage/Catalog/Block/Product/New.php
+++ b/app/code/core/Mage/Catalog/Block/Product/New.php
@@ -141,7 +141,7 @@ class Mage_Catalog_Block_Product_New extends Mage_Catalog_Block_Product_Abstract
      */
     public function getProductsCount()
     {
-        if ($this->_productsCount === null) {
+        if (is_null($this->_productsCount)) {
             $this->_productsCount = self::DEFAULT_PRODUCTS_COUNT;
         }
         return $this->_productsCount;

--- a/app/code/core/Mage/Catalog/Block/Product/Widget/Html/Pager.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Widget/Html/Pager.php
@@ -55,7 +55,7 @@ class Mage_Catalog_Block_Product_Widget_Html_Pager extends Mage_Page_Block_Html_
      */
     public function getCollectionSize()
     {
-        if ($this->_collectionSize === null) {
+        if (is_null($this->_collectionSize)) {
             $this->_collectionSize = $this->getCollection()->getSize();
             if ($this->getTotalLimit() && $this->_collectionSize > $this->getTotalLimit()) {
                 $this->_collectionSize = $this->getTotalLimit();
@@ -73,7 +73,7 @@ class Mage_Catalog_Block_Product_Widget_Html_Pager extends Mage_Page_Block_Html_
      */
     public function getCurrentPage()
     {
-        if ($this->_currentPage === null) {
+        if (is_null($this->_currentPage)) {
             $page = abs((int)$this->getRequest()->getParam($this->getPageVarName()));
             if ($page > $this->getLastPageNum()) {
                 $this->_currentPage = $this->getLastPageNum();
@@ -166,7 +166,7 @@ class Mage_Catalog_Block_Product_Widget_Html_Pager extends Mage_Page_Block_Html_
      */
     public function getLastPageNum()
     {
-        if ($this->_lastPage === null) {
+        if (is_null($this->_lastPage)) {
             $this->_lastPage = ceil($this->getCollectionSize() / $this->getLimit());
             if ($this->_lastPage <= 0) {
                 $this->_lastPage = 1;

--- a/app/code/core/Mage/Catalog/Helper/Data.php
+++ b/app/code/core/Mage/Catalog/Helper/Data.php
@@ -378,7 +378,7 @@ class Mage_Catalog_Helper_Data extends Mage_Core_Helper_Abstract
             $result = true;
         }
 
-        if ($result && $visibility !== null) {
+        if ($result && !is_null($visibility)) {
             $productVisibility = $product->getMsrpDisplayActualPriceType();
             if ($productVisibility == Mage_Catalog_Model_Product_Attribute_Source_Msrp_Type_Price::TYPE_USE_CONFIG) {
                 $productVisibility = $this->getMsrpDisplayActualPriceType();
@@ -388,10 +388,10 @@ class Mage_Catalog_Helper_Data extends Mage_Core_Helper_Abstract
 
         if ($product->getTypeInstance(true)->isComposite($product)
             && $checkAssociatedItems
-            && (!$result || $visibility !== null)
+            && (!$result || !is_null($visibility))
         ) {
             $resultInOptions = $product->getTypeInstance(true)->isMapEnabledInOptions($product, $visibility);
-            if ($resultInOptions !== null) {
+            if (!is_null($resultInOptions)) {
                 $result = $resultInOptions;
             }
         }

--- a/app/code/core/Mage/Catalog/Helper/Data.php
+++ b/app/code/core/Mage/Catalog/Helper/Data.php
@@ -407,7 +407,7 @@ class Mage_Catalog_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function canApplyMsrpToProductType($product)
     {
-        if ($this->_mapApplyToProductType === null) {
+        if (is_null($this->_mapApplyToProductType)) {
             /** @var Mage_Catalog_Model_Resource_Eav_Attribute $attribute */
             $attribute = Mage::getSingleton('eav/config')
                 ->getAttribute(Mage_Catalog_Model_Product::ENTITY, 'msrp_enabled');

--- a/app/code/core/Mage/Catalog/Helper/Image.php
+++ b/app/code/core/Mage/Catalog/Helper/Image.php
@@ -564,7 +564,7 @@ class Mage_Catalog_Helper_Image extends Mage_Core_Helper_Abstract
      */
     protected function parseSize($string)
     {
-        if ($string === null) {
+        if (is_null($string)) {
             return false;
         }
 

--- a/app/code/core/Mage/Catalog/Helper/Image.php
+++ b/app/code/core/Mage/Catalog/Helper/Image.php
@@ -649,6 +649,6 @@ class Mage_Catalog_Helper_Image extends Mage_Core_Helper_Abstract
         // Force garbage collection since image handler resource uses memory without counting toward memory limit
         unset($_processor);
 
-        return $mimeType !== null;
+        return !is_null($mimeType);
     }
 }

--- a/app/code/core/Mage/Catalog/Helper/Output.php
+++ b/app/code/core/Mage/Catalog/Helper/Output.php
@@ -45,7 +45,7 @@ class Mage_Catalog_Helper_Output extends Mage_Core_Helper_Abstract
      */
     protected function _getTemplateProcessor()
     {
-        if ($this->_templateProcessor === null) {
+        if (is_null($this->_templateProcessor)) {
             $this->_templateProcessor = Mage::helper('catalog')->getPageTemplateProcessor();
         }
 

--- a/app/code/core/Mage/Catalog/Helper/Product.php
+++ b/app/code/core/Mage/Catalog/Helper/Product.php
@@ -449,7 +449,7 @@ class Mage_Catalog_Helper_Product extends Mage_Core_Helper_Url
         $product = Mage::getModel('catalog/product')->setStoreId(Mage::app()->getStore($store)->getId());
 
         $expectedIdType = false;
-        if ($identifierType === null) {
+        if (is_null($identifierType)) {
             if (is_string($productId) && !preg_match('/^[+-]?[1-9][0-9]*$|^0$/', $productId)) {
                 $expectedIdType = 'sku';
             }

--- a/app/code/core/Mage/Catalog/Helper/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Flat.php
@@ -124,7 +124,7 @@ class Mage_Catalog_Helper_Product_Flat extends Mage_Catalog_Helper_Flat_Abstract
      */
     public function isBuilt($store = null)
     {
-        if ($store !== null) {
+        if (!is_null($store)) {
             return $this->getFlag()->isStoreBuilt(Mage::app()->getStore($store)->getId());
         }
         return $this->getFlag()->getIsBuilt();

--- a/app/code/core/Mage/Catalog/Helper/Product/Url.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Url.php
@@ -115,6 +115,6 @@ class Mage_Catalog_Helper_Product_Url extends Mage_Core_Helper_Url
      */
     public function format($string)
     {
-        return $string === null ? '' : strtr($string, $this->getConvertTable());
+        return is_null($string) ? '' : strtr($string, $this->getConvertTable());
     }
 }

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Admin/V1.php
@@ -267,7 +267,7 @@ class Mage_Catalog_Model_Api2_Product_Rest_Admin_V1 extends Mage_Catalog_Model_A
         if (isset($productData['use_config_gift_message_available'])) {
             $product->setData('use_config_gift_message_available', $productData['use_config_gift_message_available']);
             if (!$productData['use_config_gift_message_available']
-                && ($product->getData('gift_message_available') === null)
+                && (is_null($product->getData('gift_message_available')))
             ) {
                 $product->setData('gift_message_available', Mage::getStoreConfigAsInt(
                     Mage_GiftMessage_Helper_Message::XPATH_CONFIG_GIFT_MESSAGE_ALLOW_ITEMS,
@@ -278,7 +278,7 @@ class Mage_Catalog_Model_Api2_Product_Rest_Admin_V1 extends Mage_Catalog_Model_A
         if (isset($productData['use_config_gift_wrapping_available'])) {
             $product->setData('use_config_gift_wrapping_available', $productData['use_config_gift_wrapping_available']);
             if (!$productData['use_config_gift_wrapping_available']
-                && ($product->getData('gift_wrapping_available') === null)
+                && (is_null($product->getData('gift_wrapping_available')))
             ) {
                 $xmlPathGiftWrappingAvailable = 'sales/gift_options/wrapping_allow_items';
                 $product->setData('gift_wrapping_available', Mage::getStoreConfigAsInt(

--- a/app/code/core/Mage/Catalog/Model/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Category.php
@@ -485,7 +485,7 @@ class Mage_Catalog_Model_Category extends Mage_Catalog_Model_Abstract
      */
     public function getUrlModel()
     {
-        if ($this->_urlModel === null) {
+        if (is_null($this->_urlModel)) {
             $this->_urlModel = Mage::getSingleton('catalog/factory')->getCategoryUrlInstance();
         }
         return $this->_urlModel;

--- a/app/code/core/Mage/Catalog/Model/Category/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Api.php
@@ -43,8 +43,8 @@ class Mage_Catalog_Model_Category_Api extends Mage_Catalog_Model_Api_Resource
         if ($website !== null) {
             try {
                 $website = Mage::app()->getWebsite($website);
-                if ($store === null) {
-                    if ($categoryId === null) {
+                if (is_null($store)) {
+                    if (is_null($categoryId)) {
                         foreach ($website->getStores() as $store) {
                             $ids[] = $store->getRootCategoryId();
                         }
@@ -62,7 +62,7 @@ class Mage_Catalog_Model_Category_Api extends Mage_Catalog_Model_Api_Resource
             }
         } elseif ($store !== null) {
             // load children of root category of store
-            if ($categoryId === null) {
+            if (is_null($categoryId)) {
                 try {
                     $store = Mage::app()->getStore($store);
                     $storeId = $store->getId();
@@ -348,7 +348,7 @@ class Mage_Catalog_Model_Category_Api extends Mage_Catalog_Model_Api_Resource
         $parent_category = $this->_initCategory($parentId);
 
         // if $afterId is null - move category to the down
-        if ($afterId === null && $parent_category->hasChildren()) {
+        if (is_null($afterId) && $parent_category->hasChildren()) {
             $parentChildren = $parent_category->getChildren();
             $afterId = array_pop(explode(',', $parentChildren));
         }

--- a/app/code/core/Mage/Catalog/Model/Category/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Api.php
@@ -40,7 +40,7 @@ class Mage_Catalog_Model_Category_Api extends Mage_Catalog_Model_Api_Resource
         $storeId = Mage_Catalog_Model_Category::DEFAULT_STORE_ID;
 
         // load root categories of website
-        if ($website !== null) {
+        if (!is_null($website)) {
             try {
                 $website = Mage::app()->getWebsite($website);
                 if (is_null($store)) {
@@ -60,7 +60,7 @@ class Mage_Catalog_Model_Category_Api extends Mage_Catalog_Model_Api_Resource
             } catch (Mage_Core_Exception $e) {
                 $this->_fault('website_not_exists', $e->getMessage());
             }
-        } elseif ($store !== null) {
+        } elseif (!is_null($store)) {
             // load children of root category of store
             if (is_null($categoryId)) {
                 try {

--- a/app/code/core/Mage/Catalog/Model/Category/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Url.php
@@ -58,7 +58,7 @@ class Mage_Catalog_Model_Category_Url
     public function getCategoryUrl(Mage_Catalog_Model_Category $category)
     {
         $url = $category->getData('url');
-        if ($url !== null) {
+        if (!is_null($url)) {
             return $url;
         }
 

--- a/app/code/core/Mage/Catalog/Model/Category/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Url.php
@@ -120,7 +120,7 @@ class Mage_Catalog_Model_Category_Url
      */
     public function getUrlInstance()
     {
-        if ($this->_url === null) {
+        if (is_null($this->_url)) {
             $this->_url = $this->_factory->getModel('core/url');
         }
         return $this->_url;
@@ -133,7 +133,7 @@ class Mage_Catalog_Model_Category_Url
      */
     public function getUrlRewrite()
     {
-        if ($this->_urlRewrite === null) {
+        if (is_null($this->_urlRewrite)) {
             $this->_urlRewrite = $this->_factory->getUrlRewriteInstance();
         }
         return $this->_urlRewrite;

--- a/app/code/core/Mage/Catalog/Model/Layer.php
+++ b/app/code/core/Mage/Catalog/Model/Layer.php
@@ -54,7 +54,7 @@ class Mage_Catalog_Model_Layer extends Varien_Object
      */
     public function getStateKey()
     {
-        if ($this->_stateKey === null) {
+        if (is_null($this->_stateKey)) {
             $this->_stateKey = 'STORE_' . Mage::app()->getStore()->getId()
                 . '_CAT_' . $this->getCurrentCategory()->getId()
                 . '_CUSTGROUP_' . Mage::getSingleton('customer/session')->getCustomerGroupId();
@@ -288,7 +288,7 @@ class Mage_Catalog_Model_Layer extends Varien_Object
         $key = $this->getStateKey() . '_SET_IDS';
         $setIds = $this->getAggregator()->getCacheData($key);
 
-        if ($setIds === null) {
+        if (is_null($setIds)) {
             $setIds = $this->getProductCollection()->getSetIds();
             $this->getAggregator()->saveCacheData($setIds, $key, $this->getStateTags());
         }

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Attribute.php
@@ -113,7 +113,7 @@ class Mage_Catalog_Model_Layer_Filter_Attribute extends Mage_Catalog_Model_Layer
         $key = $this->getLayer()->getStateKey() . '_' . $this->_requestVar;
         $data = $this->getLayer()->getAggregator()->getCacheData($key);
 
-        if ($data === null) {
+        if (is_null($data)) {
             $options = $attribute->getFrontend()->getSelectOptions();
             $optionsCount = $this->_getResource()->getCount($this);
             $data = [];

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Category.php
@@ -144,7 +144,7 @@ class Mage_Catalog_Model_Layer_Filter_Category extends Mage_Catalog_Model_Layer_
         $key = $this->getLayer()->getStateKey() . '_SUBCATEGORIES';
         $data = $this->getLayer()->getAggregator()->getCacheData($key);
 
-        if ($data === null) {
+        if (is_null($data)) {
             $categoty   = $this->getCategory();
             $categories = $categoty->getChildrenCategories();
 

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Decimal.php
@@ -199,7 +199,7 @@ class Mage_Catalog_Model_Layer_Filter_Decimal extends Mage_Catalog_Model_Layer_F
         $key = $this->_getCacheKey();
 
         $data = $this->getLayer()->getAggregator()->getCacheData($key);
-        if ($data === null) {
+        if (is_null($data)) {
             $data       = [];
             $range      = $this->getRange();
             $dbRanges   = $this->getRangeItemCounts($range);

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -393,7 +393,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
      */
     public function getUrlModel()
     {
-        if ($this->_urlModel === null) {
+        if (is_null($this->_urlModel)) {
             $this->_urlModel = Mage::getSingleton('catalog/factory')->getProductUrlInstance();
         }
         return $this->_urlModel;
@@ -489,7 +489,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
             return $this->_typeInstanceSingleton;
         }
 
-        if ($this->_typeInstance === null) {
+        if (is_null($this->_typeInstance)) {
             $this->_typeInstance = Mage::getSingleton('catalog/product_type')
                 ->factory($this);
         }
@@ -2062,7 +2062,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
      */
     public function getReservedAttributes()
     {
-        if ($this->_reservedAttributes === null) {
+        if (is_null($this->_reservedAttributes)) {
             $_reserved = ['position'];
             $methods = get_class_methods(__CLASS__);
             foreach ($methods as $method) {

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -786,7 +786,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
      */
     public function canAffectOptions($value = null)
     {
-        if ($value !== null) {
+        if (!is_null($value)) {
             $this->_canAffectOptions = (bool)$value;
         }
         return $this->_canAffectOptions;

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Media.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Media.php
@@ -171,12 +171,12 @@ class Mage_Catalog_Model_Product_Attribute_Backend_Media extends Mage_Eav_Model_
         foreach ($value['values'] as $mediaAttrCode => $attrData) {
             if (array_key_exists($attrData, $newImages)) {
                 $object->setData($mediaAttrCode, $newImages[$attrData]['new_file']);
-                $label = $newImages[$attrData]['label'] === null || !empty($newImages[$attrData]['label_use_default']) ? $newImages[$attrData]['label_default'] : $newImages[$attrData]['label'];
+                $label = is_null($newImages[$attrData]['label']) || !empty($newImages[$attrData]['label_use_default']) ? $newImages[$attrData]['label_default'] : $newImages[$attrData]['label'];
                 $object->setData($mediaAttrCode . '_label', $label);
             }
 
             if (array_key_exists($attrData, $existImages)) {
-                $label = $existImages[$attrData]['label'] === null || !empty($existImages[$attrData]['label_use_default']) ? $existImages[$attrData]['label_default'] : $existImages[$attrData]['label'];
+                $label = is_null($existImages[$attrData]['label']) || !empty($existImages[$attrData]['label_use_default']) ? $existImages[$attrData]['label_default'] : $existImages[$attrData]['label'];
                 $object->setData($mediaAttrCode . '_label', $label);
             }
         }
@@ -265,8 +265,8 @@ class Mage_Catalog_Model_Product_Attribute_Backend_Media extends Mage_Eav_Model_
             // Add per store labels, position, disabled
             $data = [];
             $data['value_id'] = $image['value_id'];
-            $data['label']    = ($image['label'] === null || $image['label_use_default']) ? null : $image['label'];
-            $data['position'] = ($image['position'] === null || $image['position_use_default']) ? null : (int) $image['position'];
+            $data['label']    = (is_null($image['label']) || $image['label_use_default']) ? null : $image['label'];
+            $data['position'] = (is_null($image['position']) || $image['position_use_default']) ? null : (int) $image['position'];
             $data['disabled'] = (int) $image['disabled'];
             $data['store_id'] = (int) $object->getStoreId();
 

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Inputtype.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Inputtype.php
@@ -53,10 +53,10 @@ class Mage_Catalog_Model_Product_Attribute_Source_Inputtype extends Mage_Eav_Mod
             }
         }
 
-        if (Mage::registry('attribute_type_hidden_fields') === null) {
+        if (is_null(Mage::registry('attribute_type_hidden_fields'))) {
             Mage::register('attribute_type_hidden_fields', $_hiddenFields);
         }
-        if (Mage::registry('attribute_type_disabled_types') === null) {
+        if (is_null(Mage::registry('attribute_type_disabled_types'))) {
             Mage::register('attribute_type_disabled_types', $_disabledTypes);
         }
 

--- a/app/code/core/Mage/Catalog/Model/Product/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Image.php
@@ -307,7 +307,7 @@ class Mage_Catalog_Model_Product_Image extends Mage_Core_Model_Abstract
     {
         $result = [];
         foreach ($rgbArray as $value) {
-            if ($value === null) {
+            if (is_null($value)) {
                 $result[] = 'null';
             } else {
                 $result[] = sprintf('%02s', dechex($value));

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
@@ -150,7 +150,7 @@ class Mage_Catalog_Model_Product_Option_Type_Date extends Mage_Catalog_Model_Pro
      */
     public function getFormattedOptionValue($optionValue)
     {
-        if ($this->_formattedOptionValue === null) {
+        if (is_null($this->_formattedOptionValue)) {
             $option = $this->getOption();
             if ($this->getOption()->getType() == Mage_Catalog_Model_Product_Option::OPTION_TYPE_DATE) {
                 $format = Mage::app()->getLocale()->getDateFormat(Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM);

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
@@ -94,7 +94,7 @@ class Mage_Catalog_Model_Product_Option_Type_Date extends Mage_Catalog_Model_Pro
      */
     public function prepareForCart()
     {
-        if ($this->getIsValid() && $this->getUserValue() !== null) {
+        if ($this->getIsValid() && !is_null($this->getUserValue())) {
             $option = $this->getOption();
             $value = $this->getUserValue();
 

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
@@ -327,7 +327,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
             break;
         }
 
-        if ($fileFullPath === null) {
+        if (is_null($fileFullPath)) {
             return false;
         }
 
@@ -464,7 +464,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
      */
     public function getFormattedOptionValue($optionValue)
     {
-        if ($this->_formattedOptionValue === null) {
+        if (is_null($this->_formattedOptionValue)) {
             try {
                 $value = Mage::helper('core/unserializeArray')->unserialize($optionValue);
 
@@ -546,7 +546,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
     public function getPrintableOptionValue($optionValue)
     {
         $value = $this->getFormattedOptionValue($optionValue);
-        return $value === null ? '' : strip_tags($value);
+        return is_null($value) ? '' : strip_tags($value);
     }
 
     /**

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
@@ -124,7 +124,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
 
         $fileInfo = $this->_getCurrentConfigFileInfo();
 
-        if ($fileInfo !== null) {
+        if (!is_null($fileInfo)) {
             if (is_array($fileInfo) && $this->_validateFile($fileInfo)) {
                 $value = $fileInfo;
             } else {
@@ -214,11 +214,11 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
 
         // File extension
         $_allowed = $this->_parseExtensionsString($option->getFileExtension());
-        if ($_allowed !== null) {
+        if (!is_null($_allowed)) {
             $upload->addValidator('Extension', false, $_allowed);
         } else {
             $_forbidden = $this->_parseExtensionsString($this->getConfigData('forbidden_extensions'));
-            if ($_forbidden !== null) {
+            if (!is_null($_forbidden)) {
                 $upload->addValidator('ExcludeExtension', false, $_forbidden);
             }
         }
@@ -352,11 +352,11 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
 
         // File extension
         $_allowed = $this->_parseExtensionsString($option->getFileExtension());
-        if ($_allowed !== null) {
+        if (!is_null($_allowed)) {
             $validatorChain->addValidator(new Zend_Validate_File_Extension($_allowed));
         } else {
             $_forbidden = $this->_parseExtensionsString($this->getConfigData('forbidden_extensions'));
-            if ($_forbidden !== null) {
+            if (!is_null($_forbidden)) {
                 $validatorChain->addValidator(new Zend_Validate_File_ExcludeExtension($_forbidden));
             }
         }
@@ -425,7 +425,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
 
         // Prepare value and fill buyRequest with option
         $requestOptions = $buyRequest->getOptions();
-        if ($this->getIsValid() && $this->getUserValue() !== null) {
+        if ($this->getIsValid() && !is_null($this->getUserValue())) {
             $value = $this->getUserValue();
 
             // Save option in request, because we have no $_FILES['options']

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Select.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Select.php
@@ -73,7 +73,7 @@ class Mage_Catalog_Model_Product_Option_Type_Select extends Mage_Catalog_Model_P
      */
     public function getFormattedOptionValue($optionValue)
     {
-        if ($this->_formattedOptionValue === null) {
+        if (is_null($this->_formattedOptionValue)) {
             $this->_formattedOptionValue = Mage::helper('core')->escapeHtml(
                 $this->getEditableOptionValue($optionValue)
             );

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
@@ -519,7 +519,7 @@ abstract class Mage_Catalog_Model_Product_Type_Abstract
                 ->validateUserValue($buyRequest->getOptions());
 
             $preparedValue = $group->prepareForCart();
-            if ($preparedValue !== null) {
+            if (!is_null($preparedValue)) {
                 $transport->options[$_option->getId()] = $preparedValue;
             }
         }

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
@@ -561,7 +561,7 @@ abstract class Mage_Catalog_Model_Product_Type_Abstract
                 if ($option->getIsRequire()) {
                     $customOption = $this->getProduct($product)
                         ->getCustomOption(self::OPTION_PREFIX . $option->getId());
-                    if (!$customOption || $customOption->getValue() === null || (string) $customOption->getValue() === '') {
+                    if (!$customOption || is_null($customOption->getValue()) || (string) $customOption->getValue() === '') {
                         $this->getProduct($product)->setSkipCheckRequiredOption(true);
                         Mage::throwException(
                             Mage::helper('catalog')->__('The product has required options')

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
@@ -396,7 +396,7 @@ class Mage_Catalog_Model_Product_Type_Price
                 ->getRulePrice($storeTimestamp, $wId, $gId, $productId);
         }
 
-        if ($rulePrice !== null && $rulePrice !== false) {
+        if (!is_null($rulePrice) && $rulePrice !== false) {
             $finalPrice = min($finalPrice, $rulePrice);
         }
 

--- a/app/code/core/Mage/Catalog/Model/Product/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Url.php
@@ -65,7 +65,7 @@ class Mage_Catalog_Model_Product_Url extends Varien_Object
      */
     public function getUrlInstance()
     {
-        if ($this->_url === null) {
+        if (is_null($this->_url)) {
             $this->_url = Mage::getModel('core/url');
         }
         return $this->_url;
@@ -78,7 +78,7 @@ class Mage_Catalog_Model_Product_Url extends Varien_Object
      */
     public function getUrlRewrite()
     {
-        if ($this->_urlRewrite === null) {
+        if (is_null($this->_urlRewrite)) {
             $this->_urlRewrite = $this->_factory->getUrlRewriteInstance();
         }
         return $this->_urlRewrite;
@@ -119,7 +119,7 @@ class Mage_Catalog_Model_Product_Url extends Varien_Object
      */
     public function getProductUrl($product, $useSid = null)
     {
-        if ($useSid === null) {
+        if (is_null($useSid)) {
             $useSid = Mage::app()->getUseSessionInUrl();
         }
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Attribute.php
@@ -139,7 +139,7 @@ class Mage_Catalog_Model_Resource_Attribute extends Mage_Eav_Model_Resource_Enti
             ->group('main_table.attribute_id')
             ->limit(1);
 
-        if ($attributeSet !== null) {
+        if (!is_null($attributeSet)) {
             $bind['attribute_set_id'] = $attributeSet;
             $select->where('entity.attribute_set_id = :attribute_set_id');
         }

--- a/app/code/core/Mage/Catalog/Model/Resource/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category.php
@@ -169,7 +169,7 @@ class Mage_Catalog_Model_Resource_Category extends Mage_Catalog_Model_Resource_A
         if (!$object->getChildrenCount()) {
             $object->setChildrenCount(0);
         }
-        if ($object->getLevel() === null) {
+        if (is_null($object->getLevel())) {
             $object->setLevel(1);
         }
 
@@ -278,7 +278,7 @@ class Mage_Catalog_Model_Resource_Category extends Mage_Catalog_Model_Resource_A
         /**
          * Example re-save category
          */
-        if ($products === null) {
+        if (is_null($products)) {
             return $this;
         }
 
@@ -471,7 +471,7 @@ class Mage_Catalog_Model_Resource_Category extends Mage_Catalog_Model_Resource_A
      */
     protected function _getIsActiveAttributeId()
     {
-        if ($this->_isActiveAttributeId === null) {
+        if (is_null($this->_isActiveAttributeId)) {
             $attributeId = Mage::getSingleton('eav/config')
                 ->getAttribute(Mage_Catalog_Model_Category::ENTITY, 'is_active')
                 ->getId();

--- a/app/code/core/Mage/Catalog/Model/Resource/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category.php
@@ -893,7 +893,7 @@ class Mage_Catalog_Model_Resource_Category extends Mage_Catalog_Model_Resource_A
                 $positionField . ' > ?' => $position
             ];
             $adapter->update($table, $bind, $where);
-        } elseif ($afterCategoryId !== null) {
+        } elseif (!is_null($afterCategoryId)) {
             $position = 0;
             $bind = [
                 'position' => new Zend_Db_Expr($positionField . ' + 1')

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
@@ -449,7 +449,7 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
     public function isBuilt($storeView = null)
     {
         $storeView = is_null($storeView) ? Mage::app()->getDefaultStoreView() : Mage::app()->getStore($storeView);
-        if ($storeView === null) {
+        if (is_null($storeView)) {
             $storeId = Mage_Core_Model_App::ADMIN_STORE_ID;
         } else {
             $storeId = $storeView->getId();
@@ -475,7 +475,7 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
      */
     public function rebuild($stores = null)
     {
-        if ($stores === null) {
+        if (is_null($stores)) {
             $stores = Mage::app()->getStores();
         }
 
@@ -569,7 +569,7 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
             ->setComment(sprintf('Catalog Category Flat (Store %d)', $store));
 
         //Adding columns
-        if ($this->_columnsSql === null) {
+        if (is_null($this->_columnsSql)) {
             $this->_columns = array_merge($this->_getStaticColumns(), $this->_getEavColumns());
             foreach ($this->_columns as $fieldName => $fieldProp) {
                 $default = $fieldProp['default'];
@@ -782,7 +782,7 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
      */
     protected function _getAttributes()
     {
-        if ($this->_attributeCodes === null) {
+        if (is_null($this->_attributeCodes)) {
             $select = $this->_getWriteAdapter()->select()
                 ->from($this->getTable('eav/entity_type'), [])
                 ->join(

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
@@ -1150,7 +1150,7 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
         $data = [];
         $idFieldName = Mage::getSingleton('catalog/category')->getIdFieldName();
         foreach (array_keys($table) as $column) {
-            if ($column != $idFieldName || $category->getData($column) !== null) {
+            if ($column != $idFieldName || $category->getData(!is_null($column))) {
                 if (array_key_exists($column, $replaceFields)) {
                     $value = $category->getData($replaceFields[$column]);
                 } else {

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
@@ -272,7 +272,7 @@ class Mage_Catalog_Model_Resource_Category_Flat_Collection extends Mage_Core_Mod
      */
     public function addAttributeToFilter($attribute, $condition = null)
     {
-        if (!is_string($attribute) || $condition === null) {
+        if (!is_string($attribute) || is_null($condition)) {
             return $this;
         }
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
@@ -217,7 +217,7 @@ class Mage_Catalog_Model_Resource_Category_Flat_Collection extends Mage_Core_Mod
                 }
 
                 // Joined columns
-                if ($column[2] !== null) {
+                if (!is_null($column[2])) {
                     $expression = [$column[2] => $column[1]];
                 } else {
                     $expression = $column[2];

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Tree.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Tree.php
@@ -104,7 +104,7 @@ class Mage_Catalog_Model_Resource_Category_Tree extends Varien_Data_Tree_Dbp
      */
     public function getStoreId()
     {
-        if ($this->_storeId === null) {
+        if (is_null($this->_storeId)) {
             $this->_storeId = Mage::app()->getStore()->getId();
         }
         return $this->_storeId;

--- a/app/code/core/Mage/Catalog/Model/Resource/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Config.php
@@ -70,7 +70,7 @@ class Mage_Catalog_Model_Resource_Config extends Mage_Core_Model_Resource_Db_Abs
      */
     public function getEntityTypeId()
     {
-        if ($this->_entityTypeId === null) {
+        if (is_null($this->_entityTypeId)) {
             $this->_entityTypeId = Mage::getSingleton('eav/config')->getEntityType(Mage_Catalog_Model_Product::ENTITY)->getId();
         }
         return $this->_entityTypeId;

--- a/app/code/core/Mage/Catalog/Model/Resource/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product.php
@@ -405,7 +405,7 @@ class Mage_Catalog_Model_Resource_Product extends Mage_Catalog_Model_Resource_Ab
                 ),
                 []
             );
-        } elseif ($store === null) {
+        } elseif (is_null($store)) {
             foreach ($product->getStoreIds() as $storeId) {
                 $store = Mage::app()->getStore($storeId);
                 $this->refreshEnabledIndex($store, $product);

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
@@ -644,7 +644,7 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
      */
     public function addStoreFilter($store = null)
     {
-        if ($store === null) {
+        if (is_null($store)) {
             $store = $this->getStoreId();
         }
         $store = Mage::app()->getStore($store);
@@ -965,7 +965,7 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
      */
     public function getProductCountSelect()
     {
-        if ($this->_productCountSelect === null) {
+        if (is_null($this->_productCountSelect)) {
             $this->_productCountSelect = clone $this->getSelect();
             $this->_productCountSelect->reset(Zend_Db_Select::COLUMNS)
                 ->reset(Zend_Db_Select::GROUP)
@@ -1439,7 +1439,7 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
         $classToRate = [];
         $request = Mage::getSingleton('tax/calculation')->getRateRequest();
         foreach ($this as &$item) {
-            if ($item->getTaxClassId() === null) {
+            if (is_null($item->getTaxClassId())) {
                 $item->setTaxClassId($item->getMinimalTaxClassId());
             }
             if (!isset($classToRate[$item->getTaxClassId()])) {

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Flat.php
@@ -79,7 +79,7 @@ class Mage_Catalog_Model_Resource_Product_Flat extends Mage_Core_Model_Resource_
      */
     public function getFlatTableName($store = null)
     {
-        if ($store === null) {
+        if (is_null($store)) {
             $store = $this->getStoreId();
         }
         return $this->getTable(['catalog/product_flat', $store]);
@@ -220,7 +220,7 @@ class Mage_Catalog_Model_Resource_Product_Flat extends Mage_Core_Model_Resource_
      */
     public function isBuilt($storeView = null)
     {
-        if ($storeView === null) {
+        if (is_null($storeView)) {
             $storeId = Mage::app()->getAnyStoreView()->getId();
         } elseif (is_int($storeView)) {
             $storeId = $storeView;

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Flat/Indexer.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Flat/Indexer.php
@@ -521,10 +521,10 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
          * Process the case when 'is_null' prohibits null value, and 'default' proposed to be null
          * It just means that default value not specified
          */
-        if ($fieldProp['is_null'] === false && $fieldProp['default'] === null) {
+        if ($fieldProp['is_null'] === false && is_null($fieldProp['default'])) {
             $defaultValue = '';
         } else {
-            $defaultValue = $fieldProp['default'] === null ? ' DEFAULT NULL' : $this->_getReadAdapter()
+            $defaultValue = is_null($fieldProp['default']) ? ' DEFAULT NULL' : $this->_getReadAdapter()
                 ->quoteInto(' DEFAULT ?', $fieldProp['default']);
         }
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Flat/Indexer.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Flat/Indexer.php
@@ -411,7 +411,7 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
                     ->setFlatAddFilterableAttributes($this->getFlatHelper()->isAddFilterableAttributes())
                     ->setFlatAddChildData($this->getFlatHelper()->isAddChildData())
                     ->getFlatColumns();
-                if ($columns !== null) {
+                if (!is_null($columns)) {
                     $this->_columns = array_merge($this->_columns, $columns);
                 }
             }
@@ -472,7 +472,7 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
                     ->setFlatAddFilterableAttributes($this->getFlatHelper()->isAddFilterableAttributes())
                     ->setFlatAddChildData($this->getFlatHelper()->isAddChildData())
                     ->getFlatIndexes();
-                if ($indexes !== null) {
+                if (!is_null($indexes)) {
                     $this->_indexes = array_merge($this->_indexes, $indexes);
                 }
             }
@@ -897,7 +897,7 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
             }
         }
 
-        if ($productIds !== null) {
+        if (!is_null($productIds)) {
             $select->where('e.entity_id IN(?)', $productIds);
         }
 
@@ -938,7 +938,7 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
                 implode(' AND ', $joinCondition),
                 []
             );
-        if ($productIds !== null) {
+        if (!is_null($productIds)) {
             $condition = [
                 $adapter->quoteInto('e.entity_id IN(?)', $productIds)
             ];
@@ -985,7 +985,7 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
             if ($this->getFlatHelper()->isAddChildData()) {
                 $select->where('e.is_child = ?', 0);
             }
-            if ($productIds !== null) {
+            if (!is_null($productIds)) {
                 $select->where('main_table.entity_id IN(?)', $productIds);
             }
 
@@ -1004,7 +1004,7 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
 
             $select = $attribute->getFlatUpdateSelect($storeId);
             if ($select instanceof Varien_Db_Select) {
-                if ($productIds !== null) {
+                if (!is_null($productIds)) {
                     $select->where('e.entity_id IN(?)', $productIds);
                 }
 
@@ -1113,10 +1113,10 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
                         "e.entity_id = t.{$relation->getChildFieldName()}",
                         array_keys($columns)
                     );
-                if ($relation->getWhere() !== null) {
+                if (!is_null($relation->getWhere())) {
                     $select->where($relation->getWhere());
                 }
-                if ($productIds !== null) {
+                if (!is_null($productIds)) {
                     $cond = [
                         $adapter->quoteInto("{$relation->getChildFieldName()} IN(?)", $productIds),
                         $adapter->quoteInto("{$relation->getParentFieldName()} IN(?)", $productIds)
@@ -1161,7 +1161,7 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
             )
             ->where('t2.is_child = ?', 1);
 
-        if ($productIds !== null) {
+        if (!is_null($productIds)) {
             $select->where('t2.child_id IN(?)', $productIds);
         }
 
@@ -1204,7 +1204,7 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
                     "e.entity_id = t.{$relation->getParentFieldName()}",
                     "e.child_id = t.{$relation->getChildFieldName()}"
                 ];
-                if ($relation->getWhere() !== null) {
+                if (!is_null($relation->getWhere())) {
                     $select->where($relation->getWhere());
                     $joinLeftCond[] = $relation->getWhere();
                 }

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Flat/Indexer.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Flat/Indexer.php
@@ -100,7 +100,7 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
      */
     public function rebuild($store = null)
     {
-        if ($store === null) {
+        if (is_null($store)) {
             foreach (Mage::app()->getStores() as $store) {
                 $this->rebuild($store->getId());
             }
@@ -139,7 +139,7 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
      */
     public function getAttributeCodes()
     {
-        if ($this->_attributeCodes === null) {
+        if (is_null($this->_attributeCodes)) {
             $adapter               = $this->_getReadAdapter();
             $this->_attributeCodes = [];
 
@@ -204,7 +204,7 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
      */
     public function getEntityTypeId()
     {
-        if ($this->_entityTypeId === null) {
+        if (is_null($this->_entityTypeId)) {
             $this->_entityTypeId = Mage::getResourceModel('catalog/config')
                 ->getEntityTypeId();
         }
@@ -218,7 +218,7 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
      */
     public function getAttributes()
     {
-        if ($this->_attributes === null) {
+        if (is_null($this->_attributes)) {
             $this->_attributes = [];
             $attributeCodes    = $this->getAttributeCodes();
             $entity = Mage::getSingleton('eav/config')
@@ -398,7 +398,7 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
      */
     public function getFlatColumns()
     {
-        if ($this->_columns === null) {
+        if (is_null($this->_columns)) {
             if (Mage::helper('core')->useDbCompatibleMode()) {
                 $this->_columns = $this->_getFlatColumnsOldDefinition();
             } else {
@@ -435,7 +435,7 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
      */
     public function getFlatIndexes()
     {
-        if ($this->_indexes === null) {
+        if (is_null($this->_indexes)) {
             $this->_indexes = [];
 
             if ($this->getFlatHelper()->isAddChildData()) {
@@ -1059,7 +1059,7 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
      */
     public function getProductTypeInstances()
     {
-        if ($this->_productTypes === null) {
+        if (is_null($this->_productTypes)) {
             $this->_productTypes = [];
             $productEmulator     = new Varien_Object();
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Collection.php
@@ -135,7 +135,7 @@ class Mage_Catalog_Model_Resource_Product_Option_Collection extends Mage_Core_Mo
      */
     public function addValuesToResult($storeId = null)
     {
-        if ($storeId === null) {
+        if (is_null($storeId)) {
             $storeId = Mage::app()->getStore()->getId();
         }
         $optionIds = [];

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Status.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Status.php
@@ -155,7 +155,7 @@ class Mage_Catalog_Model_Resource_Product_Status extends Mage_Core_Model_Resourc
             $productIds = [$productIds];
         }
 
-        if ($storeId === null || $storeId == Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID) {
+        if (is_null($storeId) || $storeId == Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID) {
             $select = $adapter->select()
                 ->from($attributeTable, ['entity_id', 'value'])
                 ->where('entity_id IN (?)', $productIds)

--- a/app/code/core/Mage/Catalog/Model/Resource/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Url.php
@@ -721,7 +721,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             []
         );
 
-        if ($storeId !== null) {
+        if (!is_null($storeId)) {
             $rootCategoryPath = $this->getStores($storeId)->getRootCategoryPath();
             $rootCategoryPathLength = strlen($rootCategoryPath);
         }
@@ -732,7 +732,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
 
         $rowSet = $adapter->fetchAll($select, $bind);
         foreach ($rowSet as $row) {
-            if ($storeId !== null) {
+            if (!is_null($storeId)) {
                 // Check the category to be either store's root or its descendant
                 // First - check that category's start is the same as root category
                 if (substr($row['path'], 0, $rootCategoryPathLength) != $rootCategoryPath) {
@@ -755,7 +755,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
         }
         unset($rowSet);
 
-        if ($storeId !== null && $categories) {
+        if (!is_null($storeId) && $categories) {
             foreach (['name', 'url_key', 'url_path'] as $attributeCode) {
                 $attributes = $this->_getCategoryAttribute(
                     $attributeCode,
@@ -929,7 +929,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
         $products   = [];
         $websiteId  = Mage::app()->getStore($storeId)->getWebsiteId();
         $adapter    = $this->_getReadAdapter();
-        if ($productIds !== null) {
+        if (!is_null($productIds)) {
             if (!is_array($productIds)) {
                 $productIds = [$productIds];
             }
@@ -949,7 +949,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             ->where('e.entity_id > :entity_id')
             ->order('e.entity_id')
             ->limit($this->_productLimit);
-        if ($productIds !== null) {
+        if (!is_null($productIds)) {
             $select->where('e.entity_id IN(?)', $productIds);
         }
 
@@ -1213,7 +1213,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             $condition['product_id IN (?)'] = $productIds;
         }
 
-        if ($storeId !== null) {
+        if (!is_null($storeId)) {
             $condition['store_id IN(?)'] = $storeId;
         }
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Url.php
@@ -73,7 +73,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
      */
     public function getStores($storeId = null)
     {
-        if ($this->_stores === null) {
+        if (is_null($this->_stores)) {
             $this->_stores = $this->_prepareStoreRootCategories(Mage::app()->getStores());
         }
         if ($storeId && isset($this->_stores[$storeId])) {
@@ -237,7 +237,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             ->where('store_id = :store_id')
             ->where('is_system = ?', 1);
         $bind = ['store_id' => $storeId];
-        if ($categoryIds === null) {
+        if (is_null($categoryIds)) {
             $select->where('category_id IS NULL');
         } elseif ($categoryIds) {
             $catIds = is_array($categoryIds) ? $categoryIds : [$categoryIds];
@@ -258,7 +258,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             }
         }
 
-        if ($productIds === null) {
+        if (is_null($productIds)) {
             $select->where('product_id IS NULL');
         } elseif ($productIds) {
             $select->where('product_id IN(?)', $productIds);
@@ -697,7 +697,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
                 'main_table.path']);
 
         // Prepare variables for checking whether categories belong to store
-        if ($path === null) {
+        if (is_null($path)) {
             $select->where('main_table.entity_id IN(?)', $categoryIds);
         } else {
             // Ensure that path ends with '/', otherwise we can get wrong results - e.g. $path = '1/2' will get '1/20'
@@ -811,7 +811,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
      */
     public function loadCategoryChilds(Varien_Object $category)
     {
-        if ($category->getId() === null || $category->getStoreId() === null) {
+        if (is_null($category->getId()) || is_null($category->getStoreId())) {
             return $category;
         }
 

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -120,7 +120,7 @@ class Mage_Catalog_Model_Url
             return;
         }
 
-        if (self::$_categoryForUrlPath === null) {
+        if (is_null(self::$_categoryForUrlPath)) {
             self::$_categoryForUrlPath = Mage::getModel('catalog/category');
         }
 

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -707,7 +707,7 @@ class Mage_Catalog_Model_Url
         }
 
         $categoryUrlSuffix = $this->getCategoryUrlSuffix($storeId);
-        if ($parentPath === null) {
+        if (is_null($parentPath)) {
             $parentPath = $this->getResource()->getCategoryParentPath($category);
         } elseif ($parentPath == '/') {
             $parentPath = '';
@@ -878,7 +878,7 @@ class Mage_Catalog_Model_Url
                 }
 
                 $categoryUrlSuffix = $this->getCategoryUrlSuffix($category->getStoreId());
-                if ($parentPath === null) {
+                if (is_null($parentPath)) {
                     $parentPath = $this->getResource()->getCategoryParentPath($category);
                 } elseif ($parentPath == '/') {
                     $parentPath = '';

--- a/app/code/core/Mage/CatalogIndex/Model/Aggregation.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Aggregation.php
@@ -102,7 +102,7 @@ class Mage_CatalogIndex_Model_Aggregation extends Mage_Core_Model_Abstract
     public function clearCacheData($tags = [], $store = null)
     {
         $tags    = $this->_processTags($tags);
-        if ($store !== null) {
+        if (!is_null($store)) {
             $store = Mage::app()->getStore($store)->getId();
         }
         $this->_getResource()->clearCacheData($tags, $store);

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Aggregation.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Aggregation.php
@@ -140,7 +140,7 @@ class Mage_CatalogIndex_Model_Resource_Aggregation extends Mage_Core_Model_Resou
             $conditions[] = $write->quoteInto('aggregation_id IN ?', $select);
         }
 
-        if ($storeId !== null) {
+        if (!is_null($storeId)) {
             $conditions[] = $write->quoteInto('store_id=?', $storeId);
         }
 

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Grouped.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Grouped.php
@@ -55,7 +55,7 @@ class Mage_CatalogIndex_Model_Resource_Data_Grouped extends Mage_CatalogIndex_Mo
                 $retreiver = Mage::getSingleton('catalogindex/retreiver')->getRetreiver($type);
                 foreach ($typeIds as $id) {
                     $finalPrice = $retreiver->getFinalPrice($id, $store, $group);
-                    if (($resultMinimal === null) || ($finalPrice < $resultMinimal)) {
+                    if ((is_null($resultMinimal)) || ($finalPrice < $resultMinimal)) {
                         $resultMinimal    = $finalPrice;
                         $resultTaxClassId = $retreiver->getTaxClassId($id, $store);
                     }
@@ -65,7 +65,7 @@ class Mage_CatalogIndex_Model_Resource_Data_Grouped extends Mage_CatalogIndex_Mo
                         if ($tier['customer_group_id'] != $customerGroup && !$tier['all_groups']) {
                             continue;
                         }
-                        if (($resultMinimal === null) || ($tier['value'] < $resultMinimal)) {
+                        if ((is_null($resultMinimal)) || ($tier['value'] < $resultMinimal)) {
                             $resultMinimal    = $tier['value'];
                             $resultTaxClassId = $retreiver->getTaxClassId($tier['entity_id'], $store);
                         }
@@ -78,7 +78,7 @@ class Mage_CatalogIndex_Model_Resource_Data_Grouped extends Mage_CatalogIndex_Mo
                     continue;
                 }
 
-                if (($resultMinimal === null) || ($one['value'] < $resultMinimal)) {
+                if ((is_null($resultMinimal)) || ($one['value'] < $resultMinimal)) {
                     $resultMinimal = $one['value'];
                     $taxClassId    = $one['tax_class_id'];
                 } else {

--- a/app/code/core/Mage/CatalogInventory/Block/Qtyincrements.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Qtyincrements.php
@@ -55,7 +55,7 @@ class Mage_CatalogInventory_Block_Qtyincrements extends Mage_Core_Block_Template
      */
     public function getProductQtyIncrements()
     {
-        if ($this->_qtyIncrements === null) {
+        if (is_null($this->_qtyIncrements)) {
             $this->_qtyIncrements = $this->_getProduct()->getStockItem()->getQtyIncrements();
             if (!$this->_getProduct()->isSaleable()) {
                 $this->_qtyIncrements = false;

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Composite.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Composite.php
@@ -42,7 +42,7 @@ abstract class Mage_CatalogInventory_Block_Stockqty_Composite extends Mage_Catal
      */
     public function getChildProducts()
     {
-        if ($this->_childProducts === null) {
+        if (is_null($this->_childProducts)) {
             $this->_childProducts = $this->_getChildProducts();
         }
         return $this->_childProducts;

--- a/app/code/core/Mage/CatalogInventory/Helper/Data.php
+++ b/app/code/core/Mage/CatalogInventory/Helper/Data.php
@@ -61,7 +61,7 @@ class Mage_CatalogInventory_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function getIsQtyTypeIds($filter = null)
     {
-        if (self::$_isQtyTypeIds === null) {
+        if (is_null(self::$_isQtyTypeIds)) {
             self::$_isQtyTypeIds = [];
             $productTypesXml = Mage::getConfig()->getNode('global/catalog/product/type');
             foreach ($productTypesXml->children() as $typeId => $configXml) {

--- a/app/code/core/Mage/CatalogInventory/Helper/Data.php
+++ b/app/code/core/Mage/CatalogInventory/Helper/Data.php
@@ -68,7 +68,7 @@ class Mage_CatalogInventory_Helper_Data extends Mage_Core_Helper_Abstract
                 self::$_isQtyTypeIds[$typeId] = (bool)$configXml->is_qty;
             }
         }
-        if ($filter === null) {
+        if (is_null($filter)) {
             return self::$_isQtyTypeIds;
         }
         $result = self::$_isQtyTypeIds;

--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -932,7 +932,7 @@ class Mage_CatalogInventory_Model_Observer
         $entityField    = $observer->getEvent()->getEntityField();
         $websiteField   = $observer->getEvent()->getWebsiteField();
 
-        if ($entityField === null || $websiteField === null) {
+        if (is_null($entityField) || is_null($websiteField)) {
             return $this;
         }
 

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
@@ -386,7 +386,7 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
      */
     public function getQtyIncrements()
     {
-        if ($this->_qtyIncrements === null) {
+        if (is_null($this->_qtyIncrements)) {
             if ($this->getEnableQtyIncrements()) {
                 $this->_qtyIncrements = (float)($this->getUseConfigQtyIncrements()
                     ? Mage::getStoreConfig(self::XML_PATH_QTY_INCREMENTS)
@@ -789,7 +789,7 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
      */
     public function verifyStock($qty = null)
     {
-        if ($qty === null) {
+        if (is_null($qty)) {
             $qty = $this->getQty();
         }
         if ($this->getBackorders() == Mage_CatalogInventory_Model_Stock::BACKORDERS_NO && $qty <= $this->getMinQty()) {
@@ -806,7 +806,7 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
      */
     public function verifyNotification($qty = null)
     {
-        if ($qty === null) {
+        if (is_null($qty)) {
             $qty = $this->getQty();
         }
         return (float)$qty < $this->getNotifyStockQty();

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Status.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Status.php
@@ -443,10 +443,10 @@ class Mage_CatalogInventory_Model_Stock_Status extends Mage_Core_Model_Abstract
      */
     public function addStockStatusToProducts($productCollection, $websiteId = null, $stockId = null)
     {
-        if ($stockId === null) {
+        if (is_null($stockId)) {
             $stockId = Mage_CatalogInventory_Model_Stock::DEFAULT_STOCK_ID;
         }
-        if ($websiteId === null) {
+        if (is_null($websiteId)) {
             $websiteId = Mage::app()->getStore()->getWebsiteId();
             if ((int)$websiteId == 0 && $productCollection->getStoreId()) {
                 $websiteId = Mage::app()->getStore($productCollection->getStoreId())->getWebsiteId();

--- a/app/code/core/Mage/CatalogRule/Model/Observer.php
+++ b/app/code/core/Mage/CatalogRule/Model/Observer.php
@@ -228,11 +228,11 @@ class Mage_CatalogRule_Model_Observer
         /** @var Mage_Catalog_Model_Product $product */
         $product = $observer->getEvent()->getProduct();
         if ($product instanceof Mage_Catalog_Model_Product
-            && $product->getConfigurablePrice() !== null
+            && !is_null($product->getConfigurablePrice())
         ) {
             $configurablePrice = $product->getConfigurablePrice();
             $productPriceRule = Mage::getModel('catalogrule/rule')->calcProductPriceRule($product, $configurablePrice);
-            if ($productPriceRule !== null) {
+            if (!is_null($productPriceRule)) {
                 $product->setConfigurablePrice($productPriceRule);
             }
         }

--- a/app/code/core/Mage/CatalogRule/Model/Resource/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Resource/Rule.php
@@ -468,7 +468,7 @@ class Mage_CatalogRule_Model_Resource_Rule extends Mage_Rule_Model_Resource_Abst
             ['default_price' => 'pp_default.value']
         );
 
-        if ($websiteId !== null) {
+        if (!is_null($websiteId)) {
             $website  = Mage::app()->getWebsite($websiteId);
             $defaultGroup = $website->getDefaultGroup();
             if ($defaultGroup instanceof Mage_Core_Model_Store_Group) {
@@ -587,7 +587,7 @@ class Mage_CatalogRule_Model_Resource_Rule extends Mage_Rule_Model_Resource_Abst
      */
     protected function _calcRuleProductPrice($ruleData, $productData = null)
     {
-        if ($productData !== null && isset($productData['rule_price'])) {
+        if (!is_null($productData) && isset($productData['rule_price'])) {
             $productPrice = $productData['rule_price'];
         } else {
             $websiteId = $ruleData['website_id'];

--- a/app/code/core/Mage/CatalogSearch/Helper/Data.php
+++ b/app/code/core/Mage/CatalogSearch/Helper/Data.php
@@ -114,7 +114,7 @@ class Mage_CatalogSearch_Helper_Data extends Mage_Core_Helper_Abstract
     {
         if (!isset($this->_queryText)) {
             $this->_queryText = $this->_getRequest()->getParam($this->getQueryParamName());
-            if ($this->_queryText === null) {
+            if (is_null($this->_queryText)) {
                 $this->_queryText = '';
             } else {
                 /** @var Mage_Core_Helper_String $stringHelper */

--- a/app/code/core/Mage/CatalogSearch/Model/Layer.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Layer.php
@@ -66,7 +66,7 @@ class Mage_CatalogSearch_Model_Layer extends Mage_Catalog_Model_Layer
      */
     public function getStateKey()
     {
-        if ($this->_stateKey === null) {
+        if (is_null($this->_stateKey)) {
             $this->_stateKey = 'Q_' . Mage::helper('catalogsearch')->getQuery()->getId()
                 . '_' . parent::getStateKey();
         }

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
@@ -758,7 +758,7 @@ class Mage_CatalogSearch_Model_Resource_Fulltext extends Mage_Core_Model_Resourc
             }
         }
 
-        $value = $value === null ? '' : preg_replace("#\s+#siu", ' ', trim(strip_tags($value)));
+        $value = is_null($value) ? '' : preg_replace("#\s+#siu", ' ', trim(strip_tags($value)));
 
         return $value;
     }

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Query/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Query/Collection.php
@@ -114,7 +114,7 @@ class Mage_CatalogSearch_Model_Resource_Query_Collection extends Mage_Core_Model
         if ($storeIds) {
             $this->addStoreFilter($storeIds);
             $this->getSelect()->where('num_results > 0');
-        } elseif ($storeIds === null) {
+        } elseif (is_null($storeIds)) {
             $this->addStoreFilter(Mage::app()->getStore()->getId());
             $this->getSelect()->where('num_results > 0');
         }

--- a/app/code/core/Mage/Centinel/Model/Service.php
+++ b/app/code/core/Mage/Centinel/Model/Service.php
@@ -124,7 +124,7 @@ class Mage_Centinel_Model_Service extends Varien_Object
      */
     protected function _getApi()
     {
-        if ($this->_api !== null) {
+        if (!is_null($this->_api)) {
             return $this->_api;
         }
 

--- a/app/code/core/Mage/Checkout/Block/Cart.php
+++ b/app/code/core/Mage/Checkout/Block/Cart.php
@@ -100,7 +100,7 @@ class Mage_Checkout_Block_Cart extends Mage_Checkout_Block_Cart_Abstract
     public function isWishlistActive()
     {
         $isActive = $this->_getData('is_wishlist_active');
-        if ($isActive === null) {
+        if (is_null($isActive)) {
             $isActive = Mage::getStoreConfig('wishlist/general/active')
                 && Mage::getSingleton('customer/session')->isLoggedIn();
             $this->setIsWishlistActive($isActive);

--- a/app/code/core/Mage/Checkout/Block/Cart/Abstract.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Abstract.php
@@ -104,7 +104,7 @@ abstract class Mage_Checkout_Block_Cart_Abstract extends Mage_Core_Block_Templat
      */
     public function getCustomer()
     {
-        if ($this->_customer === null) {
+        if (is_null($this->_customer)) {
             $this->_customer = Mage::getSingleton('customer/session')->getCustomer();
         }
         return $this->_customer;
@@ -117,7 +117,7 @@ abstract class Mage_Checkout_Block_Cart_Abstract extends Mage_Core_Block_Templat
      */
     public function getCheckout()
     {
-        if ($this->_checkout === null) {
+        if (is_null($this->_checkout)) {
             $this->_checkout = Mage::getSingleton('checkout/session');
         }
         return $this->_checkout;
@@ -130,7 +130,7 @@ abstract class Mage_Checkout_Block_Cart_Abstract extends Mage_Core_Block_Templat
      */
     public function getQuote()
     {
-        if ($this->_quote === null) {
+        if (is_null($this->_quote)) {
             $this->_quote = $this->getCheckout()->getQuote();
         }
         return $this->_quote;

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer.php
@@ -321,7 +321,7 @@ class Mage_Checkout_Block_Cart_Item_Renderer extends Mage_Core_Block_Template
      */
     public function getCheckoutSession()
     {
-        if ($this->_checkoutSession === null) {
+        if (is_null($this->_checkoutSession)) {
             $this->_checkoutSession = Mage::getSingleton('checkout/session');
         }
         return $this->_checkoutSession;

--- a/app/code/core/Mage/Checkout/Block/Cart/Shipping.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Shipping.php
@@ -199,7 +199,7 @@ class Mage_Checkout_Block_Cart_Shipping extends Mage_Checkout_Block_Cart_Abstrac
      */
     public function getCarriers()
     {
-        if ($this->_carriers === null) {
+        if (is_null($this->_carriers)) {
             $this->_carriers = [];
             $this->getEstimateRates();
             foreach ($this->_rates as $rateGroup) {

--- a/app/code/core/Mage/Checkout/Block/Cart/Sidebar.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Sidebar.php
@@ -59,7 +59,7 @@ class Mage_Checkout_Block_Cart_Sidebar extends Mage_Checkout_Block_Cart_Minicart
         if (!$this->getSummaryCount()) {
             return [];
         }
-        if ($count === null) {
+        if (is_null($count)) {
             $count = $this->getItemCount();
         }
         return array_slice(array_reverse($this->getItems()), 0, $count);

--- a/app/code/core/Mage/Checkout/Block/Cart/Totals.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Totals.php
@@ -146,7 +146,7 @@ class Mage_Checkout_Block_Cart_Totals extends Mage_Checkout_Block_Cart_Abstract
             return $this->getCustomQuote();
         }
 
-        if ($this->_quote === null) {
+        if (is_null($this->_quote)) {
             $this->_quote = $this->getCheckout()->getQuote();
         }
         return $this->_quote;

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Overview.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Overview.php
@@ -299,7 +299,7 @@ class Mage_Checkout_Block_Multishipping_Overview extends Mage_Sales_Block_Items_
      */
     public function renderTotals($totals, $colspan = null)
     {
-        if ($colspan === null) {
+        if (is_null($colspan)) {
             /** @var Mage_Tax_Helper_Data $helper */
             $helper = $this->helper('tax');
             $colspan = $helper->displayCartBothPrices() ? 5 : 3;

--- a/app/code/core/Mage/Checkout/Helper/Data.php
+++ b/app/code/core/Mage/Checkout/Helper/Data.php
@@ -303,7 +303,7 @@ class Mage_Checkout_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function isAllowedGuestCheckout(Mage_Sales_Model_Quote $quote, $store = null)
     {
-        if ($store === null) {
+        if (is_null($store)) {
             $store = $quote->getStoreId();
         }
         $guestCheckout = Mage::getStoreConfigFlag(self::XML_PATH_GUEST_CHECKOUT, $store);

--- a/app/code/core/Mage/Checkout/Model/Cart.php
+++ b/app/code/core/Mage/Checkout/Model/Cart.php
@@ -270,7 +270,7 @@ class Mage_Checkout_Model_Cart extends Varien_Object implements Mage_Checkout_Mo
                     )
                     : $product->getProductUrl();
                 $this->getCheckoutSession()->setRedirectUrl($redirectUrl);
-                if ($this->getCheckoutSession()->getUseNotice() === null) {
+                if (is_null($this->getCheckoutSession()->getUseNotice())) {
                     $this->getCheckoutSession()->setUseNotice(true);
                 }
                 Mage::throwException($result);
@@ -481,7 +481,7 @@ class Mage_Checkout_Model_Cart extends Varien_Object implements Mage_Checkout_Mo
     public function getProductIds()
     {
         $quoteId = Mage::getSingleton('checkout/session')->getQuoteId();
-        if ($this->_productIds === null) {
+        if (is_null($this->_productIds)) {
             $this->_productIds = [];
             if ($this->getSummaryQty() > 0) {
                 foreach ($this->getQuote()->getAllItems() as $item) {
@@ -510,7 +510,7 @@ class Mage_Checkout_Model_Cart extends Varien_Object implements Mage_Checkout_Mo
             $quoteId = Mage::getSingleton('checkout/session')->getQuoteId();
         }
 
-        if ($quoteId && $this->_summaryQty === null) {
+        if ($quoteId && is_null($this->_summaryQty)) {
             if (Mage::getStoreConfig('checkout/cart_link/use_qty')) {
                 $this->_summaryQty = $this->getItemsQty();
             } else {
@@ -584,7 +584,7 @@ class Mage_Checkout_Model_Cart extends Varien_Object implements Mage_Checkout_Mo
          * We can get string if updating process had some errors
          */
         if (is_string($result)) {
-            if ($this->getCheckoutSession()->getUseNotice() === null) {
+            if (is_null($this->getCheckoutSession()->getUseNotice())) {
                 $this->getCheckoutSession()->setUseNotice(true);
             }
             Mage::throwException($result);

--- a/app/code/core/Mage/Checkout/Model/Cart/Customer/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Customer/Api/V2.php
@@ -29,7 +29,7 @@ class Mage_Checkout_Model_Cart_Customer_Api_V2 extends Mage_Checkout_Model_Cart_
      */
     protected function _prepareCustomerData($data)
     {
-        if (($_data = get_object_vars($data)) !== null) {
+        if (($_data = get_object_vars(!is_null($data)))) {
             return parent::_prepareCustomerData($_data);
         }
         return [];
@@ -46,7 +46,7 @@ class Mage_Checkout_Model_Cart_Customer_Api_V2 extends Mage_Checkout_Model_Cart_
         if (is_array($data)) {
             $dataAddresses = [];
             foreach ($data as $addressItem) {
-                if (($_addressItem = get_object_vars($addressItem)) !== null) {
+                if (($_addressItem = get_object_vars(!is_null($addressItem)))) {
                     $dataAddresses[] = $_addressItem;
                 }
             }

--- a/app/code/core/Mage/Checkout/Model/Cart/Payment/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Payment/Api/V2.php
@@ -27,7 +27,7 @@ class Mage_Checkout_Model_Cart_Payment_Api_V2 extends Mage_Checkout_Model_Cart_P
       */
     protected function _preparePaymentData($data)
     {
-        if (($_data = get_object_vars($data)) !== null) {
+        if (($_data = get_object_vars(!is_null($data)))) {
             return parent::_preparePaymentData($_data);
         }
 

--- a/app/code/core/Mage/Checkout/Model/Session.php
+++ b/app/code/core/Mage/Checkout/Model/Session.php
@@ -185,7 +185,7 @@ class Mage_Checkout_Model_Session extends Mage_Core_Model_Session_Abstract
     {
         Mage::dispatchEvent('custom_quote_process', ['checkout_session' => $this]);
 
-        if ($this->_quote === null) {
+        if (is_null($this->_quote)) {
             /** @var Mage_Sales_Model_Quote $quote */
             $quote = Mage::getModel('sales/quote')->setStoreId(Mage::app()->getStore()->getId());
             if ($this->getQuoteId()) {

--- a/app/code/core/Mage/Checkout/Model/Session.php
+++ b/app/code/core/Mage/Checkout/Model/Session.php
@@ -513,7 +513,7 @@ class Mage_Checkout_Model_Session extends Mage_Core_Model_Session_Abstract
     public function getLastRealOrder()
     {
         $orderId = $this->getLastRealOrderId();
-        if ($this->_order !== null && $orderId == $this->_order->getIncrementId()) {
+        if (!is_null($this->_order) && $orderId == $this->_order->getIncrementId()) {
             return $this->_order;
         }
         $this->_order = $this->_getOrderModel();

--- a/app/code/core/Mage/Checkout/Model/Type/Multishipping.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Multishipping.php
@@ -105,7 +105,7 @@ class Mage_Checkout_Model_Type_Multishipping extends Mage_Checkout_Model_Type_Ab
      */
     public function getQuoteShippingAddressesItems()
     {
-        if ($this->_quoteShippingAddressesItems !== null) {
+        if (!is_null($this->_quoteShippingAddressesItems)) {
             return $this->_quoteShippingAddressesItems;
         }
         $items = [];

--- a/app/code/core/Mage/Cms/Block/Widget/Page/Link.php
+++ b/app/code/core/Mage/Cms/Block/Widget/Page/Link.php
@@ -72,7 +72,7 @@ class Mage_Cms_Block_Widget_Page_Link extends Mage_Core_Block_Html_Link implemen
     {
         if (!$this->_title) {
             $this->_title = '';
-            if ($this->getData('title') !== null) {
+            if (!is_null($this->getData('title'))) {
                 // compare to null used here bc user can specify blank title
                 $this->_title = $this->getData('title');
             } elseif ($this->getData('page_id')) {

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
@@ -164,7 +164,7 @@ class Mage_Cms_Model_Wysiwyg_Images_Storage extends Varien_Object
     public function getCollection($path = null)
     {
         $collection = Mage::getModel('cms/wysiwyg_images_storage_collection');
-        if ($path !== null) {
+        if (!is_null($path)) {
             $collection->addTargetDir($path);
         }
         return $collection;

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/Abstract.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/Abstract.php
@@ -71,7 +71,7 @@ abstract class Mage_ConfigurableSwatches_Block_Catalog_Media_Js_Abstract extends
 
         $products = $this->getProducts();
 
-        if ($keepFrame === null) {
+        if (is_null($keepFrame)) {
             $keepFrame = $this->isKeepFrame();
         }
 

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
@@ -74,7 +74,7 @@ class Mage_ConfigurableSwatches_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public static function normalizeKey($key)
     {
-        if ($key === null || $key === '') {
+        if (is_null($key) || $key === '') {
             return '';
         }
         if (function_exists('mb_strtolower')) {

--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -939,7 +939,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         /**
          * Use single transport object instance for all blocks
          */
-        if (self::$_transportObject === null) {
+        if (is_null(self::$_transportObject)) {
             self::$_transportObject = new Varien_Object();
         }
         self::$_transportObject->setHtml($html);

--- a/app/code/core/Mage/Core/Controller/Request/Http.php
+++ b/app/code/core/Mage/Core/Controller/Request/Http.php
@@ -124,9 +124,9 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
      */
     public function setPathInfo($pathInfo = null)
     {
-        if ($pathInfo === null) {
+        if (is_null($pathInfo)) {
             $requestUri = $this->getRequestUri();
-            if ($requestUri === null) {
+            if (is_null($requestUri)) {
                 return $this;
             }
 
@@ -144,7 +144,7 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
                 $this->setActionName('noRoute');
             } elseif ($baseUrl !== null && !$pathInfo) {
                 $pathInfo = '';
-            } elseif ($baseUrl === null) {
+            } elseif (is_null($baseUrl)) {
                 $pathInfo = $requestUri;
             }
 
@@ -181,7 +181,7 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
      */
     public function rewritePathInfo($pathInfo)
     {
-        if (($pathInfo != $this->getPathInfo()) && ($this->_rewritedPathInfo === null)) {
+        if (($pathInfo != $this->getPathInfo()) && (is_null($this->_rewritedPathInfo))) {
             $this->_rewritedPathInfo = explode('/', trim($this->getPathInfo(), '/'));
         }
         $this->setPathInfo($pathInfo);
@@ -440,7 +440,7 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
         if (isset($this->_routingInfo['requested_route'])) {
             return $this->_routingInfo['requested_route'];
         }
-        if ($this->_requestedRouteName === null) {
+        if (is_null($this->_requestedRouteName)) {
             if ($this->_rewritedPathInfo !== null && isset($this->_rewritedPathInfo[0])) {
                 $fronName = $this->_rewritedPathInfo[0];
                 $router = Mage::app()->getFrontController()->getRouterByFrontName($fronName);

--- a/app/code/core/Mage/Core/Controller/Request/Http.php
+++ b/app/code/core/Mage/Core/Controller/Request/Http.php
@@ -142,7 +142,7 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
             if ($baseUrl && $pathInfo && (stripos($pathInfo, '/') !== 0)) {
                 $pathInfo = '';
                 $this->setActionName('noRoute');
-            } elseif ($baseUrl !== null && !$pathInfo) {
+            } elseif (!is_null($baseUrl) && !$pathInfo) {
                 $pathInfo = '';
             } elseif (is_null($baseUrl)) {
                 $pathInfo = $requestUri;
@@ -441,7 +441,7 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
             return $this->_routingInfo['requested_route'];
         }
         if (is_null($this->_requestedRouteName)) {
-            if ($this->_rewritedPathInfo !== null && isset($this->_rewritedPathInfo[0])) {
+            if (!is_null($this->_rewritedPathInfo) && isset($this->_rewritedPathInfo[0])) {
                 $fronName = $this->_rewritedPathInfo[0];
                 $router = Mage::app()->getFrontController()->getRouterByFrontName($fronName);
                 $this->_requestedRouteName = $router->getRouteByFrontName($fronName);
@@ -463,7 +463,7 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
         if (isset($this->_routingInfo['requested_controller'])) {
             return $this->_routingInfo['requested_controller'];
         }
-        if (($this->_rewritedPathInfo !== null) && isset($this->_rewritedPathInfo[1])) {
+        if ((!is_null($this->_rewritedPathInfo)) && isset($this->_rewritedPathInfo[1])) {
             return $this->_rewritedPathInfo[1];
         }
         return $this->getControllerName();
@@ -479,7 +479,7 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
         if (isset($this->_routingInfo['requested_action'])) {
             return $this->_routingInfo['requested_action'];
         }
-        if (($this->_rewritedPathInfo !== null) && isset($this->_rewritedPathInfo[2])) {
+        if ((!is_null($this->_rewritedPathInfo)) && isset($this->_rewritedPathInfo[2])) {
             return $this->_rewritedPathInfo[2];
         }
         return $this->getActionName();
@@ -546,7 +546,7 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
      */
     public function isStraight($flag = null)
     {
-        if ($flag !== null) {
+        if (!is_null($flag)) {
             $this->_isStraight = $flag;
         }
         return $this->_isStraight;

--- a/app/code/core/Mage/Core/Controller/Response/Http.php
+++ b/app/code/core/Mage/Core/Controller/Response/Http.php
@@ -83,7 +83,7 @@ class Mage_Core_Controller_Response_Http extends Zend_Controller_Response_Http
         /**
          * Use single transport object instance
          */
-        if (self::$_transportObject === null) {
+        if (is_null(self::$_transportObject)) {
             self::$_transportObject = new Varien_Object();
         }
         self::$_transportObject->setUrl($url);

--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -937,7 +937,7 @@ abstract class Mage_Core_Controller_Varien_Action
             if ($text === false) {
                 $this->_removeDefaultTitle = false;
                 $this->_titles = [];
-            } elseif ($text === null) {
+            } elseif (is_null($text)) {
                 $this->_removeDefaultTitle = true;
                 $this->_titles = [];
             }

--- a/app/code/core/Mage/Core/Controller/Varien/Exception.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Exception.php
@@ -40,7 +40,7 @@ class Mage_Core_Controller_Varien_Exception extends Exception
     public function prepareForward($actionName = null, $controllerName = null, $moduleName = null, array $params = [])
     {
         $this->_resultCallback = self::RESULT_FORWARD;
-        if ($actionName === null) {
+        if (is_null($actionName)) {
             $actionName = $this->_defaultActionName;
         }
         $this->_resultCallbackParams = [$actionName, $controllerName, $moduleName, $params];
@@ -69,7 +69,7 @@ class Mage_Core_Controller_Varien_Exception extends Exception
      */
     public function prepareFork($actionName = null)
     {
-        if ($actionName === null) {
+        if (is_null($actionName)) {
             $actionName = $this->_defaultActionName;
         }
         $this->_resultCallback = $actionName;
@@ -107,7 +107,7 @@ class Mage_Core_Controller_Varien_Exception extends Exception
      */
     public function getResultCallback()
     {
-        if ($this->_resultCallback === null) {
+        if (is_null($this->_resultCallback)) {
             $this->prepareFork();
         }
         return [$this->_resultCallback, $this->_resultCallbackParams];

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -127,7 +127,7 @@ abstract class Mage_Core_Helper_Abstract
      */
     public function isModuleOutputEnabled($moduleName = null)
     {
-        if ($moduleName === null) {
+        if (is_null($moduleName)) {
             $moduleName = $this->_getModuleName();
         }
 
@@ -149,7 +149,7 @@ abstract class Mage_Core_Helper_Abstract
      */
     public function isModuleEnabled($moduleName = null)
     {
-        if ($moduleName === null) {
+        if (is_null($moduleName)) {
             $moduleName = $this->_getModuleName();
         }
 
@@ -251,7 +251,7 @@ abstract class Mage_Core_Helper_Abstract
      */
     public function stripTags($data, $allowableTags = null, $escape = false)
     {
-        if ($data === null) {
+        if (is_null($data)) {
             return '';
         }
         $result = strip_tags($data, $allowableTags);

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -69,7 +69,7 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function getEncryptor()
     {
-        if ($this->_encryptor === null) {
+        if (is_null($this->_encryptor)) {
             $encryptionModel = (string)Mage::getConfig()->getNode(self::XML_PATH_ENCRYPTION_MODEL);
             if ($encryptionModel) {
                 $this->_encryptor = new $encryptionModel();
@@ -706,7 +706,7 @@ XML;
     public function jsonDecode($encodedValue, $objectDecodeType = Zend_Json::TYPE_ARRAY)
     {
         switch (true) {
-            case ($encodedValue === null):
+            case (is_null($encodedValue)):
                 $encodedValue = 'null';
                 break;
             case ($encodedValue === true):

--- a/app/code/core/Mage/Core/Helper/File/Storage/Database.php
+++ b/app/code/core/Mage/Core/Helper/File/Storage/Database.php
@@ -57,7 +57,7 @@ class Mage_Core_Helper_File_Storage_Database extends Mage_Core_Helper_Abstract
      */
     public function checkDbUsage()
     {
-        if ($this->_useDb === null) {
+        if (is_null($this->_useDb)) {
             $currentStorage = (int) Mage::app()->getConfig()
                 ->getNode(Mage_Core_Model_File_Storage::XML_PATH_STORAGE_MEDIA);
             $this->_useDb = ($currentStorage == Mage_Core_Model_File_Storage::STORAGE_MEDIA_DATABASE);
@@ -293,7 +293,7 @@ class Mage_Core_Helper_File_Storage_Database extends Mage_Core_Helper_Abstract
      */
     public function getMediaBaseDir()
     {
-        if ($this->_mediaBaseDirectory === null) {
+        if (is_null($this->_mediaBaseDirectory)) {
             $this->_mediaBaseDirectory = rtrim(Mage::getBaseDir('media'), '\\/');
         }
         return $this->_mediaBaseDirectory;

--- a/app/code/core/Mage/Core/Helper/Hint.php
+++ b/app/code/core/Mage/Core/Helper/Hint.php
@@ -37,7 +37,7 @@ class Mage_Core_Helper_Hint extends Mage_Core_Helper_Abstract
      */
     public function getAvailableHints()
     {
-        if ($this->_availableHints === null) {
+        if (is_null($this->_availableHints)) {
             $hints = [];
             $config = Mage::getConfig()->getNode('default/hints');
             if ($config) {

--- a/app/code/core/Mage/Core/Helper/Js.php
+++ b/app/code/core/Mage/Core/Helper/Js.php
@@ -132,7 +132,7 @@ class Mage_Core_Helper_Js extends Mage_Core_Helper_Abstract
      */
     protected function _getTranslateData()
     {
-        if ($this->_translateData === null) {
+        if (is_null($this->_translateData)) {
             $this->_translateData = [];
             $messages = $this->_getXmlConfig()->getXpath('*/message');
             if (!empty($messages)) {

--- a/app/code/core/Mage/Core/Model/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Abstract.php
@@ -415,7 +415,7 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
      */
     public function isObjectNew($flag = null)
     {
-        if ($flag !== null) {
+        if (!is_null($flag)) {
             $this->_isObjectNew = $flag;
         }
         return $this->_isObjectNew ?? !(bool)$this->getId();

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -270,7 +270,7 @@ class Mage_Core_Model_App
         $this->_config->init($options);
         Varien_Profiler::stop('mage::app::init::config');
 
-        if ($this->_isInstalled === null) {
+        if (is_null($this->_isInstalled)) {
             $this->_isInstalled = Mage::isInstalled($options);
         }
 
@@ -716,7 +716,7 @@ class Mage_Core_Model_App
      */
     public function isSingleStoreMode()
     {
-        if ($this->_isInstalled === null) {
+        if (is_null($this->_isInstalled)) {
             $this->_isInstalled = Mage::isInstalled();
         }
 
@@ -847,7 +847,7 @@ class Mage_Core_Model_App
      */
     public function getStore($id = null)
     {
-        if ($this->_isInstalled === null) {
+        if (is_null($this->_isInstalled)) {
             $this->_isInstalled = Mage::isInstalled();
         }
 

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -461,7 +461,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      */
     protected function _canUseLocalModules()
     {
-        if ($this->_canUseLocalModules !== null) {
+        if (!is_null($this->_canUseLocalModules)) {
             return $this->_canUseLocalModules;
         }
 
@@ -762,7 +762,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
         /**
          * Check path cache loading
          */
-        if ($this->_useCache && ($path !== null)) {
+        if ($this->_useCache && (!is_null($path))) {
             $path   = explode('/', $path);
             $section = $path[0];
             if (isset($this->_cacheSections[$section])) {
@@ -785,7 +785,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      */
     public function setNode($path, $value, $overwrite = true)
     {
-        if ($this->_useCache && ($path !== null)) {
+        if ($this->_useCache && (!is_null($path))) {
             $sectionPath = explode('/', $path);
             $config = $this->_getSectionConfig($sectionPath);
             if ($config) {
@@ -1210,7 +1210,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      */
     public function getVarDir($path = null, $type = 'var')
     {
-        $dir = Mage::getBaseDir($type) . ($path !== null ? DS . $path : '');
+        $dir = Mage::getBaseDir($type) . (!is_null($path) ? DS . $path : '');
         if (!$this->createDirIfNotExists($dir)) {
             return false;
         }

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -999,7 +999,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      */
     public function determineOmittedNamespace($name, $asFullModuleName = false)
     {
-        if ($this->_moduleNamespaces === null) {
+        if (is_null($this->_moduleNamespaces)) {
             $this->_moduleNamespaces = [];
             foreach ($this->_xml->xpath('modules/*') as $m) {
                 if ((string)$m->active == 'true') {
@@ -1046,11 +1046,11 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     {
         $disableLocalModules = !$this->_canUseLocalModules();
 
-        if ($mergeToObject === null) {
+        if (is_null($mergeToObject)) {
             $mergeToObject = clone $this->_prototype;
             $mergeToObject->loadString('<config/>');
         }
-        if ($mergeModel === null) {
+        if (is_null($mergeModel)) {
             $mergeModel = clone $this->_prototype;
         }
         $modules = $this->getNode('modules')->children();

--- a/app/code/core/Mage/Core/Model/Cookie.php
+++ b/app/code/core/Mage/Core/Model/Cookie.php
@@ -284,7 +284,7 @@ class Mage_Core_Model_Cookie
      */
     public function renew($name, $period = null, $path = null, $domain = null, $secure = null, $httponly = null, $sameSite = null)
     {
-        if (($period === null) && !$this->getLifetime()) {
+        if ((is_null($period)) && !$this->getLifetime()) {
             return $this;
         }
         $value = $this->_getRequest()->getCookie($name, false);

--- a/app/code/core/Mage/Core/Model/Design/Package.php
+++ b/app/code/core/Mage/Core/Model/Design/Package.php
@@ -214,7 +214,7 @@ class Mage_Core_Model_Design_Package
      */
     public function getPackageName()
     {
-        if ($this->_name === null) {
+        if (is_null($this->_name)) {
             $this->setPackageName();
         }
         return $this->_name;

--- a/app/code/core/Mage/Core/Model/Email/Queue.php
+++ b/app/code/core/Mage/Core/Model/Email/Queue.php
@@ -191,7 +191,7 @@ class Mage_Core_Model_Email_Queue extends Mage_Core_Model_Abstract
         foreach ($collection as $message) {
             if ($message->getId()) {
                 $parameters = new Varien_Object($message->getMessageParameters());
-                if ($parameters->getReturnPathEmail() !== null) {
+                if (!is_null($parameters->getReturnPathEmail())) {
                     $mailTransport = new Zend_Mail_Transport_Sendmail('-f' . $parameters->getReturnPathEmail());
                     Zend_Mail::setDefaultTransport($mailTransport);
                 }
@@ -219,10 +219,10 @@ class Mage_Core_Model_Email_Queue extends Mage_Core_Model_Abstract
 
                 $mailer->setSubject('=?utf-8?B?' . base64_encode($parameters->getSubject()) . '?=');
                 $mailer->setFrom($parameters->getFromEmail(), $parameters->getFromName());
-                if ($parameters->getReplyTo() !== null) {
+                if (!is_null($parameters->getReplyTo())) {
                     $mailer->setReplyTo($parameters->getReplyTo());
                 }
-                if ($parameters->getReturnTo() !== null) {
+                if (!is_null($parameters->getReturnTo())) {
                     $mailer->setReturnPath($parameters->getReturnTo());
                 }
 

--- a/app/code/core/Mage/Core/Model/Email/Template.php
+++ b/app/code/core/Mage/Core/Model/Email/Template.php
@@ -430,7 +430,7 @@ class Mage_Core_Model_Email_Template extends Mage_Core_Model_Email_Template_Abst
 
         $mail = $this->getMail();
 
-        if ($returnPathEmail !== null) {
+        if (!is_null($returnPathEmail)) {
             $mailTransport = new Zend_Mail_Transport_Sendmail('-f' . $returnPathEmail);
             Zend_Mail::setDefaultTransport($mailTransport);
         }

--- a/app/code/core/Mage/Core/Model/Email/Template.php
+++ b/app/code/core/Mage/Core/Model/Email/Template.php
@@ -500,7 +500,7 @@ class Mage_Core_Model_Email_Template extends Mage_Core_Model_Email_Template_Abst
     public function sendTransactional($templateId, $sender, $email, $name, $vars = [], $storeId = null)
     {
         $this->setSentSuccess(false);
-        if (($storeId === null) && $this->getDesignConfig()->getStore()) {
+        if ((is_null($storeId)) && $this->getDesignConfig()->getStore()) {
             $storeId = $this->getDesignConfig()->getStore();
         }
 

--- a/app/code/core/Mage/Core/Model/Email/Template/Filter.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Filter.php
@@ -142,7 +142,7 @@ class Mage_Core_Model_Email_Template_Filter extends Varien_Filter_Template
      */
     public function getStoreId()
     {
-        if ($this->_storeId === null) {
+        if (is_null($this->_storeId)) {
             $this->_storeId = Mage::app()->getStore()->getId();
         }
         return $this->_storeId;

--- a/app/code/core/Mage/Core/Model/Encryption.php
+++ b/app/code/core/Mage/Core/Model/Encryption.php
@@ -166,7 +166,7 @@ class Mage_Core_Model_Encryption
     protected function _getCrypt($key = null)
     {
         if (!$this->_crypt) {
-            if ($key === null) {
+            if (is_null($key)) {
                 $key = (string)Mage::getConfig()->getNode('global/crypt/key');
             }
             $this->_crypt = Varien_Crypt::factory()->init($key);

--- a/app/code/core/Mage/Core/Model/File/Storage/Abstract.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Abstract.php
@@ -35,7 +35,7 @@ abstract class Mage_Core_Model_File_Storage_Abstract extends Mage_Core_Model_Abs
      */
     public function getMediaBaseDirectory()
     {
-        if ($this->_mediaBaseDirectory === null) {
+        if (is_null($this->_mediaBaseDirectory)) {
             /** @var Mage_Core_Helper_File_Storage_Database $helper */
             $helper = Mage::helper('core/file_storage_database');
             $this->_mediaBaseDirectory = $helper->getMediaBaseDir();

--- a/app/code/core/Mage/Core/Model/File/Validator/Image.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/Image.php
@@ -89,7 +89,7 @@ class Mage_Core_Model_File_Validator_Image
                     $imageQuality = (int) $imageQuality;
                 } else {
                     // Value not set in backend. For BC, if depcrecated config does not exist, default to 85.
-                    $imageQuality = Mage::getStoreConfig('general/reprocess_images/active') === null
+                    $imageQuality = is_null(Mage::getStoreConfig('general/reprocess_images/active'))
                         ? 85
                         : (Mage::getStoreConfigFlag('general/reprocess_images/active') ? 85 : 0);
                 }

--- a/app/code/core/Mage/Core/Model/Input/Filter.php
+++ b/app/code/core/Mage/Core/Model/Input/Filter.php
@@ -178,7 +178,7 @@ class Mage_Core_Model_Input_Filter implements Zend_Filter_Interface
      */
     public function getFilters($name = null)
     {
-        if ($name === null) {
+        if (is_null($name)) {
             return $this->_filters;
         } else {
             return $this->_filters[$name] ?? null;
@@ -207,7 +207,7 @@ class Mage_Core_Model_Input_Filter implements Zend_Filter_Interface
      */
     protected function _filter(array $data, &$filters = null, $isFilterListSimple = false)
     {
-        if ($filters === null) {
+        if (is_null($filters)) {
             $filters = &$this->_filters;
         }
         foreach ($data as $key => $value) {

--- a/app/code/core/Mage/Core/Model/Input/Filter/MaliciousCode.php
+++ b/app/code/core/Mage/Core/Model/Input/Filter/MaliciousCode.php
@@ -53,7 +53,7 @@ class Mage_Core_Model_Input_Filter_MaliciousCode implements Zend_Filter_Interfac
      */
     public function filter($value)
     {
-        if ($value === null) {
+        if (is_null($value)) {
             return '';
         }
 

--- a/app/code/core/Mage/Core/Model/Layout.php
+++ b/app/code/core/Mage/Core/Model/Layout.php
@@ -162,7 +162,7 @@ class Mage_Core_Model_Layout extends Varien_Simplexml_Config
                     }
 
                     foreach ($ignoreNodes as $block) {
-                        if ($block->getAttribute('ignore') !== null) {
+                        if (!is_null($block->getAttribute('ignore'))) {
                             continue;
                         }
                         $acl = (string)$attributes->acl;

--- a/app/code/core/Mage/Core/Model/Layout/Update.php
+++ b/app/code/core/Mage/Core/Model/Layout/Update.php
@@ -424,7 +424,7 @@ class Mage_Core_Model_Layout_Update
      */
     public function getFileLayoutUpdatesXml($area, $package, $theme, $storeId = null)
     {
-        if ($storeId === null) {
+        if (is_null($storeId)) {
             $storeId = Mage::app()->getStore()->getId();
         }
         /** @var Mage_Core_Model_Design_Package $design */

--- a/app/code/core/Mage/Core/Model/Locale.php
+++ b/app/code/core/Mage/Core/Model/Locale.php
@@ -178,7 +178,7 @@ class Mage_Core_Model_Locale
      */
     public function getLocaleCode()
     {
-        if ($this->_localeCode === null) {
+        if (is_null($this->_localeCode)) {
             $this->setLocale();
         }
         return $this->_localeCode;

--- a/app/code/core/Mage/Core/Model/Locale.php
+++ b/app/code/core/Mage/Core/Model/Locale.php
@@ -125,7 +125,7 @@ class Mage_Core_Model_Locale
      */
     public function setLocale($locale = null)
     {
-        if (($locale !== null) && is_string($locale)) {
+        if ((!is_null($locale)) && is_string($locale)) {
             $this->_localeCode = $locale;
         } else {
             $this->_localeCode = $this->getDefaultLocale();

--- a/app/code/core/Mage/Core/Model/Log/Adapter.php
+++ b/app/code/core/Mage/Core/Model/Log/Adapter.php
@@ -60,7 +60,7 @@ class Mage_Core_Model_Log_Adapter
      */
     public function log($data = null)
     {
-        if ($data === null) {
+        if (is_null($data)) {
             $data = $this->_data;
         } else {
             if (!is_array($data)) {

--- a/app/code/core/Mage/Core/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Abstract.php
@@ -200,7 +200,7 @@ abstract class Mage_Core_Model_Resource_Abstract
                 if ($fieldValue instanceof Zend_Db_Expr) {
                     $data[$field] = $fieldValue;
                 } else {
-                    if ($fieldValue !== null) {
+                    if (!is_null($fieldValue)) {
                         $fieldValue   = $this->_prepareTableValueForSave($fieldValue, $fields[$field]['DATA_TYPE']);
                         $data[$field] = $this->_getWriteAdapter()->prepareColumnValue($fields[$field], $fieldValue);
                     } elseif (!empty($fields[$field]['NULLABLE'])) {

--- a/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
@@ -138,7 +138,7 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends Varien_Da
      */
     public function getMainTable()
     {
-        if ($this->_mainTable === null) {
+        if (is_null($this->_mainTable)) {
             $this->setMainTable($this->getResource()->getMainTable());
         }
 
@@ -233,7 +233,7 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends Varien_Da
 
                 if (($alias !== null && in_array($alias, $columnsToSelect)) ||
                     // If field already joined from another table
-                    ($alias === null && isset($alias, $columnsToSelect))
+                    (is_null($alias) && isset($alias, $columnsToSelect))
                 ) {
                     continue;
                 }
@@ -258,7 +258,7 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends Varien_Da
      */
     protected function _getInitialFieldsToSelect()
     {
-        if ($this->_initialFieldsToSelect === null) {
+        if (is_null($this->_initialFieldsToSelect)) {
             $this->_initialFieldsToSelect = [];
             $this->_initInitialFieldsToSelect();
         }
@@ -296,7 +296,7 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends Varien_Da
         }
 
         if (is_array($field)) {
-            if ($this->_fieldsToSelect === null) {
+            if (is_null($this->_fieldsToSelect)) {
                 $this->_fieldsToSelect = $this->_getInitialFieldsToSelect();
             }
 
@@ -311,7 +311,7 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends Varien_Da
             return $this;
         }
 
-        if ($alias === null) {
+        if (is_null($alias)) {
             $this->_fieldsToSelect[] = $field;
         } else {
             $this->_fieldsToSelect[$alias] = $field;
@@ -496,7 +496,7 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends Varien_Da
      */
     public function getData()
     {
-        if ($this->_data === null) {
+        if (is_null($this->_data)) {
             $this->_renderFilters()
                  ->_renderOrders()
                  ->_renderLimit();

--- a/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
@@ -157,7 +157,7 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends Varien_Da
             $table = $this->getTable($table);
         }
 
-        if ($this->_mainTable !== null && $table !== $this->_mainTable && $this->getSelect() !== null) {
+        if (!is_null($this->_mainTable) && $table !== $this->_mainTable && !is_null($this->getSelect())) {
             $from = $this->getSelect()->getPart(Zend_Db_Select::FROM);
             if (isset($from['main_table'])) {
                 $from['main_table']['tableName'] = $table;
@@ -218,7 +218,7 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends Varien_Da
 
         $columnsToSelect = array_keys($columnsToSelect);
 
-        if ($this->_fieldsToSelect !== null) {
+        if (!is_null($this->_fieldsToSelect)) {
             $insertIndex = 0;
             foreach ($this->_fieldsToSelect as $alias => $field) {
                 if (!is_string($alias)) {
@@ -231,7 +231,7 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends Varien_Da
                     $column = $field;
                 }
 
-                if (($alias !== null && in_array($alias, $columnsToSelect)) ||
+                if ((!is_null($alias) && in_array($alias, $columnsToSelect)) ||
                     // If field already joined from another table
                     (is_null($alias) && isset($alias, $columnsToSelect))
                 ) {

--- a/app/code/core/Mage/Core/Model/Resource/File/Storage/File.php
+++ b/app/code/core/Mage/Core/Model/Resource/File/Storage/File.php
@@ -143,7 +143,7 @@ class Mage_Core_Model_Resource_File_Storage_File
      */
     protected function _getIgnoredFiles()
     {
-        if ($this->_ignoredFiles === null) {
+        if (is_null($this->_ignoredFiles)) {
             $ignored = (string)Mage::app()->getConfig()
                 ->getNode(Mage_Core_Model_File_Storage::XML_PATH_MEDIA_RESOURCE_IGNORED);
             $this->_ignoredFiles = $ignored ? explode(',', $ignored) : [];

--- a/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
@@ -306,7 +306,7 @@ abstract class Mage_Core_Model_Resource_Helper_Abstract
          * Process the case when 'is_null' prohibits null value, and 'default' proposed to be null.
          * It just means that default value not specified, and we must remove it from column definition.
          */
-        if ($column['is_null'] === false && $column['default'] === null) {
+        if ($column['is_null'] === false && is_null($column['default'])) {
             unset($result['default']);
         }
 

--- a/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
@@ -59,7 +59,7 @@ abstract class Mage_Core_Model_Resource_Helper_Abstract
      */
     protected function _getReadAdapter()
     {
-        if ($this->_readAdapter === null) {
+        if (is_null($this->_readAdapter)) {
             $this->_readAdapter = $this->_getConnection('read');
         }
 
@@ -73,7 +73,7 @@ abstract class Mage_Core_Model_Resource_Helper_Abstract
      */
     protected function _getWriteAdapter()
     {
-        if ($this->_writeAdapter === null) {
+        if (is_null($this->_writeAdapter)) {
             $this->_writeAdapter = $this->_getConnection('write');
         }
 

--- a/app/code/core/Mage/Core/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Core/Model/Resource/Helper/Mysql4.php
@@ -216,7 +216,7 @@ class Mage_Core_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Resource_He
      */
     protected function _assembleLimit($query, $limitCount, $limitOffset, $columnList = [])
     {
-        if ($limitCount !== null) {
+        if (!is_null($limitCount)) {
             $limitCount = (int) $limitCount;
             $limitOffset = (int) $limitOffset;
 
@@ -253,7 +253,7 @@ class Mage_Core_Model_Resource_Helper_Mysql4 extends Mage_Core_Model_Resource_He
         foreach ($columns as $columnEntry) {
             list($correlationName, $column, $alias) = $columnEntry;
             if ($column instanceof Zend_Db_Expr) {
-                if ($alias !== null) {
+                if (!is_null($alias)) {
                     if (preg_match('/(^|[^a-zA-Z_])^(SELECT)?(SUM|MIN|MAX|AVG|COUNT)\s*\(/i', (string)$column, $matches)) {
                         $column = $this->prepareColumn($column, $groupByCondition);
                     }

--- a/app/code/core/Mage/Core/Model/Resource/Translate/String.php
+++ b/app/code/core/Mage/Core/Model/Resource/Translate/String.php
@@ -163,7 +163,7 @@ class Mage_Core_Model_Resource_Translate_String extends Mage_Core_Model_Resource
 
         if ($storeId === false) {
             $where['store_id > ?'] = Mage_Core_Model_App::ADMIN_STORE_ID;
-        } elseif ($storeId !== null) {
+        } elseif (!is_null($storeId)) {
             $where['store_id = ?'] = $storeId;
         }
 

--- a/app/code/core/Mage/Core/Model/Session/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract.php
@@ -341,7 +341,7 @@ class Mage_Core_Model_Session_Abstract extends Mage_Core_Model_Session_Abstract_
             }
 
             // Check for duplication
-            if ($text !== null) {
+            if (!is_null($text)) {
                 if (isset($messagesAlready[$text])) {
                     continue;
                 }

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -888,7 +888,7 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
         // remove base currency code, if it is not allowed by config (optional)
         if ($skipBaseNotAllowed) {
             $disallowedBaseCodeIndex = $this->getData('disallowed_base_currency_code_index');
-            if ($disallowedBaseCodeIndex !== null) {
+            if (!is_null($disallowedBaseCodeIndex)) {
                 unset($codes[$disallowedBaseCodeIndex]);
             }
         }
@@ -1209,7 +1209,7 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
      */
     public function isReadOnly($value = null)
     {
-        if ($value !== null) {
+        if (!is_null($value)) {
             $this->_isReadOnly = (bool) $value;
         }
         return $this->_isReadOnly;

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -366,7 +366,7 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
         /**
          * Functionality related with config separation
          */
-        if ($this->_configCache === null) {
+        if (is_null($this->_configCache)) {
             $code = $this->getCode();
             if ($code) {
                 if (Mage::app()->useCache('config')) {
@@ -720,7 +720,7 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
      */
     public function isAdminUrlSecure()
     {
-        if ($this->_isAdminSecure === null) {
+        if (is_null($this->_isAdminSecure)) {
             $this->_isAdminSecure = (bool) (int) (string) Mage::getConfig()
                 ->getNode(Mage_Core_Model_Url::XML_PATH_SECURE_IN_ADMIN);
         }
@@ -734,7 +734,7 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
      */
     public function isFrontUrlSecure()
     {
-        if ($this->_isFrontSecure === null) {
+        if (is_null($this->_isFrontSecure)) {
             $this->_isFrontSecure = Mage::getStoreConfigFlag(
                 Mage_Core_Model_Url::XML_PATH_SECURE_IN_FRONT,
                 $this->getId()

--- a/app/code/core/Mage/Core/Model/Store/Group.php
+++ b/app/code/core/Mage/Core/Model/Store/Group.php
@@ -345,7 +345,7 @@ class Mage_Core_Model_Store_Group extends Mage_Core_Model_Abstract
      */
     public function isReadOnly($value = null)
     {
-        if ($value !== null) {
+        if (!is_null($value)) {
             $this->_isReadOnly = (bool)$value;
         }
         return $this->_isReadOnly;

--- a/app/code/core/Mage/Core/Model/Translate.php
+++ b/app/code/core/Mage/Core/Model/Translate.php
@@ -224,7 +224,7 @@ class Mage_Core_Model_Translate
                 continue;
             }
             $key    = $this->_prepareDataString($key);
-            $value  = $value === null ? '' : $this->_prepareDataString($value);
+            $value  = is_null($value) ? '' : $this->_prepareDataString($value);
             if ($scope && isset($this->_dataScope[$key]) && !$forceReload) {
                 /**
                  * Checking previous value

--- a/app/code/core/Mage/Core/Model/Url.php
+++ b/app/code/core/Mage/Core/Model/Url.php
@@ -490,7 +490,7 @@ class Mage_Core_Model_Url extends Varien_Object
     {
         if (!$this->hasData('route_path')) {
             $routePath = $this->getRequest()->getAlias(Mage_Core_Model_Url_Rewrite::REWRITE_REQUEST_PATH_ALIAS);
-            if (!empty($routeParams['_use_rewrite']) && ($routePath !== null)) {
+            if (!empty($routeParams['_use_rewrite']) && (!is_null($routePath))) {
                 $this->setData('route_path', $routePath);
                 return $routePath;
             }
@@ -989,7 +989,7 @@ class Mage_Core_Model_Url extends Varien_Object
         /**
          * Apply query params, need call after getRouteUrl for rewrite _current values
          */
-        if ($query !== null) {
+        if (!is_null($query)) {
             if (is_string($query)) {
                 $this->setQuery($query);
             } elseif (is_array($query)) {

--- a/app/code/core/Mage/Core/Model/Url/Rewrite/Request.php
+++ b/app/code/core/Mage/Core/Model/Url/Rewrite/Request.php
@@ -117,7 +117,7 @@ class Mage_Core_Model_Url_Rewrite_Request
      */
     protected function _rewriteDb()
     {
-        if ($this->_rewrite->getStoreId() === null || $this->_rewrite->getStoreId() === false) {
+        if (is_null($this->_rewrite->getStoreId()) || $this->_rewrite->getStoreId() === false) {
             $this->_rewrite->setStoreId($this->_app->getStore()->getId());
         }
 

--- a/app/code/core/Mage/Core/Model/Variable.php
+++ b/app/code/core/Mage/Core/Model/Variable.php
@@ -87,7 +87,7 @@ class Mage_Core_Model_Variable extends Mage_Core_Model_Abstract
      */
     public function getValue($type = null)
     {
-        if ($type === null) {
+        if (is_null($type)) {
             $type = self::TYPE_HTML;
         }
         if ($type == self::TYPE_TEXT || !(strlen((string)$this->getData('html_value')))) {

--- a/app/code/core/Mage/Core/Model/Website.php
+++ b/app/code/core/Mage/Core/Model/Website.php
@@ -557,7 +557,7 @@ class Mage_Core_Model_Website extends Mage_Core_Model_Abstract
      */
     public function isReadOnly($value = null)
     {
-        if ($value !== null) {
+        if (!is_null($value)) {
             $this->_isReadOnly = (bool)$value;
         }
         return $this->_isReadOnly;

--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -75,7 +75,7 @@ function now($dayOnly = false)
  */
 function is_empty_date($date)
 {
-    return $date === null || preg_replace('#[ 0:-]#', '', $date) === '';
+    return is_null($date) || preg_replace('#[ 0:-]#', '', $date) === '';
 }
 
 /**

--- a/app/code/core/Mage/Cron/Model/Observer.php
+++ b/app/code/core/Mage/Cron/Model/Observer.php
@@ -346,7 +346,7 @@ class Mage_Cron_Model_Observer
     {
         /** @var Mage_Cron_Model_Schedule $schedule */
         $schedule = Mage::getModel('cron/schedule')->load($jobCode, 'job_code');
-        if ($schedule->getId() === null) {
+        if (is_null($schedule->getId())) {
             $ts = date('Y-m-d H:i:00');
             $schedule->setJobCode($jobCode)
                 ->setCreatedAt($ts)

--- a/app/code/core/Mage/Customer/Model/Address/Abstract.php
+++ b/app/code/core/Mage/Customer/Model/Address/Abstract.php
@@ -141,7 +141,7 @@ class Mage_Customer_Model_Address_Abstract extends Mage_Core_Model_Abstract
             return $street;
         } else {
             $arr = is_array($street) ? $street : explode("\n", (string)$street);
-            if ($line === 0 || $line === null) {
+            if ($line === 0 || is_null($line)) {
                 return $arr;
             } elseif (isset($arr[$line - 1])) {
                 return $arr[$line - 1];

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Rest/Admin/V1.php
@@ -38,7 +38,7 @@ class Mage_Customer_Model_Api2_Customer_Rest_Admin_V1 extends Mage_Customer_Mode
         $data['is_confirmed'] = (int) !(isset($data['confirmation']) && $data['confirmation']);
 
         $lastLoginAt = $log->getLoginAt();
-        if ($lastLoginAt !== null) {
+        if (!is_null($lastLoginAt)) {
             $data['last_logged_in'] = $lastLoginAt;
         }
         return $data;

--- a/app/code/core/Mage/Customer/Model/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Customer.php
@@ -304,7 +304,7 @@ class Mage_Customer_Model_Customer extends Mage_Core_Model_Abstract
         parent::_beforeSave();
 
         $storeId = $this->getStoreId();
-        if ($storeId === null) {
+        if (is_null($storeId)) {
             $this->setStoreId(Mage::app()->getStore()->getId());
         }
 
@@ -421,7 +421,7 @@ class Mage_Customer_Model_Customer extends Mage_Core_Model_Abstract
      */
     public function getAddressesCollection()
     {
-        if ($this->_addressesCollection === null) {
+        if (is_null($this->_addressesCollection)) {
             $this->_addressesCollection = $this->getAddressCollection()
                 ->setCustomerFilter($this)
                 ->addAttributeToSelect('*')
@@ -455,7 +455,7 @@ class Mage_Customer_Model_Customer extends Mage_Core_Model_Abstract
      */
     public function getAttributes()
     {
-        if ($this->_attributes === null) {
+        if (is_null($this->_attributes)) {
             $this->_attributes = $this->_getResource()
             ->loadAllAttributes($this)
             ->getSortedAttributes();
@@ -980,7 +980,7 @@ class Mage_Customer_Model_Customer extends Mage_Core_Model_Abstract
     public function getSharedStoreIds()
     {
         $ids = $this->_getData('shared_store_ids');
-        if ($ids === null) {
+        if (is_null($ids)) {
             $ids = [];
             if ((bool)$this->getSharingConfig()->isWebsiteScope()) {
                 $ids = Mage::app()->getWebsite($this->getWebsiteId())->getStoreIds();
@@ -1003,7 +1003,7 @@ class Mage_Customer_Model_Customer extends Mage_Core_Model_Abstract
     public function getSharedWebsiteIds()
     {
         $ids = $this->_getData('shared_website_ids');
-        if ($ids === null) {
+        if (is_null($ids)) {
             $ids = [];
             if ((bool)$this->getSharingConfig()->isWebsiteScope()) {
                 $ids[] = $this->getWebsiteId();

--- a/app/code/core/Mage/Customer/Model/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Customer.php
@@ -760,7 +760,7 @@ class Mage_Customer_Model_Customer extends Mage_Core_Model_Abstract
         if ($this->canSkipConfirmation()) {
             return false;
         }
-        if (self::$_isConfirmationRequired === null) {
+        if (is_null(self::$_isConfirmationRequired)) {
             $storeId = $this->getStoreId() ?: null;
             self::$_isConfirmationRequired = Mage::getStoreConfigFlag(self::XML_PATH_IS_CONFIRM, $storeId);
         }

--- a/app/code/core/Mage/Customer/Model/Customer/Api/V2.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Api/V2.php
@@ -30,7 +30,7 @@ class Mage_Customer_Model_Customer_Api_V2 extends Mage_Customer_Model_Customer_A
      */
     protected function _prepareData($data)
     {
-        if (($_data = get_object_vars($data)) !== null) {
+        if (($_data = get_object_vars(!is_null($data)))) {
             return parent::_prepareData($_data);
         }
         return [];

--- a/app/code/core/Mage/Customer/Model/Session.php
+++ b/app/code/core/Mage/Customer/Model/Session.php
@@ -211,7 +211,7 @@ class Mage_Customer_Model_Session extends Mage_Core_Model_Session_Abstract
      */
     public function checkCustomerId($customerId)
     {
-        if ($this->_isCustomerIdChecked === null) {
+        if (is_null($this->_isCustomerIdChecked)) {
             $this->_isCustomerIdChecked = Mage::getResourceSingleton('customer/customer')->checkCustomerId($customerId);
         }
         return $this->_isCustomerIdChecked;

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Csv.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Csv.php
@@ -89,7 +89,7 @@ class Mage_Dataflow_Model_Convert_Parser_Csv extends Mage_Dataflow_Model_Convert
 
         $countRows = 0;
         while (($csvData = $batchIoAdapter->read(true, $fDel, $fEnc)) !== false) {
-            if (count($csvData) == 1 && $csvData[0] === null) {
+            if (count($csvData) == 1 && is_null($csvData[0])) {
                 continue;
             }
 

--- a/app/code/core/Mage/Dataflow/Model/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Profile.php
@@ -87,7 +87,7 @@ class Mage_Dataflow_Model_Profile extends Mage_Core_Model_Abstract
         parent::_beforeSave();
         $actionsXML = $this->getData('actions_xml');
         // @phpstan-ignore-next-line because of https://github.com/phpstan/phpstan/issues/10570
-        if ($actionsXML !== null && strlen($actionsXML) < 0 &&
+        if (!is_null($actionsXML) && strlen($actionsXML) < 0 &&
             @simplexml_load_string('<data>' . $actionsXML . '</data>', null, LIBXML_NOERROR) === false
         ) {
             Mage::throwException(Mage::helper('dataflow')->__('Actions XML is not valid.'));

--- a/app/code/core/Mage/Directory/Helper/Data.php
+++ b/app/code/core/Mage/Directory/Helper/Data.php
@@ -239,7 +239,7 @@ class Mage_Directory_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function getCountriesWithOptionalZip($asJson = false)
     {
-        if ($this->_optionalZipCountries === null) {
+        if (is_null($this->_optionalZipCountries)) {
             $this->_optionalZipCountries = preg_split(
                 '/\,/',
                 Mage::getStoreConfig(self::OPTIONAL_ZIP_COUNTRIES_CONFIG_PATH),

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -60,7 +60,7 @@ class Mage_Downloadable_Block_Adminhtml_Catalog_Product_Edit_Tab_Downloadable_Li
      */
     public function getPurchasedSeparatelyAttribute()
     {
-        if ($this->_purchasedSeparatelyAttribute === null) {
+        if (is_null($this->_purchasedSeparatelyAttribute)) {
             $_attributeCode = 'links_purchased_separately';
 
             $attribute = Mage::getSingleton('eav/config')

--- a/app/code/core/Mage/Downloadable/Helper/File.php
+++ b/app/code/core/Mage/Downloadable/Helper/File.php
@@ -129,7 +129,7 @@ class Mage_Downloadable_Helper_File extends Mage_Core_Helper_Abstract
      */
     public function getFilePath($path, $file)
     {
-        if ($file === null || $file === '') {
+        if (is_null($file) || $file === '') {
             return $path . DS;
         }
 

--- a/app/code/core/Mage/Downloadable/Model/Product/Type.php
+++ b/app/code/core/Mage/Downloadable/Model/Product/Type.php
@@ -217,7 +217,7 @@ class Mage_Downloadable_Model_Product_Type extends Mage_Catalog_Model_Product_Ty
                             ->setStoreId($product->getStoreId())
                             ->setWebsiteId($product->getStore()->getWebsiteId())
                             ->setProductWebsiteIds($product->getWebsiteIds());
-                        if ($linkModel->getPrice() === null) {
+                        if (is_null($linkModel->getPrice())) {
                             $linkModel->setPrice(0);
                         }
                         if ($linkModel->getIsUnlimited()) {

--- a/app/code/core/Mage/Downloadable/Model/Product/Type.php
+++ b/app/code/core/Mage/Downloadable/Model/Product/Type.php
@@ -298,7 +298,7 @@ class Mage_Downloadable_Model_Product_Type extends Mage_Catalog_Model_Product_Ty
                 $preparedLinks[] = $link->getId();
             }
         }
-        if ($originalLinksPurchasedSeparately !== null) {
+        if (!is_null($originalLinksPurchasedSeparately)) {
             $this->getProduct($product)
                 ->setLinksPurchasedSeparately($originalLinksPurchasedSeparately);
         }

--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -480,7 +480,7 @@ class Mage_Eav_Model_Config
             return $code;
         }
 
-        $storeId = $storeId !== null ? $storeId : $this->_storeId();
+        $storeId = !is_null($storeId) ? $storeId : $this->_storeId();
         $this->_initializeStore($storeId);
         $entityType = $this->getEntityType($entityType);
 

--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -142,7 +142,7 @@ class Mage_Eav_Model_Config
      */
     protected function _initializeStore($storeId = null)
     {
-        if ($storeId === null) {
+        if (is_null($storeId)) {
             $storeId = $this->_storeId();
         } else {
             // ensure store id is consistent
@@ -341,7 +341,7 @@ class Mage_Eav_Model_Config
      */
     protected function _isCacheEnabled()
     {
-        if ($this->_isCacheEnabled === null) {
+        if (is_null($this->_isCacheEnabled)) {
             $this->_isCacheEnabled = Mage::app()->useCache('eav');
         }
         return $this->_isCacheEnabled;

--- a/app/code/core/Mage/Eav/Model/Entity/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Abstract.php
@@ -306,7 +306,7 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
      */
     public function unsetAttributes($attributes = null)
     {
-        if ($attributes === null) {
+        if (is_null($attributes)) {
             $this->_attributesByCode    = [];
             $this->_attributesById      = [];
             $this->_attributesByTable   = [];
@@ -524,7 +524,7 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
     public function getSortedAttributes($setId = null)
     {
         $attributes = $this->getAttributesByCode();
-        if ($setId === null) {
+        if (is_null($setId)) {
             $setId = $this->getEntityType()->getDefaultAttributeSetId();
         }
 
@@ -1548,7 +1548,7 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
                 $this->_insertAttribute($object, $attribute, $newValue);
             } elseif ($origValueId !== false && ($newValue !== null)) {
                 $this->_updateAttribute($object, $attribute, $origValueId, $newValue);
-            } elseif ($origValueId !== false && ($newValue === null)) {
+            } elseif ($origValueId !== false && (is_null($newValue))) {
                 $adapter->delete($table, $where);
             }
             $this->_processAttributeValues();

--- a/app/code/core/Mage/Eav/Model/Entity/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Abstract.php
@@ -461,7 +461,7 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
     public function isPartialLoad($flag = null)
     {
         $result = $this->_isPartialLoad;
-        if ($flag !== null) {
+        if (!is_null($flag)) {
             $this->_isPartialLoad = (bool)$flag;
         }
         return $result;
@@ -476,7 +476,7 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
     public function isPartialSave($flag = null)
     {
         $result = $this->_isPartialSave;
-        if ($flag !== null) {
+        if (!is_null($flag)) {
             $this->_isPartialSave = (bool)$flag;
         }
         return $result;
@@ -1544,9 +1544,9 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
                 ->where($where);
             $origValueId = $adapter->fetchOne($select);
 
-            if ($origValueId === false && ($newValue !== null)) {
+            if ($origValueId === false && (!is_null($newValue))) {
                 $this->_insertAttribute($object, $attribute, $newValue);
-            } elseif ($origValueId !== false && ($newValue !== null)) {
+            } elseif ($origValueId !== false && (!is_null($newValue))) {
                 $this->_updateAttribute($object, $attribute, $origValueId, $newValue);
             } elseif ($origValueId !== false && (is_null($newValue))) {
                 $adapter->delete($table, $where);

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
@@ -360,7 +360,7 @@ abstract class Mage_Eav_Model_Entity_Attribute_Abstract extends Mage_Core_Model_
     public function getAlias($entity = null)
     {
         $alias = '';
-        if (($entity === null) || ($entity->getType() !== $this->getEntity()->getType())) {
+        if ((is_null($entity)) || ($entity->getType() !== $this->getEntity()->getType())) {
             $alias .= $this->getEntity()->getType() . '/';
         }
         $alias .= $this->getAttributeCode();
@@ -532,7 +532,7 @@ abstract class Mage_Eav_Model_Entity_Attribute_Abstract extends Mage_Core_Model_
     {
         $attrType = $this->getBackend()->getType();
         return is_array($value)
-            || ($value === null)
+            || (is_null($value))
             || $value === false && $attrType !== 'int'
             || $value === '' && ($attrType === 'int' || $attrType === 'decimal' || $attrType === 'datetime');
     }
@@ -624,7 +624,7 @@ abstract class Mage_Eav_Model_Entity_Attribute_Abstract extends Mage_Core_Model_
      */
     public function getBackendTable()
     {
-        if ($this->_dataTable === null) {
+        if (is_null($this->_dataTable)) {
             if ($this->isStatic()) {
                 $this->_dataTable = $this->getEntityType()->getValueTablePrefix();
             } else {
@@ -906,7 +906,7 @@ abstract class Mage_Eav_Model_Entity_Attribute_Abstract extends Mage_Core_Model_
      */
     public function getFlatUpdateSelect($store = null)
     {
-        if ($store === null) {
+        if (is_null($store)) {
             foreach (Mage::app()->getStores() as $store) {
                 $this->getFlatUpdateSelect($store->getId());
             }

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Abstract.php
@@ -206,7 +206,7 @@ abstract class Mage_Eav_Model_Entity_Attribute_Backend_Abstract implements Mage_
      */
     public function getDefaultValue()
     {
-        if ($this->_defaultValue === null) {
+        if (is_null($this->_defaultValue)) {
             if ($this->getAttribute()->getDefaultValue()) {
                 $this->_defaultValue = $this->getAttribute()->getDefaultValue();
             } else {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Abstract.php
@@ -68,7 +68,7 @@ abstract class Mage_Eav_Model_Entity_Attribute_Frontend_Abstract implements Mage
     public function getLabel()
     {
         $label = $this->getAttribute()->getFrontendLabel();
-        if (($label === null) || $label == '') {
+        if ((is_null($label)) || $label == '') {
             $label = $this->getAttribute()->getAttributeCode();
         }
 

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Set.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Set.php
@@ -253,7 +253,7 @@ class Mage_Eav_Model_Entity_Attribute_Set extends Mage_Core_Model_Abstract
      */
     public function getDefaultGroupId($setId = null)
     {
-        if ($setId === null) {
+        if (is_null($setId)) {
             $setId = $this->getId();
         }
         if ($setId) {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Config.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Config.php
@@ -38,7 +38,7 @@ class Mage_Eav_Model_Entity_Attribute_Source_Config extends Mage_Eav_Model_Entit
      */
     public function getAllOptions()
     {
-        if ($this->_options === null) {
+        if (is_null($this->_options)) {
             $this->_options = [];
             $rootNode = null;
             if ($this->_configNodePath) {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Store.php
@@ -30,7 +30,7 @@ class Mage_Eav_Model_Entity_Attribute_Source_Store extends Mage_Eav_Model_Entity
      */
     public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
-        if ($this->_options === null) {
+        if (is_null($this->_options)) {
             $this->_options = Mage::getResourceModel('core/store_collection')->load()->toOptionArray();
         }
         return $this->_options;

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -172,7 +172,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
     protected function _init($model, $entityModel = null)
     {
         $this->setItemObjectClass(Mage::getConfig()->getModelClassName($model));
-        if ($entityModel === null) {
+        if (is_null($entityModel)) {
             $entityModel = $model;
         }
         $entity = Mage::getResourceSingleton($entityModel);
@@ -286,7 +286,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
      */
     public function addAttributeToFilter($attribute, $condition = null, $joinType = 'inner')
     {
-        if ($attribute === null) {
+        if (is_null($attribute)) {
             $this->getSelect();
             return $this;
         }
@@ -304,7 +304,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
             }
             $conditionSql = '(' . implode(') OR (', $sqlArr) . ')';
         } elseif (is_string($attribute)) {
-            if ($condition === null) {
+            if (is_null($condition)) {
                 $condition = '';
             }
             $conditionSql = $this->_getAttributeConditionSql($attribute, $condition, $joinType);
@@ -823,7 +823,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
      */
     public function removeAttributeToSelect($attribute = null)
     {
-        if ($attribute === null) {
+        if (is_null($attribute)) {
             $this->_selectAttributes = [];
         } else {
             unset($this->_selectAttributes[$attribute]);
@@ -1011,7 +1011,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
      */
     public function getRowIdFieldName()
     {
-        if ($this->_idFieldName === null) {
+        if (is_null($this->_idFieldName)) {
             $this->_setIdFieldName($this->getEntity()->getIdFieldName());
         }
         return $this->getIdFieldName();

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -713,7 +713,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
         $condArr = [$bindCond];
 
         // add where condition if needed
-        if ($cond !== null) {
+        if (!is_null($cond)) {
             if (is_array($cond)) {
                 foreach ($cond as $k => $v) {
                     $condArr[] = $this->_getConditionSql($tableAlias . '.' . $k, $v);
@@ -798,7 +798,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
         $condArr = [$bindCond];
 
         // add where condition if needed
-        if ($cond !== null) {
+        if (!is_null($cond)) {
             if (is_array($cond)) {
                 foreach ($cond as $k => $v) {
                     $condArr[] = $this->_getConditionSql($tableAlias . '.' . $k, $v);

--- a/app/code/core/Mage/Eav/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Setup.php
@@ -458,7 +458,7 @@ class Mage_Eav_Model_Entity_Setup extends Mage_Core_Model_Resource_Setup
         if ($groupId) {
             $this->updateAttributeGroup($entityTypeId, $setId, $groupId, $data);
         } else {
-            if ($sortOrder === null) {
+            if (is_null($sortOrder)) {
                 $data['sort_order'] = $this->getAttributeGroupSortOrder($entityTypeId, $setId, $sortOrder);
             }
             $this->_conn->insert($this->getTable('eav/attribute_group'), $data);
@@ -1162,7 +1162,7 @@ class Mage_Eav_Model_Entity_Setup extends Mage_Core_Model_Resource_Setup
                 $this->getConnection()->quoteInto('entity_attribute_id=?', $row['entity_attribute_id'])
             );
         } else {
-            if ($sortOrder === null) {
+            if (is_null($sortOrder)) {
                 $select = $this->getConnection()->select()
                     ->from($this->getTable('eav/entity_attribute'), 'MAX(sort_order)')
                     ->where('entity_type_id = :entity_type_id')
@@ -1191,7 +1191,7 @@ class Mage_Eav_Model_Entity_Setup extends Mage_Core_Model_Resource_Setup
     {
         $this->cleanCache();
 
-        if ($entities === null) {
+        if (is_null($entities)) {
             $entities = $this->getDefaultEntities();
         }
 

--- a/app/code/core/Mage/Eav/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Setup.php
@@ -376,7 +376,7 @@ class Mage_Eav_Model_Entity_Setup extends Mage_Core_Model_Resource_Setup
             ->from($this->getTable('eav/attribute_set'), 'attribute_set_id');
 
         $bind = [];
-        if ($entityTypeId !== null) {
+        if (!is_null($entityTypeId)) {
             $bind['entity_type_id'] = $this->getEntityTypeId($entityTypeId);
             $select->where('entity_type_id = :entity_type_id');
         }
@@ -450,7 +450,7 @@ class Mage_Eav_Model_Entity_Setup extends Mage_Core_Model_Resource_Setup
             $data['default_id'] = $this->defaultGroupIdAssociations[$name];
         }
 
-        if ($sortOrder !== null) {
+        if (!is_null($sortOrder)) {
             $data['sort_order'] = $sortOrder;
         }
 
@@ -826,7 +826,7 @@ class Mage_Eav_Model_Entity_Setup extends Mage_Core_Model_Resource_Setup
      */
     protected function _updateAttribute($entityTypeId, $id, $field, $value = null, $sortOrder = null)
     {
-        if ($sortOrder !== null) {
+        if (!is_null($sortOrder)) {
             $this->updateTableRow(
                 'eav/entity_attribute',
                 'attribute_id',
@@ -956,7 +956,7 @@ class Mage_Eav_Model_Entity_Setup extends Mage_Core_Model_Resource_Setup
         }
 
         $row = $this->_setupCache[$mainTable][$entityTypeId][$id];
-        if ($field !== null) {
+        if (!is_null($field)) {
             return $row[$field] ?? false;
         }
 
@@ -1152,7 +1152,7 @@ class Mage_Eav_Model_Entity_Setup extends Mage_Core_Model_Resource_Setup
         $row = $this->getConnection()->fetchRow($select, $bind);
         if ($row) {
             // update
-            if ($sortOrder !== null) {
+            if (!is_null($sortOrder)) {
                 $data['sort_order'] = $sortOrder;
             }
 

--- a/app/code/core/Mage/Eav/Model/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Type.php
@@ -97,7 +97,7 @@ class Mage_Eav_Model_Entity_Type extends Mage_Core_Model_Abstract
      */
     public function getAttributeCollection($setId = null)
     {
-        if ($setId === null && $this->_attributes !== null) {
+        if (is_null($setId) && $this->_attributes !== null) {
             return $this->_attributes;
         } elseif (isset($this->_attributesBySet[$setId])) {
             return $this->_attributesBySet[$setId];
@@ -105,7 +105,7 @@ class Mage_Eav_Model_Entity_Type extends Mage_Core_Model_Abstract
 
         $collection = $this->newAttributeCollection($setId);
 
-        if ($setId === null) {
+        if (is_null($setId)) {
             $this->_attributes = $collection;
         } else {
             $this->_attributesBySet[$setId] = $collection;
@@ -175,7 +175,7 @@ class Mage_Eav_Model_Entity_Type extends Mage_Core_Model_Abstract
             return false;
         }
 
-        if (!$this->getIncrementPerStore() || ($storeId === null)) {
+        if (!$this->getIncrementPerStore() || (is_null($storeId))) {
             /**
              * store_id null we can have for entity from removed store
              */

--- a/app/code/core/Mage/Eav/Model/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Type.php
@@ -97,7 +97,7 @@ class Mage_Eav_Model_Entity_Type extends Mage_Core_Model_Abstract
      */
     public function getAttributeCollection($setId = null)
     {
-        if (is_null($setId) && $this->_attributes !== null) {
+        if (is_null($setId) && !is_null($this->_attributes)) {
             return $this->_attributes;
         } elseif (isset($this->_attributesBySet[$setId])) {
             return $this->_attributesBySet[$setId];
@@ -125,7 +125,7 @@ class Mage_Eav_Model_Entity_Type extends Mage_Core_Model_Abstract
         $collection = $this->_getAttributeCollection()
             ->setEntityTypeFilter($this);
 
-        if ($setId !== null) {
+        if (!is_null($setId)) {
             $collection->setAttributeSetFilter($setId);
         }
 

--- a/app/code/core/Mage/Eav/Model/Form.php
+++ b/app/code/core/Mage/Eav/Model/Form.php
@@ -510,7 +510,7 @@ abstract class Mage_Eav_Model_Form
      */
     public function ignoreInvisible($setValue = null)
     {
-        if ($setValue !== null) {
+        if (!is_null($setValue)) {
             $this->_ignoreInvisible = (bool)$setValue;
             return $this;
         }

--- a/app/code/core/Mage/Eav/Model/Resource/Attribute/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Attribute/Collection.php
@@ -64,7 +64,7 @@ abstract class Mage_Eav_Model_Resource_Attribute_Collection extends Mage_Eav_Mod
      */
     public function getEntityType()
     {
-        if ($this->_entityType === null) {
+        if (is_null($this->_entityType)) {
             $this->_entityType = Mage::getSingleton('eav/config')->getEntityType($this->_getEntityTypeCode());
         }
         return $this->_entityType;
@@ -90,7 +90,7 @@ abstract class Mage_Eav_Model_Resource_Attribute_Collection extends Mage_Eav_Mod
      */
     public function getWebsite()
     {
-        if ($this->_website === null) {
+        if (is_null($this->_website)) {
             $this->_website = Mage::app()->getStore()->getWebsite();
         }
         return $this->_website;

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Attribute/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Attribute/Collection.php
@@ -94,7 +94,7 @@ class Mage_Eav_Model_Resource_Form_Attribute_Collection extends Mage_Core_Model_
      */
     public function getStore()
     {
-        if ($this->_store === null) {
+        if (is_null($this->_store)) {
             $this->_store = Mage::app()->getStore();
         }
         return $this->_store;
@@ -119,7 +119,7 @@ class Mage_Eav_Model_Resource_Form_Attribute_Collection extends Mage_Core_Model_
      */
     public function getEntityType()
     {
-        if ($this->_entityType === null) {
+        if (is_null($this->_entityType)) {
             $this->setEntityType($this->_entityTypeCode);
         }
         return $this->_entityType;

--- a/app/code/core/Mage/GiftMessage/Block/Message/Inline.php
+++ b/app/code/core/Mage/GiftMessage/Block/Message/Inline.php
@@ -242,7 +242,7 @@ class Mage_GiftMessage_Block_Message_Inline extends Mage_Core_Block_Template
      */
     public function getEscaped($value, $defaultValue = '')
     {
-        if ($value === null || strlen($value) == 0) {
+        if (is_null($value) || strlen($value) == 0) {
             return $defaultValue;
         }
         return $this->escapeHtml(trim($value));

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Frame/Result.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Frame/Result.php
@@ -58,7 +58,7 @@ class Mage_ImportExport_Block_Adminhtml_Import_Frame_Result extends Mage_Adminht
     public function addAction($actionName, $elementId, $value = null)
     {
         if (isset($this->_actions[$actionName])) {
-            if ($value === null) {
+            if (is_null($value)) {
                 if (is_array($elementId)) {
                     foreach ($elementId as $oneId) {
                         $this->_actions[$actionName][] = $oneId;

--- a/app/code/core/Mage/ImportExport/Model/Export/Adapter/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Adapter/Abstract.php
@@ -140,7 +140,7 @@ abstract class Mage_ImportExport_Model_Export_Adapter_Abstract
      */
     public function setHeaderCols(array $headerCols)
     {
-        if ($this->_headerCols !== null) {
+        if (!is_null($this->_headerCols)) {
             Mage::throwException(Mage::helper('importexport')->__('Header column names already set'));
         }
         if ($headerCols) {

--- a/app/code/core/Mage/ImportExport/Model/Export/Adapter/Csv.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Adapter/Csv.php
@@ -94,7 +94,7 @@ class Mage_ImportExport_Model_Export_Adapter_Csv extends Mage_ImportExport_Model
      */
     public function writeRow(array $rowData)
     {
-        if ($this->_headerCols === null) {
+        if (is_null($this->_headerCols)) {
             $this->setHeaderCols(array_keys($rowData));
         }
 

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Abstract.php
@@ -213,7 +213,7 @@ abstract class Mage_ImportExport_Model_Export_Entity_Abstract
      */
     protected function _getExportAttrCodes()
     {
-        if (self::$attrCodes === null) {
+        if (is_null(self::$attrCodes)) {
             if (!empty($this->_parameters[Mage_ImportExport_Model_Export::FILTER_ELEMENT_SKIP])
                     && is_array($this->_parameters[Mage_ImportExport_Model_Export::FILTER_ELEMENT_SKIP])
             ) {

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Customer.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Customer.php
@@ -170,7 +170,7 @@ class Mage_ImportExport_Model_Export_Entity_Customer extends Mage_ImportExport_M
             }
             foreach ($allAddressAttributeOptions as $attrCode => $attrValues) {
                 $column = Mage_ImportExport_Model_Import_Entity_Customer_Address::getColNameForAttrCode($attrCode);
-                if ($address->getData($attrCode) !== null) {
+                if ($address->getData(!is_null($attrCode))) {
                     if (!isset($addressAttributes[$attrCode])) {
                         $addressAttributes = array_merge($addressAttributes, $address->getAttributes());
                     }
@@ -396,7 +396,7 @@ class Mage_ImportExport_Model_Export_Entity_Customer extends Mage_ImportExport_M
             ) {
                 $attrValue = $this->_attributeValues[$attrCode][$attrValue];
             }
-            if ($attrValue !== null) {
+            if (!is_null($attrValue)) {
                 $row[$attrCode] = $attrValue;
             }
         }

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
@@ -942,7 +942,7 @@ class Mage_ImportExport_Model_Export_Entity_Product extends Mage_ImportExport_Mo
                             $dataRow[$colPrefix . 'position'] = $linkData['position'];
                             $dataRow[$colPrefix . 'sku'] = $linkData['sku'];
 
-                            if ($linkData['default_qty'] !== null) {
+                            if (!is_null($linkData['default_qty'])) {
                                 $dataRow[$colPrefix . 'default_qty'] = $linkData['default_qty'];
                             }
                         }
@@ -1020,7 +1020,7 @@ class Mage_ImportExport_Model_Export_Entity_Product extends Mage_ImportExport_Mo
                                     $dataRow[$colPrefix . 'position'] = $linkData['position'];
                                     $dataRow[$colPrefix . 'sku']      = $linkData['sku'];
 
-                                    if ($linkData['default_qty'] !== null) {
+                                    if (!is_null($linkData['default_qty'])) {
                                         $dataRow[$colPrefix . 'default_qty'] = $linkData['default_qty'];
                                     }
                                 }

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer.php
@@ -646,7 +646,7 @@ class Mage_ImportExport_Model_Import_Entity_Customer extends Mage_ImportExport_M
                 $email = false; // mark row as invalid for next address rows
             }
         } elseif (self::SCOPE_OPTIONS != $rowScope) {
-            if ($email === null) { // first row is not SCOPE_DEFAULT
+            if (is_null($email)) { // first row is not SCOPE_DEFAULT
                 $this->addRowError(self::ERROR_EMAIL_IS_EMPTY, $rowNum);
             } elseif ($email === false) { // SCOPE_DEFAULT row is invalid
                 $this->addRowError(self::ERROR_ROW_IS_ORPHAN, $rowNum);

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
@@ -882,7 +882,7 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
                     $type = $rowData['_custom_option_type'];
                     $rowIsMain = true;
                 } else {
-                    if ($type === null) {
+                    if (is_null($type)) {
                         continue;
                     }
                     $rowIsMain = false;
@@ -1396,7 +1396,7 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
                             continue;
                         }
                     }
-                } elseif ($rowSku === null) {
+                } elseif (is_null($rowSku)) {
                     $this->_rowsToSkip[$rowNum] = true;
                     continue; // skip rows when SKU is NULL
                 } elseif (self::SCOPE_STORE == $rowScope) { // set necessary data from SCOPE_DEFAULT row
@@ -2131,7 +2131,7 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
                 }
             }
         } else {
-            if ($sku === null) {
+            if (is_null($sku)) {
                 $this->addRowError(self::ERROR_SKU_IS_EMPTY, $rowNum);
             } elseif ($sku === false) {
                 $this->addRowError(self::ERROR_ROW_IS_ORPHAN, $rowNum);
@@ -2201,7 +2201,7 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
      */
     protected function _getUrlKeyAttributeId()
     {
-        if ($this->_urlKeyAttributeId === null) {
+        if (is_null($this->_urlKeyAttributeId)) {
             $adapter  = $this->getConnection();
             $resource = $this->getResourceModel('eav/entity_attribute');
 

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Abstract.php
@@ -294,7 +294,7 @@ abstract class Mage_ImportExport_Model_Import_Entity_Product_Type_Abstract
                         ($attrParams['type'] == 'select' || $attrParams['type'] == 'multiselect')
                         ? $attrParams['options'][strtolower($rowData[$attrCode])]
                         : $rowData[$attrCode];
-                } elseif ($withDefaultValue && $attrParams['default_value'] !== null) {
+                } elseif ($withDefaultValue && !is_null($attrParams['default_value'])) {
                     $resultAttrs[$attrCode] = $attrParams['default_value'];
                 }
             }

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Configurable.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Configurable.php
@@ -397,7 +397,7 @@ class Mage_ImportExport_Model_Import_Entity_Product_Type_Configurable extends Ma
                                              ? [] : $this->_skuSuperData[$productId],
                         'assoc_ids'       => []
                     ];
-                } elseif ($productData === null) {
+                } elseif (is_null($productData)) {
                     continue;
                 }
                 if (!empty($rowData['_super_products_sku'])) {

--- a/app/code/core/Mage/ImportExport/Model/Resource/Import/Data.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Import/Data.php
@@ -112,7 +112,7 @@ class Mage_ImportExport_Model_Resource_Import_Data extends Mage_Core_Model_Resou
      */
     public function getNextBunch()
     {
-        if ($this->_iterator === null) {
+        if (is_null($this->_iterator)) {
             $this->_iterator = $this->getIterator();
             $this->_iterator->rewind();
         }

--- a/app/code/core/Mage/Index/Model/Lock.php
+++ b/app/code/core/Mage/Index/Model/Lock.php
@@ -280,7 +280,7 @@ class Mage_Index_Model_Lock
      */
     protected function _getLockFile($lockName)
     {
-        if (!isset(self::$_lockFileResource[$lockName]) || self::$_lockFileResource[$lockName] === null) {
+        if (!isset(self::$_lockFileResource[$lockName]) || is_null(self::$_lockFileResource[$lockName])) {
             $varDir = Mage::getConfig()->getVarDir('locks');
             $file = $varDir . DS . $lockName . '.lock';
             if (is_file($file)) {

--- a/app/code/core/Mage/Index/Model/Process.php
+++ b/app/code/core/Mage/Index/Model/Process.php
@@ -284,7 +284,7 @@ class Mage_Index_Model_Process extends Mage_Core_Model_Abstract
      */
     public function getIndexer()
     {
-        if ($this->_indexer === null) {
+        if (is_null($this->_indexer)) {
             $code = $this->_getData('indexer_code');
             if (!$code) {
                 Mage::throwException(Mage::helper('index')->__('Indexer code is not defined.'));

--- a/app/code/core/Mage/Index/Model/Process.php
+++ b/app/code/core/Mage/Index/Model/Process.php
@@ -154,7 +154,7 @@ class Mage_Index_Model_Process extends Mage_Core_Model_Abstract
      */
     public function matchEntityAndType($entity, $type)
     {
-        if ($entity !== null && $type !== null) {
+        if (!is_null($entity) && !is_null($type)) {
             return $this->getIndexer()->matchEntityAndType($entity, $type);
         }
         return true;
@@ -316,7 +316,7 @@ class Mage_Index_Model_Process extends Mage_Core_Model_Abstract
         /**
          * Check if process indexer can match entity code and action type
          */
-        if ($entity !== null && $type !== null) {
+        if (!is_null($entity) && !is_null($type)) {
             if (!$this->getIndexer()->matchEntityAndType($entity, $type)) {
                 return $this;
             }
@@ -336,10 +336,10 @@ class Mage_Index_Model_Process extends Mage_Core_Model_Abstract
              * Prepare events collection
              */
             $eventsCollection = $this->getUnprocessedEventsCollection();
-            if ($entity !== null) {
+            if (!is_null($entity)) {
                 $eventsCollection->addEntityFilter($entity);
             }
-            if ($type !== null) {
+            if (!is_null($type)) {
                 $eventsCollection->addTypeFilter($type);
             }
 

--- a/app/code/core/Mage/Index/Model/Resource/Event/Collection.php
+++ b/app/code/core/Mage/Index/Model/Resource/Event/Collection.php
@@ -80,7 +80,7 @@ class Mage_Index_Model_Resource_Event_Collection extends Mage_Core_Model_Resourc
             $this->addFieldToFilter('process_event.process_id', $process);
         }
 
-        if ($status !== null) {
+        if (!is_null($status)) {
             if (is_array($status) && !empty($status)) {
                 $this->addFieldToFilter('process_event.status', ['in' => $status]);
             } else {

--- a/app/code/core/Mage/Newsletter/controllers/SubscriberController.php
+++ b/app/code/core/Mage/Newsletter/controllers/SubscriberController.php
@@ -56,7 +56,7 @@ class Mage_Newsletter_SubscriberController extends Mage_Core_Controller_Front_Ac
                         ->setWebsiteId(Mage::app()->getStore()->getWebsiteId())
                         ->loadByEmail($email)
                         ->getId();
-                if ($ownerId !== null && $ownerId != $customerSession->getId()) {
+                if (!is_null($ownerId) && $ownerId != $customerSession->getId()) {
                     Mage::throwException($this->__('This email address is already assigned to another user.'));
                 }
 

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit.php
@@ -35,7 +35,7 @@ class Mage_Oauth_Block_Adminhtml_Oauth_Consumer_Edit extends Mage_Adminhtml_Bloc
      */
     public function getModel()
     {
-        if ($this->_model === null) {
+        if (is_null($this->_model)) {
             $this->_model = Mage::registry('current_consumer');
         }
         return $this->_model;

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit/Form.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit/Form.php
@@ -35,7 +35,7 @@ class Mage_Oauth_Block_Adminhtml_Oauth_Consumer_Edit_Form extends Mage_Adminhtml
      */
     public function getModel()
     {
-        if ($this->_model === null) {
+        if (is_null($this->_model)) {
             $this->_model = Mage::registry('current_consumer');
         }
         return $this->_model;

--- a/app/code/core/Mage/Oauth/Block/Authorize/Abstract.php
+++ b/app/code/core/Mage/Oauth/Block/Authorize/Abstract.php
@@ -59,7 +59,7 @@ abstract class Mage_Oauth_Block_Authorize_Abstract extends Mage_Core_Block_Templ
      */
     public function getConsumer()
     {
-        if ($this->_consumer === null) {
+        if (is_null($this->_consumer)) {
             /** @var Mage_Oauth_Model_Token $token */
             $token = Mage::getModel('oauth/token');
             $token->load($this->getToken(), 'token');

--- a/app/code/core/Mage/Oauth/Model/Observer.php
+++ b/app/code/core/Mage/Oauth/Model/Observer.php
@@ -36,7 +36,7 @@ class Mage_Oauth_Model_Observer
      */
     public function afterCustomerLogin(Varien_Event_Observer $observer)
     {
-        if ($this->_getOauthToken() !== null) {
+        if (!is_null($this->_getOauthToken())) {
             $userType = Mage_Oauth_Model_Token::USER_TYPE_CUSTOMER;
             $url = Mage::helper('oauth')->getAuthorizeUrl($userType);
             Mage::app()->getResponse()
@@ -52,7 +52,7 @@ class Mage_Oauth_Model_Observer
      */
     public function afterAdminLogin(Varien_Event_Observer $observer)
     {
-        if ($this->_getOauthToken() !== null) {
+        if (!is_null($this->_getOauthToken())) {
             $userType = Mage_Oauth_Model_Token::USER_TYPE_ADMIN;
             $url = Mage::helper('oauth')->getAuthorizeUrl($userType);
             Mage::app()->getResponse()
@@ -68,7 +68,7 @@ class Mage_Oauth_Model_Observer
      */
     public function afterAdminLoginFailed(Varien_Event_Observer $observer)
     {
-        if ($this->_getOauthToken() !== null) {
+        if (!is_null($this->_getOauthToken())) {
             /** @var Mage_Admin_Model_Session $session */
             $session = Mage::getSingleton('admin/session');
             $session->addError($observer->getException()->getMessage());

--- a/app/code/core/Mage/Oauth/Model/Server.php
+++ b/app/code/core/Mage/Oauth/Model/Server.php
@@ -269,7 +269,7 @@ class Mage_Oauth_Model_Server
      */
     protected function _getResponse()
     {
-        if ($this->_response === null) {
+        if (is_null($this->_response)) {
             $this->setResponse(Mage::app()->getResponse());
         }
         return $this->_response;

--- a/app/code/core/Mage/Oauth/Model/Token.php
+++ b/app/code/core/Mage/Oauth/Model/Token.php
@@ -253,7 +253,7 @@ class Mage_Oauth_Model_Token extends Mage_Core_Model_Abstract
             Mage::throwException(array_shift($messages));
         }
 
-        if (($verifier = $this->getVerifier()) !== null) {
+        if (($verifier = !is_null($this->getVerifier()))) {
             $validatorLength->setLength(self::LENGTH_VERIFIER);
             $validatorLength->setName('Verifier Key');
             if (!$validatorLength->isValid($verifier)) {

--- a/app/code/core/Mage/Oauth/Model/Token.php
+++ b/app/code/core/Mage/Oauth/Model/Token.php
@@ -210,7 +210,7 @@ class Mage_Oauth_Model_Token extends Mage_Core_Model_Abstract
     {
         $this->validate();
 
-        if ($this->isObjectNew() && $this->getCreatedAt() === null) {
+        if ($this->isObjectNew() && is_null($this->getCreatedAt())) {
             $this->setCreatedAt(Varien_Date::now());
         }
         parent::_beforeSave();

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/Admin/TokenController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/Admin/TokenController.php
@@ -71,7 +71,7 @@ class Mage_Oauth_Adminhtml_Oauth_Admin_TokenController extends Mage_Adminhtml_Co
             return;
         }
 
-        if ($status === null) {
+        if (is_null($status)) {
             // No status selected
             $this->_getSession()->addError($this->__('Please select revoke status.'));
             $this->_redirect('*/*/index');

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizedTokensController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizedTokensController.php
@@ -69,7 +69,7 @@ class Mage_Oauth_Adminhtml_Oauth_AuthorizedTokensController extends Mage_Adminht
             return;
         }
 
-        if ($status === null) {
+        if (is_null($status)) {
             // No status selected
             $this->_getSession()->addError($this->__('Please select revoke status.'));
             $this->_redirect('*/*/index');

--- a/app/code/core/Mage/Oauth/controllers/Customer/TokenController.php
+++ b/app/code/core/Mage/Oauth/controllers/Customer/TokenController.php
@@ -94,7 +94,7 @@ class Mage_Oauth_Customer_TokenController extends Mage_Core_Controller_Front_Act
             return;
         }
 
-        if ($status === null) {
+        if (is_null($status)) {
             // No status selected
             $this->_session->addError($this->__('Invalid revoke status.'));
             $this->_redirectBack();

--- a/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
+++ b/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
@@ -110,7 +110,7 @@ class Mage_Page_Block_Html_Breadcrumbs extends Mage_Core_Block_Template
      */
     public function getCacheKeyInfo()
     {
-        if ($this->_cacheKeyInfo === null) {
+        if (is_null($this->_cacheKeyInfo)) {
             $this->_cacheKeyInfo = parent::getCacheKeyInfo() + [
                 'crumbs' => base64_encode(serialize($this->_crumbs)),
                 'name'   => $this->getNameInLayout(),

--- a/app/code/core/Mage/Page/Block/Html/Pager.php
+++ b/app/code/core/Mage/Page/Block/Html/Pager.php
@@ -90,7 +90,7 @@ class Mage_Page_Block_Html_Pager extends Mage_Core_Block_Template
      */
     public function getLimit()
     {
-        if ($this->_limit !== null) {
+        if (!is_null($this->_limit)) {
             return $this->_limit;
         }
         $limits = $this->getAvailableLimit();
@@ -551,7 +551,7 @@ class Mage_Page_Block_Html_Pager extends Mage_Core_Block_Template
      */
     public function canShowPreviousJump()
     {
-        return $this->getPreviousJumpPage() !== null;
+        return !is_null($this->getPreviousJumpPage());
     }
 
     /**
@@ -561,7 +561,7 @@ class Mage_Page_Block_Html_Pager extends Mage_Core_Block_Template
      */
     public function canShowNextJump()
     {
-        return $this->getNextJumpPage() !== null;
+        return !is_null($this->getNextJumpPage());
     }
 
     /**

--- a/app/code/core/Mage/Page/Block/Html/Topmenu.php
+++ b/app/code/core/Mage/Page/Block/Html/Topmenu.php
@@ -240,7 +240,7 @@ class Mage_Page_Block_Html_Topmenu extends Mage_Core_Block_Template
      */
     public function getCurrentEntityKey()
     {
-        if ($this->_currentEntityKey === null) {
+        if (is_null($this->_currentEntityKey)) {
             $this->_currentEntityKey = Mage::registry('current_entity_key')
                 ? Mage::registry('current_entity_key') : Mage::app()->getStore()->getRootCategoryId();
         }

--- a/app/code/core/Mage/Page/Helper/Layout.php
+++ b/app/code/core/Mage/Page/Helper/Layout.php
@@ -53,7 +53,7 @@ class Mage_Page_Helper_Layout extends Mage_Core_Helper_Abstract
      */
     public function applyTemplate($pageLayout = null)
     {
-        if ($pageLayout === null) {
+        if (is_null($pageLayout)) {
             $pageLayout = $this->getCurrentPageLayout();
         } else {
             $pageLayout = $this->_getConfig()->getPageLayout($pageLayout);

--- a/app/code/core/Mage/Page/Model/Config.php
+++ b/app/code/core/Mage/Page/Model/Config.php
@@ -38,7 +38,7 @@ class Mage_Page_Model_Config
      */
     protected function _initPageLayouts()
     {
-        if ($this->_pageLayouts === null) {
+        if (is_null($this->_pageLayouts)) {
             $this->_pageLayouts = [];
             $this->_appendPageLayouts(self::XML_PATH_CMS_LAYOUTS);
             $this->_appendPageLayouts(self::XML_PATH_PAGE_LAYOUTS);

--- a/app/code/core/Mage/Page/Model/Source/Layout.php
+++ b/app/code/core/Mage/Page/Model/Source/Layout.php
@@ -41,7 +41,7 @@ class Mage_Page_Model_Source_Layout
      */
     public function getOptions()
     {
-        if ($this->_options === null) {
+        if (is_null($this->_options)) {
             $this->_options = [];
             foreach (Mage::getSingleton('page/config')->getPageLayouts() as $layout) {
                 $this->_options[$layout->getCode()] = $layout->getLabel();

--- a/app/code/core/Mage/Payment/Block/Form/Container.php
+++ b/app/code/core/Mage/Payment/Block/Form/Container.php
@@ -96,7 +96,7 @@ class Mage_Payment_Block_Form_Container extends Mage_Core_Block_Template
     public function getMethods()
     {
         $methods = $this->getData('methods');
-        if ($methods === null) {
+        if (is_null($methods)) {
             /** @var Mage_Payment_Helper_Data $helper */
             $helper = $this->helper('payment');
 

--- a/app/code/core/Mage/Payment/Block/Info.php
+++ b/app/code/core/Mage/Payment/Block/Info.php
@@ -150,8 +150,8 @@ class Mage_Payment_Block_Info extends Mage_Core_Block_Template
      */
     protected function _prepareSpecificInformation($transport = null)
     {
-        if ($this->_paymentSpecificInformation === null) {
-            if ($transport === null) {
+        if (is_null($this->_paymentSpecificInformation)) {
+            if (is_null($transport)) {
                 $transport = new Varien_Object();
             } elseif (is_array($transport)) {
                 $transport = new Varien_Object($transport);

--- a/app/code/core/Mage/Payment/Block/Info/Cc.php
+++ b/app/code/core/Mage/Payment/Block/Info/Cc.php
@@ -78,7 +78,7 @@ class Mage_Payment_Block_Info_Cc extends Mage_Payment_Block_Info
      */
     protected function _prepareSpecificInformation($transport = null)
     {
-        if ($this->_paymentSpecificInformation !== null) {
+        if (!is_null($this->_paymentSpecificInformation)) {
             return $this->_paymentSpecificInformation;
         }
         $transport = parent::_prepareSpecificInformation($transport);

--- a/app/code/core/Mage/Payment/Block/Info/Ccsave.php
+++ b/app/code/core/Mage/Payment/Block/Info/Ccsave.php
@@ -29,7 +29,7 @@ class Mage_Payment_Block_Info_Ccsave extends Mage_Payment_Block_Info_Cc
      */
     protected function _prepareSpecificInformation($transport = null)
     {
-        if ($this->_paymentSpecificInformation !== null) {
+        if (!is_null($this->_paymentSpecificInformation)) {
             return $this->_paymentSpecificInformation;
         }
         $info = $this->getInfo();

--- a/app/code/core/Mage/Payment/Model/Info.php
+++ b/app/code/core/Mage/Payment/Model/Info.php
@@ -165,7 +165,7 @@ class Mage_Payment_Model_Info extends Mage_Core_Model_Abstract
     public function getAdditionalInformation($key = null)
     {
         $this->_initAdditionalInformation();
-        if ($key === null) {
+        if (is_null($key)) {
             return $this->_additionalInformation;
         }
         return $this->_additionalInformation[$key] ?? null;
@@ -196,7 +196,7 @@ class Mage_Payment_Model_Info extends Mage_Core_Model_Abstract
     public function hasAdditionalInformation($key = null)
     {
         $this->_initAdditionalInformation();
-        return $key === null
+        return is_null($key)
             ? !empty($this->_additionalInformation)
             : array_key_exists($key, $this->_additionalInformation);
     }
@@ -209,7 +209,7 @@ class Mage_Payment_Model_Info extends Mage_Core_Model_Abstract
         if ($this->_additionalInformation === -1) {
             $this->_additionalInformation = $this->_getData('additional_information');
         }
-        if ($this->_additionalInformation === null) {
+        if (is_null($this->_additionalInformation)) {
             $this->_additionalInformation = [];
         }
     }

--- a/app/code/core/Mage/Payment/Model/Method/Abstract.php
+++ b/app/code/core/Mage/Payment/Model/Method/Abstract.php
@@ -596,7 +596,7 @@ abstract class Mage_Payment_Model_Method_Abstract extends Varien_Object
      */
     public function getConfigData($field, $storeId = null)
     {
-        if ($storeId === null) {
+        if (is_null($storeId)) {
             $storeId = $this->getStore();
         }
         $path = 'payment/' . $this->getCode() . '/' . $field;

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Group.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Group.php
@@ -53,7 +53,7 @@ class Mage_Paypal_Block_Adminhtml_System_Config_Fieldset_Group extends Mage_Admi
             return $extra['configState'][$element->getId()];
         }
 
-        if ($element->getExpanded() !== null) {
+        if (!is_null($element->getExpanded())) {
             return 1;
         }
 

--- a/app/code/core/Mage/Paypal/Block/Express/Shortcut.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Shortcut.php
@@ -98,7 +98,7 @@ class Mage_Paypal_Block_Express_Shortcut extends Mage_Core_Block_Template
         }
 
         // validate minimum quote amount and validate quote for zero grandtotal
-        if ($quote !== null && (!$quote->validateMinimumAmount()
+        if (!is_null($quote) && (!$quote->validateMinimumAmount()
             || (!$quote->getGrandTotal() && !$quote->hasNominalItems()))
         ) {
             $this->_shouldRender = false;

--- a/app/code/core/Mage/Paypal/Block/Express/Shortcut.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Shortcut.php
@@ -121,7 +121,7 @@ class Mage_Paypal_Block_Express_Shortcut extends Mage_Core_Block_Template
         $this->_getBmlShortcut($quote);
 
         // use static image if in catalog
-        if ($isInCatalog || $quote === null) {
+        if ($isInCatalog || is_null($quote)) {
             $this->setImageUrl($config->getExpressCheckoutShortcutImageUrl(Mage::app()->getLocale()->getLocaleCode()));
         } else {
             $this->setImageUrl(Mage::getModel($this->_checkoutType, [

--- a/app/code/core/Mage/Paypal/Controller/Express/Abstract.php
+++ b/app/code/core/Mage/Paypal/Controller/Express/Abstract.php
@@ -471,7 +471,7 @@ abstract class Mage_Paypal_Controller_Express_Abstract extends Mage_Core_Control
      */
     protected function _initToken($setToken = null)
     {
-        if ($setToken !== null) {
+        if (!is_null($setToken)) {
             if ($setToken === false) {
                 // security measure for avoid unsetting token twice
                 if (!$this->_getSession()->getExpressCheckoutToken()) {

--- a/app/code/core/Mage/Paypal/Helper/Data.php
+++ b/app/code/core/Mage/Paypal/Helper/Data.php
@@ -48,7 +48,7 @@ class Mage_Paypal_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function shouldAskToCreateBillingAgreement(Mage_Paypal_Model_Config $config, $customerId)
     {
-        if (self::$_shouldAskToCreateBillingAgreement === null) {
+        if (is_null(self::$_shouldAskToCreateBillingAgreement)) {
             self::$_shouldAskToCreateBillingAgreement = false;
             if ($customerId && $config->shouldAskToCreateBillingAgreement()) {
                 if (Mage::getModel('sales/billing_agreement')->needToCreateForCustomer($customerId)) {

--- a/app/code/core/Mage/Paypal/Model/Cart.php
+++ b/app/code/core/Mage/Paypal/Model/Cart.php
@@ -467,7 +467,7 @@ class Mage_Paypal_Model_Cart
      */
     private function _totalAsItem($var, $setValue = null)
     {
-        if ($setValue !== null) {
+        if (!is_null($setValue)) {
             if ($setValue != $this->$var) {
                 $this->_shouldRender = true;
             }

--- a/app/code/core/Mage/Paypal/Model/Config.php
+++ b/app/code/core/Mage/Paypal/Model/Config.php
@@ -1179,8 +1179,8 @@ class Mage_Paypal_Model_Config
     public function getPaymentMarkWhatIsPaypalUrl(?Mage_Core_Model_Locale $locale = null)
     {
         $countryCode = 'US';
-        if ($locale !== null) {
-            $shouldEmulate = ($this->_storeId !== null) && (Mage::app()->getStore()->getId() != $this->_storeId);
+        if (!is_null($locale)) {
+            $shouldEmulate = (!is_null($this->_storeId)) && (Mage::app()->getStore()->getId() != $this->_storeId);
             if ($shouldEmulate) {
                 $locale->emulate($this->_storeId);
             }

--- a/app/code/core/Mage/Paypal/Model/Config.php
+++ b/app/code/core/Mage/Paypal/Model/Config.php
@@ -706,7 +706,7 @@ class Mage_Paypal_Model_Config
      */
     public function isMethodAvailable($methodCode = null)
     {
-        if ($methodCode === null) {
+        if (is_null($methodCode)) {
             $methodCode = $this->getMethodCode();
         }
 
@@ -858,10 +858,10 @@ class Mage_Paypal_Model_Config
      */
     public function isMethodSupportedForCountry($method = null, $countryCode = null)
     {
-        if ($method === null) {
+        if (is_null($method)) {
             $method = $this->getMethodCode();
         }
-        if ($countryCode === null) {
+        if (is_null($countryCode)) {
             $countryCode = $this->getMerchantCountry();
         }
         $countryMethods = $this->getCountryMethods($countryCode);
@@ -958,7 +958,7 @@ class Mage_Paypal_Model_Config
                 self::METHOD_BILLING_AGREEMENT,
             ],
         ];
-        if ($countryCode === null) {
+        if (is_null($countryCode)) {
             return $countryMethods;
         }
         return $countryMethods[$countryCode] ?? $countryMethods['other'];
@@ -1151,7 +1151,7 @@ class Mage_Paypal_Model_Config
             return $this->_getDynamicImageUrl(self::EC_BUTTON_TYPE_MARK, $localeCode, $orderTotal, $pal);
         }
 
-        if ($staticSize === null) {
+        if (is_null($staticSize)) {
             $staticSize = $this->paymentMarkSize;
         }
         switch ($staticSize) {
@@ -1626,7 +1626,7 @@ class Mage_Paypal_Model_Config
                 break;
         }
 
-        if ($path === null) {
+        if (is_null($path)) {
             switch ($this->_methodCode) {
                 case self::METHOD_WPP_EXPRESS:
                 case self::METHOD_BML:
@@ -1644,10 +1644,10 @@ class Mage_Paypal_Model_Config
             }
         }
 
-        if ($path === null) {
+        if (is_null($path)) {
             $path = $this->_mapGeneralFieldset($fieldName);
         }
-        if ($path === null) {
+        if (is_null($path)) {
             $path = $this->_mapGenericStyleFieldset($fieldName);
         }
         return $path;

--- a/app/code/core/Mage/Paypal/Model/Direct.php
+++ b/app/code/core/Mage/Paypal/Model/Direct.php
@@ -77,7 +77,7 @@ class Mage_Paypal_Model_Direct extends Mage_Payment_Model_Method_Cc
     public function setStore($store)
     {
         $this->setData('store', $store);
-        if ($store === null) {
+        if (is_null($store)) {
             $store = Mage::app()->getStore()->getId();
         }
         $this->_pro->getConfig()->setStoreId(is_object($store) ? $store->getId() : $store);

--- a/app/code/core/Mage/Paypal/Model/Express.php
+++ b/app/code/core/Mage/Paypal/Model/Express.php
@@ -111,7 +111,7 @@ class Mage_Paypal_Model_Express extends Mage_Payment_Model_Method_Abstract imple
     public function setStore($store)
     {
         $this->setData('store', $store);
-        if ($store === null) {
+        if (is_null($store)) {
             $store = Mage::app()->getStore()->getId();
         }
         $this->_pro->getConfig()->setStoreId(is_object($store) ? $store->getId() : $store);

--- a/app/code/core/Mage/Paypal/Model/Express/Checkout.php
+++ b/app/code/core/Mage/Paypal/Model/Express/Checkout.php
@@ -772,7 +772,7 @@ class Mage_Paypal_Model_Express_Checkout
      */
     protected function _getApi()
     {
-        if ($this->_api === null) {
+        if (is_null($this->_api)) {
             $this->_api = Mage::getModel($this->_apiType)->setConfigObject($this->_config);
         }
         return $this->_api;

--- a/app/code/core/Mage/Paypal/Model/Ipn.php
+++ b/app/code/core/Mage/Paypal/Model/Ipn.php
@@ -76,7 +76,7 @@ class Mage_Paypal_Model_Ipn
      */
     public function getRequestData($key = null)
     {
-        if ($key === null) {
+        if (is_null($key)) {
             return $this->_request;
         }
         return $this->_request[$key] ?? null;

--- a/app/code/core/Mage/Paypal/Model/Method/Agreement.php
+++ b/app/code/core/Mage/Paypal/Model/Method/Agreement.php
@@ -76,7 +76,7 @@ class Mage_Paypal_Model_Method_Agreement extends Mage_Sales_Model_Payment_Method
     public function setStore($store)
     {
         $this->setData('store', $store);
-        if ($store === null) {
+        if (is_null($store)) {
             $store = Mage::app()->getStore()->getId();
         }
         $this->_pro->getConfig()->setStoreId(is_object($store) ? $store->getId() : $store);

--- a/app/code/core/Mage/Paypal/Model/Payment/Transaction.php
+++ b/app/code/core/Mage/Paypal/Model/Payment/Transaction.php
@@ -181,7 +181,7 @@ class Mage_Paypal_Model_Payment_Transaction extends Mage_Core_Model_Abstract
      */
     public function isFailsafe($setFailsafe = null)
     {
-        if ($setFailsafe === null) {
+        if (is_null($setFailsafe)) {
             return $this->_isFailsafe;
         }
         $this->_isFailsafe = (bool)$setFailsafe;

--- a/app/code/core/Mage/Paypal/Model/Payment/Transaction.php
+++ b/app/code/core/Mage/Paypal/Model/Payment/Transaction.php
@@ -207,7 +207,7 @@ class Mage_Paypal_Model_Payment_Transaction extends Mage_Core_Model_Abstract
      */
     protected function _verifyTxnId($txnId)
     {
-        if ($txnId !== null && strlen($txnId) == 0) {
+        if (!is_null($txnId) && strlen($txnId) == 0) {
             Mage::throwException(Mage::helper('paypal')->__('Transaction ID must not be empty.'));
         }
     }

--- a/app/code/core/Mage/Paypal/Model/Pro.php
+++ b/app/code/core/Mage/Paypal/Model/Pro.php
@@ -76,13 +76,13 @@ class Mage_Paypal_Model_Pro
     {
         if (is_null($this->_config)) {
             $params = [$code];
-            if ($storeId !== null) {
+            if (!is_null($storeId)) {
                 $params[] = $storeId;
             }
             $this->_config = Mage::getModel($this->_configType, $params);
         } else {
             $this->_config->setMethod($code);
-            if ($storeId !== null) {
+            if (!is_null($storeId)) {
                 $this->_config->setStoreId($storeId);
             }
         }
@@ -98,7 +98,7 @@ class Mage_Paypal_Model_Pro
     public function setConfig(Mage_Paypal_Model_Config $instace, $storeId = null)
     {
         $this->_config = $instace;
-        if ($storeId !== null) {
+        if (!is_null($storeId)) {
             $this->_config->setStoreId($storeId);
         }
         return $this;

--- a/app/code/core/Mage/Paypal/Model/Pro.php
+++ b/app/code/core/Mage/Paypal/Model/Pro.php
@@ -74,7 +74,7 @@ class Mage_Paypal_Model_Pro
      */
     public function setMethod($code, $storeId = null)
     {
-        if ($this->_config === null) {
+        if (is_null($this->_config)) {
             $params = [$code];
             if ($storeId !== null) {
                 $params[] = $storeId;
@@ -122,7 +122,7 @@ class Mage_Paypal_Model_Pro
      */
     public function getApi()
     {
-        if ($this->_api === null) {
+        if (is_null($this->_api)) {
             $this->_api = Mage::getModel($this->_apiType);
         }
         $this->_api->setConfigObject($this->_config);
@@ -148,7 +148,7 @@ class Mage_Paypal_Model_Pro
      */
     public function getInfo()
     {
-        if ($this->_infoInstance === null) {
+        if (is_null($this->_infoInstance)) {
             $this->_infoInstance = Mage::getModel('paypal/info');
         }
         return $this->_infoInstance;

--- a/app/code/core/Mage/Paypal/Model/Report/Settlement/Row.php
+++ b/app/code/core/Mage/Paypal/Model/Report/Settlement/Row.php
@@ -90,7 +90,7 @@ class Mage_Paypal_Model_Report_Settlement_Row extends Mage_Core_Model_Abstract
             'SUB' => Mage::helper('paypal')->__('Subscription ID'),
             'PAP' => Mage::helper('paypal')->__('Preapproved Payment ID')
         ];
-        if ($code === null) {
+        if (is_null($code)) {
             asort($types);
             return $types;
         }
@@ -133,7 +133,7 @@ class Mage_Paypal_Model_Report_Settlement_Row extends Mage_Core_Model_Abstract
             'CR' => Mage::helper('paypal')->__('Credit'),
             'DR' => Mage::helper('paypal')->__('Debit'),
         ];
-        if ($code === null) {
+        if (is_null($code)) {
             return $options;
         }
         return $options[$code] ?? $code;

--- a/app/code/core/Mage/Paypal/Model/Standard.php
+++ b/app/code/core/Mage/Paypal/Model/Standard.php
@@ -156,7 +156,7 @@ class Mage_Paypal_Model_Standard extends Mage_Payment_Model_Method_Abstract
      */
     public function getConfig()
     {
-        if ($this->_config === null) {
+        if (is_null($this->_config)) {
             $params = [$this->_code];
             if ($store = $this->getStore()) {
                 $params[] = is_object($store) ? $store->getId() : $store;

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Collection.php
@@ -88,7 +88,7 @@ class Mage_Rating_Model_Resource_Rating_Collection extends Mage_Core_Model_Resou
     {
         $adapter = $this->getConnection();
         if (!is_array($storeId)) {
-            $storeId = [$storeId === null ? -1 : $storeId];
+            $storeId = [is_null($storeId) ? -1 : $storeId];
         }
         if (empty($storeId)) {
             return $this;

--- a/app/code/core/Mage/Reports/Model/Grouped/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Grouped/Collection.php
@@ -61,7 +61,7 @@ class Mage_Reports_Model_Grouped_Collection extends Varien_Data_Collection //Mag
         parent::load($printQuery, $logQuery);
         $this->_setIsLoaded();
 
-        if ($this->_columnGroupBy !== null) {
+        if (!is_null($this->_columnGroupBy)) {
             $this->_mergeWithEmptyData();
             $this->_groupResourceData();
         }

--- a/app/code/core/Mage/Reports/Model/Resource/Event.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Event.php
@@ -114,7 +114,7 @@ class Mage_Reports_Model_Resource_Event extends Mage_Core_Model_Resource_Db_Abst
         $stores = [];
         // get all or specified stores
         if (Mage::app()->getStore()->getId() == 0) {
-            if ($predefinedStoreIds !== null) {
+            if (!is_null($predefinedStoreIds)) {
                 $stores = $predefinedStoreIds;
             } else {
                 foreach (Mage::app()->getStores() as $store) {

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Lowstock/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Lowstock/Collection.php
@@ -49,7 +49,7 @@ class Mage_Reports_Model_Resource_Product_Lowstock_Collection extends Mage_Repor
      */
     protected function _getInventoryItemResource()
     {
-        if ($this->_inventoryItemResource === null) {
+        if (is_null($this->_inventoryItemResource)) {
             $this->_inventoryItemResource = Mage::getResourceSingleton('cataloginventory/stock_item');
         }
         return $this->_inventoryItemResource;

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
@@ -35,7 +35,7 @@ abstract class Mage_Reports_Model_Resource_Report_Abstract extends Mage_Core_Mod
      */
     protected function _getFlag()
     {
-        if ($this->_flag === null) {
+        if (is_null($this->_flag)) {
             $this->_flag = Mage::getModel('reports/flag');
         }
         return $this->_flag;
@@ -119,7 +119,7 @@ abstract class Mage_Reports_Model_Resource_Report_Abstract extends Mage_Core_Mod
         $subSelect = null,
         $doNotUseTruncate = false
     ) {
-        if ($from === null && $to === null && !$doNotUseTruncate) {
+        if (is_null($from) && is_null($to) && !$doNotUseTruncate) {
             $this->_truncateTable($table);
             return $this;
         }
@@ -488,7 +488,7 @@ abstract class Mage_Reports_Model_Resource_Report_Abstract extends Mage_Core_Mod
      */
     protected function _dateToUtc($date)
     {
-        if ($date === null) {
+        if (is_null($date)) {
             return null;
         }
         $dateUtc = new Zend_Date($date);

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
@@ -55,7 +55,7 @@ abstract class Mage_Reports_Model_Resource_Report_Abstract extends Mage_Core_Mod
             ->unsetData()
             ->loadSelf();
 
-        if ($value !== null) {
+        if (!is_null($value)) {
             $this->_getFlag()->setFlagData($value);
         }
 
@@ -124,15 +124,15 @@ abstract class Mage_Reports_Model_Resource_Report_Abstract extends Mage_Core_Mod
             return $this;
         }
 
-        if ($subSelect !== null) {
+        if (!is_null($subSelect)) {
             $deleteCondition = $this->_makeConditionFromDateRangeSelect($subSelect, 'period');
         } else {
             $condition = [];
-            if ($from !== null) {
+            if (!is_null($from)) {
                 $condition[] = $this->_getWriteAdapter()->quoteInto('period >= ?', $from);
             }
 
-            if ($to !== null) {
+            if (!is_null($to)) {
                 $condition[] = $this->_getWriteAdapter()->quoteInto('period <= ?', $to);
             }
             $deleteCondition = implode(' AND ', $condition);
@@ -172,11 +172,11 @@ abstract class Mage_Reports_Model_Resource_Report_Abstract extends Mage_Core_Mod
             )
             ->distinct(true);
 
-        if ($from !== null) {
+        if (!is_null($from)) {
             $select->where($alias . '.' . $whereColumn . ' >= ?', $from);
         }
 
-        if ($to !== null) {
+        if (!is_null($to)) {
             $select->where($alias . '.' . $whereColumn . ' <= ?', $to);
         }
 
@@ -289,11 +289,11 @@ abstract class Mage_Reports_Model_Resource_Report_Abstract extends Mage_Core_Mod
             )
             ->distinct(true);
 
-        if ($from !== null) {
+        if (!is_null($from)) {
             $select->where($relatedAlias . '.' . $whereColumn . ' >= ?', $from);
         }
 
-        if ($to !== null) {
+        if (!is_null($to)) {
             $select->where($relatedAlias . '.' . $whereColumn . ' <= ?', $to);
         }
 
@@ -328,11 +328,11 @@ abstract class Mage_Reports_Model_Resource_Report_Abstract extends Mage_Core_Mod
      */
     protected function _checkDates(&$from, &$to)
     {
-        if ($from !== null) {
+        if (!is_null($from)) {
             $from = $this->formatDate($from);
         }
 
-        if ($to !== null) {
+        if (!is_null($to)) {
             $to = $this->formatDate($to);
         }
 

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Collection/Abstract.php
@@ -132,10 +132,10 @@ class Mage_Reports_Model_Resource_Report_Collection_Abstract extends Mage_Core_M
     protected function _applyDateRangeFilter()
     {
         // Remember that field PERIOD is a DATE(YYYY-MM-DD) in all databases including Oracle
-        if ($this->_from !== null) {
+        if (!is_null($this->_from)) {
             $this->getSelect()->where('period >= ?', $this->_from);
         }
-        if ($this->_to !== null) {
+        if (!is_null($this->_to)) {
             $this->getSelect()->where('period <= ?', $this->_to);
         }
 

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed.php
@@ -50,7 +50,7 @@ class Mage_Reports_Model_Resource_Report_Product_Viewed extends Mage_Sales_Model
 
         $this->_checkDates($from, $to);
 
-        if ($from !== null || $to !== null) {
+        if (!is_null($from) || !is_null($to)) {
             $subSelect = $this->_getTableDateRangeSelect(
                 $this->getTable('reports/event'),
                 'logged_at',

--- a/app/code/core/Mage/Reports/Model/Totals.php
+++ b/app/code/core/Mage/Reports/Model/Totals.php
@@ -33,7 +33,7 @@ class Mage_Reports_Model_Totals
     {
         $columns = [];
         foreach ($grid->getColumns() as $col) {
-            if ($col->getTotal() === null) {
+            if (is_null($col->getTotal())) {
                 continue;
             }
             $columns[$col->getIndex()] = ['total' => $col->getTotal(), 'value' => 0];

--- a/app/code/core/Mage/Review/Block/Product/View.php
+++ b/app/code/core/Mage/Review/Block/Product/View.php
@@ -66,7 +66,7 @@ class Mage_Review_Block_Product_View extends Mage_Catalog_Block_Product_View
      */
     public function getReviewsCollection()
     {
-        if ($this->_reviewsCollection === null) {
+        if (is_null($this->_reviewsCollection)) {
             $this->_reviewsCollection = Mage::getModel('review/review')->getCollection()
                 ->addStoreFilter(Mage::app()->getStore()->getId())
                 ->addStatusFilter(Mage_Review_Model_Review::STATUS_APPROVED)

--- a/app/code/core/Mage/Rule/Model/Condition/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Abstract.php
@@ -381,7 +381,7 @@ abstract class Mage_Rule_Model_Condition_Abstract extends Varien_Object implemen
                     break;
             }
 
-            if ($format !== null) {
+            if (!is_null($format)) {
                 $this->setValue(
                     Mage::app()->getLocale()->date(
                         $this->getData('value'),

--- a/app/code/core/Mage/Rule/Model/Condition/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Abstract.php
@@ -122,7 +122,7 @@ abstract class Mage_Rule_Model_Condition_Abstract extends Varien_Object implemen
      */
     public function getDefaultOperatorInputByType()
     {
-        if ($this->_defaultOperatorInputByType === null) {
+        if (is_null($this->_defaultOperatorInputByType)) {
             $this->_defaultOperatorInputByType = [
                 'string'      => ['==', '!=', '>=', '>', '<=', '<', '{}', '!{}', '()', '!()'],
                 'numeric'     => ['==', '!=', '>=', '>', '<=', '<', '()', '!()'],
@@ -146,7 +146,7 @@ abstract class Mage_Rule_Model_Condition_Abstract extends Varien_Object implemen
      */
     public function getDefaultOperatorOptions()
     {
-        if ($this->_defaultOperatorOptions === null) {
+        if (is_null($this->_defaultOperatorOptions)) {
             $this->_defaultOperatorOptions = [
                 '=='  => static::$translate ? Mage::helper('rule')->__('is') : 'is',
                 '!='  => static::$translate ? Mage::helper('rule')->__('is not') : 'is not',

--- a/app/code/core/Mage/Rule/Model/Condition/Product/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Product/Abstract.php
@@ -63,7 +63,7 @@ abstract class Mage_Rule_Model_Condition_Product_Abstract extends Mage_Rule_Mode
      */
     public function getDefaultOperatorInputByType()
     {
-        if ($this->_defaultOperatorInputByType === null) {
+        if (is_null($this->_defaultOperatorInputByType)) {
             parent::getDefaultOperatorInputByType();
             /*
              * '{}' and '!{}' are left for back-compatibility and equal to '==' and '!='

--- a/app/code/core/Mage/Rule/Model/Condition/Product/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Product/Abstract.php
@@ -231,7 +231,7 @@ abstract class Mage_Rule_Model_Condition_Product_Abstract extends Mage_Rule_Mode
         }
 
         // Set new values only if we really got them
-        if ($selectOptions !== null) {
+        if (!is_null($selectOptions)) {
             // Overwrite only not already existing values
             if (!$selectReady) {
                 $this->setData('value_select_options', $selectOptions);

--- a/app/code/core/Mage/Sales/Block/Order/Creditmemo/Totals.php
+++ b/app/code/core/Mage/Sales/Block/Order/Creditmemo/Totals.php
@@ -26,7 +26,7 @@ class Mage_Sales_Block_Order_Creditmemo_Totals extends Mage_Sales_Block_Order_To
      */
     public function getCreditmemo()
     {
-        if ($this->_creditmemo === null) {
+        if (is_null($this->_creditmemo)) {
             if ($this->hasData('creditmemo')) {
                 $this->_creditmemo = $this->_getData('creditmemo');
             } elseif (Mage::registry('current_creditmemo')) {

--- a/app/code/core/Mage/Sales/Block/Order/Invoice/Totals.php
+++ b/app/code/core/Mage/Sales/Block/Order/Invoice/Totals.php
@@ -26,7 +26,7 @@ class Mage_Sales_Block_Order_Invoice_Totals extends Mage_Sales_Block_Order_Total
      */
     public function getInvoice()
     {
-        if ($this->_invoice === null) {
+        if (is_null($this->_invoice)) {
             if ($this->hasData('invoice')) {
                 $this->_invoice = $this->_getData('invoice');
             } elseif (Mage::registry('current_invoice')) {

--- a/app/code/core/Mage/Sales/Block/Order/Totals.php
+++ b/app/code/core/Mage/Sales/Block/Order/Totals.php
@@ -53,7 +53,7 @@ class Mage_Sales_Block_Order_Totals extends Mage_Core_Block_Template
      */
     public function getOrder()
     {
-        if ($this->_order === null) {
+        if (is_null($this->_order)) {
             if ($this->hasData('order')) {
                 $this->_order = $this->_getData('order');
             } elseif (Mage::registry('current_order')) {
@@ -274,7 +274,7 @@ class Mage_Sales_Block_Order_Totals extends Mage_Core_Block_Template
     public function getTotals($area = null)
     {
         $totals = [];
-        if ($area === null) {
+        if (is_null($area)) {
             $totals = $this->_totals;
         } else {
             $area = (string)$area;

--- a/app/code/core/Mage/Sales/Block/Order/Totals.php
+++ b/app/code/core/Mage/Sales/Block/Order/Totals.php
@@ -160,7 +160,7 @@ class Mage_Sales_Block_Order_Totals extends Mage_Core_Block_Template
      */
     public function addTotal(Varien_Object $total, $after = null)
     {
-        if ($after !== null && $after != 'last' && $after != 'first') {
+        if (!is_null($after) && $after != 'last' && $after != 'first') {
             $totals = [];
             $added = false;
             foreach ($this->_totals as $code => $item) {
@@ -197,7 +197,7 @@ class Mage_Sales_Block_Order_Totals extends Mage_Core_Block_Template
      */
     public function addTotalBefore(Varien_Object $total, $before = null)
     {
-        if ($before !== null) {
+        if (!is_null($before)) {
             if (!is_array($before)) {
                 $before = [$before];
             }

--- a/app/code/core/Mage/Sales/Block/Payment/Info/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Block/Payment/Info/Billing/Agreement.php
@@ -29,7 +29,7 @@ class Mage_Sales_Block_Payment_Info_Billing_Agreement extends Mage_Payment_Block
      */
     protected function _prepareSpecificInformation($transport = null)
     {
-        if ($this->_paymentSpecificInformation !== null) {
+        if (!is_null($this->_paymentSpecificInformation)) {
             return $this->_paymentSpecificInformation;
         }
         $info = $this->getInfo();

--- a/app/code/core/Mage/Sales/Block/Recurring/Profile/View.php
+++ b/app/code/core/Mage/Sales/Block/Recurring/Profile/View.php
@@ -315,7 +315,7 @@ class Mage_Sales_Block_Recurring_Profile_View extends Mage_Core_Block_Template
     public function renderRowValue(Varien_Object $row)
     {
         $value = $row->getValue();
-        if ($value === null) {
+        if (is_null($value)) {
             return '';
         }
         if (is_array($value)) {
@@ -334,7 +334,7 @@ class Mage_Sales_Block_Recurring_Profile_View extends Mage_Core_Block_Template
      */
     protected function _prepareRelatedOrders($fieldsToSelect = '*')
     {
-        if ($this->_relatedOrders === null) {
+        if (is_null($this->_relatedOrders)) {
             $this->_relatedOrders = Mage::getResourceModel('sales/order_collection')
                 ->addFieldToSelect($fieldsToSelect)
                 ->addFieldToFilter('customer_id', Mage::registry('current_customer')->getId())

--- a/app/code/core/Mage/Sales/Controller/Abstract.php
+++ b/app/code/core/Mage/Sales/Controller/Abstract.php
@@ -66,7 +66,7 @@ abstract class Mage_Sales_Controller_Abstract extends Mage_Core_Controller_Front
      */
     protected function _loadValidOrder($orderId = null)
     {
-        if ($orderId === null) {
+        if (is_null($orderId)) {
             $orderId = (int) $this->getRequest()->getParam('order_id');
         }
         if (!$orderId) {

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -2420,7 +2420,7 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
      */
     protected function _afterSave()
     {
-        if ($this->_addresses !== null) {
+        if (!is_null($this->_addresses)) {
             $this->_addresses->save();
             $billingAddress = $this->getBillingAddress();
             $attributesForSave = [];
@@ -2439,13 +2439,13 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
                 $this->_getResource()->saveAttribute($this, $attributesForSave);
             }
         }
-        if ($this->_items !== null) {
+        if (!is_null($this->_items)) {
             $this->_items->save();
         }
-        if ($this->_payments !== null) {
+        if (!is_null($this->_payments)) {
             $this->_payments->save();
         }
-        if ($this->_statusHistory !== null) {
+        if (!is_null($this->_statusHistory)) {
             $this->_statusHistory->save();
         }
         foreach ($this->getRelatedObjects() as $object) {

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -2355,11 +2355,11 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
             $this->setCustomerId($this->getCustomer()->getId());
         }
 
-        if ($this->hasBillingAddressId() && $this->getBillingAddressId() === null) {
+        if ($this->hasBillingAddressId() && is_null($this->getBillingAddressId())) {
             $this->unsBillingAddressId();
         }
 
-        if ($this->hasShippingAddressId() && $this->getShippingAddressId() === null) {
+        if ($this->hasShippingAddressId() && is_null($this->getShippingAddressId())) {
             $this->unsShippingAddressId();
         }
 

--- a/app/code/core/Mage/Sales/Model/Order/Config.php
+++ b/app/code/core/Mage/Sales/Model/Order/Config.php
@@ -229,7 +229,7 @@ class Mage_Sales_Model_Order_Config extends Mage_Core_Model_Config_Base
      */
     private function _getStates()
     {
-        if ($this->_states === null) {
+        if (is_null($this->_states)) {
             $this->_states = [
                 'all'       => [],
                 'visible'   => [],

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -1001,7 +1001,7 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
      */
     protected function _afterSave()
     {
-        if ($this->_items !== null) {
+        if (!is_null($this->_items)) {
             /**
              * Save invoice items
              */
@@ -1011,7 +1011,7 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
             }
         }
 
-        if ($this->_comments !== null) {
+        if (!is_null($this->_comments)) {
             foreach ($this->_comments as $comment) {
                 $comment->save();
             }

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
@@ -137,7 +137,7 @@ class Mage_Sales_Model_Order_Invoice_Api extends Mage_Sales_Model_Api_Resource
 
         $invoice->register();
 
-        if ($comment !== null) {
+        if (!is_null($comment)) {
             $invoice->addComment($comment, $email);
         }
 

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Api/V2.php
@@ -54,7 +54,7 @@ class Mage_Sales_Model_Order_Invoice_Api_V2 extends Mage_Sales_Model_Order_Invoi
 
         $invoice->register();
 
-        if ($comment !== null) {
+        if (!is_null($comment)) {
             $invoice->addComment($comment, $email);
         }
 

--- a/app/code/core/Mage/Sales/Model/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Payment.php
@@ -1262,7 +1262,7 @@ class Mage_Sales_Model_Order_Payment extends Mage_Payment_Model_Info
 
         // look for set transaction ids
         $transactionId = $this->getTransactionId();
-        if ($transactionId !== null) {
+        if (!is_null($transactionId)) {
             // set transaction parameters
             $transaction = false;
             if ($this->getOrder()->getId()) {
@@ -1372,7 +1372,7 @@ class Mage_Sales_Model_Order_Payment extends Mage_Payment_Model_Info
     protected function _updateTotals($data)
     {
         foreach ($data as $key => $amount) {
-            if ($amount !== null) {
+            if (!is_null($amount)) {
                 $was = $this->getDataUsingMethod($key);
                 $this->setDataUsingMethod($key, $was + $amount);
             }

--- a/app/code/core/Mage/Sales/Model/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Payment.php
@@ -654,7 +654,7 @@ class Mage_Sales_Model_Order_Payment extends Mage_Payment_Model_Info
      */
     public function canVoid(Varien_Object $document)
     {
-        if ($this->_canVoidLookup === null) {
+        if (is_null($this->_canVoidLookup)) {
             $this->_canVoidLookup = (bool)$this->getMethodInstance()->canVoid($document);
             if ($this->_canVoidLookup) {
                 $authTransaction = $this->getAuthorizationTransaction();
@@ -1404,7 +1404,7 @@ class Mage_Sales_Model_Order_Payment extends Mage_Payment_Model_Info
      */
     protected function _isTransactionExists($txnId = null)
     {
-        if ($txnId === null) {
+        if (is_null($txnId)) {
             $txnId = $this->getTransactionId();
         }
         return $txnId && $this->_lookupTransaction($txnId);

--- a/app/code/core/Mage/Sales/Model/Order/Payment/Transaction.php
+++ b/app/code/core/Mage/Sales/Model/Order/Payment/Transaction.php
@@ -199,7 +199,7 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
      */
     public function getParentTransaction($shouldLoad = true)
     {
-        if ($this->_parentTransaction === null) {
+        if (is_null($this->_parentTransaction)) {
             $this->_verifyThisTransactionExists();
             $this->_parentTransaction = false;
             $parentId = $this->getParentId();
@@ -239,7 +239,7 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
         $this->_loadChildren();
 
         // grab all transactions
-        if (empty($types) && $txnId === null) {
+        if (empty($types) && is_null($txnId)) {
             return $this->_children;
         } elseif ($types && !is_array($types)) {
             $types = [$types];
@@ -376,7 +376,7 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
         if ($whetherHasChild !== null) {
             $this->_hasChild = (bool)$whetherHasChild;
             return $this;
-        } elseif ($this->_hasChild === null) {
+        } elseif (is_null($this->_hasChild)) {
             if ($this->getChildTransactions()) {
                 $this->_hasChild = true;
             } else {
@@ -529,7 +529,7 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
     public function getOrderPaymentObject($shouldLoad = true)
     {
         $this->_verifyThisTransactionExists();
-        if ($this->_paymentObject === null && $shouldLoad) {
+        if (is_null($this->_paymentObject) && $shouldLoad) {
             $payment = Mage::getModel('sales/order_payment')->load($this->getPaymentId());
             if ($payment->getId()) {
                 $this->setOrderPaymentObject($payment);
@@ -563,7 +563,7 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
      */
     public function getOrder()
     {
-        if ($this->_order === null) {
+        if (is_null($this->_order)) {
             $this->setOrder();
         }
 
@@ -579,10 +579,10 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
      */
     public function setOrder($order = null)
     {
-        if ($order === null || $order === true) {
+        if (is_null($order) || $order === true) {
             if ($this->_paymentObject !== null && $this->_paymentObject->getOrder()) {
                 $this->_order = $this->_paymentObject->getOrder();
-            } elseif ($this->getOrderId() && $order === null) {
+            } elseif ($this->getOrderId() && is_null($order)) {
                 $this->_order = Mage::getModel('sales/order')->load($this->getOrderId());
             } else {
                 $this->_order = false;
@@ -604,7 +604,7 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
      */
     public function isFailsafe($setFailsafe = null)
     {
-        if ($setFailsafe === null) {
+        if (is_null($setFailsafe)) {
             return $this->_isFailsafe;
         }
         $this->_isFailsafe = (bool)$setFailsafe;
@@ -743,7 +743,7 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
      */
     protected function _verifyTxnType($txnType = null)
     {
-        if ($txnType === null) {
+        if (is_null($txnType)) {
             $txnType = $this->getTxnType();
         }
         switch ($txnType) {

--- a/app/code/core/Mage/Sales/Model/Order/Payment/Transaction.php
+++ b/app/code/core/Mage/Sales/Model/Order/Payment/Transaction.php
@@ -373,7 +373,7 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
      */
     public function hasChildTransaction($whetherHasChild = null)
     {
-        if ($whetherHasChild !== null) {
+        if (!is_null($whetherHasChild)) {
             $this->_hasChild = (bool)$whetherHasChild;
             return $this;
         } elseif (is_null($this->_hasChild)) {
@@ -580,7 +580,7 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
     public function setOrder($order = null)
     {
         if (is_null($order) || $order === true) {
-            if ($this->_paymentObject !== null && $this->_paymentObject->getOrder()) {
+            if (!is_null($this->_paymentObject) && $this->_paymentObject->getOrder()) {
                 $this->_order = $this->_paymentObject->getOrder();
             } elseif ($this->getOrderId() && is_null($order)) {
                 $this->_order = Mage::getModel('sales/order')->load($this->getOrderId());
@@ -622,11 +622,11 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
         $this->_verifyPaymentObject();
         if (!$this->getId()) {
             // We need to set order and payment ids only for new transactions
-            if ($this->_paymentObject !== null) {
+            if (!is_null($this->_paymentObject)) {
                 $this->setPaymentId($this->_paymentObject->getId());
             }
 
-            if ($this->_order !== null) {
+            if (!is_null($this->_order)) {
                 $this->setOrderId($this->_order->getId());
             }
 
@@ -641,7 +641,7 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
      */
     protected function _loadChildren()
     {
-        if ($this->_children !== null) {
+        if (!is_null($this->_children)) {
             return;
         }
 
@@ -783,7 +783,7 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
      */
     protected function _verifyTxnId($txnId)
     {
-        if ($txnId !== null && strlen($txnId) == 0) {
+        if (!is_null($txnId) && strlen($txnId) == 0) {
             Mage::throwException(Mage::helper('sales')->__('Transaction ID must not be empty.'));
         }
     }

--- a/app/code/core/Mage/Sales/Model/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment.php
@@ -594,7 +594,7 @@ class Mage_Sales_Model_Order_Shipment extends Mage_Sales_Model_Abstract
      */
     protected function _beforeSave()
     {
-        if ((!$this->getId() || $this->_items !== null) && !count($this->getAllItems())) {
+        if ((!$this->getId() || !is_null($this->_items)) && !count($this->getAllItems())) {
             Mage::throwException(
                 Mage::helper('sales')->__('Cannot create an empty shipment.')
             );
@@ -629,19 +629,19 @@ class Mage_Sales_Model_Order_Shipment extends Mage_Sales_Model_Abstract
      */
     protected function _afterSave()
     {
-        if ($this->_items !== null) {
+        if (!is_null($this->_items)) {
             foreach ($this->_items as $item) {
                 $item->save();
             }
         }
 
-        if ($this->_tracks !== null) {
+        if (!is_null($this->_tracks)) {
             foreach ($this->_tracks as $track) {
                 $track->save();
             }
         }
 
-        if ($this->_comments !== null) {
+        if (!is_null($this->_comments)) {
             foreach ($this->_comments as $comment) {
                 $comment->save();
             }

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -1669,7 +1669,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
         foreach ($errorLists as $type => $errorList) {
             $removedItems = $errorList->removeItemsByParams($params);
             foreach ($removedItems as $item) {
-                if ($item['message'] !== null) {
+                if (!is_null($item['message'])) {
                     $this->removeMessageByText($type, $item['message']);
                 }
             }

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -371,15 +371,15 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
     {
         parent::_afterSave();
 
-        if ($this->_addresses !== null) {
+        if (!is_null($this->_addresses)) {
             $this->getAddressesCollection()->save();
         }
 
-        if ($this->_items !== null) {
+        if (!is_null($this->_items)) {
             $this->getItemsCollection()->save();
         }
 
-        if ($this->_payments !== null) {
+        if (!is_null($this->_payments)) {
             $this->getPaymentsCollection()->save();
         }
         return $this;
@@ -1636,7 +1636,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
 
         $this->_errorInfoGroups[$type]->addItem($origin, $code, $message, $additionalData);
 
-        if ($message !== null) {
+        if (!is_null($message)) {
             $this->addMessage($message, $type);
         }
         $this->_setHasError(true);

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -1027,7 +1027,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
      */
     public function addProductAdvanced(Mage_Catalog_Model_Product $product, $request = null, $processMode = null)
     {
-        if ($request === null) {
+        if (is_null($request)) {
             $request = 1;
         }
         if (is_numeric($request)) {

--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -396,10 +396,10 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
     protected function _afterSave()
     {
         parent::_afterSave();
-        if ($this->_items !== null) {
+        if (!is_null($this->_items)) {
             $this->getItemsCollection()->save();
         }
-        if ($this->_rates !== null) {
+        if (!is_null($this->_rates)) {
             $this->getShippingRatesCollection()->save();
         }
         return $this;

--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -372,7 +372,7 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
      */
     protected function _isNotRegisteredCustomer()
     {
-        return !$this->getQuote()->getCustomerId() || $this->getCustomerAddressId() === null;
+        return !$this->getQuote()->getCustomerId() || is_null($this->getCustomerAddressId());
     }
 
     /**
@@ -633,7 +633,7 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
      */
     protected function _filterNominal($item)
     {
-        return ($this->_nominalOnly === null)
+        return (is_null($this->_nominalOnly))
             || (($this->_nominalOnly === false) && !$item->isNominal())
             || (($this->_nominalOnly === true) && $item->isNominal())
             ? $item : false;
@@ -1056,7 +1056,7 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
      */
     public function getTotalCollector()
     {
-        if ($this->_totalCollector === null) {
+        if (is_null($this->_totalCollector)) {
             $this->_totalCollector = Mage::getSingleton(
                 'sales/quote_address_total_collector',
                 ['store' => $this->getQuote()->getStore()]

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Abstract.php
@@ -125,7 +125,7 @@ abstract class Mage_Sales_Model_Quote_Address_Total_Abstract
      */
     protected function _getAddress()
     {
-        if ($this->_address === null) {
+        if (is_null($this->_address)) {
             Mage::throwException(
                 Mage::helper('sales')->__('Address model is not defined.')
             );

--- a/app/code/core/Mage/Sales/Model/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item.php
@@ -878,7 +878,7 @@ class Mage_Sales_Model_Quote_Item extends Mage_Sales_Model_Quote_Item_Abstract
     public function addErrorInfo($origin = null, $code = null, $message = null, $additionalData = null)
     {
         $this->_errorInfos->addItem($origin, $code, $message, $additionalData);
-        if ($message !== null) {
+        if (!is_null($message)) {
             $this->setMessage($message);
         }
         $this->_setHasError(true);

--- a/app/code/core/Mage/Sales/Model/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item.php
@@ -908,7 +908,7 @@ class Mage_Sales_Model_Quote_Item extends Mage_Sales_Model_Quote_Item_Abstract
     {
         $removedItems = $this->_errorInfos->removeItemsByParams($params);
         foreach ($removedItems as $item) {
-            if ($item['message'] !== null) {
+            if (!is_null($item['message'])) {
                 $this->removeMessageByText($item['message']);
             }
         }

--- a/app/code/core/Mage/Sales/Model/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item.php
@@ -482,7 +482,7 @@ class Mage_Sales_Model_Quote_Item extends Mage_Sales_Model_Quote_Item_Abstract
                 continue;
             }
             if (!isset($options2[$code])
-                || ($options2[$code]->getValue() === null)
+                || is_null($options2[$code]->getValue())
                 || $options2[$code]->getValue() != $option->getValue()
             ) {
                 return false;

--- a/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
@@ -714,7 +714,7 @@ abstract class Mage_Sales_Model_Quote_Item_Abstract extends Mage_Core_Model_Abst
             $calculate = $this->getProduct()->getPriceType();
         }
 
-        if (($calculate !== null) && (int)$calculate === Mage_Catalog_Model_Product_Type_Abstract::CALCULATE_CHILD) {
+        if ((!is_null($calculate)) && (int)$calculate === Mage_Catalog_Model_Product_Type_Abstract::CALCULATE_CHILD) {
             return true;
         }
         return false;
@@ -734,7 +734,7 @@ abstract class Mage_Sales_Model_Quote_Item_Abstract extends Mage_Core_Model_Abst
             $shipmentType = $this->getProduct()->getShipmentType();
         }
 
-        if (($shipmentType !== null) &&
+        if ((!is_null($shipmentType)) &&
             (int)$shipmentType === Mage_Catalog_Model_Product_Type_Abstract::SHIPMENT_SEPARATELY
         ) {
             return true;

--- a/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
@@ -206,7 +206,7 @@ abstract class Mage_Sales_Model_Quote_Item_Abstract extends Mage_Core_Model_Abst
     public function getProduct()
     {
         $product = $this->_getData('product');
-        if ($product === null && $this->getProductId()) {
+        if (is_null($product) && $this->getProductId()) {
             $product = Mage::getModel('catalog/product')
                 ->setStoreId($this->getQuote()->getStoreId())
                 ->load($this->getProductId());

--- a/app/code/core/Mage/Sales/Model/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Model/Recurring/Profile.php
@@ -568,7 +568,7 @@ class Mage_Sales_Model_Recurring_Profile extends Mage_Payment_Model_Recurring_Pr
      */
     protected function _initWorkflow()
     {
-        if ($this->_workflow === null) {
+        if (is_null($this->_workflow)) {
             $this->_workflow = [
                 'unknown'   => ['pending', 'active', 'suspended', 'canceled'],
                 'pending'   => ['active', 'canceled'],

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Abstract.php
@@ -106,7 +106,7 @@ abstract class Mage_Sales_Model_Resource_Order_Abstract extends Mage_Sales_Model
      */
     public function getVirtualGridColumns()
     {
-        if ($this->_virtualGridColumns === null) {
+        if (is_null($this->_virtualGridColumns)) {
             $this->_initVirtualGridColumns();
         }
 
@@ -178,7 +178,7 @@ abstract class Mage_Sales_Model_Resource_Order_Abstract extends Mage_Sales_Model
                 $this->getMainTable()
             ));
 
-        if ($gridColumns === null) {
+        if (is_null($gridColumns)) {
             $gridColumns = $this->getGridColumns();
         }
 
@@ -237,7 +237,7 @@ abstract class Mage_Sales_Model_Resource_Order_Abstract extends Mage_Sales_Model
      */
     public function getGridColumns()
     {
-        if ($this->_gridColumns === null) {
+        if (is_null($this->_gridColumns)) {
             if ($this->_grid) {
                 $this->_gridColumns = array_keys(
                     $this->_getReadAdapter()->describeTable($this->getGridTable())

--- a/app/code/core/Mage/Sales/Model/Resource/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote.php
@@ -186,7 +186,7 @@ class Mage_Sales_Model_Resource_Quote extends Mage_Sales_Model_Resource_Abstract
                 'qi.product_id = pp.product_id',
                 []
             );
-        if ($productIdList !== null) {
+        if (!is_null($productIdList)) {
             $subSelect->where('qi.product_id IN (?)', $productIdList);
         }
 

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers.php
@@ -51,7 +51,7 @@ class Mage_Sales_Model_Resource_Report_Bestsellers extends Mage_Sales_Model_Reso
         //$this->_getWriteAdapter()->beginTransaction();
 
         try {
-            if ($from !== null || $to !== null) {
+            if (!is_null($from) || !is_null($to)) {
                 $subSelect = $this->_getTableDateRangeSelect(
                     $this->getTable('sales/order'),
                     'created_at',
@@ -198,7 +198,7 @@ class Mage_Sales_Model_Resource_Report_Bestsellers extends Mage_Sales_Model_Reso
                 []
             );
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->having($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 
@@ -279,7 +279,7 @@ class Mage_Sales_Model_Resource_Report_Bestsellers extends Mage_Sales_Model_Reso
             []
         );
 
-        if ($subSelect !== null) {
+        if (!is_null($subSelect)) {
             $select->where($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
         }
 

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced.php
@@ -66,7 +66,7 @@ class Mage_Sales_Model_Resource_Report_Invoiced extends Mage_Sales_Model_Resourc
         $adapter->beginTransaction();
 
         try {
-            if ($from !== null || $to !== null) {
+            if (!is_null($from) || !is_null($to)) {
                 $subSelect = $this->_getTableDateRangeRelatedSelect(
                     $sourceTable,
                     $orderTable,
@@ -122,7 +122,7 @@ class Mage_Sales_Model_Resource_Report_Invoiced extends Mage_Sales_Model_Resourc
             $filterSubSelect->from(['filter_source_table' => $sourceTable], 'MAX(filter_source_table.entity_id)')
                 ->where('filter_source_table.order_id = source_table.order_id');
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->having($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 
@@ -155,7 +155,7 @@ class Mage_Sales_Model_Resource_Report_Invoiced extends Mage_Sales_Model_Resourc
                 ->from($table, $columns)
                 ->where('store_id <> ?', 0);
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->where($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 
@@ -188,7 +188,7 @@ class Mage_Sales_Model_Resource_Report_Invoiced extends Mage_Sales_Model_Resourc
         $sourceTable = $this->getTable('sales/order');
         $adapter     = $this->_getWriteAdapter();
 
-        if ($from !== null || $to !== null) {
+        if (!is_null($from) || !is_null($to)) {
             $subSelect = $this->_getTableDateRangeSelect($sourceTable, 'created_at', 'updated_at', $from, $to);
         } else {
             $subSelect = null;
@@ -244,7 +244,7 @@ class Mage_Sales_Model_Resource_Report_Invoiced extends Mage_Sales_Model_Resourc
         $select->from($sourceTable, $columns)
                 ->where('state <> ?', Mage_Sales_Model_Order::STATE_CANCELED);
 
-        if ($subSelect !== null) {
+        if (!is_null($subSelect)) {
             $select->having($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
         }
 
@@ -276,7 +276,7 @@ class Mage_Sales_Model_Resource_Report_Invoiced extends Mage_Sales_Model_Resourc
         $select->from($table, $columns)
             ->where('store_id <> ?', 0);
 
-        if ($subSelect !== null) {
+        if (!is_null($subSelect)) {
             $select->where($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
         }
 

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order/Createdat.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order/Createdat.php
@@ -58,7 +58,7 @@ class Mage_Sales_Model_Resource_Report_Order_Createdat extends Mage_Sales_Model_
 
         $adapter->beginTransaction();
         try {
-            if ($from !== null || $to !== null) {
+            if (!is_null($from) || !is_null($to)) {
                 $subSelect = $this->_getTableDateRangeSelect(
                     $this->getTable('sales/order'),
                     $aggregationField,
@@ -217,7 +217,7 @@ class Mage_Sales_Model_Resource_Report_Order_Createdat extends Mage_Sales_Model_
                     Mage_Sales_Model_Order::STATE_NEW
                 ]);
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->having($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 
@@ -241,7 +241,7 @@ class Mage_Sales_Model_Resource_Report_Order_Createdat extends Mage_Sales_Model_
             $select->from($this->getMainTable(), $columns)
                 ->where('store_id <> 0');
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->where($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Refunded.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Refunded.php
@@ -65,7 +65,7 @@ class Mage_Sales_Model_Resource_Report_Refunded extends Mage_Sales_Model_Resourc
         $adapter->beginTransaction();
 
         try {
-            if ($from !== null || $to !== null) {
+            if (!is_null($from) || !is_null($to)) {
                 $subSelect = $this->_getTableDateRangeSelect($sourceTable, 'created_at', 'updated_at', $from, $to);
             } else {
                 $subSelect = null;
@@ -91,7 +91,7 @@ class Mage_Sales_Model_Resource_Report_Refunded extends Mage_Sales_Model_Resourc
                 ->where('state != ?', Mage_Sales_Model_Order::STATE_CANCELED)
                 ->where('base_total_refunded > ?', 0);
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->having($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 
@@ -124,7 +124,7 @@ class Mage_Sales_Model_Resource_Report_Refunded extends Mage_Sales_Model_Resourc
                 ->from($table, $columns)
                 ->where('store_id != ?', 0);
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->where($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 
@@ -160,7 +160,7 @@ class Mage_Sales_Model_Resource_Report_Refunded extends Mage_Sales_Model_Resourc
         $adapter->beginTransaction();
 
         try {
-            if ($from !== null || $to !== null) {
+            if (!is_null($from) || !is_null($to)) {
                 $subSelect = $this->_getTableDateRangeRelatedSelect(
                     $sourceTable,
                     $orderTable,
@@ -219,7 +219,7 @@ class Mage_Sales_Model_Resource_Report_Refunded extends Mage_Sales_Model_Resourc
                 )
                 ->where('filter_source_table.order_id = source_table.order_id');
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->having($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 
@@ -255,7 +255,7 @@ class Mage_Sales_Model_Resource_Report_Refunded extends Mage_Sales_Model_Resourc
                 ->from($table, $columns)
                 ->where('store_id != ?', 0);
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->where($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Shipping.php
@@ -61,7 +61,7 @@ class Mage_Sales_Model_Resource_Report_Shipping extends Mage_Sales_Model_Resourc
         $adapter->beginTransaction();
 
         try {
-            if ($from !== null || $to !== null) {
+            if (!is_null($from) || !is_null($to)) {
                 $subSelect = $this->_getTableDateRangeSelect($sourceTable, 'created_at', 'updated_at', $from, $to);
             } else {
                 $subSelect = null;
@@ -96,7 +96,7 @@ class Mage_Sales_Model_Resource_Report_Shipping extends Mage_Sales_Model_Resourc
                  ])
                 ->where('is_virtual = 0');
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->having($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 
@@ -130,7 +130,7 @@ class Mage_Sales_Model_Resource_Report_Shipping extends Mage_Sales_Model_Resourc
                 ->from($table, $columns)
                 ->where('store_id != ?', 0);
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->where($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 
@@ -166,7 +166,7 @@ class Mage_Sales_Model_Resource_Report_Shipping extends Mage_Sales_Model_Resourc
         $adapter->beginTransaction();
 
         try {
-            if ($from !== null || $to !== null) {
+            if (!is_null($from) || !is_null($to)) {
                 $subSelect = $this->_getTableDateRangeRelatedSelect(
                     $sourceTable,
                     $orderTable,
@@ -220,7 +220,7 @@ class Mage_Sales_Model_Resource_Report_Shipping extends Mage_Sales_Model_Resourc
                 ->from(['filter_source_table' => $sourceTable], 'MIN(filter_source_table.entity_id)')
                 ->where('filter_source_table.order_id = source_table.order_id');
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->having($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 
@@ -255,7 +255,7 @@ class Mage_Sales_Model_Resource_Report_Shipping extends Mage_Sales_Model_Resourc
                 ->from($table, $columns)
                 ->where('store_id != ?', 0);
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->where($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 

--- a/app/code/core/Mage/Sales/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Setup.php
@@ -168,7 +168,7 @@ class Mage_Sales_Model_Resource_Setup extends Mage_Eav_Model_Entity_Setup
                 $length = 255;
                 break;
         }
-        if ($type !== null) {
+        if (!is_null($type)) {
             $data['type'] = $type;
             $data['length'] = $length;
         }

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule/Createdat.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule/Createdat.php
@@ -64,7 +64,7 @@ class Mage_SalesRule_Model_Resource_Report_Rule_Createdat extends Mage_Reports_M
         $adapter->beginTransaction();
 
         try {
-            if ($from !== null || $to !== null) {
+            if (!is_null($from) || !is_null($to)) {
                 $subSelect = $this->_getTableDateRangeSelect($sourceTable, 'created_at', 'updated_at', $from, $to);
             } else {
                 $subSelect = null;
@@ -121,7 +121,7 @@ class Mage_SalesRule_Model_Resource_Report_Rule_Createdat extends Mage_Reports_M
             $select->from(['source_table' => $sourceTable], $columns)
                  ->where('coupon_code IS NOT NULL');
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->having($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 
@@ -158,7 +158,7 @@ class Mage_SalesRule_Model_Resource_Report_Rule_Createdat extends Mage_Reports_M
                 ->from($table, $columns)
                 ->where('store_id <> 0');
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->where($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Collection.php
@@ -72,7 +72,7 @@ class Mage_SalesRule_Model_Resource_Rule_Collection extends Mage_Rule_Model_Reso
             $select = $this->getSelect();
 
             $connection = $this->getConnection();
-            if ($couponCode !== null && strlen($couponCode)) {
+            if (!is_null($couponCode) && strlen($couponCode)) {
                 $select->joinLeft(
                     ['rule_coupons' => $this->getTable('salesrule/coupon')],
                     $connection->quoteInto(

--- a/app/code/core/Mage/SalesRule/Model/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule.php
@@ -285,7 +285,7 @@ class Mage_SalesRule_Model_Rule extends Mage_Rule_Model_Abstract
      */
     public function getPrimaryCoupon()
     {
-        if ($this->_primaryCoupon === null) {
+        if (is_null($this->_primaryCoupon)) {
             $this->_primaryCoupon = Mage::getModel('salesrule/coupon');
             $this->_primaryCoupon->loadPrimaryByRule($this->getId());
             $this->_primaryCoupon->setRule($this)->setIsPrimary(true);
@@ -350,7 +350,7 @@ class Mage_SalesRule_Model_Rule extends Mage_Rule_Model_Abstract
      */
     public function getCoupons()
     {
-        if ($this->_coupons === null) {
+        if (is_null($this->_coupons)) {
             $collection = Mage::getResourceModel('salesrule/coupon_collection');
             $collection->addRuleToFilter($this);
             $this->_coupons = $collection->getItems();
@@ -365,7 +365,7 @@ class Mage_SalesRule_Model_Rule extends Mage_Rule_Model_Abstract
      */
     public function getCouponTypes()
     {
-        if ($this->_couponTypes === null) {
+        if (is_null($this->_couponTypes)) {
             $this->_couponTypes = [
                 self::COUPON_TYPE_NO_COUPON => Mage::helper('salesrule')->__('No Coupon'),
                 self::COUPON_TYPE_SPECIFIC  => Mage::helper('salesrule')->__('Specific Coupon'),

--- a/app/code/core/Mage/SalesRule/Model/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule.php
@@ -187,7 +187,7 @@ class Mage_SalesRule_Model_Rule extends Mage_Rule_Model_Abstract
     protected function _afterLoad()
     {
         $this->setCouponCode($this->getPrimaryCoupon()->getCode());
-        if ($this->getUsesPerCoupon() !== null && !$this->getUseAutoGeneration()) {
+        if (!is_null($this->getUsesPerCoupon()) && !$this->getUseAutoGeneration()) {
             $this->setUsesPerCoupon($this->getPrimaryCoupon()->getUsageLimit());
         }
         return parent::_afterLoad();

--- a/app/code/core/Mage/SalesRule/Model/Validator.php
+++ b/app/code/core/Mage/SalesRule/Model/Validator.php
@@ -743,7 +743,7 @@ class Mage_SalesRule_Model_Validator extends Mage_Core_Model_Abstract
     public function processShippingAmount(Mage_Sales_Model_Quote_Address $address)
     {
         $shippingAmount = $address->getShippingAmountForDiscount();
-        if ($shippingAmount !== null) {
+        if (!is_null($shippingAmount)) {
             $baseShippingAmount = $address->getBaseShippingAmountForDiscount();
         } else {
             $shippingAmount     = $address->getShippingAmount();
@@ -1001,7 +1001,7 @@ class Mage_SalesRule_Model_Validator extends Mage_Core_Model_Abstract
     protected function _getItemBasePrice($item)
     {
         $price = $item->getDiscountCalculationPrice();
-        return ($price !== null) ? $item->getBaseDiscountCalculationPrice() : $item->getBaseCalculationPrice();
+        return (!is_null($price)) ? $item->getBaseDiscountCalculationPrice() : $item->getBaseCalculationPrice();
     }
 
     /**

--- a/app/code/core/Mage/Tax/Helper/Data.php
+++ b/app/code/core/Mage/Tax/Helper/Data.php
@@ -148,7 +148,7 @@ class Mage_Tax_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function getCalculator()
     {
-        if ($this->_calculator === null) {
+        if (is_null($this->_calculator)) {
             $this->_calculator = Mage::getSingleton('tax/calculation');
         }
         return $this->_calculator;

--- a/app/code/core/Mage/Tax/Helper/Data.php
+++ b/app/code/core/Mage/Tax/Helper/Data.php
@@ -1220,7 +1220,7 @@ class Mage_Tax_Helper_Data extends Mage_Core_Helper_Abstract
             return (bool) $flag->getFlagData();
         }
         $configValue = $this->_app->getStore()->getConfig($key);
-        if ($configValue !== null) {
+        if (!is_null($configValue)) {
             $flag->setFlagData((bool) $configValue)->save();
             return (bool) $configValue;
         }

--- a/app/code/core/Mage/Tax/Model/Calculation.php
+++ b/app/code/core/Mage/Tax/Model/Calculation.php
@@ -153,7 +153,7 @@ class Mage_Tax_Model_Calculation extends Mage_Core_Model_Abstract
      */
     public function getDefaultCustomerTaxClass($store = null)
     {
-        if ($this->_defaultCustomerTaxClass === null) {
+        if (is_null($this->_defaultCustomerTaxClass)) {
             $defaultCustomerGroup = Mage::helper('customer')->getDefaultCustomerGroupId($store);
             $this->_defaultCustomerTaxClass = Mage::getModel('customer/group')->getTaxClassId($defaultCustomerGroup);
         }
@@ -167,7 +167,7 @@ class Mage_Tax_Model_Calculation extends Mage_Core_Model_Abstract
      */
     public function getCustomer()
     {
-        if ($this->_customer === null) {
+        if (is_null($this->_customer)) {
             $session = Mage::getSingleton('customer/session');
             if ($session->isLoggedIn()) {
                 $this->_customer = $session->getCustomer();

--- a/app/code/core/Mage/Tax/Model/Config.php
+++ b/app/code/core/Mage/Tax/Model/Config.php
@@ -316,7 +316,7 @@ class Mage_Tax_Model_Config
      */
     public function shippingPriceIncludesTax($store = null)
     {
-        if ($this->_shippingPriceIncludeTax === null) {
+        if (is_null($this->_shippingPriceIncludeTax)) {
             $this->_shippingPriceIncludeTax = (bool)$this->_getStoreConfig(
                 self::CONFIG_XML_PATH_SHIPPING_INCLUDES_TAX,
                 $store

--- a/app/code/core/Mage/Tax/Model/Observer.php
+++ b/app/code/core/Mage/Tax/Model/Observer.php
@@ -190,7 +190,7 @@ class Mage_Tax_Model_Observer
         if ($collection->requireTaxPercent()) {
             $request = Mage::getSingleton('tax/calculation')->getRateRequest();
             foreach ($collection as $item) {
-                if ($item->getTaxClassId() === null) {
+                if (is_null($item->getTaxClassId())) {
                     $item->setTaxClassId($item->getMinimalTaxClassId());
                 }
                 if (!isset($classToRate[$item->getTaxClassId()])) {

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation.php
@@ -461,7 +461,7 @@ class Mage_Tax_Model_Resource_Calculation extends Mage_Core_Model_Resource_Db_Ab
             $adapter->quoteInto('calc_table.customer_tax_class_id = ?', $customerTaxClassId),
 
         ];
-        if ($productTaxClass !== null) {
+        if (!is_null($productTaxClass)) {
             $productTaxClassId = (int)$productTaxClass;
             $calcJoinConditions[] = $adapter->quoteInto('calc_table.product_tax_class_id = ?', $productTaxClassId);
         }

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Tax/Createdat.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Tax/Createdat.php
@@ -58,7 +58,7 @@ class Mage_Tax_Model_Resource_Report_Tax_Createdat extends Mage_Reports_Model_Re
         $writeAdapter->beginTransaction();
 
         try {
-            if ($from !== null || $to !== null) {
+            if (!is_null($from) || !is_null($to)) {
                 $subSelect = $this->_getTableDateRangeSelect(
                     $this->getTable('sales/order'),
                     'created_at',
@@ -101,7 +101,7 @@ class Mage_Tax_Model_Resource_Report_Tax_Createdat extends Mage_Reports_Model_Re
                 Mage_Sales_Model_Order::STATE_NEW
             ]);
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->having($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 
@@ -126,7 +126,7 @@ class Mage_Tax_Model_Resource_Report_Tax_Createdat extends Mage_Reports_Model_Re
                 ->from($this->getMainTable(), $columns)
                 ->where('store_id <> ?', 0);
 
-            if ($subSelect !== null) {
+            if (!is_null($subSelect)) {
                 $select->where($this->_makeConditionFromDateRangeSelect($subSelect, 'period'));
             }
 

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl.php
@@ -508,7 +508,7 @@ class Mage_Usa_Model_Shipping_Carrier_Dhl extends Mage_Usa_Model_Shipping_Carrie
         $request = $xml->asXML();
         $request = mb_convert_encoding($request, 'UTF-8', 'ISO-8859-1');
         $responseBody = $this->_getCachedQuotes($request);
-        if ($responseBody === null) {
+        if (is_null($responseBody)) {
             $debugData = ['request' => $request];
             try {
                 $url = $this->getConfigData('gateway_url');

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
@@ -785,7 +785,7 @@ class Mage_Usa_Model_Shipping_Carrier_Dhl_International extends Mage_Usa_Model_S
                 $debugPoint['request'] = $request;
                 $responseBody = $this->_getCachedQuotes($request);
 
-                if ($debugPoint['from_cache'] = ($responseBody === null)) {
+                if ($debugPoint['from_cache'] = (is_null($responseBody))) {
                     $responseBody = $this->_getQuotesFromServer($request);
                 }
 
@@ -1386,7 +1386,7 @@ class Mage_Usa_Model_Shipping_Carrier_Dhl_International extends Mage_Usa_Model_S
         $request = mb_convert_encoding($request, 'UTF-8', 'ISO-8859-1');
 
         $responseBody = $this->_getCachedQuotes($request);
-        if ($responseBody === null) {
+        if (is_null($responseBody)) {
             $debugData = ['request' => $request];
             try {
                 $client = new Varien_Http_Client();
@@ -1583,7 +1583,7 @@ class Mage_Usa_Model_Shipping_Carrier_Dhl_International extends Mage_Usa_Model_S
         $request = mb_convert_encoding($request, 'UTF-8', 'ISO-8859-1');
 
         $responseBody = $this->_getCachedQuotes($request);
-        if ($responseBody === null) {
+        if (is_null($responseBody)) {
             $debugData = ['request' => $request];
             try {
                 $client = new Varien_Http_Client();

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/Page.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/Page.php
@@ -40,7 +40,7 @@ class Mage_Usa_Model_Shipping_Carrier_Dhl_Label_Pdf_Page extends Zend_Pdf_Page
     public function __construct($param1, $param2 = null, $param3 = null)
     {
         if ($param1 instanceof Mage_Usa_Model_Shipping_Carrier_Dhl_Label_Pdf_Page
-            && $param2 === null && $param3 === null
+            && is_null($param2) && is_null($param3)
         ) {
             $this->_contents = $param1->getContents();
         }

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex.php
@@ -387,7 +387,7 @@ class Mage_Usa_Model_Shipping_Carrier_Fedex extends Mage_Usa_Model_Shipping_Carr
         $requestString = serialize($ratesRequest);
         $response = $this->_getCachedQuotes($requestString);
         $debugData = ['request' => $ratesRequest];
-        if ($response === null) {
+        if (is_null($response)) {
             try {
                 $client = $this->_createRateSoapClient();
                 $response = $client->getRates($ratesRequest);
@@ -636,7 +636,7 @@ class Mage_Usa_Model_Shipping_Carrier_Fedex extends Mage_Usa_Model_Shipping_Carr
         $request = $xml->asXML();
 
         $responseBody = $this->_getCachedQuotes($request);
-        if ($responseBody === null) {
+        if (is_null($responseBody)) {
             $debugData = ['request' => $request];
             try {
                 $url = $this->getConfigData('gateway_url');
@@ -1013,7 +1013,7 @@ class Mage_Usa_Model_Shipping_Carrier_Fedex extends Mage_Usa_Model_Shipping_Carr
         $requestString = serialize($trackRequest);
         $response = $this->_getCachedQuotes($requestString);
         $debugData = ['request' => $trackRequest];
-        if ($response === null) {
+        if (is_null($response)) {
             try {
                 $client = $this->_createTrackSoapClient();
                 $response = $client->track($trackRequest);

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
@@ -708,7 +708,7 @@ class Mage_Usa_Model_Shipping_Carrier_Ups extends Mage_Usa_Model_Shipping_Carrie
   <Shipment>
 XMLRequest;
 
-        if ($params['serviceCode'] !== null) {
+        if (!is_null($params['serviceCode'])) {
             $xmlRequest .= '<Service>' .
                 "<Code>{$params['serviceCode']}</Code>" .
                 "<Description>{$params['serviceDescription']}</Description>" .

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
@@ -354,7 +354,7 @@ class Mage_Usa_Model_Shipping_Carrier_Ups extends Mage_Usa_Model_Shipping_Carrie
      */
     public function getShipmentByCode($code, $origin = null)
     {
-        if ($origin === null) {
+        if (is_null($origin)) {
             $origin = $this->getConfigData('origin_shipment');
         }
         $arr = $this->getCode('originShipment', $origin);
@@ -788,7 +788,7 @@ XMLRequest;
 XMLRequest;
 
         $xmlResponse = $this->_getCachedQuotes($xmlRequest);
-        if ($xmlResponse === null) {
+        if (is_null($xmlResponse)) {
             $debugData = ['request' => $xmlRequest];
             $ch = curl_init();
             curl_setopt($ch, CURLOPT_URL, $url);
@@ -1298,7 +1298,7 @@ XMLAuth;
      */
     public function getResponse()
     {
-        if ($this->_trackingResult === null) {
+        if (is_null($this->_trackingResult)) {
             $trackings = [];
         } else {
             $trackings = $this->_trackingResult->getAllTrackings();
@@ -1955,7 +1955,7 @@ XMLAuth;
         $xmlRequest = $this->_formShipmentRequest($request);
         $xmlResponse = $this->_getCachedQuotes($xmlRequest);
 
-        if ($xmlResponse === null) {
+        if (is_null($xmlResponse)) {
             $url = $this->getConfigData('shipconfirm_xml_url');
             if (!$url) {
                 if ($this->getConfigFlag('mode_xml')) {

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
@@ -1706,7 +1706,7 @@ XMLAuth;
             return $result;
         }
 
-        if ($package !== null) {
+        if (!is_null($package)) {
             $result->setTrackingNumber($package->TrackingNumber);
             // ShippingLabel is not guaranteed to be set, but if it is, GraphicImage will be set.
             if (isset($package->ShippingLabel->GraphicImage)) {
@@ -2248,7 +2248,7 @@ XMLAuth;
             $rateParams['RateRequest']['Shipment']['TaxInformationIndicator'] = 'Y';
         }
 
-        if ($serviceCode !== null) {
+        if (!is_null($serviceCode)) {
             $rateParams['RateRequest']['Shipment']['Service']['Code'] = $serviceCode;
             $rateParams['RateRequest']['Shipment']['Service']['Description'] = $serviceDescription;
         }

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
@@ -400,7 +400,7 @@ class Mage_Usa_Model_Shipping_Carrier_Usps extends Mage_Usa_Model_Shipping_Carri
         $request = $xml->asXML();
 
         $responseBody = $this->_getCachedQuotes($request);
-        if ($responseBody === null) {
+        if (is_null($responseBody)) {
             $debugData = ['request' => $request];
             try {
                 $url = $this->getConfigData('gateway_url');

--- a/app/code/core/Mage/Widget/Model/Template/Filter.php
+++ b/app/code/core/Mage/Widget/Model/Template/Filter.php
@@ -48,7 +48,7 @@ class Mage_Widget_Model_Template_Filter extends Mage_Cms_Model_Template_Filter
 
         // we have no other way to avoid fatal errors for type like 'cms/widget__link', '_cms/widget_link' etc.
         $xml = Mage::getSingleton('widget/widget')->getXmlElementByType($type);
-        if ($xml === null) {
+        if (is_null($xml)) {
             return '';
         }
 

--- a/app/code/core/Mage/Widget/Model/Widget.php
+++ b/app/code/core/Mage/Widget/Model/Widget.php
@@ -84,7 +84,7 @@ class Mage_Widget_Model_Widget extends Varien_Object
         $xml = $this->getConfigAsXml($type);
 
         $object = new Varien_Object();
-        if ($xml === null) {
+        if (is_null($xml)) {
             return $object;
         }
 

--- a/app/code/core/Mage/Widget/Model/Widget/Instance.php
+++ b/app/code/core/Mage/Widget/Model/Widget/Instance.php
@@ -376,7 +376,7 @@ class Mage_Widget_Model_Widget_Instance extends Mage_Core_Model_Abstract
      */
     public function getWidgetConfig()
     {
-        if ($this->_widgetConfigXml === null) {
+        if (is_null($this->_widgetConfigXml)) {
             $this->_widgetConfigXml = Mage::getSingleton('widget/widget')
                 ->getXmlElementByType($this->getType());
             if ($this->_widgetConfigXml) {

--- a/app/code/core/Mage/Wishlist/Model/Item.php
+++ b/app/code/core/Mage/Wishlist/Model/Item.php
@@ -545,7 +545,7 @@ class Mage_Wishlist_Model_Item extends Mage_Core_Model_Abstract implements Mage_
                 continue;
             }
             if (!isset($options2[$code])
-                || ($options2[$code]->getValue() === null)
+                || is_null($options2[$code]->getValue())
                 || $options2[$code]->getValue() != $option->getValue()
             ) {
                 return false;

--- a/app/code/core/Mage/Wishlist/Model/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Model/Wishlist.php
@@ -172,7 +172,7 @@ class Mage_Wishlist_Model_Wishlist extends Mage_Core_Model_Abstract
     {
         parent::_afterSave();
 
-        if ($this->_itemCollection !== null) {
+        if (!is_null($this->_itemCollection)) {
             $this->getItemCollection()->save();
         }
         return $this;

--- a/app/code/core/Mage/Wishlist/Model/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Model/Wishlist.php
@@ -195,7 +195,7 @@ class Mage_Wishlist_Model_Wishlist extends Mage_Core_Model_Abstract
             }
         }
 
-        if ($item === null) {
+        if (is_null($item)) {
             $storeId = $product->hasWishlistStoreId() ? $product->getWishlistStoreId() : $this->getStore()->getId();
             $item = Mage::getModel('wishlist/item');
             $item->setProductId($product->getId())

--- a/errors/processor.php
+++ b/errors/processor.php
@@ -236,10 +236,10 @@ class Error_Processor
         $config->skin           = self::DEFAULT_SKIN;
 
         //combine xml data to one object
-        if ($design !== null && ($skin = (string)$design->skin)) {
+        if (!is_null($design) && ($skin = (string)$design->skin)) {
             $this->_setSkin($skin, $config);
         }
-        if ($local !== null) {
+        if (!is_null($local)) {
             if ($action = (string)$local->report->action) {
                 $config->action = $action;
             }

--- a/errors/processor.php
+++ b/errors/processor.php
@@ -315,7 +315,7 @@ class Error_Processor
      */
     protected function _getFilePath(string $file, $directories = null)
     {
-        if ($directories === null) {
+        if (is_null($directories)) {
             $directories = [];
 
             if (!$this->_root) {

--- a/lib/Mage/Cache/Backend/File.php
+++ b/lib/Mage/Cache/Backend/File.php
@@ -94,7 +94,7 @@ class Mage_Cache_Backend_File extends Zend_Cache_Backend_File
         }
 
         // Check cache dir
-        if ($this->_options['cache_dir'] !== null) {
+        if (!is_null($this->_options['cache_dir'])) {
             $this->setCacheDir($this->_options['cache_dir']);
         } else {
             $this->setCacheDir(self::getTmpDir() . DIRECTORY_SEPARATOR, false);

--- a/lib/Magento/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Magento/Db/Adapter/Pdo/Mysql.php
@@ -124,7 +124,7 @@ class Magento_Db_Adapter_Pdo_Mysql extends Varien_Db_Adapter_Pdo_Mysql
     {
         $this->_connect();
 
-        if ($type !== null
+        if (!is_null($type)
             && array_key_exists($type = strtoupper($type), $this->_numericDataTypes)
             && $this->_numericDataTypes[$type] == Zend_Db::FLOAT_TYPE
         ) {

--- a/lib/Magento/Profiler.php
+++ b/lib/Magento/Profiler.php
@@ -124,7 +124,7 @@ class Magento_Profiler
      */
     public static function reset($timerName = null)
     {
-        if ($timerName === null) {
+        if (is_null($timerName)) {
             self::$_timers = [];
             self::$_currentPath = [];
             return;

--- a/lib/Magento/Profiler.php
+++ b/lib/Magento/Profiler.php
@@ -188,7 +188,7 @@ class Magento_Profiler
         $time = microtime(true);
 
         $latestTimerName = end(self::$_currentPath);
-        if ($timerName !== null && $timerName !== $latestTimerName) {
+        if (!is_null($timerName) && $timerName !== $latestTimerName) {
             if (in_array($timerName, self::$_currentPath)) {
                 $exceptionMsg = sprintf('Timer "%s" should be stopped before "%s".', $latestTimerName, $timerName);
             } else {

--- a/lib/Magento/Profiler/OutputAbstract.php
+++ b/lib/Magento/Profiler/OutputAbstract.php
@@ -205,7 +205,7 @@ abstract class Magento_Profiler_OutputAbstract
      */
     public function setThreshold($fetchKey, $minAllowedValue)
     {
-        if ($minAllowedValue === null) {
+        if (is_null($minAllowedValue)) {
             unset($this->_thresholds[$fetchKey]);
         } else {
             $this->_thresholds[$fetchKey] = $minAllowedValue;

--- a/lib/Varien/Cache/Backend/Database.php
+++ b/lib/Varien/Cache/Backend/Database.php
@@ -182,7 +182,7 @@ class Varien_Cache_Backend_Database extends Zend_Cache_Backend implements Zend_C
 
             $lifetime = $this->getLifetime($specificLifetime);
             $time     = time();
-            $expire   = ($lifetime === 0 || $lifetime === null) ? 0 : $time + $lifetime;
+            $expire   = ($lifetime === 0 || is_null($lifetime)) ? 0 : $time + $lifetime;
 
             $dataCol    = $adapter->quoteIdentifier('data');
             $expireCol  = $adapter->quoteIdentifier('expire_time');

--- a/lib/Varien/Cache/Core.php
+++ b/lib/Varien/Cache/Core.php
@@ -78,7 +78,7 @@ class Varien_Cache_Core extends Zend_Cache_Core
      */
     protected function _id($id)
     {
-        if ($id !== null) {
+        if (!is_null($id)) {
             $id = preg_replace('/([^a-zA-Z0-9_]{1,1})/', '_', $id);
             if (isset($this->_options['cache_id_prefix'])) {
                 $id = $this->_options['cache_id_prefix'] . $id;

--- a/lib/Varien/Data/Collection/Db.php
+++ b/lib/Varien/Data/Collection/Db.php
@@ -684,7 +684,7 @@ class Varien_Data_Collection_Db extends Varien_Data_Collection
      */
     public function getData()
     {
-        if ($this->_data === null) {
+        if (is_null($this->_data)) {
             $this->_renderFilters()
                  ->_renderOrders()
                  ->_renderLimit();

--- a/lib/Varien/Data/Form/Element/Editor.php
+++ b/lib/Varien/Data/Form/Element/Editor.php
@@ -344,7 +344,7 @@ class Varien_Data_Form_Element_Editor extends Varien_Data_Form_Element_Textarea
             $config = new Varien_Object();
             $this->setConfig($config);
         }
-        if ($key !== null) {
+        if (!is_null($key)) {
             return $this->_getData('config')->getData($key);
         }
         return $this->_getData('config');

--- a/lib/Varien/Data/Form/Filter/Date.php
+++ b/lib/Varien/Data/Form/Filter/Date.php
@@ -58,7 +58,7 @@ class Varien_Data_Form_Filter_Date implements Varien_Data_Form_Filter_Interface
      */
     public function inputFilter($value)
     {
-        if ($value === null || $value === '') {
+        if (is_null($value) || $value === '') {
             return $value;
         }
 
@@ -84,7 +84,7 @@ class Varien_Data_Form_Filter_Date implements Varien_Data_Form_Filter_Interface
      */
     public function outputFilter($value)
     {
-        if ($value === null || $value === '') {
+        if (is_null($value) || $value === '') {
             return $value;
         }
 

--- a/lib/Varien/Data/Form/Filter/Datetime.php
+++ b/lib/Varien/Data/Form/Filter/Datetime.php
@@ -29,7 +29,7 @@ class Varien_Data_Form_Filter_Datetime extends Varien_Data_Form_Filter_Date
      */
     public function inputFilter($value)
     {
-        if ($value === null || $value === '') {
+        if (is_null($value) || $value === '') {
             return $value;
         }
 
@@ -55,7 +55,7 @@ class Varien_Data_Form_Filter_Datetime extends Varien_Data_Form_Filter_Date
      */
     public function outputFilter($value)
     {
-        if ($value === null || $value === '') {
+        if (is_null($value) || $value === '') {
             return $value;
         }
 

--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -2906,7 +2906,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
         if (!is_null($onDelete)) {
             $query .= ' ON DELETE ' . strtoupper($onDelete);
         }
-        if ($onUpdate  !== null) {
+        if (!is_null($onUpdate )) {
             $query .= ' ON UPDATE ' . strtoupper($onUpdate);
         }
 
@@ -3735,7 +3735,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
                 $joinType = strtoupper($joinProp['joinType']);
             }
             $joinTable = '';
-            if ($joinProp['schema'] !== null) {
+            if (!is_null($joinProp['schema'])) {
                 $joinTable = sprintf('%s.', $this->quoteIdentifier($joinProp['schema']));
             }
             $joinTable .= $this->quoteTableAs($joinProp['tableName'], $correlationName);

--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -1088,7 +1088,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
     public function showTableStatus($tableName, $schemaName = null)
     {
         $fromDbName = null;
-        if ($schemaName !== null) {
+        if (!is_null($schemaName)) {
             $fromDbName = ' FROM ' . $this->quoteIdentifier($schemaName);
         }
         $query = sprintf('SHOW TABLE STATUS%s LIKE %s', $fromDbName, $this->quote($tableName));
@@ -2226,10 +2226,10 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
     public function newTable($tableName = null, $schemaName = null)
     {
         $table = new Varien_Db_Ddl_Table();
-        if ($tableName !== null) {
+        if (!is_null($tableName)) {
             $table->setName($tableName);
         }
-        if ($schemaName !== null) {
+        if (!is_null($schemaName)) {
             $table->setSchema($schemaName);
         }
 
@@ -2434,7 +2434,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
         ];
         foreach ($tableProps as $key => $mask) {
             $v = $table->getOption($key);
-            if ($v !== null) {
+            if (!is_null($v)) {
                 $definition[] = sprintf($mask, $v);
             }
         }
@@ -2549,7 +2549,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
          *  where default value can be quoted already.
          *  We need to avoid "double-quoting" here
          */
-        if ($cDefault !== null && strlen($cDefault)) {
+        if (!is_null($cDefault) && strlen($cDefault)) {
             $cDefault = str_replace("'", '', $cDefault);
         }
 
@@ -2659,7 +2659,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
     public function isTableExists($tableName, $schemaName = null)
     {
         $fromDbName = 'DATABASE()';
-        if ($schemaName !== null) {
+        if (!is_null($schemaName)) {
             $fromDbName = $this->quote($schemaName);
         }
 
@@ -2903,7 +2903,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
             $this->quoteIdentifier($refColumnName)
         );
 
-        if ($onDelete !== null) {
+        if (!is_null($onDelete)) {
             $query .= ' ON DELETE ' . strtoupper($onDelete);
         }
         if ($onUpdate  !== null) {
@@ -3221,7 +3221,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
         foreach ($casesResults as $case => $result) {
             $expression .= ' WHEN ' . $case . ' THEN ' . $result;
         }
-        if ($defaultValue !== null) {
+        if (!is_null($defaultValue)) {
             $expression .= ' ELSE ' . $defaultValue;
         }
         $expression .= ' END';
@@ -3838,7 +3838,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
      */
     public function orderRand(Varien_Db_Select $select, $field = null)
     {
-        if ($field !== null) {
+        if (!is_null($field)) {
             $expression = new Zend_Db_Expr(sprintf('RAND() * %s', $this->quoteIdentifier($field)));
             $select->columns(['mage_rand' => $expression]);
             $spec = new Zend_Db_Expr('mage_rand');

--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -1632,7 +1632,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
         if (!$this->_isDdlCacheAllowed) {
             return $this;
         }
-        if ($tableName === null) {
+        if (is_null($tableName)) {
             $this->_ddlCache = [];
             if ($this->_cacheAdapter instanceof Zend_Cache_Core) {
                 $this->_cacheAdapter->clean(Zend_Cache::CLEANING_MODE_MATCHING_TAG, [self::DDL_CACHE_TAG]);
@@ -2478,7 +2478,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
         $cIdentity  = false;
 
         // detect and validate column type
-        if ($ddlType === null) {
+        if (is_null($ddlType)) {
             $ddlType = $this->_getDdlType($options);
         }
 
@@ -2555,7 +2555,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
 
         // prepare default value string
         if ($ddlType == Varien_Db_Ddl_Table::TYPE_TIMESTAMP) {
-            if ($cDefault === null) {
+            if (is_null($cDefault)) {
                 $cDefault = new Zend_Db_Expr('NULL');
             } elseif ($cDefault == Varien_Db_Ddl_Table::TIMESTAMP_INIT) {
                 $cDefault = new Zend_Db_Expr('CURRENT_TIMESTAMP');
@@ -2926,7 +2926,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
     {
         $date = Varien_Date::formatDate($date, $includeTime);
 
-        if ($date === null) {
+        if (is_null($date)) {
             return new Zend_Db_Expr('NULL');
         }
 

--- a/lib/Varien/Db/Ddl/Table.php
+++ b/lib/Varien/Db/Ddl/Table.php
@@ -184,7 +184,7 @@ class Varien_Db_Ddl_Table
     public function setName($name)
     {
         $this->_tableName = $name;
-        if ($this->_tableComment === null) {
+        if (is_null($this->_tableComment)) {
             $this->_tableComment = $name;
         }
         return $this;
@@ -392,7 +392,7 @@ class Varien_Db_Ddl_Table
             $identity = true;
         }
 
-        if ($comment === null) {
+        if (is_null($comment)) {
             $comment = ucfirst($name);
         }
 

--- a/lib/Varien/Db/Ddl/Table.php
+++ b/lib/Varien/Db/Ddl/Table.php
@@ -339,7 +339,7 @@ class Varien_Db_Ddl_Table
                         $precision  = $size[0];
                         $scale      = $size[1];
                     }
-                } elseif ($size !== null && preg_match('#^(\d+),(\d+)$#', $size, $match)) {
+                } elseif (!is_null($size) && preg_match('#^(\d+),(\d+)$#', $size, $match)) {
                     $precision  = $match[1];
                     $scale      = $match[2];
                 }

--- a/lib/Varien/Db/Select.php
+++ b/lib/Varien/Db/Select.php
@@ -280,12 +280,12 @@ class Varien_Db_Select extends Zend_Db_Select
      */
     public function limit($count = null, $offset = null)
     {
-        if ($count === null) {
+        if (is_null($count)) {
             $this->reset(self::LIMIT_COUNT);
         } else {
             $this->_parts[self::LIMIT_COUNT]  = (int) $count;
         }
-        if ($offset === null) {
+        if (is_null($offset)) {
             $this->reset(self::LIMIT_OFFSET);
         } else {
             $this->_parts[self::LIMIT_OFFSET] = (int) $offset;

--- a/lib/Varien/File/Object.php
+++ b/lib/Varien/File/Object.php
@@ -62,7 +62,7 @@ class Varien_File_Object extends SplFileObject implements IFactory
     public function getFileName(&$files = null)
     {
         if ($this->_isCorrect) {
-            if ($files === null) {
+            if (is_null($files)) {
                 return $this->_filename;
             }
             $files[] = $this->_filename;
@@ -89,7 +89,7 @@ class Varien_File_Object extends SplFileObject implements IFactory
     public function getFilePath(&$path = null)
     {
         if ($this->_isCorrect) {
-            if ($path === null) {
+            if (is_null($path)) {
                 return $this->_path;
             }
             $paths[] = $this->_path;

--- a/lib/Varien/Filter/Template.php
+++ b/lib/Varien/Filter/Template.php
@@ -116,7 +116,7 @@ class Varien_Filter_Template implements Zend_Filter_Interface
      */
     public function filter($value)
     {
-        if ($value === null) {
+        if (is_null($value)) {
             return '';
         }
 

--- a/lib/Varien/Object.php
+++ b/lib/Varien/Object.php
@@ -322,7 +322,7 @@ class Varien_Object implements ArrayAccess
         }
 
         $data = $this->_data[$key] ?? null;
-        if ($data === null && $key !== null && strpos($key, '/') !== false) {
+        if (is_null($data) && $key !== null && strpos($key, '/') !== false) {
             /* process a/b/c key as ['a']['b']['c'] */
             $data = $this->getDataByPath($key);
         }

--- a/lib/Varien/Object.php
+++ b/lib/Varien/Object.php
@@ -322,12 +322,12 @@ class Varien_Object implements ArrayAccess
         }
 
         $data = $this->_data[$key] ?? null;
-        if (is_null($data) && $key !== null && strpos($key, '/') !== false) {
+        if (is_null($data) && !is_null($key) && strpos($key, '/') !== false) {
             /* process a/b/c key as ['a']['b']['c'] */
             $data = $this->getDataByPath($key);
         }
 
-        if ($index !== null) {
+        if (!is_null($index)) {
             if ($data === (array)$data) {
                 $data = $data[$index] ?? null;
             } elseif (is_string($data)) {

--- a/lib/Varien/Simplexml/Config.php
+++ b/lib/Varien/Simplexml/Config.php
@@ -120,7 +120,7 @@ class Varien_Simplexml_Config
     {
         if (!$this->_xml instanceof Varien_Simplexml_Element) {
             return false;
-        } elseif ($path === null) {
+        } elseif (is_null($path)) {
             return $this->_xml;
         } else {
             return $this->_xml->descend($path);


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Thats an old idea to unify this, but thanks to @tmewes (https://github.com/MahoCommerce/maho/pull/35) who brought it up.

Instead of changing to `=== null` i used `is_null()` instead.

Reason, confirmed in tests ...

- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/4015#issuecomment-568508507

@tmewes there is no rector-rule, but a (risky) one for [PHP-CS-Fixer](https://cs.symfony.com/doc/rules/language_construct/is_null.html). _jtlyk_

Note: there are a few loose comparisons (`==` /`!=`) that i did not touch)

