### PR TITLE
Used `transliterator_transliterate` to generate "url_key"

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Attribute/Backend/Urlkey/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Attribute/Backend/Urlkey/Abstract.php
@@ -39,6 +39,11 @@ abstract class Mage_Catalog_Model_Attribute_Backend_Urlkey_Abstract extends Mage
             $urlKey = $object->getName();
         }
 
+        if (method_exists($object, 'setLocale')) {
+            $locale = Mage::getStoreConfig(Mage_Core_Model_Locale::XML_PATH_DEFAULT_LOCALE, $object->getStoreId());
+            $object->setLocale($locale);
+        }
+
         $object->setData($attributeName, $object->formatUrlKey($urlKey));
 
         return $this;

--- a/app/code/core/Mage/Catalog/Model/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Category.php
@@ -503,9 +503,10 @@ class Mage_Catalog_Model_Category extends Mage_Catalog_Model_Abstract
     public function getCategoryIdUrl()
     {
         Varien_Profiler::start('REGULAR: ' . __METHOD__);
-        $urlKey = $this->getUrlKey() ? $this->getUrlKey() : $this->formatUrlKey($this->getName());
+        $locale = Mage::getStoreConfig(Mage_Core_Model_Locale::XML_PATH_DEFAULT_LOCALE, $this->getStoreId());
+        $urlKey = $this->getUrlKey() ? $this->getUrlKey() : $this->setLocale($locale)->formatUrlKey($this->getName());
         $url = $this->getUrlInstance()->getUrl('catalog/category/view', [
-            's' => $urlKey,
+            's'  => $urlKey,
             'id' => $this->getId(),
         ]);
         Varien_Profiler::stop('REGULAR: ' . __METHOD__);
@@ -520,7 +521,7 @@ class Mage_Catalog_Model_Category extends Mage_Catalog_Model_Abstract
      */
     public function formatUrlKey($str)
     {
-        return $this->getUrlModel()->formatUrlKey($str);
+        return $this->getUrlModel()->setLocale($this->getLocale())->formatUrlKey($str);
     }
 
     public function getLocale(): ?string
@@ -528,7 +529,7 @@ class Mage_Catalog_Model_Category extends Mage_Catalog_Model_Abstract
         return $this->locale;
     }
 
-    public function setLocale(string $locale)
+    public function setLocale(?string $locale)
     {
         $this->locale = $locale;
         return $this;

--- a/app/code/core/Mage/Catalog/Model/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Category.php
@@ -162,6 +162,9 @@ class Mage_Catalog_Model_Category extends Mage_Catalog_Model_Abstract
      */
     protected $_urlModel;
 
+
+    protected ?string $locale = null;
+
     /**
      * Initialize resource mode
      */
@@ -522,6 +525,17 @@ class Mage_Catalog_Model_Category extends Mage_Catalog_Model_Abstract
         $urlKey = strtolower($urlKey);
         $urlKey = trim($urlKey, '-');
         return $urlKey;
+    }
+
+    public function getLocale(): ?string
+    {
+        return $this->locale;
+    }
+
+    public function setLocale(string $locale)
+    {
+        $this->locale = $locale;
+        return $this;
     }
 
     /**

--- a/app/code/core/Mage/Catalog/Model/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Category.php
@@ -520,11 +520,7 @@ class Mage_Catalog_Model_Category extends Mage_Catalog_Model_Abstract
      */
     public function formatUrlKey($str)
     {
-        $str = Mage::helper('catalog/product_url')->format($str);
-        $urlKey = preg_replace('#[^0-9a-z]+#i', '-', $str);
-        $urlKey = strtolower($urlKey);
-        $urlKey = trim($urlKey, '-');
-        return $urlKey;
+        return $this->getUrlModel()->formatUrlKey($str);
     }
 
     public function getLocale(): ?string

--- a/app/code/core/Mage/Catalog/Model/Category/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Url.php
@@ -19,61 +19,14 @@
  * @category   Mage
  * @package    Mage_Catalog
  */
