### PR TITLE
New feature: enhance security with  custom admin URL.

### DIFF
--- a/app/code/core/Mage/Adminhtml/Helper/Data.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Data.php
@@ -23,6 +23,7 @@ class Mage_Adminhtml_Helper_Data extends Mage_Adminhtml_Helper_Help_Mapping
 {
     public const XML_PATH_ADMINHTML_ROUTER_FRONTNAME   = 'admin/routers/adminhtml/args/frontName';
     public const XML_PATH_USE_CUSTOM_ADMIN_URL         = 'default/admin/url/use_custom';
+    public const XML_PATH_CUSTOM_ADMIN_URL             = 'default/admin/url/custom';
     public const XML_PATH_USE_CUSTOM_ADMIN_PATH        = 'default/admin/url/use_custom_path';
     public const XML_PATH_CUSTOM_ADMIN_PATH            = 'default/admin/url/custom_path';
     public const XML_PATH_ADMINHTML_SECURITY_USE_FORM_KEY = 'admin/security/use_form_key';
@@ -83,6 +84,21 @@ class Mage_Adminhtml_Helper_Data extends Mage_Adminhtml_Helper_Help_Mapping
     public static function getUrl($route = '', $params = [])
     {
         return Mage::getModel('adminhtml/url')->getUrl($route, $params);
+    }
+
+    /**
+     * @return string|false
+     */
+    public static function getCustomAdminUrl()
+    {
+        $config = Mage::getConfig();
+        if ($config->getNode(self::XML_PATH_USE_CUSTOM_ADMIN_URL)
+            && $config->getNode(self::XML_PATH_CUSTOM_ADMIN_URL)
+        ) {
+            return (string) $config->getNode(self::XML_PATH_CUSTOM_ADMIN_URL);
+        }
+
+        return false;
     }
 
     /**

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -614,7 +614,15 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
                 $url = str_replace('{{base_url}}', $baseUrl, $url);
             }
 
-            $this->_baseUrlCache[$cacheKey] = rtrim($url, '/') . '/';
+            $url = rtrim($url, '/') . '/';
+            $adminUrl = $this->isAdmin() ? Mage_Adminhtml_Helper_Data::getCustomAdminUrl() : false;
+            if ($adminUrl) {
+                $adminUrl = rtrim($adminUrl, '/') . '/';
+                $baseUrl = str_starts_with($url, 'https://') ? $this->getConfig(self::XML_PATH_SECURE_BASE_URL) : $this->getConfig(self::XML_PATH_UNSECURE_BASE_URL);
+                $url = str_replace($baseUrl, $adminUrl, $url);
+            }
+
+            $this->_baseUrlCache[$cacheKey] = $url;
         }
 
         return $this->_baseUrlCache[$cacheKey];


### PR DESCRIPTION
### Description (*)
Ref https://github.com/OpenMage/magento-lts/pull/1209#issuecomment-2345295441, where I was trying to make use of the [nginx config for admin](https://github.com/OpenMage/magento-lts/blob/main/dev/openmage/nginx-admin.conf) without the use of caddy. For this, I needed the ability to have a custom admin URL, which is configurable here:

![image](https://github.com/user-attachments/assets/747f4b73-0d2e-4dd1-8d33-ce1eb7732755)

However, _Custom Admin URL_ is not implemented. This PR is my attempt to complete the implementation.

### Related Pull Requests
PR #1209 

### Manual testing scenarios (*)
1. Example nginx config:
```nginx
server {
    listen 80;
    server_name admin.example.com;

    access_log /var/log/nginx/admin.example.com-access.log combined;
    error_log /var/log/nginx/admin.example.com-error.log;

    set $webroot /var/web/example; # OpenMage root

    include include/openmage-admin.conf; # See dev/openmage/nginx-admin.conf
}
```
2. It's probably not feasible to set  _Custom Admin URL_ in admin. So add it directly to the table:
```sql
UPDATE `core_config_data` SET `value` = '1' WHERE `path` = 'admin/url/use_custom';
INSERT INTO `core_config_data` (`scope`, `scope_id`, `path`, `value`, `updated_at`) VALUES ('default', '0', 'admin/url/custom', 'admin.example.com', CURRENT_TIMESTAMP);
```
3. Navigate to `admin.example.com/adminFrontName` where `adminFrontName` is set in /etc/local.xml

### Questions or comments
I am not sure if this is the best way to implement the custom admin URL. Collab welcome.

