### PR TITLE
Phpunit: ignore timezone in date tests

### DIFF
--- a/tests/unit/Mage/Core/Helper/DataTest.php
+++ b/tests/unit/Mage/Core/Helper/DataTest.php
@@ -85,7 +85,7 @@ class DataTest extends TestCase
         $data,
         string $format = Mage_Core_Model_Locale::FORMAT_TYPE_SHORT,
         bool $showTime = false,
-        bool $useTimezone = true
+        bool $useTimezone = false # disable timezone by default for tests
     ): void {
         $this->assertSame($expectedResult, $this->subject->formatTimezoneDate($data, $format, $showTime, $useTimezone));
     }
@@ -131,12 +131,6 @@ class DataTest extends TestCase
             $date,
             'long'
         ];
-//        yield 'date short w/ time and w/ timezone' => [
-//            $dateShortTime,
-//            $date,
-//            'short',
-//            true
-//        ];
         yield 'date short w/ time' => [
             $dateShortTime,
             $date,


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

One test fails depending on when running. Ignore timezone in tests.

- see https://github.com/OpenMage/magento-lts/actions/runs/11376591046/job/31650370652