### PR TITLE
Deprecated functionality: preg_match(): Passing null to parameter #4 …

### DIFF
--- a/app/code/core/Mage/Core/Model/Translate/Inline.php
+++ b/app/code/core/Mage/Core/Model/Translate/Inline.php
@@ -518,7 +518,7 @@ class Mage_Core_Model_Translate_Inline
             }
             $length = $end - $from  + $tagLength + 3;
         }
-        if (preg_match('#<\\\\?\/' . $tagName . '\s*?>#i', $body, $tagMatch, null, $end)) {
+        if (preg_match('#<\\\\?\/' . $tagName . '\s*?>#i', $body, $tagMatch, 0, $end)) {
             return $end + strlen($tagMatch[0]);
         } else {
             return false;


### PR DESCRIPTION
...($flags) of type int is deprecated.

[Test Environment]

- Windows 11 + WSL
- Docker 4.34.2
- DDEV (Apache 2.4.61, PHP 8.3.10, MariaDB 10.11.8) with MAGE_IS_DEVELOPER_MODE=1
- Magento Sample Data

Go the **Backend > System > Configuration > Advanced > Developer > Translate Inline**. Set "Enablde for Admin" to Yes and save. Here is the error message you will see in the browser page

```php
Deprecated functionality: preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated  in /var/www/html/app/code/core/Mage/Core/Model/Translate/Inline.php on line 521

#0 [internal function]: mageCoreErrorHandler()
#1 /var/www/html/app/code/core/Mage/Core/Model/Translate/Inline.php(521): preg_match()
#2 /var/www/html/app/code/core/Mage/Core/Model/Translate/Inline.php(463): Mage_Core_Model_Translate_Inline->findEndOfTag()
#3 /var/www/html/app/code/core/Mage/Core/Model/Translate/Inline.php(404): Mage_Core_Model_Translate_Inline->_translateTags()
#4 /var/www/html/app/code/core/Mage/Core/Model/Translate/Inline.php(223): Mage_Core_Model_Translate_Inline->_specialTags()
#5 /var/www/html/app/code/core/Mage/Core/Controller/Varien/Action.php(389): Mage_Core_Model_Translate_Inline->processResponseBody()
#6 /var/www/html/app/code/core/Mage/Adminhtml/controllers/DashboardController.php(37): Mage_Core_Controller_Varien_Action->renderLayout()
#7 /var/www/html/app/code/core/Mage/Core/Controller/Varien/Action.php(419): Mage_Adminhtml_DashboardController->indexAction()
#8 /var/www/html/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(255): Mage_Core_Controller_Varien_Action->dispatch()
#9 /var/www/html/app/code/core/Mage/Core/Controller/Varien/Front.php(180): Mage_Core_Controller_Varien_Router_Standard->match()
#10 /var/www/html/app/code/core/Mage/Core/Model/App.php(358): Mage_Core_Controller_Varien_Front->dispatch()
#11 /var/www/html/app/Mage.php(748): Mage_Core_Model_App->run()
#12 /var/www/html/index.php(56): Mage::run()
#13 {main}
```

From now on you cannot access the Backend. You have to change in the database > table core_config_data > "dev/translate_inline/active_admin" from 1 to 0 in the "path" column.


```php
if (preg_match('#<\\\\?\/' . $tagName . '\s*?>#i', $body, $tagMatch, null, $end))
```

This issue can be reproduced starting with PHP version 8.1. It is strange how it was not discovered by the GitHub tests.