-class Mage_Catalog_Model_Category_Url
+class Mage_Catalog_Model_Category_Url extends Mage_Catalog_Model_Url
 {
-    /**
-     * Url instance
-     *
-     * @var Mage_Core_Model_Url
-     */
-    protected $_url;
-
-    /**
-     * Url rewrite instance
-     *
-     * @var Mage_Core_Model_Url_Rewrite
-     */
-    protected $_urlRewrite;
-
-    /**
-     * Factory instance
-     *
-     * @var Mage_Catalog_Model_Factory
-     */
-    protected $_factory;
-
     /**
      * Initialize Url model
      */
     public function __construct(array $args = [])
     {
         $this->_factory = !empty($args['factory']) ? $args['factory'] : Mage::getSingleton('catalog/factory');
-    }
-
-    /**
-     * Retrieve Url instance
-     *
-     * @return Mage_Core_Model_Url
-     */
-    public function getUrlInstance()
-    {
-        if ($this->_url === null) {
-            $this->_url = $this->_factory->getModel('core/url');
-        }
-        return $this->_url;
-    }
-
-    /**
-     * Retrieve Url rewrite instance
-     *
-     * @return Mage_Core_Model_Url_Rewrite
-     */
-    public function getUrlRewrite()
-    {
-        if ($this->_urlRewrite === null) {
-            $this->_urlRewrite = $this->_factory->getUrlRewriteInstance();
-        }
-        return $this->_urlRewrite;
     }
 
     /**
@@ -137,21 +90,5 @@ class Mage_Catalog_Model_Category_Url
             return $rewrite->getRequestPath();
         }
         return false;
-    }
-
-    /**
-     * Format Key for URL
-     *
-     * @param string $str
-     * @return string
-     */
-    public function formatUrlKey($str)
-    {
-        $str = Mage::helper('catalog/product_url')->format($str);
-        $urlKey = preg_replace('#[^0-9a-z]+#i', '-', $str);
-        $urlKey = strtolower($urlKey);
-        $urlKey = trim($urlKey, '-');
-
-        return $urlKey;
     }
 }

--- a/app/code/core/Mage/Catalog/Model/Category/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Url.php
@@ -14,7 +14,7 @@
  */
 
 /**
- * Catalog category url
+ * Catalog Url model
  *
  * @category   Mage
  * @package    Mage_Catalog
@@ -29,13 +29,6 @@ class Mage_Catalog_Model_Category_Url
     protected $_url;
 
     /**
-     * Factory instance
-     *
-     * @var Mage_Catalog_Model_Factory
-     */
-    protected $_factory;
-
-    /**
      * Url rewrite instance
      *
      * @var Mage_Core_Model_Url_Rewrite
@@ -43,11 +36,44 @@ class Mage_Catalog_Model_Category_Url
     protected $_urlRewrite;
 
     /**
+     * Factory instance
+     *
+     * @var Mage_Catalog_Model_Factory
+     */
+    protected $_factory;
+
+    /**
      * Initialize Url model
      */
     public function __construct(array $args = [])
     {
         $this->_factory = !empty($args['factory']) ? $args['factory'] : Mage::getSingleton('catalog/factory');
+    }
+
+    /**
+     * Retrieve Url instance
+     *
+     * @return Mage_Core_Model_Url
+     */
+    public function getUrlInstance()
+    {
+        if ($this->_url === null) {
+            $this->_url = $this->_factory->getModel('core/url');
+        }
+        return $this->_url;
+    }
+
+    /**
+     * Retrieve Url rewrite instance
+     *
+     * @return Mage_Core_Model_Url_Rewrite
+     */
+    public function getUrlRewrite()
+    {
+        if ($this->_urlRewrite === null) {
+            $this->_urlRewrite = $this->_factory->getUrlRewriteInstance();
+        }
+        return $this->_urlRewrite;
     }
 
     /**
@@ -114,28 +140,18 @@ class Mage_Catalog_Model_Category_Url
     }
 
     /**
-     * Retrieve Url instance
+     * Format Key for URL
      *
-     * @return Mage_Core_Model_Url
+     * @param string $str
+     * @return string
      */
-    public function getUrlInstance()
+    public function formatUrlKey($str)
     {
-        if ($this->_url === null) {
-            $this->_url = $this->_factory->getModel('core/url');
-        }
-        return $this->_url;
-    }
+        $str = Mage::helper('catalog/product_url')->format($str);
+        $urlKey = preg_replace('#[^0-9a-z]+#i', '-', $str);
+        $urlKey = strtolower($urlKey);
+        $urlKey = trim($urlKey, '-');
 
-    /**
-     * Retrieve Url rewrite instance
-     *
-     * @return Mage_Core_Model_Url_Rewrite
-     */
-    public function getUrlRewrite()
-    {
-        if ($this->_urlRewrite === null) {
-            $this->_urlRewrite = $this->_factory->getUrlRewriteInstance();
-        }
-        return $this->_urlRewrite;
+        return $urlKey;
     }
 }

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -1681,7 +1681,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
      */
     public function formatUrlKey($str)
     {
-        return $this->getUrlModel()->formatUrlKey($str);
+        return $this->getUrlModel()->setLocale($this->getLocale())->formatUrlKey($str);
     }
 
     public function getLocale(): ?string
