### PR TITLE
[PHP 8.4] Warning: foreach() argument must be of type array|object, string given

### DIFF
--- a/app/design/adminhtml/default/default/template/widget/grid.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid.phtml
@@ -160,15 +160,17 @@ $numColumns = count($this->getColumns());
             <?php endforeach ?>
             </tr>
             <?php if ($_multipleRows = $this->getMultipleRows($_item)):?>
-                <?php foreach ($_multipleRows as $_i):?>
-                <tr>
-                    <?php $i=0;foreach ($this->getMultipleRowColumns($_i) as $_column): ?>
+                <?php if (is_iterable($_multipleRows):?>
+                    <?php foreach ($_multipleRows as $_i):?>
+                    <tr>
+                        <?php $i=0;foreach ($this->getMultipleRowColumns($_i) as $_column): ?>
                         <td class="<?php echo $_column->getCssProperty() ?> <?php echo ++$i==$numColumns-1?'last':'' ?>">
                             <?php echo (($_html = $_column->getRowField($_i)) != '' ? $_html : '&nbsp;') ?>
                         </td>
                     <?php endforeach ?>
-                </tr>
-                <?php endforeach ?>
+                    </tr>
+                    <?php endforeach ?>
+                <?php endif ?>
             <?php endif ?>
 
             <?php if ($this->shouldRenderSubTotal($_item)): ?>


### PR DESCRIPTION
This PR fixes issue #4312. 