### PR TITLE
[WIP] Fixes ENV overriding config

### DIFF
--- a/.ddev/commands/web/phpunit-coverage
+++ b/.ddev/commands/web/phpunit-coverage
@@ -5,5 +5,5 @@
 ## Example: ddev phpunit-coverage
 
 enable_xdebug
-XDEBUG_MODE=coverage php vendor/bin/phpunit --testdox
+XDEBUG_MODE=coverage php vendor/bin/phpunit "$@" --testdox
 disable_xdebug

--- a/.ddev/commands/web/phpunit-coverage-local
+++ b/.ddev/commands/web/phpunit-coverage-local
@@ -5,5 +5,5 @@
 ## Example: ddev phpunit-coverage-local
 
 enable_xdebug
-XDEBUG_MODE=coverage php vendor/bin/phpunit --coverage-html build/coverage --testdox
+XDEBUG_MODE=coverage php vendor/bin/phpunit --coverage-html build/coverage "$@" --testdox
 disable_xdebug

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -36,5 +36,19 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --ignore-platform-req=ext-*
 
+      - name: "Restore result cache"
+        uses: actions/cache/restore@v4
+        with:
+          path: .phpstan.cache
+          key: "phpstan-result-cache-${{ runner.os }}-${{ matrix.php-versions }}-${{ github.run_id }}"
+          restore-keys: phpstan-result-cache-
+
       - name: PHPStan Static Analysis
         run: XDEBUG_MODE=off php vendor/bin/phpstan.phar analyze
+
+      - name: "Save result cache"
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: .phpstan.cache
+          key: "phpstan-result-cache-${{ runner.os }}-${{ matrix.php-versions }}-${{ github.run_id }}"

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   rector:
-    name: Validation
+    name: Rector
     runs-on: [ubuntu-latest]
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@
 !.phpcs*.xml.dist
 
 # PhpStan
+.phpstan.cache
 .phpstan*.neon
 phpstan*.neon
 !.phpstan.dist.neon

--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -641,11 +641,6 @@ parameters:
 			path: app/code/core/Mage/Adminhtml/controllers/System/CurrencyController.php
 
 		-
-			message: "#^Method Mage_Adminhtml_System_StoreController\\:\\:_backupDatabase\\(\\) should return \\$this\\(Mage_Adminhtml_System_StoreController\\) but empty return statement found\\.$#"
-			count: 2
-			path: app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
-
-		-
 			message: "#^Variable \\$codeBase might not be defined\\.$#"
 			count: 1
 			path: app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
@@ -1047,7 +1042,7 @@ parameters:
 
 		-
 			message: "#^Offset 'option_id' does not exist on array\\{final_price\\: mixed\\}\\.$#"
-			count: 4
+			count: 2
 			path: app/code/core/Mage/Bundle/Model/Product/Price.php
 
 		-
@@ -1091,21 +1086,6 @@ parameters:
 			path: app/code/core/Mage/Captcha/Block/Captcha/Zend.php
 
 		-
-			message: "#^Call to an undefined method Mage_Captcha_Model_Interface\\:\\:isRequired\\(\\)\\.$#"
-			count: 9
-			path: app/code/core/Mage/Captcha/Model/Observer.php
-
-		-
-			message: "#^Call to an undefined method Mage_Captcha_Model_Interface\\:\\:logAttempt\\(\\)\\.$#"
-			count: 3
-			path: app/code/core/Mage/Captcha/Model/Observer.php
-
-		-
-			message: "#^Result of method Mage_Captcha_Model_Interface\\:\\:isCorrect\\(\\) \\(void\\) is used\\.$#"
-			count: 9
-			path: app/code/core/Mage/Captcha/Model/Observer.php
-
-		-
 			message: "#^Property Mage_Captcha_Model_Zend\\:\\:\\$_helper \\(Mage_Captcha_Helper_Data\\) in empty\\(\\) is not falsy\\.$#"
 			count: 1
 			path: app/code/core/Mage/Captcha/Model/Zend.php
@@ -1114,16 +1094,6 @@ parameters:
 			message: "#^Return type \\(Mage_Customer_Model_Session\\) of method Mage_Captcha_Model_Zend\\:\\:getSession\\(\\) should be compatible with return type \\(Zend_Session_Namespace\\) of method Zend_Captcha_Word\\:\\:getSession\\(\\)$#"
 			count: 1
 			path: app/code/core/Mage/Captcha/Model/Zend.php
-
-		-
-			message: "#^Call to an undefined method Mage_Captcha_Model_Interface\\:\\:getImgSrc\\(\\)\\.$#"
-			count: 1
-			path: app/code/core/Mage/Captcha/controllers/Adminhtml/RefreshController.php
-
-		-
-			message: "#^Call to an undefined method Mage_Captcha_Model_Interface\\:\\:getImgSrc\\(\\)\\.$#"
-			count: 1
-			path: app/code/core/Mage/Captcha/controllers/RefreshController.php
 
 		-
 			message: "#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#"
@@ -1496,6 +1466,11 @@ parameters:
 			path: app/code/core/Mage/Catalog/Model/Product.php
 
 		-
+			message: "#^Method Mage_Catalog_Model_Product\\:\\:getPriceModel\\(\\) should return Mage_Bundle_Model_Product_Price but returns Mage_Catalog_Model_Product_Type_Price\\.$#"
+			count: 1
+			path: app/code/core/Mage/Catalog/Model/Product.php
+
+		-
 			message: "#^Parameter \\#3 \\$attributes \\(stdClass\\) of method Mage_Catalog_Model_Product_Api_V2\\:\\:info\\(\\) should be compatible with parameter \\$attributes \\(array\\) of method Mage_Catalog_Model_Product_Api\\:\\:info\\(\\)$#"
 			count: 1
 			path: app/code/core/Mage/Catalog/Model/Product/Api/V2.php
@@ -1542,6 +1517,11 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Mage_Catalog_Model_Product_Configuration_Item_Option_Interface\\:\\:setValue\\(\\)\\.$#"
+			count: 1
+			path: app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
+
+		-
+			message: "#^Offset 0 on array\\{list\\<string\\>\\} in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 1
 			path: app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
 
@@ -3036,11 +3016,6 @@ parameters:
 			path: app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
 
 		-
-			message: "#^Return type \\(\\$this\\(Mage_Eav_Model_Entity_Attribute_Backend_Abstract\\)\\) of method Mage_Eav_Model_Entity_Attribute_Backend_Abstract\\:\\:setValueId\\(\\) should be compatible with return type \\(int\\) of method Mage_Eav_Model_Entity_Attribute_Backend_Interface\\:\\:setValueId\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Abstract.php
-
-		-
 			message: "#^Variable \\$out in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
 			path: app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Abstract.php
@@ -3856,21 +3831,6 @@ parameters:
 			path: app/code/core/Mage/Rule/Model/Condition/Product/Abstract.php
 
 		-
-			message: "#^Cannot call method setParentFilter\\(\\) on Mage_Core_Model_Resource_Db_Collection_Abstract\\|false\\.$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Block/Order/Comments.php
-
-		-
-			message: "#^Method Mage_Sales_Block_Order_Comments\\:\\:getComments\\(\\) should return Mage_Sales_Model_Resource_Order_Comment_Collection_Abstract but returns Mage_Core_Model_Resource_Db_Collection_Abstract\\|false\\.$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Block/Order/Comments.php
-
-		-
-			message: "#^Property Mage_Sales_Block_Order_Comments\\:\\:\\$_commentCollection \\(Mage_Sales_Model_Resource_Order_Comment_Collection_Abstract\\|null\\) does not accept Mage_Core_Model_Resource_Db_Collection_Abstract\\|false\\.$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Block/Order/Comments.php
-
-		-
 			message: "#^Call to method setOrderFilter\\(\\) on an unknown class Mage_Sales_Model_Resource_Invoice_Collection\\.$#"
 			count: 1
 			path: app/code/core/Mage/Sales/Block/Order/Details.php
@@ -3889,36 +3849,6 @@ parameters:
 			message: "#^Call to an undefined method Mage_Sales_Model_Resource_Quote_Collection\\:\\:addAttributeToSelect\\(\\)\\.$#"
 			count: 2
 			path: app/code/core/Mage/Sales/Model/Entity/Quote.php
-
-		-
-			message: "#^Return type \\(\\$this\\(Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend_Custbalance\\)\\) of method Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend_Custbalance\\:\\:fetchTotals\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend\\:\\:fetchTotals\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Custbalance.php
-
-		-
-			message: "#^Return type \\(\\$this\\(Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend_Discount\\)\\) of method Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend_Discount\\:\\:fetchTotals\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend\\:\\:fetchTotals\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Discount.php
-
-		-
-			message: "#^Return type \\(\\$this\\(Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend_Grand\\)\\) of method Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend_Grand\\:\\:fetchTotals\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend\\:\\:fetchTotals\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Grand.php
-
-		-
-			message: "#^Return type \\(\\$this\\(Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend_Shipping\\)\\) of method Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend_Shipping\\:\\:fetchTotals\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend\\:\\:fetchTotals\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Shipping.php
-
-		-
-			message: "#^Return type \\(\\$this\\(Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend_Subtotal\\)\\) of method Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend_Subtotal\\:\\:fetchTotals\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend\\:\\:fetchTotals\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Subtotal.php
-
-		-
-			message: "#^Return type \\(\\$this\\(Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend_Tax\\)\\) of method Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend_Tax\\:\\:fetchTotals\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend\\:\\:fetchTotals\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Tax.php
 
 		-
 			message: "#^Variable \\$oldArea might not be defined\\.$#"
@@ -4071,37 +4001,7 @@ parameters:
 			path: app/code/core/Mage/Sales/Model/Quote/Address.php
 
 		-
-			message: "#^Return type \\(\\$this\\(Mage_Sales_Model_Quote_Address_Total_Discount\\)\\) of method Mage_Sales_Model_Quote_Address_Total_Discount\\:\\:fetch\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Quote_Address_Total_Abstract\\:\\:fetch\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Quote/Address/Total/Discount.php
-
-		-
-			message: "#^Return type \\(Mage_Sales_Model_Quote_Address_Total_Grand\\) of method Mage_Sales_Model_Quote_Address_Total_Grand\\:\\:fetch\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Quote_Address_Total_Abstract\\:\\:fetch\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Quote/Address/Total/Grand.php
-
-		-
-			message: "#^Return type \\(\\$this\\(Mage_Sales_Model_Quote_Address_Total_Nominal\\)\\) of method Mage_Sales_Model_Quote_Address_Total_Nominal\\:\\:fetch\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Quote_Address_Total_Abstract\\:\\:fetch\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal.php
-
-		-
-			message: "#^Return type \\(array\\) of method Mage_Sales_Model_Quote_Address_Total_Nominal_Shipping\\:\\:fetch\\(\\) should be compatible with return type \\(Mage_Sales_Model_Quote_Address_Total_Shipping\\) of method Mage_Sales_Model_Quote_Address_Total_Shipping\\:\\:fetch\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Shipping.php
-
-		-
-			message: "#^Return type \\(array\\) of method Mage_Sales_Model_Quote_Address_Total_Nominal_Subtotal\\:\\:fetch\\(\\) should be compatible with return type \\(Mage_Sales_Model_Quote_Address_Total_Subtotal\\) of method Mage_Sales_Model_Quote_Address_Total_Subtotal\\:\\:fetch\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Subtotal.php
-
-		-
 			message: "#^Negated boolean expression is always true\\.$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Quote/Address/Total/Shipping.php
-
-		-
-			message: "#^Return type \\(Mage_Sales_Model_Quote_Address_Total_Shipping\\) of method Mage_Sales_Model_Quote_Address_Total_Shipping\\:\\:fetch\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Quote_Address_Total_Abstract\\:\\:fetch\\(\\)$#"
 			count: 1
 			path: app/code/core/Mage/Sales/Model/Quote/Address/Total/Shipping.php
 
@@ -4109,16 +4009,6 @@ parameters:
 			message: "#^Variable \\$addressQty in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 1
 			path: app/code/core/Mage/Sales/Model/Quote/Address/Total/Shipping.php
-
-		-
-			message: "#^Return type \\(Mage_Sales_Model_Quote_Address_Total_Subtotal\\) of method Mage_Sales_Model_Quote_Address_Total_Subtotal\\:\\:fetch\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Quote_Address_Total_Abstract\\:\\:fetch\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Quote/Address/Total/Subtotal.php
-
-		-
-			message: "#^Return type \\(\\$this\\(Mage_Sales_Model_Quote_Address_Total_Tax\\)\\) of method Mage_Sales_Model_Quote_Address_Total_Tax\\:\\:fetch\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Quote_Address_Total_Abstract\\:\\:fetch\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Quote/Address/Total/Tax.php
 
 		-
 			message: "#^Instanceof between Mage_Sales_Model_Quote_Item_Option and Mage_Sales_Model_Quote_Item_Option will always evaluate to true\\.$#"
@@ -4176,36 +4066,6 @@ parameters:
 			path: app/code/core/Mage/Sales/Model/Resource/Order/Payment/Transaction.php
 
 		-
-			message: "#^Return type \\(\\$this\\(Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend_Custbalance\\)\\) of method Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend_Custbalance\\:\\:fetchTotals\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend\\:\\:fetchTotals\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Custbalance.php
-
-		-
-			message: "#^Return type \\(\\$this\\(Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend_Discount\\)\\) of method Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend_Discount\\:\\:fetchTotals\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend\\:\\:fetchTotals\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Discount.php
-
-		-
-			message: "#^Return type \\(\\$this\\(Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend_Grand\\)\\) of method Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend_Grand\\:\\:fetchTotals\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend\\:\\:fetchTotals\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Grand.php
-
-		-
-			message: "#^Return type \\(\\$this\\(Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend_Shipping\\)\\) of method Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend_Shipping\\:\\:fetchTotals\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend\\:\\:fetchTotals\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Shipping.php
-
-		-
-			message: "#^Return type \\(\\$this\\(Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend_Subtotal\\)\\) of method Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend_Subtotal\\:\\:fetchTotals\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend\\:\\:fetchTotals\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Subtotal.php
-
-		-
-			message: "#^Return type \\(\\$this\\(Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend_Tax\\)\\) of method Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend_Tax\\:\\:fetchTotals\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend\\:\\:fetchTotals\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Tax.php
-
-		-
 			message: "#^Comparison operation \"\\!\\=\" between array\\|int and 0 results in an error\\.$#"
 			count: 1
 			path: app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers/Collection.php
@@ -4244,16 +4104,6 @@ parameters:
 			message: "#^Method Mage_Sales_Recurring_ProfileController\\:\\:preDispatch\\(\\) should return \\$this\\(Mage_Sales_Recurring_ProfileController\\) but empty return statement found\\.$#"
 			count: 1
 			path: app/code/core/Mage/Sales/controllers/Recurring/ProfileController.php
-
-		-
-			message: "#^Return type \\(Mage_SalesRule_Model_Quote_Discount\\) of method Mage_SalesRule_Model_Quote_Discount\\:\\:fetch\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Quote_Address_Total_Abstract\\:\\:fetch\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/SalesRule/Model/Quote/Discount.php
-
-		-
-			message: "#^Return type \\(Mage_SalesRule_Model_Quote_Freeshipping\\) of method Mage_SalesRule_Model_Quote_Freeshipping\\:\\:fetch\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Quote_Address_Total_Abstract\\:\\:fetch\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/SalesRule/Model/Quote/Freeshipping.php
 
 		-
 			message: "#^Return type \\(array\\) of method Mage_SalesRule_Model_Quote_Nominal_Discount\\:\\:fetch\\(\\) should be compatible with return type \\(Mage_SalesRule_Model_Quote_Discount\\) of method Mage_SalesRule_Model_Quote_Discount\\:\\:fetch\\(\\)$#"
@@ -4429,16 +4279,6 @@ parameters:
 			message: "#^Variable \\$zipTo might not be defined\\.$#"
 			count: 1
 			path: app/code/core/Mage/Tax/Model/Resource/Calculation.php
-
-		-
-			message: "#^Return type \\(array\\) of method Mage_Tax_Model_Sales_Total_Quote_Nominal_Tax\\:\\:fetch\\(\\) should be compatible with return type \\(\\$this\\(Mage_Tax_Model_Sales_Total_Quote_Tax\\)\\) of method Mage_Tax_Model_Sales_Total_Quote_Tax\\:\\:fetch\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Tax/Model/Sales/Total/Quote/Nominal/Tax.php
-
-		-
-			message: "#^Return type \\(\\$this\\(Mage_Tax_Model_Sales_Total_Quote_Tax\\)\\) of method Mage_Tax_Model_Sales_Total_Quote_Tax\\:\\:fetch\\(\\) should be compatible with return type \\(array\\) of method Mage_Sales_Model_Quote_Address_Total_Abstract\\:\\:fetch\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Tax/Model/Sales/Total/Quote/Tax.php
 
 		-
 			message: "#^Variable \\$baseRowTax might not be defined\\.$#"
@@ -4684,11 +4524,6 @@ parameters:
 			message: "#^Method Mage_Weee_Helper_Data\\:\\:getOriginalAmount\\(\\) should return int but returns float\\.$#"
 			count: 1
 			path: app/code/core/Mage/Weee/Helper/Data.php
-
-		-
-			message: "#^Return type \\(\\$this\\(Mage_Weee_Model_Attribute_Backend_Weee_Tax\\)\\) of method Mage_Weee_Model_Attribute_Backend_Weee_Tax\\:\\:validate\\(\\) should be compatible with return type \\(bool\\) of method Mage_Eav_Model_Entity_Attribute_Backend_Abstract\\:\\:validate\\(\\)$#"
-			count: 1
-			path: app/code/core/Mage/Weee/Model/Attribute/Backend/Weee/Tax.php
 
 		-
 			message: "#^Call to an undefined method Mage_Eav_Model_Entity_Attribute_Abstract\\:\\:isScopeGlobal\\(\\)\\.$#"
@@ -4952,6 +4787,11 @@ parameters:
 
 		-
 			message: "#^Method Varien_Db_Adapter_Pdo_Mysql\\:\\:query\\(\\) should return Zend_Db_Statement_Pdo but returns PDOStatement\\|Zend_Db_Statement_Interface\\.$#"
+			count: 1
+			path: lib/Varien/Db/Adapter/Pdo/Mysql.php
+
+		-
+			message: "#^Offset 3 on array\\{0\\: string, 1\\: string, 2\\: string, 3\\: non\\-falsy\\-string, 4\\: string, 5\\: string, 6\\?\\: ' ON DELETE…', 7\\?\\: 'CASCADE'\\|'NO ACTION'\\|'RESTRICT'\\|'SET NULL', \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
 			path: lib/Varien/Db/Adapter/Pdo/Mysql.php
 

--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -1001,27 +1001,12 @@ parameters:
 			path: app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/Items/Renderer.php
 
 		-
-			message: "#^Call to an undefined method Mage_Catalog_Model_Product_Type_Price\\:\\:getIsPricesCalculatedByIndex\\(\\)\\.$#"
-			count: 1
-			path: app/code/core/Mage/Bundle/Block/Catalog/Product/Price.php
-
-		-
-			message: "#^Call to an undefined method Mage_Catalog_Model_Product_Type_Price\\:\\:getSelectionPreFinalPrice\\(\\)\\.$#"
-			count: 3
-			path: app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option.php
-
-		-
 			message: "#^Variable \\$_items might not be defined\\.$#"
 			count: 1
 			path: app/code/core/Mage/Bundle/Block/Sales/Order/Items/Renderer.php
 
 		-
 			message: "#^Call to an undefined method Mage_Catalog_Model_Product_Configuration_Item_Interface\\:\\:getQty\\(\\)\\.$#"
-			count: 1
-			path: app/code/core/Mage/Bundle/Helper/Catalog/Product/Configuration.php
-
-		-
-			message: "#^Call to an undefined method Mage_Catalog_Model_Product_Type_Price\\:\\:getSelectionFinalTotalPrice\\(\\)\\.$#"
 			count: 1
 			path: app/code/core/Mage/Bundle/Helper/Catalog/Product/Configuration.php
 
@@ -1064,11 +1049,6 @@ parameters:
 			message: "#^Offset 'option_id' does not exist on array\\{final_price\\: mixed\\}\\.$#"
 			count: 4
 			path: app/code/core/Mage/Bundle/Model/Product/Price.php
-
-		-
-			message: "#^Call to an undefined method Mage_Catalog_Model_Product_Type_Price\\:\\:getSelectionFinalTotalPrice\\(\\)\\.$#"
-			count: 2
-			path: app/code/core/Mage/Bundle/Model/Product/Type.php
 
 		-
 			message: "#^Call to function is_array\\(\\) with string will always evaluate to false\\.$#"
@@ -1281,11 +1261,6 @@ parameters:
 			path: app/code/core/Mage/Catalog/Block/Widget/Link.php
 
 		-
-			message: "#^Property Mage_Catalog_Helper_Data\\:\\:\\$_categoryPath \\(string\\) does not accept array\\<string, array\\<string, string\\>\\>\\.$#"
-			count: 1
-			path: app/code/core/Mage/Catalog/Helper/Data.php
-
-		-
 			message: "#^Property Mage_Catalog_Helper_Output\\:\\:\\$_templateProcessor \\(Varien_Filter_Template\\) does not accept Mage_Core_Model_Abstract\\|false\\.$#"
 			count: 1
 			path: app/code/core/Mage/Catalog/Helper/Output.php
@@ -1382,11 +1357,6 @@ parameters:
 
 		-
 			message: "#^Left side of && is always true\\.$#"
-			count: 1
-			path: app/code/core/Mage/Catalog/Model/Category.php
-
-		-
-			message: "#^Method Mage_Catalog_Model_Category\\:\\:getDefaultAttributeSetId\\(\\) should return int but returns string\\|null\\.$#"
 			count: 1
 			path: app/code/core/Mage/Catalog/Model/Category.php
 
@@ -3201,11 +3171,6 @@ parameters:
 			path: app/code/core/Mage/Eav/Model/Resource/Form/Type.php
 
 		-
-			message: "#^Method Mage_GiftMessage_Model_Api_V2\\:\\:_prepareData\\(\\) should return array but returns mixed\\.$#"
-			count: 1
-			path: app/code/core/Mage/GiftMessage/Model/Api/V2.php
-
-		-
 			message: "#^Return type \\(stdClass\\) of method Mage_GiftMessage_Model_Api_V2\\:\\:_setGiftMessage\\(\\) should be compatible with return type \\(array\\) of method Mage_GiftMessage_Model_Api\\:\\:_setGiftMessage\\(\\)$#"
 			count: 1
 			path: app/code/core/Mage/GiftMessage/Model/Api/V2.php
@@ -3956,11 +3921,6 @@ parameters:
 			path: app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Tax.php
 
 		-
-			message: "#^Negated boolean expression is always true\\.$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Order.php
-
-		-
 			message: "#^Variable \\$oldArea might not be defined\\.$#"
 			count: 1
 			path: app/code/core/Mage/Sales/Model/Order/Api.php
@@ -3977,11 +3937,6 @@ parameters:
 
 		-
 			message: "#^Cannot call method addAttributeToFilter\\(\\) on Mage_Core_Model_Resource_Db_Collection_Abstract\\|false\\.$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Order/Invoice.php
-
-		-
-			message: "#^Property Mage_Core_Model_Abstract\\:\\:\\$_origData \\(array\\) does not accept null\\.$#"
 			count: 1
 			path: app/code/core/Mage/Sales/Model/Order/Invoice.php
 
@@ -4621,11 +4576,6 @@ parameters:
 			path: app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
 
 		-
-			message: "#^Invalid array key type strin\\.$#"
-			count: 3
-			path: app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
-
-		-
 			message: "#^Method Mage_Usa_Model_Shipping_Carrier_Dhl_International\\:\\:_mapRequestToShipment\\(\\) should return null but return statement is missing\\.$#"
 			count: 1
 			path: app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
@@ -4637,11 +4587,6 @@ parameters:
 
 		-
 			message: "#^Method Mage_Usa_Model_Shipping_Carrier_Dhl_International\\:\\:_parseResponse\\(\\) should return Mage_Shipping_Model_Rate_Result but returns bool\\|Mage_Shipping_Model_Rate_Result_Error\\.$#"
