### PR TITLE
Bugfix: passing invalid ID to `Mage_Catalog_Model_Url::refreshRewrites()`

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Url.php
@@ -184,6 +184,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
         $select = $adapter->select()
             ->from($this->getMainTable(), new Zend_Db_Expr('MAX(' . $urlIncrementPartExpression . ')'))
             ->where('store_id = :store_id')
+            // phpcs:ignore Ecg.Sql.SlowQuery.SlowRawSql
             ->where('request_path LIKE :request_path')
             ->where($adapter->prepareSqlCondition('request_path', [
                 'regexp' => '^' . preg_quote($prefix) . '[0-9]*' . preg_quote($suffix) . '$'
@@ -264,6 +265,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             $select->where('product_id IN(?)', $productIds);
         }
 
+        // phpcs:ignore Ecg.Performance.FetchAll.Found
         $rowSet = $adapter->fetchAll($select, $bind);
 
         foreach ($rowSet as $row) {
@@ -467,6 +469,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             $bind['store_id']     = $storeId;
         }
 
+        // phpcs:ignore Ecg.Performance.FetchAll.Found
         $rowSet = $adapter->fetchAll($select, $bind);
 
         $attributes = [];
@@ -608,6 +611,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             $bind['store_id'] = $storeId;
         }
 
+        // phpcs:ignore Ecg.Performance.FetchAll.Found
         $rowSet = $adapter->fetchAll($select, $bind);
 
         $attributes = [];
@@ -672,7 +676,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
      * Retrieve categories objects
      * Either $categoryIds or $path (with ending slash) must be specified
      *
-     * @param int|array $categoryIds
+     * @param int|array|null $categoryIds
      * @param int $storeId
      * @param string $path
      * @return array
@@ -706,6 +710,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             }
 
             $select
+                // phpcs:ignore Ecg.Sql.SlowQuery.SlowRawSql
                 ->where('main_table.path LIKE ?', $path . '%')
                 ->order('main_table.path');
         }
@@ -730,6 +735,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             'store_id'     => (int)$storeId
         ];
 
+        // phpcs:ignore Ecg.Performance.FetchAll.Found
         $rowSet = $adapter->fetchAll($select, $bind);
         foreach ($rowSet as $row) {
             if ($storeId !== null) {
@@ -856,9 +862,11 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             $adapter = $this->_getReadAdapter();
             $select = $adapter->select()
                 ->from([$this->getTable('catalog/category')], ['entity_id'])
+                // phpcs:ignore Ecg.Sql.SlowQuery.SlowRawSql
                 ->where('path LIKE ?', $categoryPath . '/%');
 
             $categoryIds = [];
+            // phpcs:ignore Ecg.Performance.FetchAll.Found
             $rowSet = $adapter->fetchAll($select);
             foreach ($rowSet as $row) {
                 $categoryIds[$row['entity_id']] = $row['entity_id'];
@@ -918,7 +926,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
     /**
      * Retrieve Product data objects
      *
-     * @param int|array $productIds
+     * @param int|array|null $productIds
      * @param int $storeId
      * @param int $entityId
      * @param int $lastEntityId
@@ -953,6 +961,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             $select->where('e.entity_id IN(?)', $productIds);
         }
 
+        // phpcs:ignore Ecg.Performance.FetchAll.Found
         $rowSet = $adapter->fetchAll($select, $bind);
         foreach ($rowSet as $row) {
             $product = new Varien_Object($row);
@@ -972,6 +981,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
                     ['product_id', 'category_id']
                 )
                 ->where('product_id IN(?)', array_keys($products));
+            // phpcs:ignore Ecg.Performance.FetchAll.Found
             $categories = $adapter->fetchAll($select);
             foreach ($categories as $category) {
                 $productId = $category['product_id'];
@@ -1103,13 +1113,17 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
     {
         // Form a list of all current store categories ids
         $store          = $this->getStores($storeId);
+        if (!$store instanceof Mage_Core_Model_Store) {
+            return $this;
+        }
+
         $rootCategoryId = $store->getRootCategoryId();
         if (!$rootCategoryId) {
             return $this;
         }
         $categoryIds = $this->getRootChildrenIds($rootCategoryId, $store->getRootCategoryPath());
 
-        // Remove all store catalog rewrites that are for some category or cartegory/product not within store categories
+        // Remove all store catalog rewrites that are for some category or category/product not within store categories
         $where   = [
             'store_id = ?' => $storeId,
             'category_id IS NOT NULL', // For sure check that it's a catalog rewrite
@@ -1136,6 +1150,10 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
     public function clearStoreProductsInvalidRewrites($storeId, $productId = null)
     {
         $store   = $this->getStores($storeId);
+        if (!$store instanceof Mage_Core_Model_Store) {
+            return $this;
+        }
+
         $adapter = $this->_getReadAdapter();
         $bind    = [
             'website_id' => (int)$store->getWebsiteId(),
@@ -1269,6 +1287,7 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
             $select->orWhere($cond);
         }
 
+        // phpcs:ignore Ecg.Performance.FetchAll.Found
         $rowSet = $adapter->fetchAll($select, $bind);
         foreach ($rowSet as $row) {
             $result[$row['product_id']] = [

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -236,7 +236,10 @@ class Mage_Catalog_Model_Url
         }
 
         $this->clearStoreInvalidRewrites($storeId);
-        $this->refreshCategoryRewrite($this->getStores($storeId)->getRootCategoryId(), $storeId, false);
+        $store = $this->getStores($storeId);
+        if ($store instanceof Mage_Core_Model_Store) {
+            $this->refreshCategoryRewrite($store->getRootCategoryId(), $storeId, false);
+        }
         $this->refreshProductRewrites($storeId);
         $this->getResource()->clearCategoryProduct($storeId);
 
@@ -504,9 +507,14 @@ class Mage_Catalog_Model_Url
      */
     public function refreshProductRewrites($storeId)
     {
+        $store = $this->getStores($storeId);
+        if (!$store instanceof Mage_Core_Model_Store) {
+            return $this;
+        }
+
         $this->_categories      = [];
-        $storeRootCategoryId    = $this->getStores($storeId)->getRootCategoryId();
-        $storeRootCategoryPath  = $this->getStores($storeId)->getRootCategoryPath();
+        $storeRootCategoryId    = $store->getRootCategoryId();
+        $storeRootCategoryPath  = $store->getRootCategoryPath();
         $this->_categories[$storeRootCategoryId] = $this->getResource()->getCategory($storeRootCategoryId, $storeId);
 
         $lastEntityId = 0;


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Part of https://github.com/OpenMage/magento-lts/pull/4236

Passing an invalid `$storeId` to `Mage_Catalog_Model_Url::refreshRewrites($storeId)` leads to multiple errors trying call methods on array.

To reproduce:

```php
$model = new Mage_Catalog_Model_Url();
$model->refreshRewrites(999);
```