### PR TITLE
[PHP 8.4] fgetcsv() - The $escape parameter must be provided as its default value will change

### DIFF
--- a/app/code/core/Mage/Dataflow/Model/Session/Parser/Csv.php
+++ b/app/code/core/Mage/Dataflow/Model/Session/Parser/Csv.php
@@ -25,6 +25,7 @@ class Mage_Dataflow_Model_Session_Parser_Csv extends Mage_Dataflow_Model_Convert
     {
         $fDel = $this->getVar('delimiter', ',');
         $fEnc = $this->getVar('enclose', '"');
+        $fEsc = $this->getVar('escape', '\\');
 
         if ($fDel == '\\t') {
             $fDel = "\t";
@@ -41,7 +42,7 @@ class Mage_Dataflow_Model_Session_Parser_Csv extends Mage_Dataflow_Model_Convert
         $sessionId = Mage::registry('current_dataflow_session_id');
         $import = Mage::getModel('dataflow/import');
         $map = new Varien_Convert_Mapper_Column();
-        for ($i = 0; $line = fgetcsv($fp, 4096, $fDel, $fEnc); $i++) {
+        for ($i = 0; $line = fgetcsv($fp, 4096, $fDel, $fEnc, $fEsc); $i++) {
             if ($i == 0) {
                 if ($this->getVar('fieldnames')) {
                     $fields = $line;

--- a/app/code/core/Mage/ImportExport/Model/Import/Adapter/Csv.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Adapter/Csv.php
@@ -36,6 +36,13 @@ class Mage_ImportExport_Model_Import_Adapter_Csv extends Mage_ImportExport_Model
     protected $_enclosure = '"';
 
     /**
+     * Field escape character.
+     *
+     * @var string
+     */
+    protected $_escape = '\\';
+
+    /**
      * Source file handler.
      *
      * @var resource
@@ -72,7 +79,7 @@ class Mage_ImportExport_Model_Import_Adapter_Csv extends Mage_ImportExport_Model
     #[\ReturnTypeWillChange]
     public function next()
     {
-        $this->_currentRow = fgetcsv($this->_fileHandler, null, $this->_delimiter, $this->_enclosure);
+        $this->_currentRow = fgetcsv($this->_fileHandler, null, $this->_delimiter, $this->_enclosure, $this->_escape);
         $this->_currentKey = $this->_currentRow ? $this->_currentKey + 1 : null;
     }
 
@@ -86,8 +93,8 @@ class Mage_ImportExport_Model_Import_Adapter_Csv extends Mage_ImportExport_Model
     {
         // rewind resource, reset column names, read first row as current
         rewind($this->_fileHandler);
-        $this->_colNames = fgetcsv($this->_fileHandler, null, $this->_delimiter, $this->_enclosure);
-        $this->_currentRow = fgetcsv($this->_fileHandler, null, $this->_delimiter, $this->_enclosure);
+        $this->_colNames = fgetcsv($this->_fileHandler, null, $this->_delimiter, $this->_enclosure, $this->_escape);
+        $this->_currentRow = fgetcsv($this->_fileHandler, null, $this->_delimiter, $this->_enclosure, $this->_escape);
 
         if ($this->_currentRow) {
             $this->_currentKey = 0;
@@ -112,7 +119,7 @@ class Mage_ImportExport_Model_Import_Adapter_Csv extends Mage_ImportExport_Model
                 if ($position < $this->_currentKey) {
                     $this->rewind();
                 }
-                while ($this->_currentRow = fgetcsv($this->_fileHandler, null, $this->_delimiter, $this->_enclosure)) {
+                while ($this->_currentRow = fgetcsv($this->_fileHandler, null, $this->_delimiter, $this->_enclosure, $this->_escape)) {
                     if (++$this->_currentKey == $position) {
                         return;
                     }

--- a/lib/Varien/Convert/Parser/Csv.php
+++ b/lib/Varien/Convert/Parser/Csv.php
@@ -39,7 +39,7 @@ class Varien_Convert_Parser_Csv extends Varien_Convert_Parser_Abstract
         fseek($fp, 0);
 
         $data = [];
-        for ($i = 0; $line = fgetcsv($fp, 4096, $fDel, $fEnc, fEsc); $i++) {
+        for ($i = 0; $line = fgetcsv($fp, 4096, $fDel, $fEnc, $fEsc); $i++) {
             if (0 == $i) {
                 if ($this->getVar('fieldnames')) {
                     $fields = $line;

--- a/lib/Varien/Convert/Parser/Csv.php
+++ b/lib/Varien/Convert/Parser/Csv.php
@@ -25,6 +25,7 @@ class Varien_Convert_Parser_Csv extends Varien_Convert_Parser_Abstract
     {
         $fDel = $this->getVar('delimiter', ',');
         $fEnc = $this->getVar('enclose', '"');
+        $fEsc = $this->getVar('escape', '\\');
 
         if ($fDel == '\\t') {
             $fDel = "\t";
@@ -38,7 +39,7 @@ class Varien_Convert_Parser_Csv extends Varien_Convert_Parser_Abstract
         fseek($fp, 0);
 
         $data = [];
-        for ($i = 0; $line = fgetcsv($fp, 4096, $fDel, $fEnc); $i++) {
+        for ($i = 0; $line = fgetcsv($fp, 4096, $fDel, $fEnc, fEsc); $i++) {
             if (0 == $i) {
                 if ($this->getVar('fieldnames')) {
                     $fields = $line;
@@ -81,7 +82,7 @@ class Varien_Convert_Parser_Csv extends Varien_Convert_Parser_Abstract
         $sessionId = Mage::registry('current_dataflow_session_id');
         $import = Mage::getModel('dataflow/import');
         $map = new Varien_Convert_Mapper_Column();
-        for ($i = 0; $line = fgetcsv($fp, 4096, $fDel, $fEnc); $i++) {
+        for ($i = 0; $line = fgetcsv($fp, 4096, $fDel, $fEnc, $fEsc); $i++) {
             if (0 == $i) {
                 if ($this->getVar('fieldnames')) {
                     $fields = $line;

--- a/lib/Varien/Convert/Parser/Csv.php
+++ b/lib/Varien/Convert/Parser/Csv.php
@@ -66,6 +66,7 @@ class Varien_Convert_Parser_Csv extends Varien_Convert_Parser_Abstract
     {
         $fDel = $this->getVar('delimiter', ',');
         $fEnc = $this->getVar('enclose', '"');
+        $fEsc = $this->getVar('escape', '\\');
 
         if ($fDel == '\\t') {
             $fDel = "\t";

--- a/lib/Varien/File/Csv.php
+++ b/lib/Varien/File/Csv.php
@@ -22,6 +22,7 @@ class Varien_File_Csv
     protected $_lineLength = 0;
     protected $_delimiter = ',';
     protected $_enclosure = '"';
+    protected $_escape = '\\';
 
     public function __construct()
     {
@@ -77,7 +78,7 @@ class Varien_File_Csv
         }
 
         $fh = fopen($file, 'r');
-        while ($rowData = fgetcsv($fh, $this->_lineLength, $this->_delimiter, $this->_enclosure)) {
+        while ($rowData = fgetcsv($fh, $this->_lineLength, $this->_delimiter, $this->_enclosure, $this->_escape)) {
             $data[] = $rowData;
         }
         fclose($fh);

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -209,7 +209,8 @@ class Varien_Io_File extends Varien_Io_Abstract
         if (!$this->_streamHandler) {
             return false;
         }
-        return @fgetcsv($this->_streamHandler, 0, $delimiter, $enclosure);
+        $escape = '\\';
+        return @fputcsv($this->_streamHandler, $row, $delimiter, $enclosure, $escape);
     }
 
     /**
@@ -241,8 +242,9 @@ class Varien_Io_File extends Varien_Io_Abstract
         if (!$this->_streamHandler) {
             return false;
         }
-
-        return @fputcsv($this->_streamHandler, $row, $delimiter, $enclosure);
+        
+        $escape = '\\';
+        return @fputcsv($this->_streamHandler, $row, $delimiter, $enclosure, $escape);
     }
 
     /**

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -210,7 +210,7 @@ class Varien_Io_File extends Varien_Io_Abstract
             return false;
         }
         $escape = '\\';
-        return @fputcsv($this->_streamHandler, $row, $delimiter, $enclosure, $escape);
+        return @fgetcsv($this->_streamHandler, 0, $delimiter, $enclosure, $escape);
     }
 
     /**

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -209,7 +209,7 @@ class Varien_Io_File extends Varien_Io_Abstract
         if (!$this->_streamHandler) {
             return false;
         }
-        return @fgetcsv($this->_streamHandler, 0, $delimiter, $enclosure, '\\');
+        return @fgetcsv($this->_streamHandler, 0, $delimiter, $enclosure);
     }
 
     /**
@@ -241,6 +241,7 @@ class Varien_Io_File extends Varien_Io_Abstract
         if (!$this->_streamHandler) {
             return false;
         }
+
         return @fputcsv($this->_streamHandler, $row, $delimiter, $enclosure, '\\');
     }
 

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -209,8 +209,7 @@ class Varien_Io_File extends Varien_Io_Abstract
         if (!$this->_streamHandler) {
             return false;
         }
-        $escape = '\\';
-        return @fgetcsv($this->_streamHandler, 0, $delimiter, $enclosure, $escape);
+        return @fgetcsv($this->_streamHandler, 0, $delimiter, $enclosure, '\\');
     }
 
     /**
@@ -242,9 +241,7 @@ class Varien_Io_File extends Varien_Io_Abstract
         if (!$this->_streamHandler) {
             return false;
         }
-        
-        $escape = '\\';
-        return @fputcsv($this->_streamHandler, $row, $delimiter, $enclosure, $escape);
+        return @fputcsv($this->_streamHandler, $row, $delimiter, $enclosure, '\\');
     }
 
     /**


### PR DESCRIPTION
Starting with PHP version 8.4 the fifth parameter of the fgetcsv() function must be specified, otherwise the following message will be displayed

```php
Deprecated functionality: fgetcsv(): the $escape parameter must be provided as its default value will change  in /var/www/html/lib/Varien/File/Csv.php on line 80
```

The PHP default value for the escape parameter is ```'\\'``` and I declared it at the beginning in some files.

Since we support the PHP version 7.4, I did not use ```escape:``` in front of the variable like others who provided similar solutions.