### PR TITLE
[WIP] Fixes ENV overriding config

### DIFF
--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -2166,11 +2166,6 @@ parameters:
 			path: app/code/core/Mage/Core/Model/Config.php
 
 		-
-			message: "#^Method Mage_Core_Model_Config\\:\\:getNode\\(\\) should return Mage_Core_Model_Config_Element but returns Varien_Simplexml_Element\\|false\\.$#"
-			count: 1
-			path: app/code/core/Mage/Core/Model/Config.php
-
-		-
 			message: "#^Return type \\(Mage_Core_Model_App\\) of method Mage_Core_Model_Config\\:\\:_saveCache\\(\\) should be compatible with return type \\(bool\\) of method Varien_Simplexml_Config\\:\\:_saveCache\\(\\)$#"
 			count: 1
 			path: app/code/core/Mage/Core/Model/Config.php

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
@@ -55,6 +55,15 @@ class Mage_Adminhtml_Block_System_Config_Form_Field extends Mage_Adminhtml_Block
             $checkboxLabel = $this->__('Use Default');
         }
 
+        $envConfig = Mage::getConfig()->getEnvOverriddenConfigPaths();
+        $envConfigIds = array_combine(str_replace('/', '_', array_keys($envConfig)), array_values($envConfig), );
+        if (array_key_exists($element->getId(), $envConfigIds)) {
+            $addInheritCheckbox = false;
+            $element->setDisabled(true);
+            $element->setScopeLabel('[ENV]');
+            $element->setValue($envConfigIds[$element->getId()]);
+        }
+
         if ($addInheritCheckbox) {
             $inherit = $element->getInherit() == 1 ? 'checked="checked"' : '';
             if ($inherit) {

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
@@ -47,6 +47,7 @@ class Mage_Adminhtml_Block_System_Config_Form_Field extends Mage_Adminhtml_Block
         $options = $element->getValues();
 
         $addInheritCheckbox = false;
+        $checkboxLabel = '';
         if ($element->getCanUseWebsiteValue()) {
             $addInheritCheckbox = true;
             $checkboxLabel = $this->__('Use Website');
@@ -56,7 +57,7 @@ class Mage_Adminhtml_Block_System_Config_Form_Field extends Mage_Adminhtml_Block
         }
 
         $envConfig = Mage::getConfig()->getEnvOverriddenConfigPaths();
-        $envConfigIds = array_combine(str_replace('/', '_', array_keys($envConfig)), array_values($envConfig), );
+        $envConfigIds = array_combine(str_replace('/', '_', array_keys($envConfig)), array_values($envConfig));
         if (array_key_exists($element->getId(), $envConfigIds)) {
             $addInheritCheckbox = false;
             $element->setDisabled(true);

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -239,6 +239,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      * Active modules array per namespace
      * @var array
      */
+    // phpcs:ignore Ecg.PHP.PrivateClassMember.PrivateClassMemberError
     private $_moduleNamespaces = null;
 
     /**
@@ -250,6 +251,11 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     protected $_allowedModules = [];
 
     /**
+     * Config paths overloaded by ENV
+     */
+    protected array $envOverriddenConfigPaths = [];
+
+    /**
      * Class construct
      *
      * @param mixed $sourceData
@@ -257,7 +263,9 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     public function __construct($sourceData = null)
     {
         $this->setCacheId('config_global');
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
         $this->_options         = new Mage_Core_Model_Config_Options($sourceData);
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
         $this->_prototype       = new Mage_Core_Model_Config_Base();
         $this->_cacheChecksum   = null;
         parent::__construct($sourceData);
@@ -338,6 +346,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     public function loadBase()
     {
         $etcDir = $this->getOptions()->getEtcDir();
+        // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
         $files = glob($etcDir . DS . '*.xml');
         $this->loadFile(current($files));
         while ($file = next($files)) {
@@ -381,7 +390,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
         $this->_loadDeclaredModules();
 
         $resourceConfig = sprintf('config.%s.xml', $this->_getResourceConnectionModel('core'));
-        $this->loadModulesConfiguration(['config.xml',$resourceConfig], $this);
+        $this->loadModulesConfiguration(['config.xml', $resourceConfig], $this);
 
         /**
          * Prevent local.xml directives overwriting
@@ -473,6 +482,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
         }
 
         if ($disableLocalModules === true) {
+            // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
             set_include_path(
                 BP . DS . 'app' . DS . 'code' . DS . 'community' . PS .
                 BP . DS . 'app' . DS . 'code' . DS . 'core' . PS .
@@ -521,6 +531,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
         if (!Mage::app()->useCache('config')) {
             return;
         }
+        // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
         $waitTime = $waitTime ?: (getenv('MAGE_CONFIG_CACHE_LOCK_WAIT') ?: (PHP_SAPI === 'cli' ? 60 : 3));
         $connection = Mage::getSingleton('core/resource')->getConnection('core_write');
         if (!$connection->fetchOne("SELECT GET_LOCK('core_config_cache_save_lock', ?)", [$waitTime])) {
@@ -530,7 +541,9 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
                 throw new Exception('Could not get lock on cache save operation.');
             } else {
                 Mage::log(sprintf('Failed to get cache save lock in %d seconds.', $waitTime), Zend_Log::NOTICE);
+                // phpcs:ignore Ecg.Security.IncludeFile.IncludeFileDetected
                 require Mage::getBaseDir() . DS . 'errors' . DS . '503.php';
+                // phpcs:ignore Ecg.Security.LanguageConstruct.ExitUsage
                 die();
             }
         }
@@ -739,7 +752,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      * Returns node found by the $path and scope info
      *
      * @inheritDoc
-     * @return Mage_Core_Model_Config_Element
+     * @return Mage_Core_Model_Config_Element|false
      */
     public function getNode($path = null, $scope = '', $scopeCode = null)
     {
@@ -805,6 +818,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     protected function _getDeclaredModuleFiles()
     {
         $etcDir = $this->getOptions()->getEtcDir();
+        // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
         $moduleFiles = glob($etcDir . DS . 'modules' . DS . '*.xml');
 
         if (!$moduleFiles) {
@@ -818,6 +832,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
 
         foreach ($moduleFiles as $v) {
             $name = explode(DIRECTORY_SEPARATOR, $v);
+            // phpcs:ignore Ecg.Performance.Loop.ArraySize
             $name = substr($name[count($name) - 1], 0, -4);
 
             if (array_key_exists($name, self::MAGE_MODULES)) {
@@ -875,6 +890,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      * @param null $mergeConfig deprecated
      * @return $this|void
      */
+    // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClass
     protected function _loadDeclaredModules($mergeConfig = null)
     {
         $moduleFiles = $this->_getDeclaredModuleFiles();
@@ -884,8 +900,10 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
 
         Varien_Profiler::start('config/load-modules-declaration');
 
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
         $unsortedConfig = new Mage_Core_Model_Config_Base();
         $unsortedConfig->loadString('<config/>');
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
         $fileConfig = new Mage_Core_Model_Config_Base();
 
         // load modules declarations
@@ -917,6 +935,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
         $moduleDepends = $this->_sortModuleDepends($moduleDepends);
 
         // create sorted config
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
         $sortedConfig = new Mage_Core_Model_Config_Base();
         $sortedConfig->loadString('<config><modules/></config>');
 
@@ -1035,9 +1054,9 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
 
     /**
      * Iterate all active modules "etc" folders and combine data from
-     * specidied xml file name to one object
+     * specified xml file name to one object
      *
-     * @param string $fileName
+     * @param string|array $fileName
      * @param null|Mage_Core_Model_Config_Base|Varien_Simplexml_Config $mergeToObject
      * @param Varien_Simplexml_Config|null $mergeModel
      * @return Mage_Core_Model_Config_Base|Varien_Simplexml_Config
@@ -1097,10 +1116,13 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     public function getDistroServerVars()
     {
         if (!$this->_distroServerVars) {
+            // phpcs:ignore Ecg.Security.Superglobal.SuperglobalUsageWarning
             if (isset($_SERVER['SCRIPT_NAME']) && isset($_SERVER['HTTP_HOST'])) {
+                // phpcs:ignore Ecg.Security.Superglobal.SuperglobalUsageWarning
                 $secure = (!empty($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] != 'off')) || $_SERVER['SERVER_PORT'] == '443';
                 $scheme = ($secure ? 'https' : 'http') . '://' ;
 
+                // phpcs:ignore Ecg.Security.Superglobal.SuperglobalUsageWarning
                 $hostArr = explode(':', $_SERVER['HTTP_HOST']);
                 $host = $hostArr[0];
                 $port = isset(
@@ -1821,5 +1843,16 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     protected function _isNodeNameHasUpperCase(Mage_Core_Model_Config_Element $event)
     {
         return (strtolower($event->getName()) !== (string)$event->getName());
+    }
+
+    public function getEnvOverriddenConfigPaths(): array
+    {
+        return $this->envOverriddenConfigPaths;
+    }
+
+    public function addEnvOverriddenConfigPaths(string $path, string $value): Mage_Core_Model_Config
+    {
+        $this->envOverriddenConfigPaths[$path] = $value;
+        return $this;
     }
 }

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -337,13 +337,22 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
      */
     public function getConfig($path)
     {
+        $config = Mage::getConfig();
+        $fullPath = 'stores/' . $this->getCode() . '/' . $path;
+        $envConfig = $config->getEnvOverriddenConfigPaths();
+
+        if (array_key_exists($fullPath, $envConfig)) {
+            return $envConfig[$fullPath];
+        }
+
+        if (array_key_exists($path, $envConfig)) {
+            return $envConfig[$path];
+        }
+
         if (isset($this->_configCache[$path])) {
             return $this->_configCache[$path];
         }
 
-        $config = Mage::getConfig();
-
-        $fullPath = 'stores/' . $this->getCode() . '/' . $path;
         $data = $config->getNode($fullPath);
         if (!$data && !Mage::isInstalled()) {
             $data = $config->getNode('default/' . $path);

--- a/lib/Varien/Data/Form/Element/Abstract.php
+++ b/lib/Varien/Data/Form/Element/Abstract.php
@@ -29,6 +29,8 @@
  * @method bool getNoSpan()
  * @method $this setName(string $value)
  * @method bool getRequired()
+ * @method string getScopeLabel()
+ * @method $this setScopeLabel(string $value)
  * @method string getValue()
  * @method array getValues()
  * @method $this setValues(array|int|string $value)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,21 @@
         </testsuite>
     </testsuites>
 
+    <php>
+        <env name="OPENMAGE_CONFIG__DEFAULT__GENERAL__STORE_INFORMATION__NAME" value="ENV default"/>
+        <env name="OPENMAGE_CONFIG__DEFAULT__GENERAL__FOO-BAR__NAME" value="ENV default dashes"/>
+        <env name="OPENMAGE_CONFIG__DEFAULT__GENERAL__FOO_BAR__NAME" value="ENV default underscore"/>
+        <env name="OPENMAGE_CONFIG__DEFAULT__GENERAL__ST" value="ENV default invalid"/>
+        <env name="OPENMAGE_CONFIG__WEBSITES__BASE__GENERAL__STORE_INFORMATION__NAME" value="ENV website"/>
+        <env name="OPENMAGE_CONFIG__WEBSITES__BASE-AT__GENERAL__STORE_INFORMATION__NAME" value="ENV website dashes"/>
+        <env name="OPENMAGE_CONFIG__WEBSITES__BASE_CH__GENERAL__STORE_INFORMATION__NAME" value="ENV website underscore"/>
+        <env name="OPENMAGE_CONFIG__WEBSITES__BASE__GENERAL__ST" value="ENV website invalid"/>
+        <env name="OPENMAGE_CONFIG__STORES__GERMAN__GENERAL__STORE_INFORMATION__NAME" value="ENV store"/>
+        <env name="OPENMAGE_CONFIG__STORES__GERMAN-AT__GENERAL__STORE_INFORMATION__NAME" value="ENV store dashes"/>
+        <env name="OPENMAGE_CONFIG__STORES__GERMAN_CH__GENERAL__STORE_INFORMATION__NAME" value="ENV store underscore"/>
+        <env name="OPENMAGE_CONFIG__STORES__GERMAN__GENERAL__ST" value="ENV store invalid"/>
+    </php>
+
     <coverage
         includeUncoveredFiles="true"
         processUncoveredFiles="false"

--- a/tests/unit/Mage/Core/Helper/EnvironmentConfigLoaderTest.php
+++ b/tests/unit/Mage/Core/Helper/EnvironmentConfigLoaderTest.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Core\Helper;
 
+use Generator;
 use Mage;
-use Mage_Core_Exception;
 use Mage_Core_Helper_EnvironmentConfigLoader;
 use PHPUnit\Framework\TestCase;
 use Varien_Simplexml_Config;
@@ -33,12 +33,12 @@ class EnvironmentConfigLoaderTest extends TestCase
 
     public const XML_PATH_STORE = 'stores/german/general/store_information/name';
 
-    /**
-     * @throws Mage_Core_Exception
-     */
+    public Mage_Core_Helper_EnvironmentConfigLoader $subject;
+
     public function setup(): void
     {
-        Mage::setRoot();
+        Mage::app();
+        $this->subject = Mage::helper('core/environmentConfigLoader');
     }
 
     /**
@@ -49,7 +49,7 @@ class EnvironmentConfigLoaderTest extends TestCase
     {
         $environmentConfigLoaderHelper = new EnvironmentConfigLoaderTestHelper();
         $path = $environmentConfigLoaderHelper->exposedBuildPath('GENERAL', 'STORE_INFORMATION', 'NAME');
-        $this->assertEquals(self::XML_PATH_GENERAL, $path);
+        $this->assertSame(self::XML_PATH_GENERAL, $path);
     }
 
     /**
@@ -60,222 +60,156 @@ class EnvironmentConfigLoaderTest extends TestCase
     {
         $environmentConfigLoaderHelper = new EnvironmentConfigLoaderTestHelper();
         $nodePath = $environmentConfigLoaderHelper->exposedBuildNodePath('DEFAULT', self::XML_PATH_GENERAL);
-        $this->assertEquals(self::XML_PATH_DEFAULT, $nodePath);
+        $this->assertSame(self::XML_PATH_DEFAULT, $nodePath);
     }
 
     /**
      * @group Mage_Core
      * @group Mage_Core_Helper
+     * @group EnvLoader
      */
     public function testXmlHasTestStrings(): void
     {
         $xmlStruct = $this->getTestXml();
         $xml = new Varien_Simplexml_Config();
         $xml->loadString($xmlStruct);
-        $this->assertEquals('test_default', (string)$xml->getNode(self::XML_PATH_DEFAULT));
-        $this->assertEquals('test_website', (string)$xml->getNode(self::XML_PATH_WEBSITE));
-        $this->assertEquals('test_store', (string)$xml->getNode(self::XML_PATH_STORE));
+
+        $this->assertSame('test_default', (string)$xml->getNode(self::XML_PATH_DEFAULT));
+        $this->assertSame('test_website', (string)$xml->getNode(self::XML_PATH_WEBSITE));
+        $this->assertSame('test_store', (string)$xml->getNode(self::XML_PATH_STORE));
     }
 
     /**
-     * @dataProvider envOverridesCorrectConfigKeysDataProvider
-     *
+     * @dataProvider provideOverrideEnvironment
      * @group Mage_Core
      * @group Mage_Core_Helper
+     *
+     * @param array<string, string> $params
      */
-    public function testEnvOverridesForValidConfigKeys(array $config): void
+    public function testOverrideEnvironmentNode(string $expectedResult, array $params): void
     {
-        $xmlStruct = $this->getTestXml();
-
-        $xmlDefault = new Varien_Simplexml_Config();
-        $xmlDefault->loadString($xmlStruct);
-        $xml = new Varien_Simplexml_Config();
-        $xml->loadString($xmlStruct);
-
-        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
-        $loader = new Mage_Core_Helper_EnvironmentConfigLoader();
-        $loader->setEnvStore([
-            $config['env_path'] => $config['value']
-        ]);
-        $loader->overrideEnvironment($xml);
-
-        $configPath = $config['xml_path'];
-        $defaultValue = $xmlDefault->getNode($configPath);
-        $valueAfterOverride = $xml->getNode($configPath);
-
-        // assert
-        $this->assertNotEquals((string)$defaultValue, (string)$valueAfterOverride, 'Default value was not overridden.');
+        $config = Mage::getConfig();
+        $this->subject->overrideEnvironment($config);
+        $this->assertSame($expectedResult, trim((string)$config->getNode($params['xmlPath'])));
     }
 
     /**
-     * @return array<array<string, array<string, string>>>
+     * @dataProvider provideOverrideEnvironment
+     * @group Mage_Core
+     * @group Mage_Core_Helper
+     *
+     * @param array<string, string> $params
      */
-    public function envOverridesCorrectConfigKeysDataProvider(): array
+    public function testOverrideEnvironmentConfig(string $expectedResult, array $params): void
     {
-        $defaultPath = 'OPENMAGE_CONFIG__DEFAULT__GENERAL__STORE_INFORMATION__NAME';
-        $defaultPathWithDash = 'OPENMAGE_CONFIG__DEFAULT__GENERAL__FOO-BAR__NAME';
-        $defaultPathWithUnderscore = 'OPENMAGE_CONFIG__DEFAULT__GENERAL__FOO_BAR__NAME';
+        $config = Mage::getConfig();
+        $this->subject->overrideEnvironment($config);
 
-        $websitePath = 'OPENMAGE_CONFIG__WEBSITES__BASE__GENERAL__STORE_INFORMATION__NAME';
-        $websiteWithDashPath = 'OPENMAGE_CONFIG__WEBSITES__BASE-AT__GENERAL__STORE_INFORMATION__NAME';
-        $websiteWithUnderscorePath = 'OPENMAGE_CONFIG__WEBSITES__BASE_CH__GENERAL__STORE_INFORMATION__NAME';
+        $configPath = explode('/', $params['xmlPath']);
+        unset($configPath[0], $configPath[1]);
+        $configPath = implode('/', $configPath);
 
-        $storeWithDashPath = 'OPENMAGE_CONFIG__STORES__GERMAN-AT__GENERAL__STORE_INFORMATION__NAME';
-        $storeWithUnderscorePath = 'OPENMAGE_CONFIG__STORES__GERMAN_CH__GENERAL__STORE_INFORMATION__NAME';
-        $storePath = 'OPENMAGE_CONFIG__STORES__GERMAN__GENERAL__STORE_INFORMATION__NAME';
+        $this->assertSame($expectedResult, (string)Mage::getStoreConfig($configPath, $params['storeId']));
+    }
 
-        return [
+    public function provideOverrideEnvironment(): Generator
+    {
+        yield 'Case DEFAULT overrides' => [
+            'ENV default',
             [
-                'Case DEFAULT overrides.' => [
-                    'case'     => 'DEFAULT',
-                    'xml_path' => self::XML_PATH_DEFAULT,
-                    'env_path' => $defaultPath,
-                    'value'    => 'default_new_value'
-                ]
-            ],
-            [
-                'Case DEFAULT overrides.' => [
-                    'case'     => 'DEFAULT',
-                    'xml_path' => 'default/general/foo-bar/name',
-                    'env_path' => $defaultPathWithDash,
-                    'value'    => 'baz'
-                ]
-            ],
-            [
-                'Case DEFAULT overrides.' => [
-                    'case'     => 'DEFAULT',
-                    'xml_path' => 'default/general/foo_bar/name',
-                    'env_path' => $defaultPathWithUnderscore,
-                    'value'    => 'baz'
-                ]
-            ],
-            [
-                'Case STORE overrides.' => [
-                    'case'     => 'STORE',
-                    'xml_path' => self::XML_PATH_STORE,
-                    'env_path' => $storePath,
-                    'value'    => 'store_new_value'
-                ]
-            ],
-            [
-                'Case STORE overrides.' => [
-                    'case'     => 'STORE',
-                    'xml_path' => 'stores/german-at/general/store_information/name',
-                    'env_path' => $storeWithDashPath,
-                    'value'    => 'store_new_value'
-                ]
-            ],
-            [
-                'Case STORE overrides.' => [
-                    'case'     => 'STORE',
-                    'xml_path' => 'stores/german_ch/general/store_information/name',
-                    'env_path' => $storeWithUnderscorePath,
-                    'value'    => 'store_new_value'
-                ]
-            ],
-            [
-                'Case WEBSITE overrides.' => [
-                    'case'     => 'WEBSITE',
-                    'xml_path' => self::XML_PATH_WEBSITE,
-                    'env_path' => $websitePath,
-                    'value'    => 'website_new_value'
-                ]
-            ],
-            [
-                'Case WEBSITE overrides.' => [
-                    'case'     => 'WEBSITE',
-                    'xml_path' => 'websites/base_ch/general/store_information/name',
-                    'env_path' => $websiteWithUnderscorePath,
-                    'value'    => 'website_new_value'
-                ]
-            ],
-            [
-                'Case WEBSITE overrides.' => [
-                    'case'     => 'WEBSITE',
-                    'xml_path' => 'websites/base-at/general/store_information/name',
-                    'env_path' => $websiteWithDashPath,
-                    'value'    => 'website_new_value'
-                ]
+                'xmlPath'   => self::XML_PATH_DEFAULT,
+                'envPath'   => 'OPENMAGE_CONFIG__DEFAULT__GENERAL__STORE_INFORMATION__NAME',
+                'storeId'   => null
             ]
         ];
-    }
-
-    /**
-     * @dataProvider envDoesNotOverrideOnWrongConfigKeysDataProvider
-     * @param array<string, string> $config
-     *
-     * @group Mage_Core
-     */
-    public function testEnvDoesNotOverrideForInvalidConfigKeys(array $config): void
-    {
-        $xmlStruct = $this->getTestXml();
-
-        $xmlDefault = new Varien_Simplexml_Config();
-        $xmlDefault->loadString($xmlStruct);
-        $xml = new Varien_Simplexml_Config();
-        $xml->loadString($xmlStruct);
-
-        $defaultValue = 'test_default';
-        $this->assertEquals($defaultValue, (string)$xml->getNode(self::XML_PATH_DEFAULT));
-        $defaultWebsiteValue = 'test_website';
-        $this->assertEquals($defaultWebsiteValue, (string)$xml->getNode(self::XML_PATH_WEBSITE));
-        $defaultStoreValue = 'test_store';
-        $this->assertEquals($defaultStoreValue, (string)$xml->getNode(self::XML_PATH_STORE));
-
-        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
-        $loader = new Mage_Core_Helper_EnvironmentConfigLoader();
-        $loader->setEnvStore([
-            $config['path'] => $config['value']
-        ]);
-        $loader->overrideEnvironment($xml);
-
-        $valueAfterCheck = '';
-        switch ($config['case']) {
-            case 'DEFAULT':
-                $valueAfterCheck = $xml->getNode(self::XML_PATH_DEFAULT);
-                break;
-            case 'STORE':
-                $valueAfterCheck = $xml->getNode(self::XML_PATH_STORE);
-                break;
-            case 'WEBSITE':
-                $valueAfterCheck = $xml->getNode(self::XML_PATH_WEBSITE);
-                break;
-        }
-
-        // assert
-        $this->assertTrue(!str_contains('value_will_not_be_changed', (string)$valueAfterCheck), 'Default value was wrongfully overridden.');
-    }
-
-    /**
-     * @return array<array<string, array<string, string>>>
-     */
-    public function envDoesNotOverrideOnWrongConfigKeysDataProvider(): array
-    {
-        $defaultPath = 'OPENMAGE_CONFIG__DEFAULT__GENERAL__ST';
-        $websitePath = 'OPENMAGE_CONFIG__WEBSITES__BASE__GENERAL__ST';
-        $storePath = 'OPENMAGE_CONFIG__STORES__GERMAN__GENERAL__ST';
-
-        return [
+        yield 'Case DEFAULT overrides w/ dashes' => [
+            'ENV default dashes',
             [
-                'Case DEFAULT with ' . $defaultPath . ' will not override.' => [
-                    'case'  => 'DEFAULT',
-                    'path'  => $defaultPath,
-                    'value' => 'default_value_will_not_be_changed'
-                ]
-            ],
+                'xmlPath'   => 'stores/default/general/foo-bar/name',
+                'envPath'   => 'OPENMAGE_CONFIG__DEFAULT__GENERAL__FOO-BAR__NAME',
+                'storeId'   => null
+            ]
+        ];
+        yield 'Case DEFAULT overrides w/ underscore' => [
+            'ENV default underscore',
             [
-                'Case STORE with ' . $storePath . ' will not override.' => [
-                    'case'  => 'STORE',
-                    'path'  => $storePath,
-                    'value' => 'store_value_will_not_be_changed'
-                ]
-            ],
+                'xmlPath'   => 'stores/default/general/foo_bar/name',
+                'envPath'   => 'OPENMAGE_CONFIG__DEFAULT__GENERAL__FOO_BAR__NAME',
+                'storeId'   => null
+            ]
+        ];
+        yield 'Case DEFAULT will not override' => [
+            '',
             [
-                'Case WEBSITE with ' . $websitePath . ' will not override.' => [
-                    'case'  => 'WEBSITE',
-                    'path'  => $websitePath,
-                    'value' => 'website_value_will_not_be_changed'
-                ]
+                'xmlPath'   => '',
+                'envPath'   => 'OPENMAGE_CONFIG__DEFAULT__GENERAL__ST',
+                'storeId'   => null
+            ]
+        ];
+
+        yield 'Case WEBSITE overrides' => [
+            'ENV website',
+            [
+                'xmlPath'   => self::XML_PATH_WEBSITE,
+                'envPath'   => 'OPENMAGE_CONFIG__WEBSITES__BASE__GENERAL__STORE_INFORMATION__NAME',
+                'storeId'   => null
+            ]
+        ];
+        yield 'Case WEBSITE overrides w/ dashes' => [
+            'ENV website dashes',
+            [
+                'xmlPath'   => 'websites/base-at/general/store_information/name',
+                'envPath'   => 'OPENMAGE_CONFIG__WEBSITES__BASE-AT__GENERAL__STORE_INFORMATION__NAME',
+                'storeId'   => null
+            ]
+        ];
+        yield 'Case WEBSITE overrides w/ underscore' => [
+            'ENV website underscore',
+            [
+                'xmlPath'   => 'websites/base_ch/general/store_information/name',
+                'envPath'   => 'OPENMAGE_CONFIG__WEBSITES__BASE_CH__GENERAL__STORE_INFORMATION__NAME',
+                'storeId'   => null
+            ]
+        ];
+        yield 'Case WEBSITE will not override' => [
+            '',
+            [
+                'xmlPath'   => '',
+                'envPath'  => 'OPENMAGE_CONFIG__WEBSITES__BASE__GENERAL__ST',
+                'storeId'   => null
+            ]
+        ];
+
+        yield 'Case STORE overrides' => [
+            'ENV store',
+            [
+                'xmlPath'   => self::XML_PATH_STORE,
+                'envPath'   => 'OPENMAGE_CONFIG__STORES__GERMAN__GENERAL__STORE_INFORMATION__NAME',
+                'storeId'   => null
+            ]
+        ];
+        yield 'Case STORE overrides w/ dashes' => [
+            'ENV store dashes',
+            [
+                'xmlPath'   => 'stores/german-at/general/store_information/name',
+                'envPath'   => 'OPENMAGE_CONFIG__STORES__GERMAN-AT__GENERAL__STORE_INFORMATION__NAME',
+                'storeId'   => null
+            ]
+        ];
+        yield 'Case STORE overrides w/ underscore' => [
+            'ENV store underscore',
+            [
+                'xmlPath'   => 'stores/german_ch/general/store_information/name',
+                'envPath'   => 'OPENMAGE_CONFIG__STORES__GERMAN_CH__GENERAL__STORE_INFORMATION__NAME',
+                'storeId'   => null
+            ]
+        ];
+        yield 'Case STORE will not override' => [
+            '',
+            [
+                'xmlPath'   => '',
+                'envPath'   => 'OPENMAGE_CONFIG__STORES__GERMAN__GENERAL__ST',
+                'storeId'   => null
             ]
         ];
     }
@@ -291,10 +225,10 @@ class EnvironmentConfigLoaderTest extends TestCase
                     <name>test_default</name>
             </store_information>
             <foo-bar>
-                    <name>test_default</name>
+                    <name>test_dashes</name>
             </foo-bar>
             <foo_bar>
-                    <name>test_default</name>
+                    <name>test_underscore</name>
             </foo_bar>
         </general>
     </default>


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

_Work in progress ..._

(some lines are only for testing and have to be removed)

- updates tests to test agains DB
- fixes `Mage::getStoreConfig()`
- fixes override existing DB values
- locked attributes in system config

Broken ...

- unittests for non-existing stores/websites (?)

### Related Pull Requests
<!-- related pull request placeholder -->
- see OpenMage/magento-lts#3863

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
- see OpenMage/magento-lts#4257

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

Set php ENV variables ... for DDEV (to match tests)

```yml
web_environment:
    - OPENMAGE_CONFIG__DEFAULT__GENERAL__STORE_INFORMATION__NAME=ENV default
    - OPENMAGE_CONFIG__DEFAULT__GENERAL__FOO-BAR__NAME=ENV default dashes
    - OPENMAGE_CONFIG__DEFAULT__GENERAL__FOO_BAR__NAME=ENV default underscore
    - OPENMAGE_CONFIG__DEFAULT__GENERAL__ST=ENV default invalid
    - OPENMAGE_CONFIG__WEBSITES__BASE__GENERAL__STORE_INFORMATION__NAME=ENV website
    - OPENMAGE_CONFIG__WEBSITES__BASE-AT__GENERAL__STORE_INFORMATION__NAME=ENV website dashes
    - OPENMAGE_CONFIG__WEBSITES__BASE_CH__GENERAL__STORE_INFORMATION__NAME=ENV website underscore
    - OPENMAGE_CONFIG__WEBSITES__BASE__GENERAL__ST=ENV website invalid
    - OPENMAGE_CONFIG__STORES__GERMAN__GENERAL__STORE_INFORMATION__NAME=ENV store
    - OPENMAGE_CONFIG__STORES__GERMAN-AT__GENERAL__STORE_INFORMATION__NAME=ENV store dashes
    - OPENMAGE_CONFIG__STORES__GERMAN_CH__GENERAL__STORE_INFORMATION__NAME=ENV store underscore
    - OPENMAGE_CONFIG__STORES__GERMAN__GENERAL__ST=ENV store invalid
```


### Comments
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
This is not nearly perfect, but may help others to debug.

@pquerner @boesbo please check.