@@ -1689,7 +1689,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
         return $this->locale;
     }
 
-    public function setLocale(string $locale)
+    public function setLocale(?string $locale)
     {
         $this->locale = $locale;
         return $this;

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -338,6 +338,8 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
      */
     protected $_reviewSummary = [];
 
+    protected ?string $locale = null;
+
     /**
      * Initialize resources
      */
@@ -1680,6 +1682,17 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     public function formatUrlKey($str)
     {
         return $this->getUrlModel()->formatUrlKey($str);
+    }
+
+    public function getLocale(): ?string
+    {
+        return $this->locale;
+    }
+
+    public function setLocale(string $locale)
+    {
+        $this->locale = $locale;
+        return $this;
     }
 
     /**

--- a/app/code/core/Mage/Catalog/Model/Product/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Url.php
@@ -24,14 +24,14 @@ class Mage_Catalog_Model_Product_Url extends Varien_Object
     public const CACHE_TAG = 'url_rewrite';
 
     /**
-     * URL instance
+     * Url instance
      *
      * @var Mage_Core_Model_Url
      */
     protected $_url;
 
     /**
-     * URL Rewrite Instance
+     * Url rewrite instance
      *
      * @var Mage_Core_Model_Url_Rewrite
      */
@@ -59,20 +59,20 @@ class Mage_Catalog_Model_Product_Url extends Varien_Object
     }
 
     /**
-     * Retrieve URL Instance
+     * Retrieve Url instance
      *
      * @return Mage_Core_Model_Url
      */
     public function getUrlInstance()
     {
         if ($this->_url === null) {
-            $this->_url = Mage::getModel('core/url');
+            $this->_url = $this->_factory->getModel('core/url');
         }
         return $this->_url;
     }
 
     /**
-     * Retrieve URL Rewrite Instance
+     * Retrieve Url rewrite instance
      *
      * @return Mage_Core_Model_Url_Rewrite
      */
@@ -129,21 +129,6 @@ class Mage_Catalog_Model_Product_Url extends Varien_Object
         }
 
         return $this->getUrl($product, $params);
-    }
-
-    /**
-     * Format Key for URL
-     *
-     * @param string $str
-     * @return string
-     */
-    public function formatUrlKey($str)
-    {
-        $urlKey = preg_replace('#[^0-9a-z]+#i', '-', Mage::helper('catalog/product_url')->format($str));
-        $urlKey = strtolower($urlKey);
-        $urlKey = trim($urlKey, '-');
-
-        return $urlKey;
     }
 
     /**
@@ -282,5 +267,21 @@ class Mage_Catalog_Model_Product_Url extends Varien_Object
         }
 
         return false;
+    }
+
+    /**
+     * Format Key for URL
+     *
+     * @param string $str
+     * @return string
+     */
+    public function formatUrlKey($str)
+    {
+        $str = Mage::helper('catalog/product_url')->format($str);
+        $urlKey = preg_replace('#[^0-9a-z]+#i', '-', $str);
+        $urlKey = strtolower($urlKey);
+        $urlKey = trim($urlKey, '-');
+
+        return $urlKey;
     }
 }

--- a/app/code/core/Mage/Catalog/Model/Product/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Url.php
@@ -19,30 +19,9 @@
  * @category   Mage
  * @package    Mage_Catalog
  */
