### PR TITLE
[PHP 8.4] fputcsv() - The $escape parameter must be provided as its default value will change

### DIFF
--- a/app/code/core/Mage/ImportExport/Model/Export/Adapter/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Adapter/Abstract.php
@@ -22,6 +22,7 @@
  * @property resource $_fileHandler
  * @property string $_delimiter
  * @property string $_enclosure
+ * @property string $_escape
  */
 abstract class Mage_ImportExport_Model_Export_Adapter_Abstract
 {
@@ -147,7 +148,7 @@ abstract class Mage_ImportExport_Model_Export_Adapter_Abstract
             foreach ($headerCols as $colName) {
                 $this->_headerCols[$colName] = false;
             }
-            fputcsv($this->_fileHandler, array_keys($this->_headerCols), $this->_delimiter, $this->_enclosure);
+            fputcsv($this->_fileHandler, array_keys($this->_headerCols), $this->_delimiter, $this->_enclosure, $this->_escape);
         }
         return $this;
     }

--- a/app/code/core/Mage/ImportExport/Model/Export/Adapter/Csv.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Adapter/Csv.php
@@ -39,6 +39,13 @@ class Mage_ImportExport_Model_Export_Adapter_Csv extends Mage_ImportExport_Model
     protected $_enclosure = '"';
 
     /**
+     * Field escape character.
+     *
+     * @var string
+     */
+    protected $_escape = '\\';
+
+    /**
      * Source file handler.
      *
      * @var resource
@@ -109,7 +116,8 @@ class Mage_ImportExport_Model_Export_Adapter_Csv extends Mage_ImportExport_Model
             $this->_fileHandler,
             $data,
             $this->_delimiter,
-            $this->_enclosure
+            $this->_enclosure,
+            $this->_escape
         );
 
         $this->_rowsCount++;

--- a/lib/Magento/Profiler/Output/Csvfile.php
+++ b/lib/Magento/Profiler/Output/Csvfile.php
@@ -34,6 +34,11 @@ class Magento_Profiler_Output_Csvfile extends Magento_Profiler_OutputAbstract
     protected $_enclosure;
 
     /**
+     * @var string
+     */
+    protected $_escape = '\\';
+
+    /**
      * Start output buffering
      *
      * @param string      $filename Target file to save CSV data
@@ -86,7 +91,7 @@ class Magento_Profiler_Output_Csvfile extends Magento_Profiler_OutputAbstract
             foreach ($this->_getColumns() as $columnId) {
                 $row[] = $this->_renderColumnValue($timerId, $columnId);
             }
-            fputcsv($fileHandle, $row, $this->_delimiter, $this->_enclosure);
+            fputcsv($fileHandle, $row, $this->_delimiter, $this->_enclosure, $this->_escape);
         }
     }
 }

--- a/lib/Varien/File/Csv.php
+++ b/lib/Varien/File/Csv.php
@@ -22,6 +22,7 @@ class Varien_File_Csv
     protected $_lineLength = 0;
     protected $_delimiter = ',';
     protected $_enclosure = '"';
+    protected $_escape = '\\';
 
     public function __construct()
     {
@@ -115,7 +116,7 @@ class Varien_File_Csv
     {
         $fh = fopen($file, 'w');
         foreach ($data as $dataRow) {
-            $this->fputcsv($fh, $dataRow, $this->_delimiter, $this->_enclosure);
+            $this->fputcsv($fh, $dataRow, $this->_delimiter, $this->_enclosure, $this->_escape);
         }
         fclose($fh);
         return $this;

--- a/lib/Varien/File/Csv.php
+++ b/lib/Varien/File/Csv.php
@@ -22,7 +22,6 @@ class Varien_File_Csv
     protected $_lineLength = 0;
     protected $_delimiter = ',';
     protected $_enclosure = '"';
-    protected $_escape = '\\';
 
     public function __construct()
     {
@@ -116,7 +115,7 @@ class Varien_File_Csv
     {
         $fh = fopen($file, 'w');
         foreach ($data as $dataRow) {
-            $this->fputcsv($fh, $dataRow, $this->_delimiter, $this->_enclosure, $this->_escape);
+            $this->fputcsv($fh, $dataRow, $this->_delimiter, $this->_enclosure);
         }
         fclose($fh);
         return $this;

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -242,8 +242,7 @@ class Varien_Io_File extends Varien_Io_Abstract
             return false;
         }
         
-        $escape = '\\';
-        return @fputcsv($this->_streamHandler, $row, $delimiter, $enclosure, $escape);
+        return @fputcsv($this->_streamHandler, $row, $delimiter, $enclosure, '\\');
     }
 
     /**

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -241,7 +241,7 @@ class Varien_Io_File extends Varien_Io_Abstract
         if (!$this->_streamHandler) {
             return false;
         }
-        
+
         return @fputcsv($this->_streamHandler, $row, $delimiter, $enclosure, '\\');
     }
 

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -241,8 +241,9 @@ class Varien_Io_File extends Varien_Io_Abstract
         if (!$this->_streamHandler) {
             return false;
         }
-
-        return @fputcsv($this->_streamHandler, $row, $delimiter, $enclosure);
+        
+        $escape = '\\';
+        return @fputcsv($this->_streamHandler, $row, $delimiter, $enclosure, $escape);
     }
 
     /**


### PR DESCRIPTION
Starting with PHP version 8.4 the fifth parameter of the fputcsv() function must be specified, otherwise the following message will be displayed

```php
Deprecated functionality: fputcsv(): the $escape parameter must be provided as its default value will change  in /var/www/html/app/code/core/Mage/ImportExport/Model/Export/Adapter/Csv.php on line 108 in /var/www/html/app/code/core/Mage/Core/functions.php:197
```

The PHP default value for the escape parameter is ```'\\'``` and I declared it at the beginning in some files.

Since we support the PHP version 7.4, I did not use ```escape:``` in front of the variable like others who provided similar solutions.