-			count: 1
-			path: app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
-
-		-
-			message: "#^Parameter \\$type of method Mage_Usa_Model_Shipping_Carrier_Dhl_International\\:\\:getCode\\(\\) has invalid type strin\\.$#"
 			count: 1
 			path: app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
 

--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -907,7 +907,7 @@ parameters:
 
 		-
 			message: "#^Offset 'option_id' does not exist on array\\{final_price\\: mixed\\}\\.$#"
-			count: 4
+			count: 2
 			path: app/code/core/Mage/Bundle/Model/Product/Price.php
 
 		-
@@ -1382,6 +1382,11 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Mage_Catalog_Model_Product_Configuration_Item_Option_Interface\\:\\:setValue\\(\\)\\.$#"
+			count: 1
+			path: app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
+
+		-
+			message: "#^Offset 0 on array\\{list\\<string\\>\\} in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 1
 			path: app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
 
@@ -3706,11 +3711,6 @@ parameters:
 			path: app/code/core/Mage/Sales/Model/Entity/Quote.php
 
 		-
-			message: "#^Negated boolean expression is always true\\.$#"
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Order.php
-
-		-
 			message: "#^Variable \\$oldArea might not be defined\\.$#"
 			count: 1
 			path: app/code/core/Mage/Sales/Model/Order/Api.php
@@ -4647,6 +4647,11 @@ parameters:
 
 		-
 			message: "#^Method Varien_Db_Adapter_Pdo_Mysql\\:\\:query\\(\\) should return Zend_Db_Statement_Pdo but returns PDOStatement\\|Zend_Db_Statement_Interface\\.$#"
+			count: 1
+			path: lib/Varien/Db/Adapter/Pdo/Mysql.php
+
+		-
+			message: "#^Offset 3 on array\\{0\\: string, 1\\: string, 2\\: string, 3\\: non\\-falsy\\-string, 4\\: string, 5\\: string, 6\\?\\: ' ON DELETE…', 7\\?\\: 'CASCADE'\\|'NO ACTION'\\|'RESTRICT'\\|'SET NULL', \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
 			path: lib/Varien/Db/Adapter/Pdo/Mysql.php
 

--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -1042,7 +1042,7 @@ parameters:
 
 		-
 			message: "#^Offset 'option_id' does not exist on array\\{final_price\\: mixed\\}\\.$#"
-			count: 2
+			count: 4
 			path: app/code/core/Mage/Bundle/Model/Product/Price.php
 
 		-
@@ -1517,11 +1517,6 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Mage_Catalog_Model_Product_Configuration_Item_Option_Interface\\:\\:setValue\\(\\)\\.$#"
-			count: 1
-			path: app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
-
-		-
-			message: "#^Offset 0 on array\\{list\\<string\\>\\} in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 1
 			path: app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
 
@@ -2247,11 +2242,6 @@ parameters:
 
 		-
 			message: "#^Method Mage_Core_Model_Config\\:\\:cleanCache\\(\\) should return \\$this\\(Mage_Core_Model_Config\\) but returns Mage_Core_Model_Config\\.$#"
-			count: 1
-			path: app/code/core/Mage/Core/Model/Config.php
-
-		-
-			message: "#^Method Mage_Core_Model_Config\\:\\:getNode\\(\\) should return Mage_Core_Model_Config_Element but returns Varien_Simplexml_Element\\|false\\.$#"
 			count: 1
 			path: app/code/core/Mage/Core/Model/Config.php
 
@@ -3851,6 +3841,11 @@ parameters:
 			path: app/code/core/Mage/Sales/Model/Entity/Quote.php
 
 		-
+			message: "#^Negated boolean expression is always true\\.$#"
+			count: 1
+			path: app/code/core/Mage/Sales/Model/Order.php
+
+		-
 			message: "#^Variable \\$oldArea might not be defined\\.$#"
 			count: 1
 			path: app/code/core/Mage/Sales/Model/Order/Api.php
@@ -4787,11 +4782,6 @@ parameters:
 
 		-
 			message: "#^Method Varien_Db_Adapter_Pdo_Mysql\\:\\:query\\(\\) should return Zend_Db_Statement_Pdo but returns PDOStatement\\|Zend_Db_Statement_Interface\\.$#"
-			count: 1
-			path: lib/Varien/Db/Adapter/Pdo/Mysql.php
-
-		-
-			message: "#^Offset 3 on array\\{0\\: string, 1\\: string, 2\\: string, 3\\: non\\-falsy\\-string, 4\\: string, 5\\: string, 6\\?\\: ' ON DELETE…', 7\\?\\: 'CASCADE'\\|'NO ACTION'\\|'RESTRICT'\\|'SET NULL', \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
 			path: lib/Varien/Db/Adapter/Pdo/Mysql.php
 

--- a/.phpstan.dist.neon
+++ b/.phpstan.dist.neon
@@ -69,5 +69,6 @@ parameters:
     checkFunctionNameCase: true
     checkInternalClassCaseSensitivity: true
     treatPhpDocTypesAsCertain: false
+    tmpDir: .phpstan.cache
 #    universalObjectCratesClasses:
 #        - Varien_Object

--- a/app/code/core/Mage/Admin/Model/Block.php
+++ b/app/code/core/Mage/Admin/Model/Block.php
@@ -37,7 +37,7 @@ class Mage_Admin_Model_Block extends Mage_Core_Model_Abstract
     }
 
     /**
-     * @return array|bool
+     * @return array|true
      * @throws Exception
      * @throws Zend_Validate_Exception
      */

--- a/app/code/core/Mage/Admin/Model/User.php
+++ b/app/code/core/Mage/Admin/Model/User.php
@@ -364,7 +364,7 @@ class Mage_Admin_Model_User extends Mage_Core_Model_Abstract
     }
 
     /**
-     * Authenticate user name and password and save loaded record
+     * Authenticate username and password and save loaded record
      *
      * @param string $username
      * @param string $password
@@ -384,7 +384,7 @@ class Mage_Admin_Model_User extends Mage_Core_Model_Abstract
             $this->loadByUsername($username);
             $sensitive = ($config) ? $username == $this->getUsername() : true;
 
-            if ($sensitive && $this->getId() && Mage::helper('core')->validateHash($password, $this->getPassword())) {
+            if ($sensitive && $this->getId() && $this->validatePasswordHash($password, $this->getPassword())) {
                 if ($this->getIsActive() != '1') {
                     Mage::throwException(Mage::helper('adminhtml')->__('This account is inactive.'));
                 }
@@ -409,6 +409,11 @@ class Mage_Admin_Model_User extends Mage_Core_Model_Abstract
             $this->unsetData();
         }
         return $result;
+    }
+
+    public function validatePasswordHash(string $string1, string $string2): bool
+    {
+        return Mage::helper('core')->validateHash($string1, $string2);
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Websites.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Websites.php
@@ -42,7 +42,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Websites extends Mage_Adminh
     /**
      * Get store ID of current product
      *
-     * @return int
+     * @return string
      */
     public function getStoreId()
     {

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit.php
@@ -224,7 +224,7 @@ class Mage_Adminhtml_Block_Newsletter_Queue_Edit extends Mage_Adminhtml_Block_Te
     /**
      * Getter for id of current store (the only one in single-store mode and current in multi-stores mode)
      *
-     * @return int
+     * @return string
      */
     protected function getStoreId()
     {

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit.php
@@ -335,7 +335,7 @@ class Mage_Adminhtml_Block_Newsletter_Template_Edit extends Mage_Adminhtml_Block
     /**
      * Getter for id of current store (the only one in single-store mode and current in multi-stores mode)
      *
-     * @return int
+     * @return string
      */
     protected function getStoreId()
     {

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
@@ -55,6 +55,15 @@ class Mage_Adminhtml_Block_System_Config_Form_Field extends Mage_Adminhtml_Block
             $checkboxLabel = $this->__('Use Default');
         }
 
+        $envConfig = Mage::getConfig()->getEnvOverriddenConfigPaths();
+        $envConfigIds = array_combine(str_replace('/', '_', array_keys($envConfig)), array_values($envConfig), );
+        if (array_key_exists($element->getId(), $envConfigIds)) {
+            $addInheritCheckbox = false;
+            $element->setDisabled(true);
+            $element->setScopeLabel('[ENV]]');
+            $element->setValue($envConfigIds[$element->getId()]);
+        }
+
         if ($addInheritCheckbox) {
             $inherit = $element->getInherit() == 1 ? 'checked="checked"' : '';
             if ($inherit) {

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
@@ -47,6 +47,7 @@ class Mage_Adminhtml_Block_System_Config_Form_Field extends Mage_Adminhtml_Block
         $options = $element->getValues();
 
         $addInheritCheckbox = false;
+        $checkboxLabel = '';
         if ($element->getCanUseWebsiteValue()) {
             $addInheritCheckbox = true;
             $checkboxLabel = $this->__('Use Website');
@@ -56,7 +57,7 @@ class Mage_Adminhtml_Block_System_Config_Form_Field extends Mage_Adminhtml_Block
         }
 
         $envConfig = Mage::getConfig()->getEnvOverriddenConfigPaths();
-        $envConfigIds = array_combine(str_replace('/', '_', array_keys($envConfig)), array_values($envConfig), );
+        $envConfigIds = array_combine(str_replace('/', '_', array_keys($envConfig)), array_values($envConfig),);
         if (array_key_exists($element->getId(), $envConfigIds)) {
             $addInheritCheckbox = false;
             $element->setDisabled(true);

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
@@ -57,7 +57,7 @@ class Mage_Adminhtml_Block_System_Config_Form_Field extends Mage_Adminhtml_Block
         }
 
         $envConfig = Mage::getConfig()->getEnvOverriddenConfigPaths();
-        $envConfigIds = array_combine(str_replace('/', '_', array_keys($envConfig)), array_values($envConfig),);
+        $envConfigIds = array_combine(str_replace('/', '_', array_keys($envConfig)), array_values($envConfig));
         if (array_key_exists($element->getId(), $envConfigIds)) {
             $addInheritCheckbox = false;
             $element->setDisabled(true);

--- a/app/code/core/Mage/Adminhtml/Model/System/Store.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Store.php
@@ -48,6 +48,7 @@ class Mage_Adminhtml_Model_System_Store extends Varien_Object
     /**
      * @var bool
      */
+    // phpcs:ignore Ecg.PHP.PrivateClassMember.PrivateClassMemberError
     private $_isAdminScopeAllowed = true;
 
     /**
@@ -122,6 +123,7 @@ class Mage_Adminhtml_Model_System_Store extends Varien_Object
             ];
         }
 
+        // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
         $nonEscapableNbspChar = html_entity_decode('&#160;', ENT_NOQUOTES, 'UTF-8');
 
         foreach ($this->_websiteCollection as $website) {

--- a/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
@@ -442,7 +442,7 @@ class Mage_Adminhtml_System_StoreController extends Mage_Adminhtml_Controller_Ac
      *
      * @param string $failPath redirect path if backup failed
      * @param array $arguments
-     * @return $this
+     * @return $this|void
      */
     protected function _backupDatabase($failPath, $arguments = [])
     {
@@ -468,11 +468,11 @@ class Mage_Adminhtml_System_StoreController extends Mage_Adminhtml_Controller_Ac
         } catch (Mage_Core_Exception $e) {
             $this->_getSession()->addError($e->getMessage());
             $this->_redirect($failPath, $arguments);
-            return ;
+            return;
         } catch (Exception $e) {
             $this->_getSession()->addException($e, Mage::helper('backup')->__('Unable to create backup. Please, try again later.'));
             $this->_redirect($failPath, $arguments);
-            return ;
+            return;
         }
         return $this;
     }

--- a/app/code/core/Mage/Api2/Model/Resource.php
+++ b/app/code/core/Mage/Api2/Model/Resource.php
@@ -621,6 +621,7 @@ abstract class Mage_Api2_Model_Resource
             }
             $code = $errors[$message];
         }
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
         throw new Mage_Api2_Exception($message, $code);
     }
 
@@ -657,6 +658,7 @@ abstract class Mage_Api2_Model_Resource
      */
     protected function _error($message, $code)
     {
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
         $this->getResponse()->setException(new Mage_Api2_Exception($message, $code));
         return $this;
     }

--- a/app/code/core/Mage/Api2/Model/Route/ApiType.php
+++ b/app/code/core/Mage/Api2/Model/Route/ApiType.php
@@ -45,6 +45,7 @@ class Mage_Api2_Model_Route_ApiType extends Mage_Api2_Model_Route_Abstract imple
         ?Zend_Translate $translator = null,
         $locale = null
     ) {
+        // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
         parent::__construct([Mage_Api2_Model_Route_Abstract::PARAM_ROUTE => str_replace('.php', '', basename(getenv('SCRIPT_FILENAME'))) . '/:api_type']);
     }
 }

--- a/app/code/core/Mage/Bundle/Model/Product/Price.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Price.php
@@ -79,7 +79,6 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
                 $selectionIds = unserialize($customOption->getValue(), ['allowed_classes' => false]);
                 /** @var Mage_Bundle_Model_Product_Type $productType */
                 $productType = $product->getTypeInstance(true);