-class Mage_Catalog_Model_Product_Url extends Varien_Object
+class Mage_Catalog_Model_Product_Url extends Mage_Catalog_Model_Url
 {
     public const CACHE_TAG = 'url_rewrite';
-
-    /**
-     * Url instance
-     *
-     * @var Mage_Core_Model_Url
-     */
-    protected $_url;
-
-    /**
-     * Url rewrite instance
-     *
-     * @var Mage_Core_Model_Url_Rewrite
-     */
-    protected $_urlRewrite;
-
-    /**
-     * Factory instance
-     *
-     * @var Mage_Catalog_Model_Factory
-     */
-    protected $_factory;
 
     /**
      * @var Mage_Core_Model_Store
@@ -56,32 +35,6 @@ class Mage_Catalog_Model_Product_Url extends Varien_Object
     {
         $this->_factory = !empty($args['factory']) ? $args['factory'] : Mage::getSingleton('catalog/factory');
         $this->_store = !empty($args['store']) ? $args['store'] : Mage::app()->getStore();
-    }
-
-    /**
-     * Retrieve Url instance
-     *
-     * @return Mage_Core_Model_Url
-     */
-    public function getUrlInstance()
-    {
-        if ($this->_url === null) {
-            $this->_url = $this->_factory->getModel('core/url');
-        }
-        return $this->_url;
-    }
-
-    /**
-     * Retrieve Url rewrite instance
-     *
-     * @return Mage_Core_Model_Url_Rewrite
-     */
-    public function getUrlRewrite()
-    {
-        if ($this->_urlRewrite === null) {
-            $this->_urlRewrite = $this->_factory->getUrlRewriteInstance();
-        }
-        return $this->_urlRewrite;
     }
 
     /**
@@ -265,23 +218,6 @@ class Mage_Catalog_Model_Product_Url extends Varien_Object
         if ($rewrite->getId()) {
             return $rewrite->getRequestPath();
         }
-
         return false;
-    }
-
-    /**
-     * Format Key for URL
-     *
-     * @param string $str
-     * @return string
-     */
-    public function formatUrlKey($str)
-    {
-        $str = Mage::helper('catalog/product_url')->format($str);
-        $urlKey = preg_replace('#[^0-9a-z]+#i', '-', $str);
-        $urlKey = strtolower($urlKey);
-        $urlKey = trim($urlKey, '-');
-
-        return $urlKey;
     }
 }

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Urlkey.php
@@ -36,6 +36,10 @@ class Mage_Catalog_Model_Resource_Product_Attribute_Backend_Urlkey extends Mage_
             $urlKey = $object->getName();
         }
 
+        if (method_exists($object, 'setLocale')) {
+            $locale = Mage::getStoreConfig(Mage_Core_Model_Locale::XML_PATH_DEFAULT_LOCALE, $object->getStoreId());
+            $object->setLocale($locale);
+        }
         $object->setData($attributeName, $object->formatUrlKey($urlKey));
 
         return $this;

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -21,7 +21,7 @@ use Symfony\Component\String\Slugger\AsciiSlugger;
  * @category   Mage
  * @package    Mage_Catalog
  */
-class Mage_Catalog_Model_Url
+class Mage_Catalog_Model_Url extends Varien_Object
 {
     /**
      * Number of characters allowed to be in URL path
@@ -104,9 +104,56 @@ class Mage_Catalog_Model_Url
     protected ?string $locale = null;
 
     /**
+     * Url instance
+     *
+     * @var Mage_Core_Model_Url
+     */
+    protected $_url;
+
+    /**
+     * Url rewrite instance
+     *
+     * @var Mage_Core_Model_Url_Rewrite
+     */
+    protected $_urlRewrite;
+
+    /**
+     * Factory instance
+     *
+     * @var Mage_Catalog_Model_Factory
+     */
+    protected $_factory;
+
+    /**
      * @var AsciiSlugger[]
      */
     protected ?array $slugger = null;
+
+    /**
+     * Retrieve Url instance
+     *
+     * @return Mage_Core_Model_Url
+     */
+    public function getUrlInstance()
+    {
+        if ($this->_url === null) {
+            $this->_url = $this->_factory->getModel('core/url');
+        }
+        return $this->_url;
+    }
+
+    /**
+     * Retrieve Url rewrite instance
+     *
+     * @return Mage_Core_Model_Url_Rewrite
+     */
+    public function getUrlRewrite()
+    {
+        if ($this->_urlRewrite === null) {
+            $this->_urlRewrite = $this->_factory->getUrlRewriteInstance();
+        }
+        return $this->_urlRewrite;
+    }
 
     /**
      * Adds url_path property for non-root category - to ensure that url path is not empty.

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -258,6 +258,7 @@ class Mage_Catalog_Model_Url
     /**
      * Refresh category rewrite
      *
+     * @param Mage_Catalog_Model_Category $category
      * @param string $parentPath
      * @param bool $refreshProducts
      * @return $this
@@ -265,10 +266,11 @@ class Mage_Catalog_Model_Url
     protected function _refreshCategoryRewrites(Varien_Object $category, $parentPath = null, $refreshProducts = true)
     {
         if ($category->getId() != $this->getStores($category->getStoreId())->getRootCategoryId()) {
+            $locale = Mage::getStoreConfig(Mage_Core_Model_Locale::XML_PATH_DEFAULT_LOCALE, $category->getStoreId());
             if ($category->getUrlKey() == '') {
-                $urlKey = $this->getCategoryModel()->formatUrlKey($category->getName());
+                $urlKey = $this->getCategoryModel()->setLocale($locale)->formatUrlKey($category->getName());
             } else {
-                $urlKey = $this->getCategoryModel()->formatUrlKey($category->getUrlKey());
+                $urlKey = $this->getCategoryModel()->setLocale($locale)->formatUrlKey($category->getUrlKey());
             }
 
             $idPath      = $this->generatePath('id', null, $category);
@@ -330,10 +332,13 @@ class Mage_Catalog_Model_Url
         if ($category->getId() == $category->getPath()) {
             return $this;
         }
+
+        $locale = Mage::getStoreConfig(Mage_Core_Model_Locale::XML_PATH_DEFAULT_LOCALE, $product->getStoreId());
+
         if ($product->getUrlKey() == '') {
-            $urlKey = $this->getProductModel()->formatUrlKey($product->getName());
+            $urlKey = $this->getProductModel()->setLocale($locale)->formatUrlKey($product->getName());
         } else {
-            $urlKey = $this->getProductModel()->formatUrlKey($product->getUrlKey());
+            $urlKey = $this->getProductModel()->setLocale($locale)->formatUrlKey($product->getUrlKey());
         }
 
         $idPath      = $this->generatePath('id', $product, $category);

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -381,7 +381,6 @@ class Mage_Catalog_Model_Url extends Varien_Object
         }
 
         $locale = Mage::getStoreConfig(Mage_Core_Model_Locale::XML_PATH_DEFAULT_LOCALE, $product->getStoreId());
-
         if ($product->getUrlKey() == '') {
             $urlKey = $this->getProductModel()->setLocale($locale)->formatUrlKey($product->getName());
         } else {
@@ -735,7 +734,7 @@ class Mage_Catalog_Model_Url extends Varien_Object
     }
 
     /**
-     * Retrieve product rewrite sufix for store
+     * Retrieve product rewrite suffix for store
      *
      * @param int $storeId
      * @return string
@@ -746,7 +745,7 @@ class Mage_Catalog_Model_Url extends Varien_Object
     }
 
     /**
-     * Retrieve category rewrite sufix for store
+     * Retrieve category rewrite suffix for store
      *
      * @param int $storeId
      * @return string
@@ -1061,28 +1060,10 @@ class Mage_Catalog_Model_Url extends Varien_Object
 
     public function getSlugger(): AsciiSlugger
     {
-        $locale = $this->getLocale() ?? 'en_US';
+        $locale = $this->getLocale() ?: 'en_US';
 
         if (is_null($this->slugger) || !array_key_exists($locale, $this->slugger)) {
-            $config = [
-                '@'      => 'at',
-                '\u00a9' => "c",
-                '\u00ae' => "r",
-                '\u2122' => "tm"
-            ];
-
-            // @todo better config
-            $configNodes = Mage::getConfig()->getNode('global/slugger/' . $locale . '/replacements');
-            if ($configNodes instanceof Mage_Core_Model_Config_Element) {
-                $custom = [];
-                /** @var Mage_Core_Model_Config_Element $configNode */
-                foreach ($configNodes->children() as $configNode) {
-                    $configNode = $configNode->asArray();
-                    $custom[$configNode['f']] =$configNode['t'];
-                }
-                $config = [$locale => $config + $custom];
-            }
-
+            $config = $this->getSluggerConfig($locale);
             $slugger = new AsciiSlugger('en', $config);
             $slugger->setLocale($locale);
 
@@ -1090,6 +1071,30 @@ class Mage_Catalog_Model_Url extends Varien_Object
         }
 
         return $this->slugger[$locale];
+    }
+
+    public function getSluggerConfig(string $locale): array
+    {
+        $config = [
+            '@'      => 'at',
+            '\u00a9' => 'c',
+            '\u00ae' => 'r',
+            '\u2122' => 'tm'
+        ];
+
+        // @todo better config
+        $configNodes = Mage::getConfig()->getNode('global/slugger/' . $locale . '/replacements');
+        if ($configNodes instanceof Mage_Core_Model_Config_Element) {
+            $custom = [];
+            /** @var Mage_Core_Model_Config_Element $configNode */
+            foreach ($configNodes->children() as $configNode) {
+                $configNode = $configNode->asArray();
+                $custom[$configNode['f']] = $configNode['t'];
+            }
+            $config = [$locale => $config + $custom];
+        }
+
+        return $config;
     }
 
     public function getLocale(): ?string

--- a/app/code/core/Mage/Core/etc/config.xml
+++ b/app/code/core/Mage/Core/etc/config.xml
@@ -184,6 +184,44 @@
                 </observers>
             </model_delete_before>
         </events>