-                /** @var Mage_Bundle_Model_Resource_Selection_Collection $selections */
                 $selections = $productType->getSelectionsByIds($selectionIds, $product);
                 $selections->addTierPriceData();
                 Mage::dispatchEvent('prepare_catalog_product_collection_prices', [

--- a/app/code/core/Mage/Captcha/Helper/Data.php
+++ b/app/code/core/Mage/Captcha/Helper/Data.php
@@ -62,7 +62,7 @@ class Mage_Captcha_Helper_Data extends Mage_Core_Helper_Abstract
      * Get Captcha
      *
      * @param string $formId
-     * @return Mage_Captcha_Model_Interface
+     * @return Mage_Captcha_Model_Zend
      */
     public function getCaptcha($formId)
     {
@@ -76,7 +76,7 @@ class Mage_Captcha_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Returns value of the node with respect to current area (frontend or backend)
      *
-     * @param string $id The last part of XML_PATH_$area_CAPTCHA_ constant (case insensitive)
+     * @param string $id The last part of XML_PATH_$area_CAPTCHA_ constant (case-insensitive)
      * @param Mage_Core_Model_Store $store
      * @return Mage_Core_Model_Config_Element
      */

--- a/app/code/core/Mage/Catalog/Helper/Data.php
+++ b/app/code/core/Mage/Catalog/Helper/Data.php
@@ -44,7 +44,7 @@ class Mage_Catalog_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Breadcrumb Path cache
      *
-     * @var string
+     * @var string|array<string, array<string, string|null>>
      */
     protected $_categoryPath;
 

--- a/app/code/core/Mage/Catalog/Helper/Data.php
+++ b/app/code/core/Mage/Catalog/Helper/Data.php
@@ -236,7 +236,7 @@ class Mage_Catalog_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Indicate whether to save URL Rewrite History or not (create redirects to old URLs)
      *
-     * @param int $storeId Store View
+     * @param null|string|bool|int|Mage_Core_Model_Store $storeId Store View
      * @return bool
      */
     public function shouldSaveUrlRewritesHistory($storeId = null)

--- a/app/code/core/Mage/Catalog/Model/Api/Resource.php
+++ b/app/code/core/Mage/Catalog/Model/Api/Resource.php
@@ -78,7 +78,7 @@ class Mage_Catalog_Model_Api_Resource extends Mage_Api_Model_Resource_Abstract
      * it use seted session or admin store
      *
      * @param string|int $store
-     * @return int
+     * @return string
      */
     protected function _getStoreId($store = null)
     {
@@ -117,7 +117,7 @@ class Mage_Catalog_Model_Api_Resource extends Mage_Api_Model_Resource_Abstract
      * Set current store for catalog.
      *
      * @param string|int $store
-     * @return int
+     * @return string
      */
     public function currentStore($store = null)
     {

--- a/app/code/core/Mage/Catalog/Model/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Category.php
@@ -313,7 +313,7 @@ class Mage_Catalog_Model_Category extends Mage_Catalog_Model_Abstract
     /**
      * Retrieve default attribute set id
      *
-     * @return int
+     * @return string
      */
     public function getDefaultAttributeSetId()
     {

--- a/app/code/core/Mage/Catalog/Model/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Category.php
@@ -138,6 +138,7 @@ class Mage_Catalog_Model_Category extends Mage_Catalog_Model_Abstract
      *
      * @var array
      */
+    // phpcs:ignore Ecg.PHP.PrivateClassMember.PrivateClassMemberError
     private $_designAttributes  = [
         'custom_design',
         'custom_design_from',
@@ -440,9 +441,9 @@ class Mage_Catalog_Model_Category extends Mage_Catalog_Model_Abstract
     /**
      * Return store id.
      *
-     * If store id is underfined for category return current active store id
+     * If store id is undefined for category return current active store id
      *
-     * @return int
+     * @return string
      */
     public function getStoreId()
     {
@@ -629,6 +630,7 @@ class Mage_Catalog_Model_Category extends Mage_Catalog_Model_Abstract
      * @param string $attributeCode
      * @return Mage_Eav_Model_Entity_Attribute_Abstract
      */
+    // phpcs:ignore Ecg.PHP.PrivateClassMember.PrivateClassMemberError
     private function _getAttribute($attributeCode)
     {
         if (!$this->_useFlatResource) {

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -217,7 +217,7 @@
  * @method $this setStoreIds(array $storeIds)
  * @method array getSwatchPrices()
  *
- * @method int getTaxClassId()
+ * @method string getTaxClassId()
  * @method string getThumbnail()
  * @method float getTaxPercent()
  * @method $this setTaxPercent(float $value)
@@ -360,7 +360,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     /**
      * Retrieve Store Id
      *
-     * @return int
+     * @return string
      */
     public function getStoreId()
     {
@@ -417,7 +417,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     /**
      * Get product name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -442,16 +442,18 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
      * Set Price calculation flag
      *
      * @param bool $calculate
+     * @return $this
      */
     public function setPriceCalculation($calculate = true)
     {
         $this->_calculatePrice = $calculate;
+        return $this;
     }
 
     /**
      * Get product type identifier
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeId()
     {

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -138,7 +138,7 @@
  * @method string getMetaDescription()
  * @method string getMetaKeyword()
  * @method string getMetaTitle()
- * @method $this hasMsrpEnabled(bool $value)
+ * @method $this hasMsrpEnabled()
  * @method bool getMsrpEnabled()
  * @method string getMsrpDisplayActualPriceType()
  *
@@ -877,7 +877,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     /**
      * Get product price model
      *
-     * @return Mage_Catalog_Model_Product_Type_Price|Mage_Bundle_Model_Product_Price
+     * @return Mage_Bundle_Model_Product_Price
      */
     public function getPriceModel()
     {

--- a/app/code/core/Mage/Catalog/Model/Product/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Url.php
@@ -213,7 +213,7 @@ class Mage_Catalog_Model_Product_Url extends Varien_Object
      * Returns checked store_id value
      *
      * @param int|null $id
-     * @return int
+     * @return string
      */
     protected function _getStoreId($id = null)
     {

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
@@ -34,7 +34,7 @@ class Mage_Catalog_Model_Resource_Category_Flat_Collection extends Mage_Core_Mod
     /**
      * Store id of application
      *
-     * @var int|null
+     * @var string|null
      */
     protected $_storeId        = null;
 
@@ -109,7 +109,7 @@ class Mage_Catalog_Model_Resource_Category_Flat_Collection extends Mage_Core_Mod
     /**
      * Set store id
      *
-     * @param int $storeId
+     * @param string $storeId
      * @return $this
      */
     public function setStoreId($storeId)
@@ -122,7 +122,7 @@ class Mage_Catalog_Model_Resource_Category_Flat_Collection extends Mage_Core_Mod
      * Return store id.
      * If store id is not set yet, return store of application
      *
-     * @return int
+     * @return string
      */
     public function getStoreId()
     {
@@ -238,16 +238,6 @@ class Mage_Catalog_Model_Resource_Category_Flat_Collection extends Mage_Core_Mod
     }
 
     /**
-     * Retrieve resource instance
-     *
-     * @inheritDoc
-     */
-    public function getResource()
-    {
-        return parent::getResource();
-    }
-
-    /**
      * Add attribute to sort order
      *
      * @param string $attribute
@@ -325,6 +315,7 @@ class Mage_Catalog_Model_Resource_Category_Flat_Collection extends Mage_Core_Mod
         $select = $this->getSelect();
         $cond   = [];
         foreach ($paths as $path) {
+            // phpcs:ignore Ecg.Sql.SlowQuery.SlowRawSql
             $cond[] = $this->getResource()->getReadConnection()->quoteInto('main_table.path LIKE ?', "$path%");
         }
         if ($cond) {

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Tree.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Tree.php
@@ -57,7 +57,7 @@ class Mage_Catalog_Model_Resource_Category_Tree extends Varien_Data_Tree_Dbp
     /**
      * store id
      *
-     * @var int
+     * @var string
      */
     protected $_storeId                          = null;
 
@@ -88,19 +88,19 @@ class Mage_Catalog_Model_Resource_Category_Tree extends Varien_Data_Tree_Dbp
     /**
      * Set store id
      *
-     * @param int $storeId
+     * @param string $storeId
      * @return $this
      */
     public function setStoreId($storeId)
     {
-        $this->_storeId = (int) $storeId;
+        $this->_storeId = $storeId;
         return $this;
     }
 
     /**
      * Return store id
      *
-     * @return int
+     * @return string
      */
     public function getStoreId()
     {
@@ -467,6 +467,7 @@ class Mage_Catalog_Model_Resource_Category_Tree extends Varien_Data_Tree_Dbp
             ->where('entity_id IN (?)', $ids);
         $where = [$levelField . '=0' => true];
 
+        // phpcs:ignore Ecg.Performance.FetchAll.Found
         foreach ($this->_conn->fetchAll($select) as $item) {
             if (!preg_match("#^[0-9\/]+$#", $item['path'])) {
                 $item['path'] = '';
@@ -474,6 +475,7 @@ class Mage_Catalog_Model_Resource_Category_Tree extends Varien_Data_Tree_Dbp
             $pathIds  = explode('/', $item['path']);
             $level = (int)$item['level'];
             while ($level > 0) {
+                // phpcs:ignore Ecg.Performance.Loop.ArraySize
                 $pathIds[count($pathIds) - 1] = '%';
                 $path = implode('/', $pathIds);
                 $where["$levelField=$level AND $pathField LIKE '$path'"] = true;
@@ -493,6 +495,7 @@ class Mage_Catalog_Model_Resource_Category_Tree extends Varien_Data_Tree_Dbp
         $select->where(implode(' OR ', $where));
 
         // get array of records and add them as nodes to the tree
+        // phpcs:ignore Ecg.Performance.FetchAll.Found
         $arrNodes = $this->_conn->fetchAll($select);
         if (!$arrNodes) {
             return false;
@@ -535,6 +538,7 @@ class Mage_Catalog_Model_Resource_Category_Tree extends Varien_Data_Tree_Dbp
             $select
                 ->where('e.entity_id IN(?)', $pathIds)
                 ->order($this->_conn->getLengthSql('e.path') . ' ' . Varien_Db_Select::SQL_ASC);
+            // phpcs:ignore Ecg.Performance.FetchAll.Found
             $result = $this->_conn->fetchAll($select);
             $this->_updateAnchorProductCount($result);
         }
@@ -623,6 +627,7 @@ class Mage_Catalog_Model_Resource_Category_Tree extends Varien_Data_Tree_Dbp
                 ['COUNT(DISTINCT scp.product_id)']
             )
             ->where('see.entity_id = e.entity_id')
+            // phpcs:ignore Ecg.Sql.SlowQuery.SlowRawSql
             ->orWhere('see.path LIKE ?', $subConcat);
         $select->columns(['product_count' => $subSelect]);
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Url.php
@@ -1103,13 +1103,16 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
     {
         // Form a list of all current store categories ids
         $store          = $this->getStores($storeId);
+        if (!$store instanceof Mage_Core_Model_Store) {
+            return $this;
+        }
         $rootCategoryId = $store->getRootCategoryId();
         if (!$rootCategoryId) {
             return $this;
         }
         $categoryIds = $this->getRootChildrenIds($rootCategoryId, $store->getRootCategoryPath());
 
-        // Remove all store catalog rewrites that are for some category or cartegory/product not within store categories
+        // Remove all store catalog rewrites that are for some category or category/product not within store categories
         $where   = [
             'store_id = ?' => $storeId,
             'category_id IS NOT NULL', // For sure check that it's a catalog rewrite
@@ -1136,6 +1139,10 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
     public function clearStoreProductsInvalidRewrites($storeId, $productId = null)
     {
         $store   = $this->getStores($storeId);
+        if (!$store instanceof Mage_Core_Model_Store) {
+            return $this;
+        }
+
         $adapter = $this->_getReadAdapter();
         $bind    = [
             'website_id' => (int)$store->getWebsiteId(),

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -236,7 +236,12 @@ class Mage_Catalog_Model_Url
         }
 
         $this->clearStoreInvalidRewrites($storeId);
-        $this->refreshCategoryRewrite($this->getStores($storeId)->getRootCategoryId(), $storeId, false);
+
+        $store = $this->getStores($storeId);
+        if ($store instanceof Mage_Core_Model_Store) {
+            $this->refreshCategoryRewrite($store->getRootCategoryId(), $storeId, false);
+        }
+
         $this->refreshProductRewrites($storeId);
         $this->getResource()->clearCategoryProduct($storeId);
 
@@ -504,9 +509,14 @@ class Mage_Catalog_Model_Url
      */
     public function refreshProductRewrites($storeId)
     {
+        $store = $this->getStores($storeId);
+        if (!$store instanceof Mage_Core_Model_Store) {
+            return $this;
+        }
+
         $this->_categories      = [];
-        $storeRootCategoryId    = $this->getStores($storeId)->getRootCategoryId();
-        $storeRootCategoryPath  = $this->getStores($storeId)->getRootCategoryPath();
+        $storeRootCategoryId    = $store->getRootCategoryId();
+        $storeRootCategoryPath  = $store->getRootCategoryPath();
         $this->_categories[$storeRootCategoryId] = $this->getResource()->getCategory($storeRootCategoryId, $storeId);
 
         $lastEntityId = 0;

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -135,7 +135,7 @@ class Mage_Catalog_Model_Url
      * Retrieve stores array or store model
      *
      * @param int $storeId
-     * @return Mage_Core_Model_Store|array
+     * @return Mage_Core_Model_Store|Mage_Core_Model_Store[]
      */
     public function getStores($storeId = null)
     {
@@ -211,7 +211,7 @@ class Mage_Catalog_Model_Url
     /**
      * Indicate whether to save URL Rewrite History or not (create redirects to old URLs)
      *
-     * @param int $storeId Store View
+     * @param null|string|bool|int|Mage_Core_Model_Store $storeId Store View
      * @return bool
      */
     public function getShouldSaveRewritesHistory($storeId = null)

--- a/app/code/core/Mage/Checkout/Model/Api/Resource.php
+++ b/app/code/core/Mage/Checkout/Model/Api/Resource.php
@@ -75,7 +75,7 @@ class Mage_Checkout_Model_Api_Resource extends Mage_Api_Model_Resource_Abstract
      * it use set session or admin store
      *
      * @param string|int $store
-     * @return int
+     * @return string
      */
     protected function _getStoreId($store = null)
     {
@@ -124,7 +124,7 @@ class Mage_Checkout_Model_Api_Resource extends Mage_Api_Model_Resource_Abstract
      * Get store identifier by quote identifier
      *
      * @param int $quoteId
-     * @return int
+     * @return string
      */
     protected function _getStoreIdFromQuote($quoteId)
     {

--- a/app/code/core/Mage/Core/Block/Store/Switcher.php
+++ b/app/code/core/Mage/Core/Block/Store/Switcher.php
@@ -117,7 +117,7 @@ class Mage_Core_Block_Store_Switcher extends Mage_Core_Block_Template
     }
 
     /**
-     * @return int
+     * @return string
      * @throws Mage_Core_Model_Store_Exception
      */
     public function getCurrentStoreId()

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -315,8 +315,8 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Retrieve store identifier
      *
-     * @param   mixed $store
-     * @return  int
+     * @param   bool|int|Mage_Core_Model_Store|null|string $store
+     * @return  string
      */
     public function getStoreId($store = null)
     {
@@ -368,12 +368,14 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
 
             $replacements[$german] = [];
             foreach ($subst as $k => $v) {
+                // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
                 $replacements[$german][$k < 256 ? chr($k) : '&#' . $k . ';'] = $v;
             }
         }
 
         // convert string from default database format (UTF-8)
         // to encoding which replacement arrays made with (ISO-8859-1)
+        // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
         if ($s = @iconv('UTF-8', 'ISO-8859-1', $string)) {
             $string = $s;
         }
@@ -571,6 +573,7 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
      * @param mixed $value
      * @param bool $dontSkip
      */
+    // phpcs:ignore Ecg.PHP.PrivateClassMember.PrivateClassMemberError
     private function _decorateArrayObject($element, $key, $value, $dontSkip)
     {
         if ($dontSkip) {
@@ -616,6 +619,7 @@ XML;
      * @return SimpleXMLElement
      * @throws Exception
      */
+    // phpcs:ignore Ecg.PHP.PrivateClassMember.PrivateClassMemberError
     private function _assocToXml(array $array, $rootName, SimpleXMLElement &$xml)
     {
         $hasNumericKey = false;
@@ -765,14 +769,18 @@ XML;
             // check whether merger is required
             $shouldMerge = $mustMerge || !$targetFile;
             if (!$shouldMerge) {
+                // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
                 if (!file_exists($targetFile)) {
                     $shouldMerge = true;
                 } else {
+                    // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
                     $targetMtime = filemtime($targetFile);
                     foreach ($srcFiles as $file) {
+                        // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
                         if (!file_exists($file)) {
                             // no translation intentionally
                             Mage::logException(new Exception(sprintf('File %s not found.', $file)));
+                            // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged,Ecg.Security.ForbiddenFunction.Found
                         } elseif (@filemtime($file) > $targetMtime) {
                             $shouldMerge = true;
                             break;
@@ -785,6 +793,7 @@ XML;
             if ($shouldMerge) {
                 if ($targetFile && !is_writable(dirname($targetFile))) {
                     // no translation intentionally
+                    // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
                     throw new Exception(sprintf('Path %s is not writeable.', dirname($targetFile)));
                 }
 
@@ -795,6 +804,7 @@ XML;
                     }
                     if (!empty($srcFiles)) {
                         foreach ($srcFiles as $key => $file) {
+                            // phpcs:ignore Ecg.Security.DiscouragedFunction.Discouraged
                             $fileExt = strtolower(pathinfo($file, PATHINFO_EXTENSION));
                             if (!in_array($fileExt, $extensionsFilter)) {
                                 unset($srcFiles[$key]);
@@ -809,11 +819,15 @@ XML;
 
                 $data = '';
                 foreach ($srcFiles as $file) {
+                    // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
                     if (!file_exists($file)) {
                         continue;
                     }
+                    // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
                     $contents = file_get_contents($file) . "\n";
+                    // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
                     if ($beforeMergeCallback && is_callable($beforeMergeCallback)) {
+                        // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
                         $contents = call_user_func($beforeMergeCallback, $file, $contents);
                     }
                     $data .= $contents;
@@ -823,6 +837,7 @@ XML;
                     throw new Exception(sprintf("No content found in files:\n%s", implode("\n", $srcFiles)));
                 }
                 if ($targetFile) {
+                    // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
                     file_put_contents($targetFile, $data, LOCK_EX);
                 } else {
                     return $data; // no need to write to file, just return data
@@ -878,6 +893,7 @@ XML;
     public function checkLfiProtection($name)
     {
         if (preg_match('#\.\.[\\\/]#', $name)) {
+            // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
             throw new Mage_Core_Exception($this->__('Requested file may not include parent directory traversal ("../", "..\\" notation)'));
         }
         return true;

--- a/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
+++ b/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
@@ -57,7 +57,7 @@ class Mage_Core_Helper_EnvironmentConfigLoader extends Mage_Core_Helper_Abstract
     public function overrideEnvironment(Varien_Simplexml_Config $xmlConfig)
     {
         if (!$xmlConfig instanceof Mage_Core_Model_Config) {
-//            return;
+            return;
         }
 
         $env = $this->getEnv();

--- a/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
+++ b/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
@@ -56,6 +56,10 @@ class Mage_Core_Helper_EnvironmentConfigLoader extends Mage_Core_Helper_Abstract
      */
     public function overrideEnvironment(Varien_Simplexml_Config $xmlConfig)
     {
+        if (!$xmlConfig instanceof Mage_Core_Model_Config) {
+//            return;
+        }
+
         $env = $this->getEnv();
 
         foreach ($env as $configKey => $value) {
@@ -66,10 +70,12 @@ class Mage_Core_Helper_EnvironmentConfigLoader extends Mage_Core_Helper_Abstract
             list($configKeyParts, $scope) = $this->getConfigKey($configKey);
 
             switch ($scope) {
+                default:
                 case static::CONFIG_KEY_DEFAULT:
                     list($unused1, $unused2, $section, $group, $field) = $configKeyParts;
                     $path = $this->buildPath($section, $group, $field);
-                    $xmlConfig->setNode($this->buildNodePath($scope, $path), $value);
+                    $nodePath = $this->buildNodePath($scope, $path);
+                    $xmlConfig->setNode('stores/' . $nodePath, $value);
                     break;
 
                 case static::CONFIG_KEY_WEBSITES:
@@ -77,9 +83,12 @@ class Mage_Core_Helper_EnvironmentConfigLoader extends Mage_Core_Helper_Abstract
                     list($unused1, $unused2, $code, $section, $group, $field) = $configKeyParts;
                     $path = $this->buildPath($section, $group, $field);
                     $nodePath = sprintf('%s/%s/%s', strtolower($scope), strtolower($code), $path);
-                    $xmlConfig->setNode($nodePath, $value);
                     break;
             }
+
+            $xmlConfig->addEnvOverriddenConfigPaths($path, $value);
+            $xmlConfig->addEnvOverriddenConfigPaths($nodePath, $value);
+            $xmlConfig->setNode($nodePath, $value);
         }
     }
 
@@ -94,6 +103,7 @@ class Mage_Core_Helper_EnvironmentConfigLoader extends Mage_Core_Helper_Abstract
     public function getEnv(): array
     {
         if (empty($this->envStore)) {
+            // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
             $this->envStore = getenv();
         }
         return $this->envStore;
@@ -144,5 +154,6 @@ class Mage_Core_Helper_EnvironmentConfigLoader extends Mage_Core_Helper_Abstract
     protected function buildNodePath(string $scope, string $path): string
     {
         return strtolower($scope) . '/' . $path;
+//        return 'stores/' . strtolower($scope) . '/' . $path;
     }
 }

--- a/app/code/core/Mage/Core/Helper/String.php
+++ b/app/code/core/Mage/Core/Helper/String.php
@@ -34,7 +34,7 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
      * Truncate a string to a certain length if necessary, appending the $etc string.
      * $remainder will contain the string that has been replaced with $etc.
      *
-     * @param string $string
+     * @param string|null $string
      * @param int $length
      * @param string $etc
      * @param string &$remainder
@@ -241,7 +241,7 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
     /**
      * Split words
      *
-     * @param string $str The source string
+     * @param string|null $str The source string
      * @param bool $uniqueOnly Unique words only
      * @param int $maxWordLength Limit words count
      * @param string $wordSeparatorRegexp
@@ -513,7 +513,7 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
 
     /**
      * UnSerialize string
-     * @param string $str
+     * @param string|null $str
      * @return mixed|null
      * @throws Exception
      */

--- a/app/code/core/Mage/Core/Model/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Abstract.php
@@ -48,7 +48,7 @@ abstract class Mage_Core_Model_Abstract extends Varien_Object
     /**
      * Original data that was loaded
      *
-     * @var array
+     * @var array|null
      */
     protected $_origData;
 

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -364,8 +364,8 @@ class Mage_Core_Model_App
         } else {
             flush();
         }
-        if (session_status() === PHP_SESSION_ACTIVE) {
-            session_write_close();
+        if (session_status() === PHP_SESSION_ACTIVE) {  // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
+            session_write_close();                      // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
         }
 
         try {
@@ -540,6 +540,7 @@ class Mage_Core_Model_App
      */
     protected function _checkGetStore($type)
     {
+        // phpcs:ignore Ecg.Security.Superglobal.SuperglobalUsageError
         if (empty($_GET)) {
             return $this;
         }
@@ -547,10 +548,12 @@ class Mage_Core_Model_App
         /**
          * @todo check XML_PATH_STORE_IN_URL
          */
+        // phpcs:ignore Ecg.Security.Superglobal.SuperglobalUsageError
         if (!isset($_GET['___store'])) {
             return $this;
         }
 
+        // phpcs:ignore Ecg.Security.Superglobal.SuperglobalUsageError
         $store = $_GET['___store'];
         if (!isset($this->_stores[$store])) {
             return $this;
@@ -621,7 +624,7 @@ class Mage_Core_Model_App
 
     public function reinitStores()
     {
-        return $this->_initStores();
+        $this->_initStores();
     }
 
     /**
@@ -652,6 +655,7 @@ class Mage_Core_Model_App
 
         $this->_isSingleStore = false;
         if ($this->_isSingleStoreAllowed) {
+            // phpcs:ignore Ecg.Performance.CollectionCount.Found
             $this->_isSingleStore = $storeCollection->count() < 3;
         }
 
@@ -779,6 +783,7 @@ class Mage_Core_Model_App
      */
     protected function _initFrontController()
     {
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
         $this->_frontController = new Mage_Core_Controller_Varien_Front();
         Mage::register('controller', $this->_frontController);
         Varien_Profiler::start('mage::app::init_front_controller');
@@ -833,6 +838,7 @@ class Mage_Core_Model_App
     public function getArea($code)
     {
         if (!isset($this->_areas[$code])) {
+            // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
             $this->_areas[$code] = new Mage_Core_Model_App_Area($code, $this);
         }
         return $this->_areas[$code];
@@ -1264,8 +1270,8 @@ class Mage_Core_Model_App
      */
     public function cleanAllSessions()
     {
-        if (session_module_name() == 'files') {
-            $dir = session_save_path();
+        if (session_module_name() == 'files') {     // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
+            $dir = session_save_path();             // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
             mageDelTree($dir);
         }
         return $this;
@@ -1279,6 +1285,7 @@ class Mage_Core_Model_App
     public function getRequest()
     {
         if (empty($this->_request)) {
+            // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
             $this->_request = new Mage_Core_Controller_Request_Http();
         }
         return $this->_request;
@@ -1300,14 +1307,17 @@ class Mage_Core_Model_App
      */
     public function isCurrentlySecure()
     {
+        // phpcs:ignore Ecg.Security.Superglobal.SuperglobalUsageWarning
         if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
             return true;
         }
 
+        // phpcs:ignore Ecg.Security.Superglobal.SuperglobalUsageWarning
         if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
             return true;
         }
 
+        // phpcs:ignore Ecg.Security.Superglobal.SuperglobalUsageWarning
         if (isset($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == 443)) {
             return true;
         }
@@ -1317,6 +1327,7 @@ class Mage_Core_Model_App
             if ($offloaderHeader) {
                 $offloaderHeader = preg_replace('/[^A-Z]+/', '_', $offloaderHeader);
                 $offloaderHeader = str_starts_with($offloaderHeader, 'HTTP_') ? $offloaderHeader : 'HTTP_' . $offloaderHeader;
+                // phpcs:ignore Ecg.Security.Superglobal.SuperglobalUsageWarning
                 if (!empty($_SERVER[$offloaderHeader]) && $_SERVER[$offloaderHeader] !== 'http') {
                     return true;
                 }
@@ -1334,6 +1345,7 @@ class Mage_Core_Model_App
     public function getResponse()
     {
         if (empty($this->_response)) {
+            // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
             $this->_response = new Mage_Core_Controller_Response_Http();
             $this->_response->headersSentThrowsException = Mage::$headersSentThrowsException;
             $this->_response->setHeader('Content-Type', 'text/html; charset=UTF-8');
@@ -1479,6 +1491,7 @@ class Mage_Core_Model_App
      */
     public function throwStoreException($text = '')
     {
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
         throw new Mage_Core_Model_Store_Exception($text);
     }
 

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -250,6 +250,11 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     protected $_allowedModules = [];
 
     /**
+     * Config paths overloaded by ENV
+     */
+    protected array $envOverriddenConfigPaths = [];
+
+    /**
      * Class construct
      *
      * @param mixed $sourceData
@@ -739,7 +744,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      * Returns node found by the $path and scope info
      *
      * @inheritDoc
-     * @return Mage_Core_Model_Config_Element
+     * @return Mage_Core_Model_Config_Element|false
      */
     public function getNode($path = null, $scope = '', $scopeCode = null)
     {
@@ -1821,5 +1826,16 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     protected function _isNodeNameHasUpperCase(Mage_Core_Model_Config_Element $event)
     {
         return (strtolower($event->getName()) !== (string)$event->getName());
+    }
+
+    public function getEnvOverriddenConfigPaths(): array
+    {
+        return $this->envOverriddenConfigPaths;
+    }
+
+    public function addEnvOverriddenConfigPaths(string $path, string $value): Mage_Core_Model_Config
+    {
+        $this->envOverriddenConfigPaths[$path] = $value;
+        return $this;
     }
 }

--- a/app/code/core/Mage/Core/Model/Resource/Store/Group/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Store/Group/Collection.php
@@ -18,6 +18,9 @@
  *
  * @category   Mage
  * @package    Mage_Core
+ *
+ * @method Mage_Core_Model_Store_Group getItemById(int $value)
+ * @method Mage_Core_Model_Store_Group[] getItems()
  */
 class Mage_Core_Model_Resource_Store_Group_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {

--- a/app/code/core/Mage/Core/Model/Resource/Website/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Website/Collection.php
@@ -18,6 +18,9 @@
  *
  * @category   Mage
  * @package    Mage_Core
+ *
+ * @method Mage_Core_Model_Website getItemById(int $value)
+ * @method Mage_Core_Model_Website[] getItems()
  */
 class Mage_Core_Model_Resource_Website_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -696,7 +696,7 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
     /**
      * Get store identifier
      *
-     * @return  int
+     * @return string
      */
     public function getId()
     {

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -337,13 +337,22 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
      */
     public function getConfig($path)
     {
+        $config = Mage::getConfig();
+        $fullPath = 'stores/' . $this->getCode() . '/' . $path;
+
+        $envConfig = $config->getEnvOverriddenConfigPaths();
+        if (array_key_exists($fullPath, $envConfig)) {
+            return $envConfig[$fullPath];
+        }
+
+        if (array_key_exists($path, $envConfig)) {
+            return $envConfig[$path];
+        }
+
         if (isset($this->_configCache[$path])) {
             return $this->_configCache[$path];
         }
 
-        $config = Mage::getConfig();
-
-        $fullPath = 'stores/' . $this->getCode() . '/' . $path;
         $data = $config->getNode($fullPath);
         if (!$data && !Mage::isInstalled()) {
             $data = $config->getNode('default/' . $path);

--- a/app/code/core/Mage/Eav/Model/Convert/Adapter/Entity.php
+++ b/app/code/core/Mage/Eav/Model/Convert/Adapter/Entity.php
@@ -35,7 +35,7 @@ class Mage_Eav_Model_Convert_Adapter_Entity extends Mage_Dataflow_Model_Convert_
     /**
      * Retrieve store Id
      *
-     * @return int
+     * @return string
      */
     public function getStoreId()
     {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Abstract.php
@@ -222,7 +222,7 @@ abstract class Mage_Eav_Model_Entity_Attribute_Backend_Abstract implements Mage_
      *
      * @param Varien_Object $object
      * @throws Mage_Eav_Exception
-     * @return bool
+     * @return $this|bool
      */
     public function validate($object)
     {

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Interface.php
@@ -31,9 +31,10 @@ interface Mage_Eav_Model_Entity_Attribute_Backend_Interface
 
     /**
      * @param int $valueId
-     * @return int
+     * @return $this
      */
     public function setValueId($valueId);
+
     public function getValueId();
 
     /**

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset/Collection.php
@@ -24,7 +24,7 @@ class Mage_Eav_Model_Resource_Form_Fieldset_Collection extends Mage_Core_Model_R
     /**
      * Store scope ID
      *
-     * @var int|null
+     * @var string|null
      */
     protected $_storeId;
 
@@ -66,7 +66,7 @@ class Mage_Eav_Model_Resource_Form_Fieldset_Collection extends Mage_Core_Model_R
     /**
      * Retrieve label store scope
      *
-     * @return int
+     * @return string
      */
     public function getStoreId()
     {
@@ -79,7 +79,7 @@ class Mage_Eav_Model_Resource_Form_Fieldset_Collection extends Mage_Core_Model_R
     /**
      * Set store scope ID
      *
-     * @param int $storeId
+     * @param string $storeId
      * @return $this
      */
     public function setStoreId($storeId)

--- a/app/code/core/Mage/GiftMessage/Model/Api/V2.php
+++ b/app/code/core/Mage/GiftMessage/Model/Api/V2.php
@@ -24,7 +24,7 @@ class Mage_GiftMessage_Model_Api_V2 extends Mage_GiftMessage_Model_Api
     /**
      * Return an Array of Object attributes.
      *
-     * @param Mixed $data
+     * @param object|array $data
      * @return array
      */
     protected function _prepareData($data)

--- a/app/code/core/Mage/Page/Block/Switch.php
+++ b/app/code/core/Mage/Page/Block/Switch.php
@@ -42,7 +42,7 @@ class Mage_Page_Block_Switch extends Mage_Core_Block_Template
     }
 
     /**
-     * @return int
+     * @return string
      * @throws Mage_Core_Model_Store_Exception
      */
     public function getCurrentStoreId()

--- a/app/code/core/Mage/Paypal/Model/Payflowlink.php
+++ b/app/code/core/Mage/Paypal/Model/Payflowlink.php
@@ -421,13 +421,13 @@ class Mage_Paypal_Model_Payflowlink extends Mage_Paypal_Model_Payflowpro
      * Get store id from response if exists
      * or default
      *
-     * @return int
+     * @return string
      */
     protected function _getStoreId()
     {
         $response = $this->getResponse();
         if ($response->getUser1()) {
-            return (int) $response->getUser1();
+            return $response->getUser1();
         }
 
         return Mage::app()->getStore($this->getStore())->getId();
@@ -438,6 +438,7 @@ class Mage_Paypal_Model_Payflowlink extends Mage_Paypal_Model_Payflowpro
      *
      * @return Mage_Paypal_Model_Payflow_Request
      */
+    // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClass
     protected function _buildBasicRequest(Varien_Object $payment)
     {
         $request = Mage::getModel('paypal/payflow_request');
@@ -566,6 +567,7 @@ class Mage_Paypal_Model_Payflowlink extends Mage_Paypal_Model_Payflowpro
      * @param mixed $amount
      * @return $this
      */
+    // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassAfterLastUsed
     protected function _initialize(Varien_Object $payment, $amount)
     {
         return $this;
@@ -590,6 +592,7 @@ class Mage_Paypal_Model_Payflowlink extends Mage_Paypal_Model_Payflowpro
      * @param string $txnId
      * @return $this
      */
+    // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassAfterLastUsed
     protected function _authorize(Varien_Object $payment, $amount, $transaction, $txnId)
     {
         return $this;
@@ -612,6 +615,7 @@ class Mage_Paypal_Model_Payflowlink extends Mage_Paypal_Model_Payflowpro
      * @param mixed $amount
      * @return $this
      */
+    // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassAfterLastUsed
     protected function _checkTransaction($transaction, $amount)
     {
         return $this;

--- a/app/code/core/Mage/Reports/Model/Product/Index/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Product/Index/Abstract.php
@@ -113,7 +113,7 @@ abstract class Mage_Reports_Model_Product_Index_Abstract extends Mage_Core_Model
      *
      * default return current store id
      *
-     * @return int
+     * @return string
      */
     public function getStoreId()
     {

--- a/app/code/core/Mage/Rss/Block/List.php
+++ b/app/code/core/Mage/Rss/Block/List.php
@@ -86,7 +86,7 @@ class Mage_Rss_Block_List extends Mage_Core_Block_Template
     }
 
     /**
-     * @return int
+     * @return string
      * @throws Mage_Core_Model_Store_Exception
      */
     public function getCurrentStoreId()

--- a/app/code/core/Mage/Sales/Block/Order/Comments.php
+++ b/app/code/core/Mage/Sales/Block/Order/Comments.php
@@ -75,7 +75,9 @@ class Mage_Sales_Block_Order_Comments extends Mage_Core_Block_Template
                 Mage::throwException(Mage::helper('sales')->__('Invalid entity model'));
             }
 
-            $this->_commentCollection = Mage::getResourceModel($collectionClass);
+            /** @var Mage_Sales_Model_Resource_Order_Comment_Collection_Abstract $commentCollection */
+            $commentCollection = Mage::getResourceModel($collectionClass);
+            $this->_commentCollection = $commentCollection;
             $this->_commentCollection->setParentFilter($entity)
                ->setCreatedAtOrder()
                ->addVisibleOnFrontFilter();

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend.php
@@ -20,7 +20,7 @@
 class Mage_Sales_Model_Entity_Quote_Address_Attribute_Frontend extends Mage_Eav_Model_Entity_Attribute_Frontend_Abstract
 {
     /**
-     * @return array
+     * @return $this|array
      */
     public function fetchTotals(Mage_Sales_Model_Quote_Address $address)
     {

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Item/Collection.php
@@ -34,7 +34,7 @@ class Mage_Sales_Model_Entity_Quote_Item_Collection extends Mage_Eav_Model_Entit
     }
 
     /**
-     * @return int
+     * @return string
      */
     public function getStoreId()
     {

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Track.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Track.php
@@ -166,7 +166,7 @@ class Mage_Sales_Model_Order_Shipment_Track extends Mage_Sales_Model_Abstract
     /**
      * Get store id
      *
-     * @return int
+     * @return string
      */
     public function getStoreId()
     {

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -254,7 +254,7 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
     /**
      * Get quote store identifier
      *
-     * @return int
+     * @return string
      */
     public function getStoreId()
     {

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Abstract.php
@@ -98,7 +98,7 @@ abstract class Mage_Sales_Model_Quote_Address_Total_Abstract
     /**
      * Fetch (Retrieve data as array)
      *
-     * @return array
+     * @return $this|array
      */
     public function fetch(Mage_Sales_Model_Quote_Address $address)
     {

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Shipping.php
@@ -78,7 +78,7 @@ class Mage_Sales_Model_Quote_Address_Total_Nominal_Shipping extends Mage_Sales_M
     /**
      * Don't fetch anything
      *
-     * @return array
+     * @return array|Mage_Sales_Model_Quote_Address_Total_Abstract
      */
     public function fetch(Mage_Sales_Model_Quote_Address $address)
     {

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Subtotal.php
@@ -38,7 +38,7 @@ class Mage_Sales_Model_Quote_Address_Total_Nominal_Subtotal extends Mage_Sales_M
     /**
      * Don't fetch anything
      *
-     * @return array
+     * @return array|Mage_Sales_Model_Quote_Address_Total_Abstract
      */
     public function fetch(Mage_Sales_Model_Quote_Address $address)
     {

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Shipping.php
@@ -165,7 +165,7 @@ class Mage_Sales_Model_Quote_Address_Total_Shipping extends Mage_Sales_Model_Quo
     /**
      * Add shipping totals information to address object
      *
-     * @return  Mage_Sales_Model_Quote_Address_Total_Shipping
+     * @return $this
      */
     public function fetch(Mage_Sales_Model_Quote_Address $address)
     {

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend.php
@@ -24,8 +24,9 @@ class Mage_Sales_Model_Resource_Quote_Address_Attribute_Frontend extends Mage_Ea
     /**
      * Fetch totals
      *
-     * @return array
+     * @return $this|array
      */
+    // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClass
     public function fetchTotals(Mage_Sales_Model_Quote_Address $address)
     {
         return [];

--- a/app/code/core/Mage/Tax/Model/Calculation.php
+++ b/app/code/core/Mage/Tax/Model/Calculation.php
@@ -163,7 +163,7 @@ class Mage_Tax_Model_Calculation extends Mage_Core_Model_Abstract
     /**
      * Get customer object
      *
-     * @return  Mage_Customer_Model_Customer | false
+     * @return Mage_Customer_Model_Customer|false
      */
     public function getCustomer()
     {

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Nominal/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Nominal/Tax.php
@@ -38,7 +38,7 @@ class Mage_Tax_Model_Sales_Total_Quote_Nominal_Tax extends Mage_Tax_Model_Sales_
     /**
      * Don't fetch anything
      *
-     * @return array
+     * @return array|Mage_Sales_Model_Quote_Address_Total_Abstract
      */
     public function fetch(Mage_Sales_Model_Quote_Address $address)
     {

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
@@ -398,7 +398,7 @@ class Mage_Usa_Model_Shipping_Carrier_Dhl_International extends Mage_Usa_Model_S
     /**
      * Get configuration data of carrier
      *
-     * @param strin $type
+     * @param string $type
      * @param string $code
      * @return array|bool
      */

--- a/app/code/core/Mage/Widget/etc/config.xml
+++ b/app/code/core/Mage/Widget/etc/config.xml
@@ -17,7 +17,7 @@
 <config>
     <modules>
         <Mage_Widget>
-            <version>1.6.0.0</version>
+            <version>1.6.0.1</version>
         </Mage_Widget>
     </modules>
     <global>

--- a/app/code/core/Mage/Widget/sql/widget_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Widget/sql/widget_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   Mage
+ * @package    Mage_Widget
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Core_Model_Resource_Setup $installer */
+$installer = $this;
+$installer->startSetup();
+
+$installer->getConnection()->changeColumn(
+    $installer->getTable('widget/widget_instance_page'),
+    'page_group',
+    'page_group',
+    [
+        'type'      => Varien_Db_Ddl_Table::TYPE_TEXT,
+        'length'    => 255
+    ]
+);
+
+$installer->getConnection()->changeColumn(
+    $installer->getTable('widget/widget_instance_page'),
+    'page_for',
+    'page_for',
+    [
+        'type'      => Varien_Db_Ddl_Table::TYPE_TEXT,
+        'length'    => 255
+    ]
+);

--- a/composer.lock
+++ b/composer.lock
@@ -3898,16 +3898,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.3",
+            "version": "1.12.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "0fcbf194ab63d8159bb70d9aa3e1350051632009"
+                "reference": "7e6c6cb7cecb0a6254009a1a8a7d54ec99812b17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/0fcbf194ab63d8159bb70d9aa3e1350051632009",
-                "reference": "0fcbf194ab63d8159bb70d9aa3e1350051632009",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7e6c6cb7cecb0a6254009a1a8a7d54ec99812b17",
+                "reference": "7e6c6cb7cecb0a6254009a1a8a7d54ec99812b17",
                 "shasum": ""
             },
             "require": {
@@ -3952,7 +3952,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-09-09T08:10:35+00:00"
+            "time": "2024-09-26T12:45:22+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/lib/Varien/Data/Form/Element/Abstract.php
+++ b/lib/Varien/Data/Form/Element/Abstract.php
@@ -29,6 +29,8 @@
  * @method bool getNoSpan()
  * @method $this setName(string $value)
  * @method bool getRequired()
+ * @method string getScopeLabel()
+ * @method $this setScopeLabel(string $value)
  * @method string getValue()
  * @method array getValues()
  * @method $this setValues(array|int|string $value)

--- a/lib/Varien/Data/Form/Filter/Date.php
+++ b/lib/Varien/Data/Form/Filter/Date.php
@@ -31,7 +31,7 @@ class Varien_Data_Form_Filter_Date implements Varien_Data_Form_Filter_Interface
     /**
      * Local
      *
-     * @var Zend_Locale
+     * @var string|Zend_Locale
      */
     protected $_locale;
 
@@ -39,7 +39,7 @@ class Varien_Data_Form_Filter_Date implements Varien_Data_Form_Filter_Interface
      * Initialize filter
      *
      * @param string $format    Zend_Date input/output format
-     * @param Zend_Locale $locale
+     * @param string|Zend_Locale $locale
      */
     public function __construct($format = null, $locale = null)
     {
@@ -53,8 +53,8 @@ class Varien_Data_Form_Filter_Date implements Varien_Data_Form_Filter_Interface
     /**
      * Returns the result of filtering $value
      *
-     * @param string $value
-     * @return string
+     * @param string|null $value
+     * @return string|null
      */
     public function inputFilter($value)
     {

--- a/lib/Varien/Data/Form/Filter/Datetime.php
+++ b/lib/Varien/Data/Form/Filter/Datetime.php
@@ -24,8 +24,8 @@ class Varien_Data_Form_Filter_Datetime extends Varien_Data_Form_Filter_Date
     /**
      * Returns the result of filtering $value
      *
-     * @param string $value
-     * @return string
+     * @param string|null $value
+     * @return string|null
      */
     public function inputFilter($value)
     {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,21 @@
         </testsuite>
     </testsuites>
 
+    <php>
+        <env name="OPENMAGE_CONFIG__DEFAULT__GENERAL__STORE_INFORMATION__NAME" value="ENV default"/>
+        <env name="OPENMAGE_CONFIG__DEFAULT__GENERAL__FOO-BAR__NAME" value="ENV default dashes"/>
+        <env name="OPENMAGE_CONFIG__DEFAULT__GENERAL__FOO_BAR__NAME" value="ENV default underscore"/>
+        <env name="OPENMAGE_CONFIG__DEFAULT__GENERAL__ST" value="ENV default invalid"/>
+        <env name="OPENMAGE_CONFIG__WEBSITES__BASE__GENERAL__STORE_INFORMATION__NAME" value="ENV website"/>
+        <env name="OPENMAGE_CONFIG__WEBSITES__BASE-AT__GENERAL__STORE_INFORMATION__NAME" value="ENV website dashes"/>
+        <env name="OPENMAGE_CONFIG__WEBSITES__BASE_CH__GENERAL__STORE_INFORMATION__NAME" value="ENV website underscore"/>
+        <env name="OPENMAGE_CONFIG__WEBSITES__BASE__GENERAL__ST" value="ENV website invalid"/>
+        <env name="OPENMAGE_CONFIG__STORES__GERMAN__GENERAL__STORE_INFORMATION__NAME" value="ENV store"/>
+        <env name="OPENMAGE_CONFIG__STORES__GERMAN-AT__GENERAL__STORE_INFORMATION__NAME" value="ENV store dashes"/>
+        <env name="OPENMAGE_CONFIG__STORES__GERMAN_CH__GENERAL__STORE_INFORMATION__NAME" value="ENV store underscore"/>
+        <env name="OPENMAGE_CONFIG__STORES__GERMAN__GENERAL__ST" value="ENV store invalid"/>
+    </php>
+
     <coverage
         includeUncoveredFiles="true"
         processUncoveredFiles="false"

--- a/rector.php
+++ b/rector.php
@@ -19,11 +19,12 @@ return RectorConfig::configure()
     ])
     ->withSkipPath(__DIR__ . '/vendor')
     ->withSkip([
+        CodeQuality\BooleanNot\SimplifyDeMorganBinaryRector::class,
+        CodeQuality\If_\SimplifyIfReturnBoolRector::class,
         __DIR__ . '/shell/translations.php',
         __DIR__ . '/shell/update-copyright.php.php'
     ])
     ->withRules([
-//        CodeQuality\BooleanNot\SimplifyDeMorganBinaryRector::class, # wait for https://github.com/rectorphp/rector/issues/8781
         CodeQuality\BooleanNot\ReplaceMultipleBooleanNotRector::class,
         CodeQuality\Foreach_\UnusedForeachValueToArrayKeysRector::class,
         CodeQuality\FuncCall\ChangeArrayPushToArrayAssignRector::class,
@@ -31,7 +32,6 @@ return RectorConfig::configure()
         CodeQuality\Identical\SimplifyArraySearchRector::class,
         CodeQuality\Identical\SimplifyConditionsRector::class,
         CodeQuality\Identical\StrlenZeroToIdenticalEmptyStringRector::class,
-//        CodeQuality\If_\SimplifyIfReturnBoolRector::class,
         CodeQuality\NotEqual\CommonNotEqualRector::class,
         CodeQuality\LogicalAnd\LogicalToBooleanRector::class,
         CodeQuality\Ternary\SimplifyTautologyTernaryRector::class,

--- a/tests/unit/Base/ClassLoadingTest.php
+++ b/tests/unit/Base/ClassLoadingTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Base;
 
+use Generator;
 use PHPUnit\Framework\TestCase;
 
 class ClassLoadingTest extends TestCase
@@ -30,24 +31,19 @@ class ClassLoadingTest extends TestCase
         $this->assertSame($expectedResult, class_exists($class));
     }
 
-    /**
-     * @return array<string, array<int, bool|string>>
-     */
-    public function provideClassExistsData(): array
+    public function provideClassExistsData(): Generator
     {
-        return [
-            'class exists #1' => [
-                true,
-                'Mage'
-            ],
-            'class exists #2' => [
-                true,
-                'Mage_Eav_Model_Entity_Increment_Numeric'
-            ],
-            'class not exists' => [
-                false,
-                'Mage_Non_Existent'
-            ],
+        yield 'class exists #1' => [
+            true,
+            'Mage'
+        ];
+        yield 'class exists #2' => [
+            true,
+            'Mage_Eav_Model_Entity_Increment_Numeric'
+        ];
+        yield 'class not exists' => [
+            false,
+            'Mage_Non_Existent'
         ];
     }
 }

--- a/tests/unit/Base/ClassLoadingTest.php
+++ b/tests/unit/Base/ClassLoadingTest.php
@@ -22,11 +22,12 @@ use PHPUnit\Framework\TestCase;
 class ClassLoadingTest extends TestCase
 {
     /**
+     * @group Base
      * @dataProvider provideClassExistsData
      */
     public function testClassExists(bool $expectedResult, string $class): void
     {
-        $this->assertEquals($expectedResult, class_exists($class));
+        $this->assertSame($expectedResult, class_exists($class));
     }
 
     /**

--- a/tests/unit/Base/XmlFileLoadingTest.php
+++ b/tests/unit/Base/XmlFileLoadingTest.php
@@ -24,7 +24,7 @@ use XMLReader;
 class XmlFileLoadingTest extends TestCase
 {
     /**
-     *
+     * @group Base
      * @dataProvider provideXmlFiles
      */
     public function testFileLoading(string $filepath): void
@@ -39,7 +39,7 @@ class XmlFileLoadingTest extends TestCase
     }
 
     /**
-     *
+     * @group Base
      * @dataProvider provideXmlFiles
      */
     public function testXmlReaderIsValid(string $filepath): void

--- a/tests/unit/Mage/Admin/Model/BlockTest.php
+++ b/tests/unit/Mage/Admin/Model/BlockTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   OpenMage
+ * @package    OpenMage_Tests
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Admin\Model;
+
+use Generator;
+use Mage;
+use Mage_Admin_Model_Block;
+use PHPUnit\Framework\TestCase;
+
+class BlockTest extends TestCase
+{
+    public Mage_Admin_Model_Block $subject;
+
+    public function setUp(): void
+    {
+        Mage::app();
+        $this->subject = Mage::getModel('admin/block');
+    }
+
+    /**
+     * @dataProvider provideValidateData
+     * @param array<int, string> $expectedResult
+     *
+     * @group Mage_Admin
+     * @group Mage_Admin_Model
+     */
+    public function testValidate(array $expectedResult, array $methods): void
+    {
+        $mock = $this->getMockBuilder(Mage_Admin_Model_Block::class)
+            ->setMethods([
+                'getBlockName',
+                'getIsAllowed',
+            ])
+            ->getMock();
+
+        $mock->expects($this->any())->method('getBlockName')->willReturn($methods['getBlockName']);
+        $mock->expects($this->any())->method('getIsAllowed')->willReturn($methods['getIsAllowed']);
+        $this->assertEquals($expectedResult, $mock->validate());
+    }
+
+    public function provideValidateData(): Generator
+    {
+        yield 'errors' => [
+            [
+                0 => 'Block Name is required field.',
+                1 => 'Block Name is incorrect.',
+                2 => 'Is Allowed is required field.',
+            ],
+            [
+                'getBlockName' => '',
+                'getIsAllowed' => '',
+            ]
+        ];
+    }
+
+    /**
+     * @group Mage_Admin
+     * @group Mage_Admin_Model
+     */
+    public function testIsTypeAllowed(): void
+    {
+        $this->assertIsBool($this->subject->isTypeAllowed('invalid-type'));
+    }
+}

--- a/tests/unit/Mage/Admin/Model/ConfigTest.php
+++ b/tests/unit/Mage/Admin/Model/ConfigTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   OpenMage
+ * @package    OpenMage_Tests
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Admin\Model;
+
+use Mage;
+use Mage_Admin_Model_Acl;
+use Mage_Admin_Model_Config;
+use PHPUnit\Framework\TestCase;
+use Varien_Simplexml_Config;
+
+class ConfigTest extends TestCase
+{
+    public Mage_Admin_Model_Config $subject;
+
+    public function setUp(): void
+    {
+        Mage::app();
+        $this->subject = Mage::getModel('admin/config');
+    }
+
+    /**
+     * @group Mage_Admin
+     * @group Mage_Admin_Model
+     */
+    public function testGetAclAssert(): void
+    {
+        $this->assertFalse($this->subject->getAclAssert(''));
+    }
+
+    /**
+     * @group Mage_Admin
+     * @group Mage_Admin_Model
+     */
+    public function testGetAclPrivilegeSet(): void
+    {
+        $this->assertFalse($this->subject->getAclPrivilegeSet());
+    }
+
+    /**
+     * @group Mage_Admin
+     * @group Mage_Admin_Model
+     */
+    public function testLoadAclResources(): void
+    {
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
+        $this->assertInstanceOf(Mage_Admin_Model_Config::class, $this->subject->loadAclResources(new Mage_Admin_Model_Acl()));
+    }
+
+    /**
+     * @group Mage_Admin
+     * @group Mage_Admin_Model
+     */
+    public function testGetAdminhtmlConfig(): void
+    {
+        $this->assertInstanceOf(Varien_Simplexml_Config::class, $this->subject->getAdminhtmlConfig());
+    }
+}

--- a/tests/unit/Mage/Admin/Model/UserTest.php
+++ b/tests/unit/Mage/Admin/Model/UserTest.php
@@ -17,8 +17,10 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Admin\Model;
 
+use Generator;
 use Mage;
 use Mage_Admin_Model_User;
+use Mage_Core_Exception;
 use PHPUnit\Framework\TestCase;
 
 class UserTest extends TestCase
@@ -32,9 +34,94 @@ class UserTest extends TestCase
     }
 
     /**
+     * @dataProvider provideAuthenticateData
+     * @param array|true $expectedResult
+     * @group Model
+     * @group Mage_Admin
+     * @group Mage_Admin_Model
+     * @group runInSeparateProcess
+     * @runInSeparateProcess
+     */
+    public function testAuthenticate($expectedResult, array $methods): void
+    {
+        $mock = $this->getMockBuilder(Mage_Admin_Model_User::class)
+            ->setMethods([
+                'loadByUsername',
+                'getId',
+                'getUsername',
+                'getPassword',
+                'getIsActive',
+                'validatePasswordHash',
+                'hasAssigned2Role',
+            ])
+            ->getMock();
+
+        $mock->expects($this->any())->method('loadByUsername')->willReturnSelf();
+        $mock->expects($this->any())->method('getId')->willReturn($methods['getId']);
+//        $mock->expects($this->any())->method('getUsername')->willReturn($methods['getUsername']);
+        $mock->expects($this->any())->method('getPassword')->willReturn($methods['getPassword']);
+        $mock->expects($this->any())->method('validatePasswordHash')->willReturn($methods['validatePasswordHash']);
+        $mock->expects($this->any())->method('getIsActive')->willReturn($methods['getIsActive']);
+        $mock->expects($this->any())->method('hasAssigned2Role')->willReturn($methods['hasAssigned2Role']);
+
+        try {
+            $this->assertSame($expectedResult, $mock->authenticate($methods['getUsername'], $methods['getPassword']));
+        } catch (Mage_Core_Exception $e) {
+            $this->assertSame($expectedResult, $e->getMessage());
+        }
+    }
+
+    public function provideAuthenticateData(): Generator
+    {
+        yield 'pass' => [
+            true,
+            [
+                'getId'       => '1',
+                'getUsername' => 'admin',
+                'getPassword' => 'veryl0ngpassw0rd',
+                'getIsActive' => '1',
+                'validatePasswordHash' => true,
+                'hasAssigned2Role' => true,
+            ]
+        ];
+        yield 'fail #1 inactive' => [
+            'This account is inactive.',
+            [
+                'getId'       => '1',
+                'getUsername' => 'admin',
+                'getPassword' => 'veryl0ngpassw0rd',
+                'getIsActive' => '0',
+                'validatePasswordHash' => true,
+                'hasAssigned2Role' => true,
+            ]
+        ];
+        yield 'fail #2 invalid hash' => [
+            false,
+            [
+                'getId'       => '1',
+                'getUsername' => 'admin',
+                'getPassword' => 'veryl0ngpassw0rd',
+                'getIsActive' => '1',
+                'validatePasswordHash' => false,
+                'hasAssigned2Role' => true,
+            ]
+        ];
+        yield 'fail #3 no role assigned' => [
+            'Access denied.',
+            [
+                'getId'       => '1',
+                'getUsername' => 'admin',
+                'getPassword' => 'veryl0ngpassw0rd',
+                'getIsActive' => '1',
+                'validatePasswordHash' => true,
+                'hasAssigned2Role' => false,
+            ]
+        ];
+    }
+
+    /**
      * @dataProvider provideValidateData
      * @param array|true $expectedResult
-     *
      * @group Mage_Admin
      * @group Mage_Admin_Model
      */
@@ -53,48 +140,42 @@ class UserTest extends TestCase
         $mock->expects($this->any())->method('getNewPassword')->willReturn($methods['getNewPassword']);
         $mock->expects($this->any())->method('hasPassword')->willReturn($methods['hasPassword']);
         $mock->expects($this->any())->method('getPassword')->willReturn($methods['getPassword']);
-        // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
-        $this->assertEquals($expectedResult, $mock->validate());
+        $this->assertSame($expectedResult, $mock->validate());
     }
 
-    /**
-     * @return array<string, array<int, bool|array|string>>
-     */
-    public function provideValidateData(): array
+    public function provideValidateData(): Generator
     {
-        return [
-            'test_fails_1' => [
-                [
-                    0 => 'User Name is required field.',
-                    1 => 'First Name is required field.',
-                    2 => 'Last Name is required field.',
-                    3 => 'Please enter a valid email.',
-                    4 => 'Password must be at least of 14 characters.',
-                    5 => 'Password must include both numeric and alphabetic characters.',
-                ],
-                [
-                    'hasNewPassword' => true,
-                    'getNewPassword' => '123',
-                    'hasPassword' => false,
-                    'getPassword' => '456',
-                ]
+        yield 'fail #1' => [
+            [
+                0 => 'User Name is required field.',
+                1 => 'First Name is required field.',
+                2 => 'Last Name is required field.',
+                3 => 'Please enter a valid email.',
+                4 => 'Password must be at least of 14 characters.',
+                5 => 'Password must include both numeric and alphabetic characters.',
             ],
-            'test_fails_2' => [
-                [
-                    0 => 'User Name is required field.',
-                    1 => 'First Name is required field.',
-                    2 => 'Last Name is required field.',
-                    3 => 'Please enter a valid email.',
-                    4 => 'Password must be at least of 14 characters.',
-                    5 => 'Password must include both numeric and alphabetic characters.',
-                ],
-                [
-                    'hasNewPassword' => false,
-                    'getNewPassword' => '123',
-                    'hasPassword' => true,
-                    'getPassword' => '456',
-                ]
+            [
+                'hasNewPassword' => true,
+                'getNewPassword' => '123',
+                'hasPassword' => false,
+                'getPassword' => '456',
+            ]
+        ];
+        yield 'fails #2' => [
+            [
+                0 => 'User Name is required field.',
+                1 => 'First Name is required field.',
+                2 => 'Last Name is required field.',
+                3 => 'Please enter a valid email.',
+                4 => 'Password must be at least of 14 characters.',
+                5 => 'Password must include both numeric and alphabetic characters.',
             ],
+            [
+                'hasNewPassword' => false,
+                'getNewPassword' => '123',
+                'hasPassword' => true,
+                'getPassword' => '456',
+            ]
         ];
     }
 
@@ -121,18 +202,56 @@ class UserTest extends TestCase
      * @group Mage_Admin
      * @group Mage_Admin_Model
      */
+    public function testHasAssigned2Role(): void
+    {
+        $this->assertIsArray($this->subject->hasAssigned2Role(1));
+    }
+
+    /**
+     * @group Model
+     * @group Mage_Admin
+     * @group Mage_Admin_Model
+     */
     public function testChangeResetPasswordLinkToken(): void
     {
         $this->assertInstanceOf(Mage_Admin_Model_User::class, $this->subject->changeResetPasswordLinkToken('123'));
     }
 
     /**
+     * @dataProvider provideIsResetPasswordLinkTokenExpiredData
      * @group Mage_Admin
      * @group Mage_Admin_Model
      */
-    public function testIsResetPasswordLinkTokenExpired(): void
+    public function testIsResetPasswordLinkTokenExpired(bool $expectedResult, array $methods): void
     {
-        $this->assertIsBool($this->subject->isResetPasswordLinkTokenExpired());
+        $mock = $this->getMockBuilder(Mage_Admin_Model_User::class)
+            ->setMethods([
+                'getRpToken',
+                'getRpTokenCreatedAt',
+            ])
+            ->getMock();
+
+        $mock->expects($this->any())->method('getRpToken')->willReturn($methods['getRpToken']);
+        $mock->expects($this->any())->method('getRpTokenCreatedAt')->willReturn($methods['getRpTokenCreatedAt']);
+        $this->assertSame($expectedResult, $mock->isResetPasswordLinkTokenExpired());
+    }
+
+    public function provideIsResetPasswordLinkTokenExpiredData(): Generator
+    {
+        yield '#1' => [
+            true,
+            [
+                'getRpToken'       => '',
+                'getRpTokenCreatedAt' => '',
+            ]
+        ];
+        yield '#2' => [
+            true,
+            [
+                'getRpToken'       => '1',
+                'getRpTokenCreatedAt' => '0',
+            ]
+        ];
     }
 
     /**

--- a/tests/unit/Mage/Admin/Model/VariableTest.php
+++ b/tests/unit/Mage/Admin/Model/VariableTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Admin\Model;
 
+use Generator;
 use Mage;
 use Mage_Admin_Model_Variable;
 use PHPUnit\Framework\TestCase;
@@ -33,9 +34,10 @@ class VariableTest extends TestCase
 
     /**
      * @dataProvider provideValidateData
-     * @param array|true $expectedResult
-     *
      * @group Mage_Admin
+     * @group Mage_Admin_Model
+     *
+     * @param array|true $expectedResult
      */
     public function testValidate($expectedResult, string $variableName, string $isAllowed): void
     {
@@ -48,32 +50,27 @@ class VariableTest extends TestCase
         $this->assertSame($expectedResult, $mock->validate());
     }
 
-    /**
-     * @return array<string, array<int, bool|array|string>>
-     */
-    public function provideValidateData(): array
+    public function provideValidateData(): Generator
     {
-        return [
-            'test_passes' => [
-                true,
-                'test',
-                '1'
-            ],
-            'test_error_empty' => [
-                [0 => 'Variable Name is required field.'],
-                '',
-                '1'
-            ],
-            'test_error_regex' => [
-                [0 => 'Variable Name is incorrect.'],
-                '#invalid-name#',
-                '1'
-            ],
-            'test_error_allowed' => [
-                [0 => 'Is Allowed is required field.'],
-                'test',
-                'invalid'
-            ],
+        yield 'test passes' => [
+            true,
+            'test',
+            '1'
+        ];
+        yield 'test error empty' => [
+            [0 => 'Variable Name is required field.'],
+            '',
+            '1'
+        ];
+        yield 'test error regex' => [
+            [0 => 'Variable Name is incorrect.'],
+            '#invalid-name#',
+            '1'
+        ];
+        yield 'test error allowed' => [
+            [0 => 'Is Allowed is required field.'],
+            'test',
+            'invalid'
         ];
     }
 

--- a/tests/unit/Mage/Admin/Model/VariableTest.php
+++ b/tests/unit/Mage/Admin/Model/VariableTest.php
@@ -45,7 +45,7 @@ class VariableTest extends TestCase
 
         $mock->expects($this->any())->method('getVariableName')->willReturn($variableName);
         $mock->expects($this->any())->method('getIsAllowed')->willReturn($isAllowed);
-        $this->assertEquals($expectedResult, $mock->validate());
+        $this->assertSame($expectedResult, $mock->validate());
     }
 
     /**

--- a/tests/unit/Mage/Catalog/Model/CategoryTest.php
+++ b/tests/unit/Mage/Catalog/Model/CategoryTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   OpenMage
+ * @package    OpenMage_Tests
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Catalog\Model;
+
+use Mage;
+use Mage_Catalog_Model_Category;
+use Mage_Catalog_Model_Resource_Product_Collection;
+use PHPUnit\Framework\TestCase;
+
+class CategoryTest extends TestCase
+{
+    public Mage_Catalog_Model_Category $subject;
+
+    public function setUp(): void
+    {
+        Mage::app();
+        $this->subject = Mage::getModel('catalog/category');
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetDefaultAttributeSetId(): void
+    {
+        $this->assertIsString($this->subject->getDefaultAttributeSetId());
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetProductCollection(): void
+    {
+        $this->assertInstanceOf(Mage_Catalog_Model_Resource_Product_Collection::class, $this->subject->getProductCollection());
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetAvailableSortByOptions(): void
+    {
+        $this->assertIsArray($this->subject->getAvailableSortByOptions());
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetDefaultSortBy(): void
+    {
+        $this->assertSame('position', $this->subject->getDefaultSortBy());
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testValidate(): void
+    {
+        $this->assertIsArray($this->subject->validate());
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testAfterCommitCallback(): void
+    {
+        $this->assertInstanceOf(Mage_Catalog_Model_Category::class, $this->subject->afterCommitCallback());
+    }
+}

--- a/tests/unit/Mage/Catalog/Model/ProductTest.php
+++ b/tests/unit/Mage/Catalog/Model/ProductTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Catalog\Model;
 
+use Generator;
 use Mage;
 use Mage_Catalog_Model_Product;
 use Mage_Catalog_Model_Product_Link;
@@ -119,7 +120,6 @@ class ProductTest extends TestCase
 
     /**
      * @dataProvider provideTypeInstanceData
-     *
      * @group Mage_Catalog
      * @group Mage_Catalog_Model
      */
@@ -128,15 +128,13 @@ class ProductTest extends TestCase
         $this->assertInstanceOf(Mage_Catalog_Model_Product_Type_Abstract::class, $this->subject->getTypeInstance($singleton));
     }
 
-    public function provideTypeInstanceData(): array
+    public function provideTypeInstanceData(): Generator
     {
-        return [
-            'singleton false' => [
-                true,
-            ],
-            'singleton true' => [
-                false,
-            ],
+        yield 'singleton false' => [
+            true,
+        ];
+        yield 'singleton true' => [
+            true,
         ];
     }
 

--- a/tests/unit/Mage/Catalog/Model/ProductTest.php
+++ b/tests/unit/Mage/Catalog/Model/ProductTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   OpenMage
+ * @package    OpenMage_Tests
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Catalog\Model;
+
+use Mage;
+use Mage_Catalog_Model_Product;
+use Mage_Catalog_Model_Product_Link;
+use Mage_Catalog_Model_Product_Type_Abstract;
+use Mage_Catalog_Model_Product_Url;
+use Mage_Catalog_Model_Resource_Product_Collection;
+use PHPUnit\Framework\TestCase;
+
+class ProductTest extends TestCase
+{
+    public Mage_Catalog_Model_Product $subject;
+
+    public function setUp(): void
+    {
+        Mage::app();
+        $this->subject = Mage::getModel('catalog/product');
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetStoreId(): void
+    {
+        $this->assertSame('1', $this->subject->getStoreId());
+    }
+
+     /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetResourceCollection(): void
+    {
+        $this->assertInstanceOf(Mage_Catalog_Model_Resource_Product_Collection::class, $this->subject->getResourceCollection());
+    }
+
+     /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetUrlModel(): void
+    {
+        $this->assertInstanceOf(Mage_Catalog_Model_Product_Url::class, $this->subject->getUrlModel());
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testValidate(): void
+    {
+        $this->assertInstanceOf(Mage_Catalog_Model_Product::class, $this->subject->validate());
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+//    public function testGetName(): void
+//    {
+//        $this->assertNull($this->subject->getName());
+//        $this->assertIsString($this->subject->getName());
+//    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+//    public function testGetPrice(): void
+//    {
+//        $this->assertIsFloat($this->subject->getPrice());
+//    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testSetPriceCalculation(): void
+    {
+        $this->assertInstanceOf(Mage_Catalog_Model_Product::class, $this->subject->setPriceCalculation());
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+//    public function testGetTypeId(): void
+//    {
+//        $this->assertIsString($this->subject->getTypeId());
+//    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetStatus(): void
+    {
+        $this->assertSame(1, $this->subject->getStatus());
+    }
+
+    /**
+     * @dataProvider provideTypeInstanceData
+     *
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetTypeInstance(bool $singleton): void
+    {
+        $this->assertInstanceOf(Mage_Catalog_Model_Product_Type_Abstract::class, $this->subject->getTypeInstance($singleton));
+    }
+
+    public function provideTypeInstanceData(): array
+    {
+        return [
+            'singleton false' => [
+                true,
+            ],
+            'singleton true' => [
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetLinkInstance(): void
+    {
+        $this->assertInstanceOf(Mage_Catalog_Model_Product_Link::class, $this->subject->getLinkInstance());
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetDefaultAttributeSetId(): void
+    {
+        $this->assertSame('4', $this->subject->getDefaultAttributeSetId());
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testAfterCommitCallback(): void
+    {
+        $this->assertInstanceOf(Mage_Catalog_Model_Product::class, $this->subject->afterCommitCallback());
+    }
+}

--- a/tests/unit/Mage/Catalog/Model/ProductTest.php
+++ b/tests/unit/Mage/Catalog/Model/ProductTest.php
@@ -45,7 +45,7 @@ class ProductTest extends TestCase
         $this->assertSame('1', $this->subject->getStoreId());
     }
 
-     /**
+    /**
      * @group Mage_Catalog
      * @group Mage_Catalog_Model
      */
@@ -54,7 +54,7 @@ class ProductTest extends TestCase
         $this->assertInstanceOf(Mage_Catalog_Model_Resource_Product_Collection::class, $this->subject->getResourceCollection());
     }
 
-     /**
+    /**
      * @group Mage_Catalog
      * @group Mage_Catalog_Model
      */

--- a/tests/unit/Mage/Catalog/Model/UrlTest.php
+++ b/tests/unit/Mage/Catalog/Model/UrlTest.php
@@ -122,7 +122,7 @@ class UrlTest extends TestCase
                 null,
                 $category,
             ],
-           'target product' => [
+            'target product' => [
                 'catalog/product/view/id/999',
                'target',
                $product,

--- a/tests/unit/Mage/Catalog/Model/UrlTest.php
+++ b/tests/unit/Mage/Catalog/Model/UrlTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Catalog\Model;
 
+use Generator;
 use Mage;
 use Mage_Catalog_Model_Url;
 use Mage_Core_Exception;
@@ -43,7 +44,7 @@ class UrlTest extends TestCase
     }
 
     /**
-     * @dataProvider provideRefreshRewritesData
+     * @dataProvider provideRefreshRewrites
      *
      * @group Mage_Catalog
      * @group Mage_Catalog_Model
@@ -53,15 +54,16 @@ class UrlTest extends TestCase
         $this->assertInstanceOf(Mage_Catalog_Model_Url::class, $this->subject->refreshRewrites($storeId));
     }
 
-    public function provideRefreshRewritesData(): array
+    public function provideRefreshRewrites(): Generator
     {
-        return [
-            'w/o storeId' => [
-                null,
-            ],
-            'w/ storeId' => [
-                2,
-            ],
+        yield 'w/o storeId' => [
+            null,
+        ];
+        yield 'w/ valid storeId' => [
+            1,
+        ];
+        yield 'w/ invalid storeId' => [
+            999,
         ];
     }
 

--- a/tests/unit/Mage/Catalog/Model/UrlTest.php
+++ b/tests/unit/Mage/Catalog/Model/UrlTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   OpenMage
+ * @package    OpenMage_Tests
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Catalog\Model;
+
+use Mage;
+use Mage_Catalog_Model_Url;
+use Mage_Core_Exception;
+use PHPUnit\Framework\TestCase;
+use Varien_Object;
+
+class UrlTest extends TestCase
+{
+    public Mage_Catalog_Model_Url $subject;
+
+    public function setUp(): void
+    {
+        Mage::app();
+        $this->subject = Mage::getModel('catalog/url');
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetStoreRootCategory(): void
+    {
+        $this->assertInstanceOf(Varien_Object::class, $this->subject->getStoreRootCategory(1));
+    }
+
+    /**
+     * @dataProvider provideRefreshRewritesData
+     *
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testRefreshRewrites(?int $storeId): void
+    {
+        $this->assertInstanceOf(Mage_Catalog_Model_Url::class, $this->subject->refreshRewrites($storeId));
+    }
+
+    public function provideRefreshRewritesData(): array
+    {
+        return [
+            'w/o storeId' => [
+                null,
+            ],
+            'w/ storeId' => [
+                2,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideGeneratePathData
+     *
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGeneratePath(
+        string $expectedResult,
+        string $type,
+        ?Varien_Object $product,
+        ?Varien_Object $category,
+        ?string $parentPath = null
+    ): void {
+        try {
+            $this->assertSame($expectedResult, $this->subject->generatePath($type, $product, $category, $parentPath));
+        } catch (Mage_Core_Exception $e) {
+            $this->assertSame($expectedResult, $e->getMessage());
+        }
+    }
+
+    public function provideGeneratePathData(): array
+    {
+        $category = new Varien_Object([
+            'id'        => '999',
+            'store_id'  => '1',
+            'url_key'   => '',
+
+        ]);
+        $product = new Varien_Object([
+            'id' => '999'
+        ]);
+
+        return [
+            'exception' => [
+                'Please specify either a category or a product, or both.',
+                'request',
+                null,
+                null,
+            ],
+            'request' => [
+                '-.html',
+                'request',
+                $product,
+                $category,
+            ],
+//            'request w/o product' => [
+//                '-.html',
+//                'request',
+//                null,
+//                $category,
+//            ],
+            'target category' => [
+                'catalog/category/view/id/999',
+                'target',
+                null,
+                $category,
+            ],
+           'target product' => [
+                'catalog/product/view/id/999',
+               'target',
+               $product,
+               $category,
+            ],
+        ];
+    }
+}

--- a/tests/unit/Mage/Catalog/Model/UrlTest.php
+++ b/tests/unit/Mage/Catalog/Model/UrlTest.php
@@ -87,7 +87,7 @@ class UrlTest extends TestCase
         }
     }
 
-    public function provideGeneratePathData(): array
+    public function provideGeneratePathData(): Generator
     {
         $category = new Varien_Object([
             'id'        => '999',
@@ -99,37 +99,35 @@ class UrlTest extends TestCase
             'id' => '999'
         ]);
 
-        return [
-            'exception' => [
-                'Please specify either a category or a product, or both.',
-                'request',
-                null,
-                null,
-            ],
-            'request' => [
-                '-.html',
-                'request',
-                $product,
-                $category,
-            ],
-//            'request w/o product' => [
-//                '-.html',
-//                'request',
-//                null,
-//                $category,
-//            ],
-            'target category' => [
-                'catalog/category/view/id/999',
-                'target',
-                null,
-                $category,
-            ],
-            'target product' => [
-                'catalog/product/view/id/999',
-               'target',
-               $product,
-               $category,
-            ],
+        yield 'test exception' => [
+            'Please specify either a category or a product, or both.',
+            'request',
+            null,
+            null,
+        ];
+        yield 'request' => [
+            '-.html',
+            'request',
+            $product,
+            $category,
+        ];
+//        yield 'request w/o product' => [
+//            '-.html',
+//            'request',
+//            null,
+//            $category,
+//        ];
+        yield 'target category' => [
+            'catalog/category/view/id/999',
+            'target',
+            null,
+            $category,
+        ];
+        yield 'target product' => [
+            'catalog/product/view/id/999',
+            'target',
+            $product,
+            $category,
         ];
     }
 }

--- a/tests/unit/Mage/Cms/Block/BlockTest.php
+++ b/tests/unit/Mage/Cms/Block/BlockTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Cms\Block;
 
+use Generator;
 use Mage_Cms_Block_Block;
 use PHPUnit\Framework\TestCase;
 
@@ -37,18 +38,13 @@ class BlockTest extends TestCase
         $this->assertIsArray($mock->getCacheKeyInfo());
     }
 
-    /**
-     * @return array[]
-     */
-    public function provideGetCacheKeyInfoData(): array
+    public function provideGetCacheKeyInfoData(): Generator
     {
-        return [
-            'valid block ID' => [
-                '2'
-            ],
-            'invalid block ID' => [
-                '0'
-            ]
+        yield 'valid block ID' => [
+            '2'
+        ];
+        yield 'invalid block ID' => [
+            '0'
         ];
     }
 }

--- a/tests/unit/Mage/Cms/Block/PageTest.php
+++ b/tests/unit/Mage/Cms/Block/PageTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Cms\Block;
 
+use Generator;
 use Mage_Cms_Block_Page;
 use Mage_Cms_Model_Page;
 use PHPUnit\Framework\TestCase;
@@ -38,18 +39,13 @@ class PageTest extends TestCase
         $this->assertInstanceOf(Mage_Cms_Model_Page::class, $mock->getPage());
     }
 
-    /**
-     * @return array[]
-     */
-    public function provideGetPageData(): array
+    public function provideGetPageData(): Generator
     {
-        return [
-            'valid page ID' => [
-                '2'
-            ],
-            'invalid page ID' => [
-                '0'
-            ]
+        yield 'valid page ID' => [
+            '2'
+        ];
+        yield 'invalid page ID' => [
+            '0'
         ];
     }
 }

--- a/tests/unit/Mage/Cms/Block/Widget/BlockTest.php
+++ b/tests/unit/Mage/Cms/Block/Widget/BlockTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Cms\Block\Widget;
 
+use Generator;
 use Mage;
 use Mage_Cms_Block_Widget_Block;
 use PHPUnit\Framework\TestCase;
@@ -47,20 +48,15 @@ class BlockTest extends TestCase
         $this->assertIsArray($mock->getCacheKeyInfo());
     }
 
-    /**
-     * @return array[]
-     */
-    public function provideGetCacheKeyInfoData(): array
+    public function provideGetCacheKeyInfoData(): Generator
     {
-        return [
-            'valid block ID' => [
-                '2'
-            ],
-            'invalid block ID' => [
-                '0'
-            ]
+        yield 'valid block ID' => [
+            '2'
         ];
-    }
+        yield 'invalid block ID' => [
+            '0'
+        ];
+     }
 
     /**
      * @group Mage_Cms

--- a/tests/unit/Mage/Cms/Helper/Wysiwyg/ImagesTest.php
+++ b/tests/unit/Mage/Cms/Helper/Wysiwyg/ImagesTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Cms\Helper\Wysiwyg;
 
+use Generator;
 use Mage;
 use Mage_Cms_Helper_Wysiwyg_Images;
 use Mage_Cms_Model_Wysiwyg_Images_Storage;
@@ -89,22 +90,17 @@ class ImagesTest extends TestCase
         $this->assertSame($expectedResult, $this->subject->getShortFilename($filename, $maxLength));
     }
 
-    /**
-     * @return array[]
-     */
-    public function provideGetShortFilenameData(): array
+    public function provideGetShortFilenameData(): Generator
     {
-        return [
-            'full length' => [
-                '0123456789',
-                self::TEST_STRING,
-                20,
-            ],
-            'truncated' => [
-                '01234...',
-                self::TEST_STRING,
-                5,
-            ]
+        yield 'full length' => [
+            '0123456789',
+            self::TEST_STRING,
+            20,
+        ];
+        yield 'truncated' => [
+            '01234...',
+            self::TEST_STRING,
+            5,
         ];
     }
 }

--- a/tests/unit/Mage/Cms/Helper/Wysiwyg/ImagesTest.php
+++ b/tests/unit/Mage/Cms/Helper/Wysiwyg/ImagesTest.php
@@ -86,7 +86,7 @@ class ImagesTest extends TestCase
      */
     public function testGetShortFilename(string $expectedResult, string $filename, int $maxLength): void
     {
-        $this->assertEquals($expectedResult, $this->subject->getShortFilename($filename, $maxLength));
+        $this->assertSame($expectedResult, $this->subject->getShortFilename($filename, $maxLength));
     }
 
     /**

--- a/tests/unit/Mage/Cms/Model/Wysiwyg/ConfigTest.php
+++ b/tests/unit/Mage/Cms/Model/Wysiwyg/ConfigTest.php
@@ -37,6 +37,7 @@ class ConfigTest extends TestCase
     /**
      * @group Mage_Cms
      * @group Mage_Cms_Model
+     * @group runInSeparateProcess
      * @runInSeparateProcess
      */
     public function testGetConfig(): void

--- a/tests/unit/Mage/Cms/Model/Wysiwyg/Images/StorageTest.php
+++ b/tests/unit/Mage/Cms/Model/Wysiwyg/Images/StorageTest.php
@@ -47,6 +47,7 @@ class StorageTest extends TestCase
     /**
      * @group Mage_Cms
      * @group Mage_Cms_Model
+     * @group runInSeparateProcess
      * @runInSeparateProcess
      */
     public function testResizeOnTheFly(): void
@@ -66,6 +67,7 @@ class StorageTest extends TestCase
     /**
      * @group Mage_Cms
      * @group Mage_Cms_Model
+     * @group runInSeparateProcess
      * @runInSeparateProcess
      */
     public function testGetSession(): void

--- a/tests/unit/Mage/Core/Helper/DataTest.php
+++ b/tests/unit/Mage/Core/Helper/DataTest.php
@@ -123,7 +123,7 @@ class DataTest extends TestCase
     public function testRemoveAccents(): void
     {
         $str = 'Ae-Ä Oe-Ö Ue-Ü ae-ä oe-ö ue-ü';
-        $this->assertEquals('Ae-Ae Oe-Oe Ue-Ue ae-ae oe-oe ue-ue', $this->subject->removeAccents($str, true));
+        $this->assertSame('Ae-Ae Oe-Oe Ue-Ue ae-ae oe-oe ue-ue', $this->subject->removeAccents($str, true));
     }
 
     /**

--- a/tests/unit/Mage/Core/Helper/EnvironmentConfigLoaderTest.php
+++ b/tests/unit/Mage/Core/Helper/EnvironmentConfigLoaderTest.php
@@ -49,7 +49,7 @@ class EnvironmentConfigLoaderTest extends TestCase
     {
         $environmentConfigLoaderHelper = new EnvironmentConfigLoaderTestHelper();
         $path = $environmentConfigLoaderHelper->exposedBuildPath('GENERAL', 'STORE_INFORMATION', 'NAME');
-        $this->assertEquals(self::XML_PATH_GENERAL, $path);
+        $this->assertSame(self::XML_PATH_GENERAL, $path);
     }
 
     /**
@@ -60,7 +60,7 @@ class EnvironmentConfigLoaderTest extends TestCase
     {
         $environmentConfigLoaderHelper = new EnvironmentConfigLoaderTestHelper();
         $nodePath = $environmentConfigLoaderHelper->exposedBuildNodePath('DEFAULT', self::XML_PATH_GENERAL);
-        $this->assertEquals(self::XML_PATH_DEFAULT, $nodePath);
+        $this->assertSame(self::XML_PATH_DEFAULT, $nodePath);
     }
 
     /**
@@ -72,9 +72,9 @@ class EnvironmentConfigLoaderTest extends TestCase
         $xmlStruct = $this->getTestXml();
         $xml = new Varien_Simplexml_Config();
         $xml->loadString($xmlStruct);
-        $this->assertEquals('test_default', (string)$xml->getNode(self::XML_PATH_DEFAULT));
-        $this->assertEquals('test_website', (string)$xml->getNode(self::XML_PATH_WEBSITE));
-        $this->assertEquals('test_store', (string)$xml->getNode(self::XML_PATH_STORE));
+        $this->assertSame('test_default', (string)$xml->getNode(self::XML_PATH_DEFAULT));
+        $this->assertSame('test_website', (string)$xml->getNode(self::XML_PATH_WEBSITE));
+        $this->assertSame('test_store', (string)$xml->getNode(self::XML_PATH_STORE));
     }
 
     /**
@@ -216,11 +216,11 @@ class EnvironmentConfigLoaderTest extends TestCase
         $xml->loadString($xmlStruct);
 
         $defaultValue = 'test_default';
-        $this->assertEquals($defaultValue, (string)$xml->getNode(self::XML_PATH_DEFAULT));
+        $this->assertSame($defaultValue, (string)$xml->getNode(self::XML_PATH_DEFAULT));
         $defaultWebsiteValue = 'test_website';
-        $this->assertEquals($defaultWebsiteValue, (string)$xml->getNode(self::XML_PATH_WEBSITE));
+        $this->assertSame($defaultWebsiteValue, (string)$xml->getNode(self::XML_PATH_WEBSITE));
         $defaultStoreValue = 'test_store';
-        $this->assertEquals($defaultStoreValue, (string)$xml->getNode(self::XML_PATH_STORE));
+        $this->assertSame($defaultStoreValue, (string)$xml->getNode(self::XML_PATH_STORE));
 
         // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
         $loader = new Mage_Core_Helper_EnvironmentConfigLoader();

--- a/tests/unit/Mage/Core/Helper/EnvironmentConfigLoaderTest.php
+++ b/tests/unit/Mage/Core/Helper/EnvironmentConfigLoaderTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Core\Helper;
 
+use Generator;
 use Mage;
 use Mage_Core_Exception;
 use Mage_Core_Helper_EnvironmentConfigLoader;
@@ -79,9 +80,10 @@ class EnvironmentConfigLoaderTest extends TestCase
 
     /**
      * @dataProvider envOverridesCorrectConfigKeysDataProvider
-     *
      * @group Mage_Core
      * @group Mage_Core_Helper
+     *
+     * @param array<string, string> $config
      */
     public function testEnvOverridesForValidConfigKeys(array $config): void
     {
@@ -107,10 +109,7 @@ class EnvironmentConfigLoaderTest extends TestCase
         $this->assertNotEquals((string)$defaultValue, (string)$valueAfterOverride, 'Default value was not overridden.');
     }
 
-    /**
-     * @return array<array<string, array<string, string>>>
-     */
-    public function envOverridesCorrectConfigKeysDataProvider(): array
+    public function envOverridesCorrectConfigKeysDataProvider(): Generator
     {
         $defaultPath = 'OPENMAGE_CONFIG__DEFAULT__GENERAL__STORE_INFORMATION__NAME';
         $defaultPathWithDash = 'OPENMAGE_CONFIG__DEFAULT__GENERAL__FOO-BAR__NAME';
@@ -124,87 +123,67 @@ class EnvironmentConfigLoaderTest extends TestCase
         $storeWithUnderscorePath = 'OPENMAGE_CONFIG__STORES__GERMAN_CH__GENERAL__STORE_INFORMATION__NAME';
         $storePath = 'OPENMAGE_CONFIG__STORES__GERMAN__GENERAL__STORE_INFORMATION__NAME';
 
-        return [
-            [
-                'Case DEFAULT overrides.' => [
-                    'case'     => 'DEFAULT',
-                    'xml_path' => self::XML_PATH_DEFAULT,
-                    'env_path' => $defaultPath,
-                    'value'    => 'default_new_value'
-                ]
-            ],
-            [
-                'Case DEFAULT overrides.' => [
-                    'case'     => 'DEFAULT',
-                    'xml_path' => 'default/general/foo-bar/name',
-                    'env_path' => $defaultPathWithDash,
-                    'value'    => 'baz'
-                ]
-            ],
-            [
-                'Case DEFAULT overrides.' => [
-                    'case'     => 'DEFAULT',
-                    'xml_path' => 'default/general/foo_bar/name',
-                    'env_path' => $defaultPathWithUnderscore,
-                    'value'    => 'baz'
-                ]
-            ],
-            [
-                'Case STORE overrides.' => [
-                    'case'     => 'STORE',
-                    'xml_path' => self::XML_PATH_STORE,
-                    'env_path' => $storePath,
-                    'value'    => 'store_new_value'
-                ]
-            ],
-            [
-                'Case STORE overrides.' => [
-                    'case'     => 'STORE',
-                    'xml_path' => 'stores/german-at/general/store_information/name',
-                    'env_path' => $storeWithDashPath,
-                    'value'    => 'store_new_value'
-                ]
-            ],
-            [
-                'Case STORE overrides.' => [
-                    'case'     => 'STORE',
-                    'xml_path' => 'stores/german_ch/general/store_information/name',
-                    'env_path' => $storeWithUnderscorePath,
-                    'value'    => 'store_new_value'
-                ]
-            ],
-            [
-                'Case WEBSITE overrides.' => [
-                    'case'     => 'WEBSITE',
-                    'xml_path' => self::XML_PATH_WEBSITE,
-                    'env_path' => $websitePath,
-                    'value'    => 'website_new_value'
-                ]
-            ],
-            [
-                'Case WEBSITE overrides.' => [
-                    'case'     => 'WEBSITE',
-                    'xml_path' => 'websites/base_ch/general/store_information/name',
-                    'env_path' => $websiteWithUnderscorePath,
-                    'value'    => 'website_new_value'
-                ]
-            ],
-            [
-                'Case WEBSITE overrides.' => [
-                    'case'     => 'WEBSITE',
-                    'xml_path' => 'websites/base-at/general/store_information/name',
-                    'env_path' => $websiteWithDashPath,
-                    'value'    => 'website_new_value'
-                ]
-            ]
-        ];
+        yield 'Case DEFAULT overrides #1.' => [[
+            'case'     => 'DEFAULT',
+            'xml_path' => self::XML_PATH_DEFAULT,
+            'env_path' => $defaultPath,
+            'value'    => 'default_new_value'
+        ]];
+        yield 'Case DEFAULT overrides #2.' => [[
+            'case'     => 'DEFAULT',
+            'xml_path' => 'default/general/foo-bar/name',
+            'env_path' => $defaultPathWithDash,
+            'value'    => 'baz'
+        ]];
+        yield 'Case DEFAULT overrides #3.' => [[
+            'case'     => 'DEFAULT',
+            'xml_path' => 'default/general/foo_bar/name',
+            'env_path' => $defaultPathWithUnderscore,
+            'value'    => 'baz'
+        ]];
+        yield 'Case STORE overrides #1.' => [[
+            'case'     => 'STORE',
+            'xml_path' => self::XML_PATH_STORE,
+            'env_path' => $storePath,
+            'value'    => 'store_new_value'
+        ]];
+        yield 'Case STORE overrides #2.' => [[
+            'case'     => 'STORE',
+            'xml_path' => 'stores/german-at/general/store_information/name',
+            'env_path' => $storeWithDashPath,
+            'value'    => 'store_new_value'
+        ]];
+        yield 'Case STORE overrides #3.' => [[
+            'case'     => 'STORE',
+            'xml_path' => 'stores/german_ch/general/store_information/name',
+            'env_path' => $storeWithUnderscorePath,
+            'value'    => 'store_new_value'
+        ]];
+        yield 'Case WEBSITE overrides #1.' => [[
+            'case'     => 'WEBSITE',
+            'xml_path' => self::XML_PATH_WEBSITE,
+            'env_path' => $websitePath,
+            'value'    => 'website_new_value'
+        ]];
+        yield 'Case WEBSITE overrides #2.' => [[
+            'case'     => 'WEBSITE',
+            'xml_path' => 'websites/base_ch/general/store_information/name',
+            'env_path' => $websiteWithUnderscorePath,
+            'value'    => 'website_new_value'
+        ]];
+        yield 'Case WEBSITE overrides #3.' => [[
+            'case'     => 'WEBSITE',
+            'xml_path' => 'websites/base-at/general/store_information/name',
+            'env_path' => $websiteWithDashPath,
+            'value'    => 'website_new_value'
+        ]];
     }
 
     /**
      * @dataProvider envDoesNotOverrideOnWrongConfigKeysDataProvider
-     * @param array<string, string> $config
-     *
      * @group Mage_Core
+     *
+     * @param array<string, string> $config
      */
     public function testEnvDoesNotOverrideForInvalidConfigKeys(array $config): void
     {
@@ -246,38 +225,27 @@ class EnvironmentConfigLoaderTest extends TestCase
         $this->assertTrue(!str_contains('value_will_not_be_changed', (string)$valueAfterCheck), 'Default value was wrongfully overridden.');
     }
 
-    /**
-     * @return array<array<string, array<string, string>>>
-     */
-    public function envDoesNotOverrideOnWrongConfigKeysDataProvider(): array
+    public function envDoesNotOverrideOnWrongConfigKeysDataProvider(): Generator
     {
         $defaultPath = 'OPENMAGE_CONFIG__DEFAULT__GENERAL__ST';
         $websitePath = 'OPENMAGE_CONFIG__WEBSITES__BASE__GENERAL__ST';
         $storePath = 'OPENMAGE_CONFIG__STORES__GERMAN__GENERAL__ST';
 
-        return [
-            [
-                'Case DEFAULT with ' . $defaultPath . ' will not override.' => [
-                    'case'  => 'DEFAULT',
-                    'path'  => $defaultPath,
-                    'value' => 'default_value_will_not_be_changed'
-                ]
-            ],
-            [
-                'Case STORE with ' . $storePath . ' will not override.' => [
-                    'case'  => 'STORE',
-                    'path'  => $storePath,
-                    'value' => 'store_value_will_not_be_changed'
-                ]
-            ],
-            [
-                'Case WEBSITE with ' . $websitePath . ' will not override.' => [
-                    'case'  => 'WEBSITE',
-                    'path'  => $websitePath,
-                    'value' => 'website_value_will_not_be_changed'
-                ]
-            ]
-        ];
+        yield 'Case DEFAULT with ' . $defaultPath . ' will not override.' => [[
+            'case'  => 'DEFAULT',
+            'path'  => $defaultPath,
+            'value' => 'default_value_will_not_be_changed'
+        ]];
+        yield 'Case WEBSITE with ' . $websitePath . ' will not override.' => [[
+            'case'  => 'WEBSITE',
+            'path'  => $storePath,
+            'value' => 'website_value_will_not_be_changed'
+        ]];
+        yield 'Case STORE with ' . $storePath . ' will not override.' => [[
+            'case'  => 'STORE',
+            'path'  => $storePath,
+            'value' => 'store_value_will_not_be_changed'
+        ]];
     }
 
     public function getTestXml(): string

--- a/tests/unit/Mage/Core/Helper/StringTest.php
+++ b/tests/unit/Mage/Core/Helper/StringTest.php
@@ -42,16 +42,16 @@ class StringTest extends TestCase
      */
     public function testTruncate(): void
     {
-        $this->assertEquals('', $this->subject->truncate(null));
-        $this->assertEquals('', $this->subject->truncate(self::TEST_STRING, 0));
+        $this->assertSame('', $this->subject->truncate(null));
+        $this->assertSame('', $this->subject->truncate(self::TEST_STRING, 0));
 
-        $this->assertEquals('', $this->subject->truncate(self::TEST_STRING, 3));
+        $this->assertSame('', $this->subject->truncate(self::TEST_STRING, 3));
 
         $remainder = '';
-        $this->assertEquals('12...', $this->subject->truncate(self::TEST_STRING, 5, '...', $remainder, false));
+        $this->assertSame('12...', $this->subject->truncate(self::TEST_STRING, 5, '...', $remainder, false));
 
         $resultString = $this->subject->truncate(self::TEST_STRING, 5, '...');
-        $this->assertEquals('12...', $resultString);
+        $this->assertSame('12...', $resultString);
     }
 
     /**
@@ -61,7 +61,7 @@ class StringTest extends TestCase
     public function testSubstr(): void
     {
         $resultString = $this->subject->substr(self::TEST_STRING, 2, 2);
-        $this->assertEquals('34', $resultString);
+        $this->assertSame('34', $resultString);
     }
 
     /**
@@ -71,7 +71,7 @@ class StringTest extends TestCase
     public function testSplitInjection(): void
     {
         $resultString = $this->subject->splitInjection(self::TEST_STRING, 1, '-', ' ');
-        #$this->assertEquals('1-2-3-4-5-6-7-8-9-0-', $resultString);
+        #$this->assertSame('1-2-3-4-5-6-7-8-9-0-', $resultString);
         $this->assertIsString($resultString);
     }
 
@@ -81,7 +81,7 @@ class StringTest extends TestCase
      */
     public function testStrlen(): void
     {
-        $this->assertEquals(10, $this->subject->strlen(self::TEST_STRING));
+        $this->assertSame(10, $this->subject->strlen(self::TEST_STRING));
     }
 
     /**

--- a/tests/unit/Mage/Core/Model/AppTest.php
+++ b/tests/unit/Mage/Core/Model/AppTest.php
@@ -27,6 +27,8 @@ class AppTest extends TestCase
      * @dataProvider provideGetStore
      * @group Mage_Core
      * @group Mage_Core_Model
+     *
+     * @param bool|int|Mage_Core_Model_Store|null|string $id
      */
     public function testGetStore($id): void
     {
@@ -67,6 +69,8 @@ class AppTest extends TestCase
      * @dataProvider provideGetWebsite
      * @group Mage_Core
      * @group Mage_Core_Model
+     *
+     * @param int|Mage_Core_Model_Website|null|string|true $id
      */
     public function testGetWebsite($id): void
     {
@@ -107,6 +111,8 @@ class AppTest extends TestCase
      * @dataProvider provideGetGroup
      * @group Mage_Core
      * @group Mage_Core_Model
+     *
+     * @param int|Mage_Core_Model_Store_Group|null|string $id
      */
     public function testGetGroup($id): void
     {

--- a/tests/unit/Mage/Core/Model/AppTest.php
+++ b/tests/unit/Mage/Core/Model/AppTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Core\Model;
+
+use Generator;
+use Mage;
+use Mage_Core_Exception;
+use Mage_Core_Model_App;
+use Mage_Core_Model_Store;
+use Mage_Core_Model_Store_Exception;
+use Mage_Core_Model_Store_Group;
+use Mage_Core_Model_Website;
+use PHPUnit\Framework\TestCase;
+
+class AppTest extends TestCase
+{
+    public Mage_Core_Model_App $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = Mage::app();
+    }
+
+    /**
+     * @dataProvider provideGetStore
+     * @group Mage_Core
+     * @group Mage_Core_Model
+     */
+    public function testGetStore($id): void
+    {
+        try {
+            $this->assertInstanceOf(Mage_Core_Model_Store::class, $this->subject->getStore($id));
+        } catch (Mage_Core_Model_Store_Exception $e) {
+            $this->assertSame('', $e->getMessage());
+        }
+    }
+
+    public function provideGetStore(): Generator
+    {
+        yield 'null' => [
+            null,
+        ];
+        yield 'true' => [
+            true,
+        ];
+        yield 'false' => [
+            false,
+        ];
+        yield 'int valid' => [
+            1,
+        ];
+        yield 'int invalid (exception)' => [
+            999,
+        ];
+        yield 'string' => [
+            '1',
+        ];
+        yield 'Mage_Core_Model_Store' => [
+            // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
+            new Mage_Core_Model_Store(),
+        ];
+    }
+
+    /**
+     * @dataProvider provideGetWebsite
+     * @group Mage_Core
+     * @group Mage_Core_Model
+     */
+    public function testGetWebsite($id): void
+    {
+        try {
+            $this->assertInstanceOf(Mage_Core_Model_Website::class, $this->subject->getWebsite($id));
+        } catch (Mage_Core_Exception $e) {
+            $this->assertSame('Invalid website id requested.', $e->getMessage());
+        }
+    }
+
+    public function provideGetWebsite(): Generator
+    {
+        yield 'null' => [
+            null,
+        ];
+        yield 'true' => [
+            true,
+        ];
+        yield 'false' => [
+            false,
+        ];
+        yield 'int valid' => [
+            1,
+        ];
+        yield 'int invalid (exception)' => [
+            999,
+        ];
+        yield 'string' => [
+            '1',
+        ];
+        yield 'Mage_Core_Model_Website' => [
+            // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
+            new Mage_Core_Model_Website(),
+        ];
+    }
+
+    /**
+     * @dataProvider provideGetGroup
+     * @group Mage_Core
+     * @group Mage_Core_Model
+     */
+    public function testGetGroup($id): void
+    {
+        try {
+            $this->assertInstanceOf(Mage_Core_Model_Store_Group::class, $this->subject->getGroup($id));
+        } catch (Mage_Core_Exception $e) {
+            $this->assertSame('Invalid store group id requested.', $e->getMessage());
+        }
+    }
+
+    public function provideGetGroup(): Generator
+    {
+        yield 'null' => [
+            null,
+        ];
+        yield 'true' => [
+            true,
+        ];
+        yield 'false' => [
+            false,
+        ];
+        yield 'int valid' => [
+            1,
+        ];
+        yield 'int invalid (exception)' => [
+            999,
+        ];
+        yield 'string' => [
+            '1',
+        ];
+        yield 'Mage_Core_Model_Store_Group' => [
+            // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
+            new Mage_Core_Model_Store_Group(),
+        ];
+    }
+}

--- a/tests/unit/Mage/Core/Model/ConfigTest.php
+++ b/tests/unit/Mage/Core/Model/ConfigTest.php
@@ -30,7 +30,7 @@ class ConfigTest extends TestCase
         $this->assertFalse($this->subject->getConfig($path));
 
         $this->subject->saveConfig($path, $value);
-        $this->assertEquals($value, $this->subject->getConfig($path));
+        $this->assertSame($value, $this->subject->getConfig($path));
 
         $this->subject->deleteConfig($path);
         $this->assertFalse($this->subject->getConfig($path));

--- a/tests/unit/Mage/Core/Model/LocaleTest.php
+++ b/tests/unit/Mage/Core/Model/LocaleTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Core\Model;
 
+use Generator;
 use Mage;
 use Mage_Core_Model_Locale;
 use PHPUnit\Framework\TestCase;
@@ -42,36 +43,31 @@ class LocaleTest extends TestCase
         $this->assertSame($expectedResult, $this->subject->getNumber($value));
     }
 
-    /**
-     * @return array<string, array<int, array<int, int>|float|int|string|null>>
-     */
-    public function provideGetNumberData(): array
+    public function provideGetNumberData(): Generator
     {
-        return [
-            'array' => [
-                1.0,
-                [1]
-            ],
-            'int' => [
-                1.0,
-                1
-            ],
-            'string' => [
-                1.0,
-                '1'
-            ],
-            'string_comma' => [
-                1.0,
-                '1,0'
-            ],
-            'string_dot' => [
-                1.0,
-                '1.0'
-            ],
-            'null' => [
-                null,
-                null
-            ],
+        yield 'array' => [
+            1.0,
+            [1]
+        ];
+        yield 'int' => [
+            1.0,
+            1
+        ];
+        yield 'string' => [
+            1.0,
+            '1'
+        ];
+        yield 'string comma' => [
+            1.0,
+            '1,0'
+        ];
+        yield 'string dot' => [
+            1.0,
+            '1.0'
+        ];
+        yield 'null' => [
+            null,
+            null
         ];
     }
 }

--- a/tests/unit/Mage/Core/Model/LocaleTest.php
+++ b/tests/unit/Mage/Core/Model/LocaleTest.php
@@ -39,7 +39,7 @@ class LocaleTest extends TestCase
      */
     public function testGetNumber(?float $expectedResult, $value): void
     {
-        $this->assertEquals($expectedResult, $this->subject->getNumber($value));
+        $this->assertSame($expectedResult, $this->subject->getNumber($value));
     }
 
     /**

--- a/tests/unit/Mage/Core/Model/Security/HtmlEscapedStringTest.php
+++ b/tests/unit/Mage/Core/Model/Security/HtmlEscapedStringTest.php
@@ -36,7 +36,7 @@ class HtmlEscapedStringTest extends TestCase
     {
         // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
         $this->subject = new Mage_Core_Model_Security_HtmlEscapedString($string, $allowedTags);
-        $this->assertEquals($expectedResult, $this->subject->__toString());
+        $this->assertSame($expectedResult, $this->subject->__toString());
     }
 
     /**
@@ -49,7 +49,7 @@ class HtmlEscapedStringTest extends TestCase
     {
         // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
         $this->subject = new Mage_Core_Model_Security_HtmlEscapedString($string, $allowedTags);
-        $this->assertEquals($expectedResult, $this->subject->getUnescapedValue());
+        $this->assertSame($expectedResult, $this->subject->getUnescapedValue());
     }
 
     /**

--- a/tests/unit/Mage/Core/Model/Security/HtmlEscapedStringTest.php
+++ b/tests/unit/Mage/Core/Model/Security/HtmlEscapedStringTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Core\Model\Security;
 
+use Generator;
 use Mage_Core_Model_Security_HtmlEscapedString;
 use PHPUnit\Framework\TestCase;
 
@@ -52,41 +53,31 @@ class HtmlEscapedStringTest extends TestCase
         $this->assertSame($expectedResult, $this->subject->getUnescapedValue());
     }
 
-    /**
-     * @return array<string, array<int, array<int, string>|string|null>>
-     */
-    public function provideHtmlEscapedStringAsStringData(): array
+    public function provideHtmlEscapedStringAsStringData(): Generator
     {
-        return [
-            'tags_null' => [
-                'This is a bold &lt;b&gt;string&lt;/b&gt;',
-                self::TEST_STRING,
-                null
-            ],
-            'tags_array' => [
-                self::TEST_STRING,
-                self::TEST_STRING,
-                ['b']
-            ],
+        yield 'tags null' => [
+            'This is a bold &lt;b&gt;string&lt;/b&gt;',
+            self::TEST_STRING,
+            null
+        ];
+        yield 'tags array' => [
+            self::TEST_STRING,
+            self::TEST_STRING,
+            ['b']
         ];
     }
 
-    /**
-     * @return array<string, array<int, array<int, string>|string|null>>
-     */
-    public function provideHtmlEscapedStringGetUnescapedValueData(): array
+    public function provideHtmlEscapedStringGetUnescapedValueData(): Generator
     {
-        return [
-            'tags_null' => [
-                self::TEST_STRING,
-                self::TEST_STRING,
-                null
-            ],
-            'tags_array' => [
-                self::TEST_STRING,
-                self::TEST_STRING,
-                ['some-invalid-value']
-            ],
+        yield 'tags null' => [
+            self::TEST_STRING,
+            self::TEST_STRING,
+            null
+        ];
+        yield 'tags array' => [
+            self::TEST_STRING,
+            self::TEST_STRING,
+            ['some-invalid-value']
         ];
     }
 }

--- a/tests/unit/Mage/Customer/Model/Convert/Adapter/CustomerTest.php
+++ b/tests/unit/Mage/Customer/Model/Convert/Adapter/CustomerTest.php
@@ -45,7 +45,7 @@ class CustomerTest extends TestCase
     //            $this->subject->saveRow($data);
     //            $this->fail();
     //        } catch (Mage_Core_Exception $e) {
-    //            $this->assertEquals('Skipping import row, required field "website" is not defined.', $e->getMessage());
+    //            $this->assertSame('Skipping import row, required field "website" is not defined.', $e->getMessage());
     //        }
     //    }
     //
@@ -64,7 +64,7 @@ class CustomerTest extends TestCase
     //            $this->subject->saveRow($data);
     //            $this->fail();
     //        } catch (Mage_Core_Exception $e) {
-    //            $this->assertEquals('Skipping import row, required field "email" is not defined.', $e->getMessage());
+    //            $this->assertSame('Skipping import row, required field "email" is not defined.', $e->getMessage());
     //        }
     //    }
     //
@@ -84,7 +84,7 @@ class CustomerTest extends TestCase
     //            $this->subject->saveRow($data);
     //            $this->fail();
     //        } catch (Mage_Core_Exception $e) {
-    //            $this->assertEquals('Skipping import row, the value "" is not valid for the "group" field.', $e->getMessage());
+    //            $this->assertSame('Skipping import row, the value "" is not valid for the "group" field.', $e->getMessage());
     //        }
     //    }
     //
@@ -127,7 +127,7 @@ class CustomerTest extends TestCase
     //            $this->subject->saveRow($data);
     //            $this->fail();
     //        } catch (Mage_Core_Exception $e) {
-    //            $this->assertEquals('Skip import row, required field "lastname" for the new customer is not defined.', $e->getMessage());
+    //            $this->assertSame('Skip import row, required field "lastname" for the new customer is not defined.', $e->getMessage());
     //        }
     //    }
     /**

--- a/tests/unit/Mage/Downloadable/Helper/FileTest.php
+++ b/tests/unit/Mage/Downloadable/Helper/FileTest.php
@@ -39,7 +39,7 @@ class FileTest extends TestCase
     public function testGetFilePath(string $expectedResult, string $path, ?string $file): void
     {
         $result = $this->subject->getFilePath($path, $file);
-        $this->assertEquals($expectedResult, $result);
+        $this->assertSame($expectedResult, $result);
     }
 
     /**

--- a/tests/unit/Mage/Downloadable/Helper/FileTest.php
+++ b/tests/unit/Mage/Downloadable/Helper/FileTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Downloadable\Helper;
 
+use Generator;
 use Mage;
 use Mage_Downloadable_Helper_File;
 use PHPUnit\Framework\TestCase;
@@ -42,37 +43,32 @@ class FileTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    /**
-     * @return array<string, array<int, string|null>>
-     */
-    public function provideGetFilePathData(): array
+    public function provideGetFilePathData(): Generator
     {
-        return [
-            'strings path and strings file' => [
-                'path' . DS . 'file',
-                'path',
-                'file'
-            ],
-            'strings path and strings file with slash' => [
-                'path' . DS . 'file',
-                'path',
-                '/file'
-            ],
-            'string path and null file' => [
-                'path' . DS,
-                'path',
-                null
-            ],
-            'string path and empty file' => [
-                'path' . DS,
-                'path',
-                ''
-            ],
-            'strings path and strings file named 0' => [
-                'path' . DS . '0',
-                'path',
-                '0'
-            ],
+        yield 'strings path and strings file' => [
+            'path' . DS . 'file',
+            'path',
+            'file'
+        ];
+        yield 'strings path and strings file with slash' => [
+            'path' . DS . 'file',
+            'path',
+            '/file'
+        ];
+        yield 'string path and null file' => [
+            'path' . DS,
+            'path',
+            null
+        ];
+        yield 'string path and empty file' => [
+            'path' . DS,
+            'path',
+            ''
+        ];
+        yield 'strings path and strings file named 0' => [
+            'path' . DS . '0',
+            'path',
+            '0'
         ];
     }
 }

--- a/tests/unit/Mage/Log/Model/CustomerTest.php
+++ b/tests/unit/Mage/Log/Model/CustomerTest.php
@@ -37,6 +37,13 @@ class CustomerTest extends TestCase
      */
     public function testGetLoginAtTimestamp(): void
     {
-        $this->assertNull($this->subject->getLoginAtTimestamp());
+        $mock = $this->getMockBuilder(Mage_Log_Model_Customer::class)
+            ->setMethods(['getLoginAt'])
+            ->getMock();
+
+        $this->assertNull($mock->getLoginAtTimestamp());
+
+        $mock->expects($this->any())->method('getLoginAt')->willReturn(true);
+        $this->assertIsInt($mock->getLoginAtTimestamp());
     }
 }

--- a/tests/unit/Mage/Log/Model/VisitorTest.php
+++ b/tests/unit/Mage/Log/Model/VisitorTest.php
@@ -34,6 +34,7 @@ class VisitorTest extends TestCase
     /**
      * @group Mage_Log
      * @group Mage_Log_Model
+     * @group runInSeparateProcess
      * @runInSeparateProcess
      */
     public function testInitServerData(): void
@@ -44,6 +45,7 @@ class VisitorTest extends TestCase
     /**
      * @group Mage_Log
      * @group Mage_Log_Model
+     * @group runInSeparateProcess
      * @runInSeparateProcess
      */
     public function testGetOnlineMinutesInterval(): void
@@ -54,6 +56,7 @@ class VisitorTest extends TestCase
     /**
      * @group Mage_Log
      * @group Mage_Log_Model
+     * @group runInSeparateProcess
      * @runInSeparateProcess
      */
     public function testGetUrl(): void
@@ -64,6 +67,7 @@ class VisitorTest extends TestCase
     /**
      * @group Mage_Log
      * @group Mage_Log_Model
+     * @group runInSeparateProcess
      * @runInSeparateProcess
      */
     public function testGetFirstVisitAt(): void
@@ -74,6 +78,7 @@ class VisitorTest extends TestCase
     /**
      * @group Mage_Log
      * @group Mage_Log_Model
+     * @group runInSeparateProcess
      * @runInSeparateProcess
      */
     public function testGetLastVisitAt(): void

--- a/tests/unit/Mage/Page/Block/Html/HeadTest.php
+++ b/tests/unit/Mage/Page/Block/Html/HeadTest.php
@@ -34,7 +34,7 @@ class HeadTest extends TestCase
 
     /**
      * @group Mage_Page
-     * @group Mage_Page_Model
+     * @group Mage_Page_Block
      */
     public function testAddCss(): void
     {
@@ -43,7 +43,7 @@ class HeadTest extends TestCase
 
     /**
      * @group Mage_Page
-     * @group Mage_Page_Model
+     * @group Mage_Page_Block
      */
     public function testAddJs(): void
     {
@@ -52,7 +52,7 @@ class HeadTest extends TestCase
 
     /**
      * @group Mage_Page
-     * @group Mage_Page_Model
+     * @group Mage_Page_Block
      */
     public function testAddCssIe(): void
     {
@@ -61,7 +61,7 @@ class HeadTest extends TestCase
 
     /**
      * @group Mage_Page
-     * @group Mage_Page_Model
+     * @group Mage_Page_Block
      */
     public function testAddJsIe(): void
     {
@@ -70,7 +70,7 @@ class HeadTest extends TestCase
 
     /**
      * @group Mage_Page
-     * @group Mage_Page_Model
+     * @group Mage_Page_Block
      */
     public function testAddLinkRel(): void
     {

--- a/tests/unit/Mage/Page/Block/Html/HeaderTest.php
+++ b/tests/unit/Mage/Page/Block/Html/HeaderTest.php
@@ -35,7 +35,7 @@ class HeaderTest extends TestCase
 
     /**
      * @group Mage_Page
-     * @group Mage_Page_Model
+     * @group Mage_Page_Block
      */
 //    public function testGetIsHomePage(): void
 //    {
@@ -44,7 +44,7 @@ class HeaderTest extends TestCase
 
     /**
      * @group Mage_Page
-     * @group Mage_Page_Model
+     * @group Mage_Page_Block
      */
     public function testSetLogo(): void
     {
@@ -53,7 +53,7 @@ class HeaderTest extends TestCase
 
     /**
      * @group Mage_Page
-     * @group Mage_Page_Model
+     * @group Mage_Page_Block
      */
     public function testGetLogoSrc(): void
     {
@@ -62,7 +62,7 @@ class HeaderTest extends TestCase
 
     /**
      * @group Mage_Page
-     * @group Mage_Page_Model
+     * @group Mage_Page_Block
      */
     public function testGetLogoSrcSmall(): void
     {
@@ -71,7 +71,7 @@ class HeaderTest extends TestCase
 
     /**
      * @group Mage_Page
-     * @group Mage_Page_Model
+     * @group Mage_Page_Block
      */
     public function testGetLogoAlt(): void
     {

--- a/tests/unit/Mage/Page/Block/HtmlTest.php
+++ b/tests/unit/Mage/Page/Block/HtmlTest.php
@@ -34,7 +34,7 @@ class HtmlTest extends TestCase
 
     /**
      * @group Mage_Page
-     * @group Mage_Page_Model
+     * @group Mage_Page_Block
      */
     public function testGetBaseUrl(): void
     {
@@ -43,7 +43,7 @@ class HtmlTest extends TestCase
 
     /**
      * @group Mage_Page
-     * @group Mage_Page_Model
+     * @group Mage_Page_Block
      */
     public function testGetBaseSecureUrl(): void
     {
@@ -52,7 +52,7 @@ class HtmlTest extends TestCase
 
     /**
      * @group Mage_Page
-     * @group Mage_Page_Model
+     * @group Mage_Page_Block
      */
 //    public function testGetCurrentUrl(): void
 //    {
@@ -61,7 +61,7 @@ class HtmlTest extends TestCase
 
     /**
      * @group Mage_Page
-     * @group Mage_Page_Model
+     * @group Mage_Page_Block
      */
     public function testGetPrintLogoUrl(): void
     {

--- a/tests/unit/Mage/Page/Block/RedirectTest.php
+++ b/tests/unit/Mage/Page/Block/RedirectTest.php
@@ -38,7 +38,7 @@ class RedirectTest extends TestCase
      */
     public function testGetTargetUrl(): void
     {
-        $this->assertEquals('', $this->subject->getTargetURL());
+        $this->assertSame('', $this->subject->getTargetURL());
     }
 
     /**
@@ -47,7 +47,7 @@ class RedirectTest extends TestCase
      */
     public function testGetMessage(): void
     {
-        $this->assertEquals('', $this->subject->getMessage());
+        $this->assertSame('', $this->subject->getMessage());
     }
 
     /**
@@ -92,7 +92,7 @@ class RedirectTest extends TestCase
      */
     public function testGetFormId(): void
     {
-        $this->assertEquals('', $this->subject->getFormId());
+        $this->assertSame('', $this->subject->getFormId());
     }
 
     /**
@@ -101,6 +101,6 @@ class RedirectTest extends TestCase
      */
     public function testGetFormMethod(): void
     {
-        $this->assertEquals('POST', $this->subject->getFormMethod());
+        $this->assertSame('POST', $this->subject->getFormMethod());
     }
 }

--- a/tests/unit/Mage/Page/Block/RedirectTest.php
+++ b/tests/unit/Mage/Page/Block/RedirectTest.php
@@ -34,7 +34,7 @@ class RedirectTest extends TestCase
 
     /**
      * @group Mage_Page
-     * @group Mage_Page_Model
+     * @group Mage_Page_Block
      */
     public function testGetTargetUrl(): void
     {

--- a/tests/unit/Mage/Page/Helper/LayoutTest.php
+++ b/tests/unit/Mage/Page/Helper/LayoutTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   OpenMage
+ * @package    OpenMage_Tests
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Page\Helper;
+
+use Mage;
+use Mage_Page_Helper_Layout;
+use PHPUnit\Framework\TestCase;
+
+class LayoutTest extends TestCase
+{
+    public Mage_Page_Helper_Layout $subject;
+
+    public function setUp(): void
+    {
+        Mage::app();
+        $this->subject = Mage::helper('page/layout');
+    }
+
+    /**
+     * @group Mage_Page
+     * @group Mage_Page_Helper
+     */
+//    public function testApplyTemplate(): void
+//    {
+//        $this->assertInstanceOf(Mage_Page_Helper_Layout::class, $this->subject->applyTemplate());
+//    }
+}

--- a/tests/unit/Mage/Page/Model/ConfigTest.php
+++ b/tests/unit/Mage/Page/Model/ConfigTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   OpenMage
+ * @package    OpenMage_Tests
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Page\Model;
+
+use Mage;
+use Mage_Page_Model_Config;
+use PHPUnit\Framework\TestCase;
+
+class ConfigTest extends TestCase
+{
+    public Mage_Page_Model_Config $subject;
+
+    public function setUp(): void
+    {
+        Mage::app();
+        $this->subject = Mage::getModel('page/config');
+    }
+
+    /**
+     * @group Mage_Page
+     * @group Mage_Page_Model
+     */
+    public function testGetPageLayoutHandles(): void
+    {
+        $this->assertIsArray($this->subject->getPageLayoutHandles());
+    }
+}

--- a/tests/unit/Mage/Page/Model/Source/LayoutTest.php
+++ b/tests/unit/Mage/Page/Model/Source/LayoutTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   OpenMage
+ * @package    OpenMage_Tests
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Page\Model\Source;
+
+use Mage;
+use Mage_Page_Model_Source_Layout;
+use PHPUnit\Framework\TestCase;
+
+class LayoutTest extends TestCase
+{
+    public Mage_Page_Model_Source_Layout $subject;
+
+    public function setUp(): void
+    {
+        Mage::app();
+        $this->subject = Mage::getModel('page/source_layout');
+    }
+
+    /**
+     * @group Mage_Page
+     * @group Mage_Page_Model
+     */
+    public function testToOptionArray(): void
+    {
+        $this->assertIsArray($this->subject->toOptionArray(true));
+    }
+}

--- a/tests/unit/Mage/Sitemap/Model/SitemapTest.php
+++ b/tests/unit/Mage/Sitemap/Model/SitemapTest.php
@@ -33,6 +33,21 @@ class SitemapTest extends TestCase
 
     /**
      * @group Mage_Sitemap
+     * @group Mage_Sitemap_Model
+     */
+    public function testGetPreparedFilename(): void
+    {
+        $mock = $this->getMockBuilder(Mage_Sitemap_Model_Sitemap::class)
+            ->setMethods(['getSitemapFilename'])
+            ->getMock();
+
+        $mock->expects($this->any())->method('getSitemapFilename')->willReturn('text.xml');
+        $this->assertIsString($mock->getPreparedFilename());
+    }
+
+    /**
+     * @group Mage_Sitemap
+     * @group Mage_Sitemap_Model
      */
     public function testGenerateXml(): void
     {

--- a/tests/unit/Mage/Uploader/Helper/DataTest.php
+++ b/tests/unit/Mage/Uploader/Helper/DataTest.php
@@ -27,11 +27,13 @@ class DataTest extends TestCase
 
     public function setUp(): void
     {
+        Mage::app();
         $this->subject = Mage::helper('uploader/data');
     }
 
     /**
      * @group Mage_Uploader
+     * @group Mage_Uploader_Helper
      */
     public function testIsModuleEnabled(): void
     {

--- a/tests/unit/Mage/Uploader/Helper/FileTest.php
+++ b/tests/unit/Mage/Uploader/Helper/FileTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Uploader\Helper;
 
+use Generator;
 use Mage;
 use Mage_Core_Model_Config;
 use Mage_Uploader_Helper_File;
@@ -42,47 +43,44 @@ class FileTest extends TestCase
      * @param string|array<int, string> $extensionsList
      *
      * @group Mage_Uploader
+     * @group Mage_Uploader_Helper
      */
     public function testGetMimeTypeFromExtensionList(array $expectedResult, $extensionsList): void
     {
-        $this->assertEquals($expectedResult, $this->subject->getMimeTypeFromExtensionList($extensionsList));
+        $this->assertSame($expectedResult, $this->subject->getMimeTypeFromExtensionList($extensionsList));
     }
 
-    /**
-     * @return array<string, array<int, array<int, string>|string>>
-     */
-    public function provideGetMimeTypeFromExtensionListData(): array
+    public function provideGetMimeTypeFromExtensionListData(): Generator
     {
-        return [
-            'string exists' => [
-                [
-                    0 => 'application/vnd.lotus-1-2-3'
-                ],
-                '123'
+        yield 'string exists' => [
+            [
+                0 => 'application/vnd.lotus-1-2-3'
             ],
-            'string not exists' => [
-                [
-                    0 => 'application/octet-stream'
-                ],
-                'not-exists'
+            '123'
+        ];
+        yield 'string not exists' => [
+            [
+                0 => 'application/octet-stream'
             ],
-            'array' => [
-                [
-                    0 => 'application/vnd.lotus-1-2-3',
-                    1 => 'application/octet-stream',
-                    2 => 'application/octet-stream',
-                ],
-                [
-                    '123',
-                    'not-exists',
-                    'test-new-node',
-                ]
+            'not-exists'
+        ];
+        yield 'array' => [
+            [
+                0 => 'application/vnd.lotus-1-2-3',
+                1 => 'application/octet-stream',
+                2 => 'application/octet-stream',
             ],
+            [
+                '123',
+                'not-exists',
+                'test-new-node',
+            ]
         ];
     }
 
     /**
      * @group Mage_Uploader
+     * @group Mage_Uploader_Helper
      */
     public function testGetPostMaxSize(): void
     {
@@ -91,6 +89,7 @@ class FileTest extends TestCase
 
     /**
      * @group Mage_Uploader
+     * @group Mage_Uploader_Helper
      */
     public function testGetUploadMaxSize(): void
     {
@@ -99,6 +98,7 @@ class FileTest extends TestCase
 
     /**
      * @group Mage_Uploader
+     * @group Mage_Uploader_Helper
      */
     public function testGetDataMaxSize(): void
     {
@@ -108,13 +108,13 @@ class FileTest extends TestCase
 
         $mock->expects($this->once())->method('getPostMaxSize')->willReturn('1G');
         $mock->expects($this->once())->method('getUploadMaxSize')->willReturn('1M');
-        $this->assertEquals('1M', $mock->getDataMaxSize());
+        $this->assertSame('1M', $mock->getDataMaxSize());
     }
 
     /**
      * @dataProvider provideGetDataMaxSizeInBytesData
-     *
      * @group Mage_Uploader
+     * @group Mage_Uploader_Helper
      */
     public function testGetDataMaxSizeInBytes(int $expectedResult, string $maxSize): void
     {
@@ -123,31 +123,26 @@ class FileTest extends TestCase
             ->getMock();
 
         $mock->expects($this->once())->method('getDataMaxSize')->willReturn($maxSize);
-        $this->assertEquals($expectedResult, $mock->getDataMaxSizeInBytes());
+        $this->assertSame($expectedResult, $mock->getDataMaxSizeInBytes());
     }
 
-    /**
-     * @return array<string, array<int, int|string>>
-     */
-    public function provideGetDataMaxSizeInBytesData(): array
+    public function provideGetDataMaxSizeInBytesData(): Generator
     {
-        return [
-            'no unit' => [
-                1024,
-                '1024'
-            ],
-            'kilobyte' => [
-                1024,
-                '1K'
-            ],
-            'megabyte' => [
-                1048576,
-                '1M'
-            ],
-            'gigabyte' => [
-                1073741824,
-                '1G'
-            ]
+        yield 'no unit' => [
+            1024,
+            '1024'
+        ];
+        yield 'kilobyte' => [
+            1024,
+            '1K'
+        ];
+        yield 'megabyte' => [
+            1048576,
+            '1M'
+        ];
+        yield 'gigabyte' => [
+            1073741824,
+            '1G'
         ];
     }
 }

--- a/tests/unit/Varien/Data/Form/Filter/DateTest.php
+++ b/tests/unit/Varien/Data/Form/Filter/DateTest.php
@@ -32,7 +32,7 @@ class DateTest extends TestCase
     }
 
     /**
-     * @dataProvider provideFilterData
+     * @dataProvider provideFilterDateData
      *
      * @group Varien_Data
      */
@@ -47,9 +47,9 @@ class DateTest extends TestCase
         }
     }
 
-    public function provideFilterData(): Generator
+    public function provideFilterDateData(): Generator
     {
-        yield 'exception' => [
+        yield 'bcsub() exception' => [
             'bcsub():',
             '1990-18-18',
         ];

--- a/tests/unit/Varien/Data/Form/Filter/DateTest.php
+++ b/tests/unit/Varien/Data/Form/Filter/DateTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Varien\Data\Form\Filter;
 
+use Generator;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 use Varien_Data_Form_Filter_Date;
@@ -46,33 +47,35 @@ class DateTest extends TestCase
         }
     }
 
-    public function provideFilterData(): array
+    public function provideFilterData(): Generator
     {
-        return [
-            'exception' => [
-                'bcsub():',
-                '1990-18-18',
-            ],
-            'null' => [
-                null,
-                null,
-            ],
-            'empty' => [
-                '',
-                '',
-            ],
-            'YYYYMMDD' => [
-                '1990-05-18',
-                '1990-05-18',
-            ],
-            'YYMMDD' => [
-                '0090-05-18',
-                '90-05-18',
-            ],
-            'YYYYMD' => [
-                '1990-05-08',
-                '1990-5-8',
-            ],
+        yield 'exception' => [
+            'bcsub():',
+            '1990-18-18',
+        ];
+        yield 'null' => [
+            null,
+            null,
+        ];
+        yield 'empty' => [
+            '',
+            '',
+        ];
+        yield 'YYYYMMDD' => [
+            '1990-05-18',
+            '1990-05-18',
+        ];
+        yield 'YYMMDD' => [
+            '0090-05-18',
+            '90-05-18',
+        ];
+        yield 'exception' => [
+            'bcsub():',
+            '1990-18-18',
+        ];
+        yield 'YYYYMD' => [
+            '1990-05-08',
+            '1990-5-8',
         ];
     }
 }

--- a/tests/unit/Varien/Data/Form/Filter/DateTest.php
+++ b/tests/unit/Varien/Data/Form/Filter/DateTest.php
@@ -43,7 +43,7 @@ class DateTest extends TestCase
         } catch (Throwable $e) {
             // PHP7: bcsub(): bcmath function argument is not well-formed
             // PHP8: bcsub(): Argument #1 ($num1) is not well-formed
-            $this->assertStringStartsWith($expectedResult, $e->getMessage());
+            $this->assertStringStartsWith((string) $expectedResult, $e->getMessage());
         }
     }
 
@@ -68,10 +68,6 @@ class DateTest extends TestCase
         yield 'YYMMDD' => [
             '0090-05-18',
             '90-05-18',
-        ];
-        yield 'exception' => [
-            'bcsub():',
-            '1990-18-18',
         ];
         yield 'YYYYMD' => [
             '1990-05-08',

--- a/tests/unit/Varien/Data/Form/Filter/DateTest.php
+++ b/tests/unit/Varien/Data/Form/Filter/DateTest.php
@@ -31,23 +31,48 @@ class DateTest extends TestCase
     }
 
     /**
+     * @dataProvider provideFilterData
+     *
      * @group Varien_Data
      */
-    public function testInputFilter(): void
+    public function testInputFilter(?string $expectedResult, ?string $value): void
     {
-        $this->assertEquals('', $this->subject->inputFilter(''));
-        $this->assertEquals(null, $this->subject->inputFilter(null));
-        $this->assertEquals('1990-05-18', $this->subject->inputFilter('1990-05-18'));
-        $this->assertEquals('0090-05-18', $this->subject->inputFilter('90-05-18'));
-        $this->assertEquals('1990-05-08', $this->subject->inputFilter('1990-5-8'));
-        $this->assertEquals('1970-01-01', $this->subject->inputFilter('1970-01-01'));
-
         try {
-            $this->subject->inputFilter('1990-18-18');
+            $this->assertSame($expectedResult, $this->subject->inputFilter($value));
         } catch (Throwable $e) {
             // PHP7: bcsub(): bcmath function argument is not well-formed
             // PHP8: bcsub(): Argument #1 ($num1) is not well-formed
-            $this->assertStringStartsWith('bcsub():', $e->getMessage());
+            $this->assertStringStartsWith($expectedResult, $e->getMessage());
         }
+    }
+
+    public function provideFilterData(): array
+    {
+        return [
+            'exception' => [
+                'bcsub():',
+                '1990-18-18',
+            ],
+            'null' => [
+                null,
+                null,
+            ],
+            'empty' => [
+                '',
+                '',
+            ],
+            'YYYYMMDD' => [
+                '1990-05-18',
+                '1990-05-18',
+            ],
+            'YYMMDD' => [
+                '0090-05-18',
+                '90-05-18',
+            ],
+            'YYYYMD' => [
+                '1990-05-08',
+                '1990-5-8',
+            ],
+        ];
     }
 }

--- a/tests/unit/Varien/Data/Form/Filter/DatetimeTest.php
+++ b/tests/unit/Varien/Data/Form/Filter/DatetimeTest.php
@@ -43,7 +43,7 @@ class DatetimeTest extends TestCase
         } catch (Throwable $e) {
             // PHP7: bcsub(): bcmath function argument is not well-formed
             // PHP8: bcsub(): Argument #1 ($num1) is not well-formed
-            $this->assertStringStartsWith($expectedResult, $e->getMessage());
+            $this->assertStringStartsWith((string) $expectedResult, $e->getMessage());
         }
     }
 

--- a/tests/unit/Varien/Data/Form/Filter/DatetimeTest.php
+++ b/tests/unit/Varien/Data/Form/Filter/DatetimeTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Varien\Data\Form\Filter;
 
+use Generator;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 use Varien_Data_Form_Filter_Datetime;
@@ -31,22 +32,46 @@ class DatetimeTest extends TestCase
     }
 
     /**
+     * @dataProvider provideFilterData
+     *
      * @group Varien_Data
      */
-    public function testInputFilter(): void
+    public function testInputFilter(?string $expectedResult, ?string $value): void
     {
-        $this->assertEquals('', $this->subject->inputFilter(''));
-        $this->assertEquals(null, $this->subject->inputFilter(null));
-        $this->assertEquals('1990-05-18 00:00:00', $this->subject->inputFilter('1990-05-18'));
-        $this->assertEquals('0090-05-18 00:00:00', $this->subject->inputFilter('90-05-18'));
-        $this->assertEquals('1990-05-08 00:00:00', $this->subject->inputFilter('1990-5-8'));
-
         try {
-            $this->subject->inputFilter('1990-18-18');
+            $this->assertSame($expectedResult, $this->subject->inputFilter($value));
         } catch (Throwable $e) {
             // PHP7: bcsub(): bcmath function argument is not well-formed
             // PHP8: bcsub(): Argument #1 ($num1) is not well-formed
-            $this->assertStringStartsWith('bcsub():', $e->getMessage());
+            $this->assertStringStartsWith($expectedResult, $e->getMessage());
         }
+    }
+
+    public function provideFilterData(): Generator
+    {
+        yield 'exception' => [
+            'bcsub():',
+            '1990-18-18',
+        ];
+        yield 'null' => [
+            null,
+            null,
+        ];
+        yield 'empty' => [
+            '',
+            '',
+        ];
+        yield 'YYYYMMDD' => [
+            '1990-05-18 00:00:00',
+            '1990-05-18',
+        ];
+        yield 'YYMMDD' => [
+            '0090-05-18 00:00:00',
+            '90-05-18',
+        ];
+        yield 'YYYYMD' => [
+            '1990-05-08 00:00:00',
+            '1990-5-8',
+        ];
     }
 }

--- a/tests/unit/Varien/Data/Form/Filter/DatetimeTest.php
+++ b/tests/unit/Varien/Data/Form/Filter/DatetimeTest.php
@@ -32,7 +32,7 @@ class DatetimeTest extends TestCase
     }
 
     /**
-     * @dataProvider provideFilterData
+     * @dataProvider provideFilterDatetimeData
      *
      * @group Varien_Data
      */
@@ -47,9 +47,9 @@ class DatetimeTest extends TestCase
         }
     }
 
-    public function provideFilterData(): Generator
+    public function provideFilterDatetimeData(): Generator
     {
-        yield 'exception' => [
+        yield 'bcsub() exception' => [
             'bcsub():',
             '1990-18-18',
         ];

--- a/tests/unit/Varien/Db/Adapter/Pdo/MysqlTest.php
+++ b/tests/unit/Varien/Db/Adapter/Pdo/MysqlTest.php
@@ -62,8 +62,8 @@ class MysqlTest extends TestCase
         /** @var Varien_Object $hostInfo */
         $hostInfo = $method->invoke($this->adapter, $fakeSocket);
 
-        $this->assertEquals($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_UNIX_SOCKET);
-        $this->assertEquals($hostInfo->getUnixSocket(), $fakeSocket);
+        $this->assertSame(Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_UNIX_SOCKET, $hostInfo->getAddressType());
+        $this->assertSame($fakeSocket, $hostInfo->getUnixSocket(),);
         $this->assertNull($hostInfo->getHostName());
         $this->assertNull($hostInfo->getPort());
     }
@@ -79,9 +79,9 @@ class MysqlTest extends TestCase
         /** @var Varien_Object $hostInfo */
         $hostInfo = $method->invoke($this->adapter, '192.168.1.1:3306');
 
-        $this->assertEquals($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_IPV4_ADDRESS);
-        $this->assertEquals('192.168.1.1', $hostInfo->getHostName());
-        $this->assertEquals('3306', $hostInfo->getPort());
+        $this->assertSame($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_IPV4_ADDRESS);
+        $this->assertSame('192.168.1.1', $hostInfo->getHostName());
+        $this->assertSame('3306', $hostInfo->getPort());
         $this->assertNull($hostInfo->getUnixSocket());
     }
 
@@ -96,8 +96,8 @@ class MysqlTest extends TestCase
         /** @var Varien_Object $hostInfo */
         $hostInfo = $method->invoke($this->adapter, '192.168.1.1');
 
-        $this->assertEquals($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_IPV4_ADDRESS);
-        $this->assertEquals('192.168.1.1', $hostInfo->getHostName());
+        $this->assertSame($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_IPV4_ADDRESS);
+        $this->assertSame('192.168.1.1', $hostInfo->getHostName());
         $this->assertNull($hostInfo->getPort());
         $this->assertNull($hostInfo->getUnixSocket());
     }
@@ -113,9 +113,9 @@ class MysqlTest extends TestCase
         /** @var Varien_Object $hostInfo */
         $hostInfo = $method->invoke($this->adapter, 'db.example.com:3306');
 
-        $this->assertEquals($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_HOSTNAME);
-        $this->assertEquals('db.example.com', $hostInfo->getHostName());
-        $this->assertEquals('3306', $hostInfo->getPort());
+        $this->assertSame($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_HOSTNAME);
+        $this->assertSame('db.example.com', $hostInfo->getHostName());
+        $this->assertSame('3306', $hostInfo->getPort());
         $this->assertNull($hostInfo->getUnixSocket());
     }
 
@@ -130,8 +130,8 @@ class MysqlTest extends TestCase
         /** @var Varien_Object $hostInfo */
         $hostInfo = $method->invoke($this->adapter, 'db.example.com');
 
-        $this->assertEquals($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_HOSTNAME);
-        $this->assertEquals('db.example.com', $hostInfo->getHostName());
+        $this->assertSame($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_HOSTNAME);
+        $this->assertSame('db.example.com', $hostInfo->getHostName());
         $this->assertNull($hostInfo->getPort());
         $this->assertNull($hostInfo->getUnixSocket());
     }
@@ -147,9 +147,9 @@ class MysqlTest extends TestCase
         /** @var Varien_Object $hostInfo */
         $hostInfo = $method->invoke($this->adapter, '[2001:db8::1]:3306');
 
-        $this->assertEquals($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_IPV6_ADDRESS);
-        $this->assertEquals('2001:db8::1', $hostInfo->getHostName());
-        $this->assertEquals('3306', $hostInfo->getPort());
+        $this->assertSame($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_IPV6_ADDRESS);
+        $this->assertSame('2001:db8::1', $hostInfo->getHostName());
+        $this->assertSame('3306', $hostInfo->getPort());
         $this->assertNull($hostInfo->getUnixSocket());
     }
 
@@ -164,8 +164,8 @@ class MysqlTest extends TestCase
         /** @var Varien_Object $hostInfo */
         $hostInfo = $method->invoke($this->adapter, '2001:db8::1');
 
-        $this->assertEquals($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_IPV6_ADDRESS);
-        $this->assertEquals('2001:db8::1', $hostInfo->getHostName());
+        $this->assertSame($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_IPV6_ADDRESS);
+        $this->assertSame('2001:db8::1', $hostInfo->getHostName());
         $this->assertNull($hostInfo->getPort());
         $this->assertNull($hostInfo->getUnixSocket());
     }
@@ -181,9 +181,9 @@ class MysqlTest extends TestCase
         /** @var Varien_Object $hostInfo */
         $hostInfo = $method->invoke($this->adapter, '[fe80::1%eth0]:3306');
 
-        $this->assertEquals($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_IPV6_ADDRESS);
-        $this->assertEquals('fe80::1%eth0', $hostInfo->getHostName());
-        $this->assertEquals('3306', $hostInfo->getPort());
+        $this->assertSame($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_IPV6_ADDRESS);
+        $this->assertSame('fe80::1%eth0', $hostInfo->getHostName());
+        $this->assertSame('3306', $hostInfo->getPort());
         $this->assertNull($hostInfo->getUnixSocket());
     }
 
@@ -198,8 +198,8 @@ class MysqlTest extends TestCase
         /** @var Varien_Object $hostInfo */
         $hostInfo = $method->invoke($this->adapter, 'fe80::1%eth0');
 
-        $this->assertEquals($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_IPV6_ADDRESS);
-        $this->assertEquals('fe80::1%eth0', $hostInfo->getHostName());
+        $this->assertSame($hostInfo->getAddressType(), Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_IPV6_ADDRESS);
+        $this->assertSame('fe80::1%eth0', $hostInfo->getHostName());
         $this->assertNull($hostInfo->getPort());
         $this->assertNull($hostInfo->getUnixSocket());
     }

--- a/tests/unit/Varien/Db/Adapter/Pdo/MysqlTest.php
+++ b/tests/unit/Varien/Db/Adapter/Pdo/MysqlTest.php
@@ -63,7 +63,7 @@ class MysqlTest extends TestCase
         $hostInfo = $method->invoke($this->adapter, $fakeSocket);
 
         $this->assertSame(Varien_Db_Adapter_Pdo_Mysql::ADDRESS_TYPE_UNIX_SOCKET, $hostInfo->getAddressType());
-        $this->assertSame($fakeSocket, $hostInfo->getUnixSocket(),);
+        $this->assertSame($fakeSocket, $hostInfo->getUnixSocket());
         $this->assertNull($hostInfo->getHostName());
         $this->assertNull($hostInfo->getPort());
     }

--- a/tests/unit/Varien/ObjectTest.php
+++ b/tests/unit/Varien/ObjectTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Varien;
 
+use Generator;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Varien_Exception;
@@ -46,126 +47,121 @@ class ObjectTest extends TestCase
         $this->assertSame($expectedResult, $this->subject->getData($key, $index));
     }
 
-    /**
-     * @return array<string, array<int, array<int|string, array<int|string, int|string>|int|string>|int|stdClass|string|Varien_Object|null>>
-     */
-    public function provideGetDataData(): array
+    public function provideGetDataData(): Generator
     {
-        return [
-            'empty_key' => [
-                ['empty_key' => ['empty_value']],
-                'empty_key',
-                ['empty_value'],
-                ''
-            ],
-            'string' => [
-                'value',
-                'string',
-                'value',
-                'string'
-            ],
-            'int' => [
-                1,
-                'int',
-                1,
-                'int'
-            ],
-            'numeric' => [
-                '1',
-                'numeric',
-                '1',
-                'numeric'
-            ],
-            'array' => [
-                ['string', 1],
-                'array',
-                ['string', 1],
-                'array',
-            ],
-            'array_index_int' => [
-                'string',
-                'array_index_int',
-                ['string', 1],
-                'array_index_int',
-                0,
-            ],
-            'array_index_int_invalid' => [
-                null,
-                'array_index_int_invalid',
-                ['string', 1],
-                'array_index_int_invalid',
-                999,
-            ],
-            'array_index_string' => [
-                1,
-                'array_index_string',
-                ['string' => 'string', 'int' => 1],
-                'array_index_string',
-                'int',
-            ],
-            'array_index_string_string' => [
-                null,
-                'array_index_string_string',
-                'some_string',
-                'array_index_string_string',
-                'not-exists',
-            ],
-            'array_index_string_varien_object' => [
-                [],
-                'array_index_string_varien_object',
-                new Varien_Object(['array' => []]),
-                'array_index_string_varien_object',
-                'array',
-            ],
-             'array_index_string_std_class' => [
-                null,
-                'array_index_string_std_class',
-                new stdClass(),
-                'array_index_string_std_class',
-                'not-exists',
-            ],
-            'array_nested' => [
-                1,
-                'array_nested',
-                ['nested' => ['string' => 'string', 'int' => 1]],
-                'array_nested/nested/int',
-            ],
-            'array_nested_invalid_key' => [
-                null,
-                'array_nested',
-                ['nested' => ['string' => 'string', 'int' => 1]],
-                'array_nested/nested/invalid_key',
-            ],
-            'array_nested_empty_key' => [
-                null,
-                'array_nested',
-                ['nested' => ['string' => 'string', 'int' => '']],
-                'array_nested/nested/',
-            ],
-            'array_nested_string' => [
-                'some"\n"string',
-                'array_nested_string',
-                ['nested' => 'some"\n"string'],
-                'array_nested_string/nested',
-            ],
-             'array_nested_varien_object' => [
-                null,
-                'array_nested_varien_object',
-                new Varien_Object(),
-                'array_nested_varien_object/nested',
-            ],
-            'array_nested_std_class' => [
-                null,
-                'array_nested_std_class',
-                new stdClass(),
-                'array_nested_std_class/nested',
-            ],
-            'array_nested_key_not_exists' => [
-                null,
-                'array_nested_key_not_exists',
-                ['nested' => ['string' => 'string', 'int' => 1]],
-                'array_nested_key_not_exists_test/nested/int',
-            ],
+        yield 'empty_key' => [
+            ['empty_key' => ['empty_value']],
+            'empty_key',
+            ['empty_value'],
+            ''
+        ];
+        yield 'string' => [
+            'value',
+            'string',
+            'value',
+            'string'
+        ];
+        yield 'int' => [
+            1,
+            'int',
+            1,
+            'int'
+        ];
+        yield 'numeric' => [
+            '1',
+            'numeric',
+            '1',
+            'numeric'
+        ];
+        yield 'array' => [
+            ['string', 1],
+            'array',
+            ['string', 1],
+            'array',
+        ];
+        yield 'array_index_int' => [
+            'string',
+            'array_index_int',
+            ['string', 1],
+            'array_index_int',
+            0,
+        ];
+        yield 'array_index_int_invalid' => [
+            null,
+            'array_index_int_invalid',
+            ['string', 1],
+            'array_index_int_invalid',
+            999,
+        ];
+        yield 'array_index_string' => [
+            1,
+            'array_index_string',
+            ['string' => 'string', 'int' => 1],
+            'array_index_string',
+            'int',
+        ];
+        yield 'array_index_string_string' => [
+            null,
+            'array_index_string_string',
+            'some_string',
+            'array_index_string_string',
+            'not-exists',
+        ];
+        yield 'array_index_string_varien_object' => [
+            [],
+            'array_index_string_varien_object',
+            new Varien_Object(['array' => []]),
+            'array_index_string_varien_object',
+            'array',
+        ];
+        yield 'array_index_string_std_class' => [
+            null,
+            'array_index_string_std_class',
+            new stdClass(),
+            'array_index_string_std_class',
+            'not-exists',
+        ];
+        yield 'array_nested' => [
+            1,
+            'array_nested',
+            ['nested' => ['string' => 'string', 'int' => 1]],
+            'array_nested/nested/int',
+        ];
+        yield 'array_nested_invalid_key' => [
+            null,
+            'array_nested',
+            ['nested' => ['string' => 'string', 'int' => 1]],
+            'array_nested/nested/invalid_key',
+        ];
+        yield 'array_nested_empty_key' => [
+            null,
+            'array_nested',
+            ['nested' => ['string' => 'string', 'int' => '']],
+            'array_nested/nested/',
+        ];
+        yield 'array_nested_string' => [
+            'some"\n"string',
+            'array_nested_string',
+            ['nested' => 'some"\n"string'],
+            'array_nested_string/nested',
+        ];
+        yield 'array_nested_varien_object' => [
+            null,
+            'array_nested_varien_object',
+            new Varien_Object(),
+            'array_nested_varien_object/nested',
+        ];
+        yield 'array_nested_std_class' => [
+            null,
+            'array_nested_std_class',
+            new stdClass(),
+            'array_nested_std_class/nested',
+        ];
+        yield 'array_nested_key_not_exists' => [
+            null,
+            'array_nested_key_not_exists',
+            ['nested' => ['string' => 'string', 'int' => 1]],
+            'array_nested_key_not_exists_test/nested/int',
         ];
     }
 

--- a/tests/unit/Varien/ObjectTest.php
+++ b/tests/unit/Varien/ObjectTest.php
@@ -43,7 +43,7 @@ class ObjectTest extends TestCase
     public function testGetData($expectedResult, $setKey, $setValue, string $key, $index = null): void
     {
         $this->subject->setData($setKey, $setValue);
-        $this->assertEquals($expectedResult, $this->subject->getData($key, $index));
+        $this->assertSame($expectedResult, $this->subject->getData($key, $index));
     }
 
     /**
@@ -176,9 +176,9 @@ class ObjectTest extends TestCase
     {
         $this->subject->setString1('open');
         $this->subject->setString2('mage');
-        $this->assertEquals('open, mage', $this->subject->toString());
-        $this->assertEquals('openmage', $this->subject->toString('{{string1}}{{string2}}'));
-        $this->assertEquals('open', $this->subject->toString('{{string1}}{{string_not_exists}}'));
+        $this->assertSame('open, mage', $this->subject->toString());
+        $this->assertSame('openmage', $this->subject->toString('{{string1}}{{string2}}'));
+        $this->assertSame('open', $this->subject->toString('{{string1}}{{string_not_exists}}'));
     }
 
     /**
@@ -197,36 +197,36 @@ class ObjectTest extends TestCase
         $this->subject->setData('left', 'over');
         $this->assertFalse($this->subject->isEmpty());
 
-        $this->assertEquals('abc', $this->subject->getData('a_b_c'));
-        $this->assertEquals('abc', $this->subject->getABC());
+        $this->assertSame('abc', $this->subject->getData('a_b_c'));
+        $this->assertSame('abc', $this->subject->getABC());
         $this->subject->unsetData('a_b_c');
 
-        $this->assertEquals('efg', $this->subject->getData('efg'));
-        $this->assertEquals('efg', $this->subject->getEfg());
+        $this->assertSame('efg', $this->subject->getData('efg'));
+        $this->assertSame('efg', $this->subject->getEfg());
         $this->subject->unsEfg();
 
-        $this->assertEquals('123', $this->subject->getData('123'));
-        $this->assertEquals('123', $this->subject->get123());
+        $this->assertSame('123', $this->subject->getData('123'));
+        $this->assertSame('123', $this->subject->get123());
         $this->subject->uns123();
 
         $this->subject->unsetData('345');
 
-        $this->assertEquals('value_a_first', $this->subject->getData('key_a_first'));
-        $this->assertEquals('value_a_first', $this->subject->getKeyAFirst());
+        $this->assertSame('value_a_first', $this->subject->getData('key_a_first'));
+        $this->assertSame('value_a_first', $this->subject->getKeyAFirst());
         $this->subject->unsetData('key_a_first');
 
-        $this->assertEquals('value_a_2nd', $this->subject->getData('key_a_2nd'));
-        $this->assertEquals('value_a_2nd', $this->subject->getKeyA_2nd());
+        $this->assertSame('value_a_2nd', $this->subject->getData('key_a_2nd'));
+        $this->assertSame('value_a_2nd', $this->subject->getKeyA_2nd());
         $this->subject->unsetData('key_a_2nd');
 
-        $this->assertEquals('value_a_3rd', $this->subject->getData('key_a3rd'));
-        $this->assertEquals('value_a_3rd', $this->subject->getKeyA3rd());
+        $this->assertSame('value_a_3rd', $this->subject->getData('key_a3rd'));
+        $this->assertSame('value_a_3rd', $this->subject->getKeyA3rd());
         $this->subject->unsetData('key_a3rd');
 
-        $this->assertEquals(['left' => 'over'], $this->subject->getData());
+        $this->assertSame(['left' => 'over'], $this->subject->getData());
 
         $this->subject->unsetData();
-        $this->assertEquals([], $this->subject->getData());
+        $this->assertSame([], $this->subject->getData());
         $this->assertTrue($this->subject->isEmpty());
 
         try {
@@ -247,8 +247,8 @@ class ObjectTest extends TestCase
 
         $this->subject->offsetSet('off', 'set');
         $this->assertTrue($this->subject->offsetExists('off'));
-        $this->assertEquals('set', $this->subject->offsetGet('off'));
-        $this->assertEquals(null, $this->subject->offsetGet('not-exists'));
+        $this->assertSame('set', $this->subject->offsetGet('off'));
+        $this->assertSame(null, $this->subject->offsetGet('not-exists'));
 
         $this->subject->offsetUnset('off');
         $this->assertFalse($this->subject->offsetExists('off'));


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

_Work in progress ..._

- updates tests to test agains DB
- fixes `Mage::getStoreConfig()`
- fixes override existing DB values

Broken ...

- unittests for non-existing stores/websites (?)

### Related Pull Requests
<!-- related pull request placeholder -->
- see OpenMage/magento-lts#3863

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
- see OpenMage/magento-lts#4257

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

Set php ENV variables ... for DDEV (to match tests)

```yml
web_environment:
    - OPENMAGE_CONFIG__DEFAULT__GENERAL__STORE_INFORMATION__NAME=ENV default
    - OPENMAGE_CONFIG__DEFAULT__GENERAL__FOO-BAR__NAME=ENV default dashes
    - OPENMAGE_CONFIG__DEFAULT__GENERAL__FOO_BAR__NAME=ENV default underscore
    - OPENMAGE_CONFIG__DEFAULT__GENERAL__ST=ENV default invalid
    - OPENMAGE_CONFIG__WEBSITES__BASE__GENERAL__STORE_INFORMATION__NAME=ENV website
    - OPENMAGE_CONFIG__WEBSITES__BASE-AT__GENERAL__STORE_INFORMATION__NAME=ENV website dashes
    - OPENMAGE_CONFIG__WEBSITES__BASE_CH__GENERAL__STORE_INFORMATION__NAME=ENV website underscore
    - OPENMAGE_CONFIG__WEBSITES__BASE__GENERAL__ST=ENV website invalid
    - OPENMAGE_CONFIG__STORES__GERMAN__GENERAL__STORE_INFORMATION__NAME=ENV store
    - OPENMAGE_CONFIG__STORES__GERMAN-AT__GENERAL__STORE_INFORMATION__NAME=ENV store dashes
    - OPENMAGE_CONFIG__STORES__GERMAN_CH__GENERAL__STORE_INFORMATION__NAME=ENV store underscore
    - OPENMAGE_CONFIG__STORES__GERMAN__GENERAL__ST=ENV store invalid
```


### Comments
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
This is not nearly perfect, but may help @pquerner and others to debug.

**This PR is NOT based on main-branch, but on #4236.**

See https://github.com/OpenMage/magento-lts/pull/4258/commits/ec2c8a92e28a94755d1888a33efe295a12096294 for relevant changes.

@pquerner @boesbo please check.