+        <slugger>
+            <de_DE>
+                <replacements>
+                    <replach_percent>
+                        <f><![CDATA[%]]></f>
+                        <t>prozent</t>
+                    </replach_percent>
+                    <replace_and>
+                        <f><![CDATA[&]]></f>
+                        <t>und</t>
+                    </replace_and>
+                </replacements>
+            </de_DE>
+            <en_US>
+                <replacements>
+                    <replach_percent>
+                        <f><![CDATA[%]]></f>
+                        <t>percent</t>
+                    </replach_percent>
+                    <replace_and>
+                        <f><![CDATA[&]]></f>
+                        <t>and</t>
+                    </replace_and>
+                </replacements>
+            </en_US>
+            <fr_FR>
+                <replacements>
+                    <replach_percent>
+                        <f><![CDATA[%]]></f>
+                        <t>pour cent</t>
+                    </replach_percent>
+                    <replace_and>
+                        <f><![CDATA[&]]></f>
+                        <t>et</t>
+                    </replace_and>
+                </replacements>
+            </fr_FR>
+        </slugger>
     </global>
     <frontend>
         <routers>

--- a/app/code/core/Mage/Core/etc/config.xml
+++ b/app/code/core/Mage/Core/etc/config.xml
@@ -188,39 +188,63 @@
             <de_DE>
                 <replacements>
                     <replach_percent>
-                        <f><![CDATA[%]]></f>
-                        <t>prozent</t>
+                        <from><![CDATA[%]]></from>
+                        <to>prozent</to>
                     </replach_percent>
                     <replace_and>
-                        <f><![CDATA[&]]></f>
-                        <t>und</t>
+                        <from><![CDATA[&]]></from>
+                        <to>und</to>
                     </replace_and>
                 </replacements>
             </de_DE>
             <en_US>
                 <replacements>
                     <replach_percent>
-                        <f><![CDATA[%]]></f>
-                        <t>percent</t>
+                        <from><![CDATA[%]]></from>
+                        <to>percent</to>
                     </replach_percent>
                     <replace_and>
-                        <f><![CDATA[&]]></f>
-                        <t>and</t>
+                        <from><![CDATA[&]]></from>
+                        <to>and</to>
                     </replace_and>
                 </replacements>
             </en_US>
             <fr_FR>
                 <replacements>
                     <replach_percent>
-                        <f><![CDATA[%]]></f>
-                        <t>pour cent</t>
+                        <from><![CDATA[%]]></from>
+                        <to>pour cent</to>
                     </replach_percent>
                     <replace_and>
-                        <f><![CDATA[&]]></f>
-                        <t>et</t>
+                        <from><![CDATA[&]]></from>
+                        <to>et</to>
                     </replace_and>
                 </replacements>
             </fr_FR>
+            <it_IT>
+                <replacements>
+                    <replach_percent>
+                        <from><![CDATA[%]]></from>
+                        <to>per cento</to>
+                    </replach_percent>
+                    <replace_and>
+                        <from><![CDATA[&]]></from>
+                        <to>e</to>
+                    </replace_and>
+                </replacements>
+            </it_IT>
+            <es_ES>
+                <replacements>
+                    <replach_percent>
+                        <from><![CDATA[%]]></from>
+                        <to>por ciento</to>
+                    </replach_percent>
+                    <replace_and>
+                        <from><![CDATA[&]]></from>
+                        <to>et</to>
+                    </replace_and>
+                </replacements>
+            </es_ES>
         </slugger>
     </global>
     <frontend>

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
@@ -1559,7 +1559,8 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
                 $attrValue = gmdate(Varien_Date::DATETIME_PHP_FORMAT, strtotime($attrValue));
             } elseif ($attribute->getAttributeCode() === 'url_key') {
                 if (empty($attrValue)) {
-                    $attrValue = $product->formatUrlKey($product->getName());
+                    $locale = Mage::getStoreConfig(Mage_Core_Model_Locale::XML_PATH_DEFAULT_LOCALE, $product->getStoreId());
+                    $attrValue = $product->setLocale($locale)->formatUrlKey($product->getName());
                 }
             } elseif ($backModel) {
                 $attribute->getBackend()->beforeSave($product);

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
         "symfony/polyfill-php81": "^1.31",
         "symfony/polyfill-php82": "^1.31",
         "symfony/polyfill-php83": "^1.31",
-        "symfony/polyfill-php84": "^1.31"
+        "symfony/polyfill-php84": "^1.31",
+        "symfony/string": "^5.4",
+        "symfony/translation-contracts": "^2.5"
     },
     "require-dev": {
         "ext-xmlreader": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c164bfdfd01cced28e1b11221d14509",
+    "content-hash": "de310e5693caedefd6dda7141900af3a",
     "packages": [
         {
             "name": "colinmollenhour/cache-backend-redis",
@@ -2361,6 +2361,84 @@
                 }
             ],
             "time": "2024-09-20T07:56:40+00:00"
+        },
+        {
+            "name": "symfony/translation-contracts",
+            "version": "v2.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "b0073a77ac0b7ea55131020e87b1e3af540f4664"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/b0073a77ac0b7ea55131020e87b1e3af540f4664",
+                "reference": "b0073a77ac0b7ea55131020e87b1e3af540f4664",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5"
+            },
+            "suggest": {
+                "symfony/translation-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/translation-contracts/tree/v2.5.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-23T13:51:25+00:00"
         }
     ],
     "packages-dev": [

--- a/tests/unit/Mage/Catalog/Model/CategoryTest.php
+++ b/tests/unit/Mage/Catalog/Model/CategoryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   OpenMage
+ * @package    OpenMage_Tests
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Catalog\Model;
+
+use Generator;
+use Mage;
+use Mage_Catalog_Model_Category;
+use Mage_Catalog_Model_Category_Url;
+use PHPUnit\Framework\TestCase;
+
+class CategoryTest extends TestCase
+{
+    public const TEST_STRING = 'a & B, x%, ä, ö, ü';
+
+    public Mage_Catalog_Model_Category $subject;
+
+    public function setUp(): void
+    {
+        Mage::app();
+        $this->subject = Mage::getModel('catalog/category');
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetUrlModel(): void
+    {
+        $this->assertInstanceOf(Mage_Catalog_Model_Category_Url::class, $this->subject->getUrlModel());
+    }
+
+
+    /**
+     * @dataProvider provideFormatUrlKey
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     * @runInSeparateProcess
+     */
+//    public function testGetCategoryIdUrl($expectedResult, ?string $locale): void
+//    {
+//        $this->subject->setName(self::TEST_STRING);
+//        $this->subject->setLocale($locale);
+//        $this->assertSame($expectedResult, $this->subject->getCategoryIdUrl());
+//    }
+
+    /**
+     * @dataProvider provideFormatUrlKey
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testFormatUrlKey($expectedResult, ?string $locale): void
+    {
+        $this->subject->setLocale($locale);
+        $this->assertSame($expectedResult, $this->subject->formatUrlKey(self::TEST_STRING));
+    }
+
+    public function provideFormatUrlKey(): Generator
+    {
+        yield 'null locale' => [
+            'a-b-x-a-o-u',
+            null,
+        ];
+        yield 'de_DE' => [
+            'a-und-b-x-prozent-ae-oe-ue',
+            'de_DE',
+        ];
+    }
+}

--- a/tests/unit/Mage/Catalog/Model/ProductTest.php
+++ b/tests/unit/Mage/Catalog/Model/ProductTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   OpenMage
+ * @package    OpenMage_Tests
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Catalog\Model;
+
+use Generator;
+use Mage;
+use Mage_Catalog_Model_Product;
+use Mage_Catalog_Model_Product_Url;
+use PHPUnit\Framework\TestCase;
+
+class ProductTest extends TestCase
+{
+    public const TEST_STRING = 'a & B, x%, ä, ö, ü';
+
+    public Mage_Catalog_Model_Product $subject;
+
+    public function setUp(): void
+    {
+        Mage::app();
+        $this->subject = Mage::getModel('catalog/product');
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetUrlModel(): void
+    {
+        $this->assertInstanceOf(Mage_Catalog_Model_Product_Url::class, $this->subject->getUrlModel());
+    }
+
+    /**
+     * @dataProvider provideFormatUrlKey
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testFormatUrlKey($expectedResult, ?string $locale): void
+    {
+        $this->subject->setLocale($locale);
+        $this->assertSame($expectedResult, $this->subject->formatUrlKey(self::TEST_STRING));
+    }
+
+    public function provideFormatUrlKey(): Generator
+    {
+        yield 'null locale' => [
+            'a-b-x-a-o-u',
+            null,
+        ];
+        yield 'de_DE' => [
+            'a-und-b-x-prozent-ae-oe-ue',
+            'de_DE',
+        ];
+    }
+}

--- a/tests/unit/Mage/Catalog/Model/UrlTest.php
+++ b/tests/unit/Mage/Catalog/Model/UrlTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   OpenMage
+ * @package    OpenMage_Tests
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Catalog\Model;
+
+use Generator;
+use Mage;
+use Mage_Catalog_Model_Url;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+class UrlTest extends TestCase
+{
+    public const TEST_STRING = 'a & B, x%, ä, ö, ü';
+
+    public Mage_Catalog_Model_Url $subject;
+
+    public function setUp(): void
+    {
+        Mage::app();
+        $this->subject = Mage::getModel('catalog/url');
+    }
+
+    /**
+     * @dataProvider provideFormatUrlKey
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testFormatUrlKey($expectedResult, string $locale): void
+    {
+        $this->subject->setLocale($locale);
+        $this->assertSame($expectedResult, $this->subject->formatUrlKey(self::TEST_STRING));
+    }
+    public function provideFormatUrlKey(): Generator
+    {
+        yield 'de_DE' => [
+            'a-und-b-x-prozent-ae-oe-ue',
+            'de_DE',
+        ];
+        yield 'en_US' => [
+            'a-and-b-x-percent-a-o-u',
+            'en_US',
+        ];
+        yield 'fr_FR' => [
+            'a-et-b-x-pour-cent-a-o-u',
+            'fr_FR',
+        ];
+    }
+
+    /**
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetSlugger(): void
+    {
+        $this->assertInstanceOf(AsciiSlugger::class, $this->subject->getSlugger());
+    }
+
+    /**
+     * @dataProvider provideGetSluggerConfig
+     * @group Mage_Catalog
+     * @group Mage_Catalog_Model
+     */
+    public function testGetSluggerConfig($expectedResult, string $locale): void
+    {
+        $this->assertSame($expectedResult, $this->subject->getSluggerConfig($locale));
+    }
+
+    public function provideGetSluggerConfig(): Generator
+    {
+        yield 'de_DE' => [
+            ['de_DE' => [
+                '@' => 'at',
+                '\u00a9' => 'c',
+                '\u00ae' => 'r',
+                '\u2122' => 'tm',
+                '%' => 'prozent',
+                '&' => 'und',
+            ]],
+            'de_DE'
+        ];
+        yield 'en_US' => [
+            ['en_US' => [
+                '@' => 'at',
+                '\u00a9' => 'c',
+                '\u00ae' => 'r',
+                '\u2122' => 'tm',
+                '%' => 'percent',
+                '&' => 'and',
+            ]],
+            'en_US'
+        ];
+        yield 'fr_FR' => [
+            ['fr_FR' => [
+                '@' => 'at',
+                '\u00a9' => 'c',
+                '\u00ae' => 'r',
+                '\u2122' => 'tm',
+                '%' => 'pour cent',
+                '&' => 'et',
+            ]],
+            'fr_FR'
+        ];
+    }
+}

--- a/tests/unit/Mage/Catalog/Model/UrlTest.php
+++ b/tests/unit/Mage/Catalog/Model/UrlTest.php
@@ -55,9 +55,17 @@ class UrlTest extends TestCase
             'a-and-b-x-percent-a-o-u',
             'en_US',
         ];
+        yield 'es_ES' => [
+            'a-et-b-x-por-ciento-a-o-u',
+            'es_ES',
+        ];
         yield 'fr_FR' => [
             'a-et-b-x-pour-cent-a-o-u',
             'fr_FR',
+        ];
+        yield 'it_IT' => [
+            'a-e-b-x-per-cento-a-o-u',
+            'it_IT',
         ];
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

@luigifab hat a great idea to use `intl`-extension for generating url key with translating all special chars.
 
This is a non-BC-breaking try of it. It does not change method-signaturer and should be BC-safe. (I did not add all features of #1631. That could be done in another PR.)

### Related Pull Requests
<!-- related pull request placeholder -->

1. See OpenMage/magento-lts#1631

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
- have multiple store with different languages assigned (eg sample data)
-  edit product title to have some locale specific character/words
    - de_DE: umlauts (äöü) 
    - use trademark/copyright/etc.

Test product/category before and after ...

```php
$string = 'a & B, x%, ä, ö, ü';
$model = new Mage_Catalog_Model_Product_Url();
if (method_exists($model, 'setLocale')) {
    $model->setLocale('de_DE');
}
var_dump($model->formatUrlKey($string));
```


#### Actual url-key

```
'a-b-x-a-o-u'
```

#### Now

##### en_US

```
a-and-b-x-percent-a-o-u
```

##### de_DE

```
a-und-b-x-prozent-ae-oe-ue
```

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

Locale config in xml should be changed to not have language-specif config in core. Any ideas?