### PR TITLE
PHPStan: added some class vars to templates

### DIFF
--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -1526,11 +1526,6 @@ parameters:
 			path: app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Invoice.php
 
 		-
-			message: "#^Call to an undefined method Mage_Captcha_Model_Interface\\:\\:isRequired\\(\\)\\.$#"
-			count: 1
-			path: app/code/core/Mage/Captcha/Block/Captcha/Zend.php
-
-		-
 			message: "#^Property Mage_Captcha_Model_Zend\\:\\:\\$_helper \\(Mage_Captcha_Helper_Data\\) in empty\\(\\) is not falsy\\.$#"
 			count: 1
 			path: app/code/core/Mage/Captcha/Model/Zend.php
@@ -6936,11 +6931,6 @@ parameters:
 			path: app/code/core/Mage/Weee/Helper/Data.php
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 2
-			path: app/code/core/Mage/Weee/Helper/Data.php
-
-		-
 			message: "#^Parameter \\#2 \\$shipping of method Mage_Weee_Model_Tax\\:\\:getProductWeeeAttributes\\(\\) expects Mage_Sales_Model_Quote_Address\\|null, Varien_Object\\|false\\|null given\\.$#"
 			count: 1
 			path: app/code/core/Mage/Weee/Helper/Data.php
@@ -6963,11 +6953,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$renderer of method Varien_Data_Form_Element_Abstract\\:\\:setRenderer\\(\\) expects Varien_Data_Form_Element_Renderer_Interface, Mage_Core_Block_Abstract\\|false given\\.$#"
 			count: 1
-			path: app/code/core/Mage/Weee/Model/Observer.php
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 2
 			path: app/code/core/Mage/Weee/Model/Observer.php
 
 		-
@@ -7291,66 +7276,6 @@ parameters:
 			path: app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/selection.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/adminhtml/default/default/template/bundle/sales/creditmemo/create/items/renderer.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/adminhtml/default/default/template/bundle/sales/creditmemo/view/items/renderer.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/adminhtml/default/default/template/bundle/sales/invoice/create/items/renderer.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/adminhtml/default/default/template/bundle/sales/invoice/view/items/renderer.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/adminhtml/default/default/template/bundle/sales/order/view/items/renderer.phtml
-
-		-
-			message: "#^Call to method __\\(\\) on an unknown class Mage_Core_Block_Captcha_Zend\\.$#"
-			count: 3
-			path: app/design/adminhtml/default/default/template/captcha/zend.phtml
-
-		-
-			message: "#^Call to method getFormId\\(\\) on an unknown class Mage_Core_Block_Captcha_Zend\\.$#"
-			count: 3
-			path: app/design/adminhtml/default/default/template/captcha/zend.phtml
-
-		-
-			message: "#^Call to method getImgHeight\\(\\) on an unknown class Mage_Core_Block_Captcha_Zend\\.$#"
-			count: 1
-			path: app/design/adminhtml/default/default/template/captcha/zend.phtml
-
-		-
-			message: "#^Call to method getImgWidth\\(\\) on an unknown class Mage_Core_Block_Captcha_Zend\\.$#"
-			count: 1
-			path: app/design/adminhtml/default/default/template/captcha/zend.phtml
-
-		-
-			message: "#^Call to method getRefreshUrl\\(\\) on an unknown class Mage_Core_Block_Captcha_Zend\\.$#"
-			count: 1
-			path: app/design/adminhtml/default/default/template/captcha/zend.phtml
-
-		-
-			message: "#^Call to method getSkinUrl\\(\\) on an unknown class Mage_Core_Block_Captcha_Zend\\.$#"
-			count: 1
-			path: app/design/adminhtml/default/default/template/captcha/zend.phtml
-
-		-
-			message: "#^PHPDoc tag @var for variable \\$this contains unknown class Mage_Core_Block_Captcha_Zend\\.$#"
-			count: 1
-			path: app/design/adminhtml/default/default/template/captcha/zend.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 1
 			path: app/design/adminhtml/default/default/template/captcha/zend.phtml
@@ -7362,18 +7287,8 @@ parameters:
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 1
-			path: app/design/adminhtml/default/default/template/catalog/category/edit.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 20
 			path: app/design/adminhtml/default/default/template/catalog/category/edit/form.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 27
-			path: app/design/adminhtml/default/default/template/catalog/category/tree.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -7386,8 +7301,8 @@ parameters:
 			path: app/design/adminhtml/default/default/template/catalog/product/attribute/new/created.phtml
 
 		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 17
+			message: "#^Call to protected method _getHeader\\(\\) of class Mage_Adminhtml_Block_Catalog_Product_Attribute_Set_Main\\.$#"
+			count: 1
 			path: app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
 
 		-
@@ -7396,8 +7311,8 @@ parameters:
 			path: app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/add.phtml
 
 		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 2
+			message: "#^Call to protected method _getHeader\\(\\) of class Mage_Adminhtml_Block_Catalog_Product_Attribute_Set_Toolbar_Main\\.$#"
+			count: 1
 			path: app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/main.phtml
 
 		-
@@ -7427,11 +7342,6 @@ parameters:
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 16
-			path: app/design/adminhtml/default/default/template/catalog/product/edit.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 6
 			path: app/design/adminhtml/default/default/template/catalog/product/edit/action/attribute.phtml
 
@@ -7447,41 +7357,6 @@ parameters:
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 12
-			path: app/design/adminhtml/default/default/template/catalog/product/edit/categories.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 3
-			path: app/design/adminhtml/default/default/template/catalog/product/edit/options.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 42
-			path: app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 4
-			path: app/design/adminhtml/default/default/template/catalog/product/edit/options/type/date.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 13
-			path: app/design/adminhtml/default/default/template/catalog/product/edit/options/type/file.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 7
-			path: app/design/adminhtml/default/default/template/catalog/product/edit/options/type/select.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 4
-			path: app/design/adminhtml/default/default/template/catalog/product/edit/options/type/text.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 3
 			path: app/design/adminhtml/default/default/template/catalog/product/edit/serializer.phtml
 
@@ -7492,38 +7367,8 @@ parameters:
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 12
-			path: app/design/adminhtml/default/default/template/catalog/product/edit/websites.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 52
 			path: app/design/adminhtml/default/default/template/catalog/product/helper/gallery.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 5
-			path: app/design/adminhtml/default/default/template/catalog/product/js.phtml
-
-		-
-			message: "#^PHPDoc tag @var has invalid value \\(\\$_coreHelper Mage_Core_Helper_Data\\)\\: Unexpected token \"\\$_coreHelper\", expected type at offset 9 on line 1$#"
-			count: 1
-			path: app/design/adminhtml/default/default/template/catalog/product/price.phtml
-
-		-
-			message: "#^PHPDoc tag @var has invalid value \\(\\$_taxHelper Mage_Tax_Helper_Data\\)\\: Unexpected token \"\\$_taxHelper\", expected type at offset 9 on line 1$#"
-			count: 1
-			path: app/design/adminhtml/default/default/template/catalog/product/price.phtml
-
-		-
-			message: "#^PHPDoc tag @var has invalid value \\(\\$_weeeHelper Mage_Weee_Helper_Data\\)\\: Unexpected token \"\\$_weeeHelper\", expected type at offset 9 on line 1$#"
-			count: 1
-			path: app/design/adminhtml/default/default/template/catalog/product/price.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 12
-			path: app/design/adminhtml/default/default/template/catalog/product/price.phtml
 
 		-
 			message: "#^Parameter \\#2 \\$store of method Mage_Core_Helper_Data\\:\\:currencyByStore\\(\\) expects int\\|Mage_Core_Model_Store\\|null, true given\\.$#"
@@ -7539,11 +7384,6 @@ parameters:
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 2
 			path: app/design/adminhtml/default/default/template/catalog/product/tab/alert.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 70
-			path: app/design/adminhtml/default/default/template/catalog/product/tab/inventory.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -7572,11 +7412,6 @@ parameters:
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 11
-			path: app/design/adminhtml/default/default/template/customer/edit/tab/account/form/renderer/group.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 1
 			path: app/design/adminhtml/default/default/template/customer/online.phtml
 
@@ -7594,26 +7429,6 @@ parameters:
 			message: "#^Variable \\$customer might not be defined\\.$#"
 			count: 2
 			path: app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 24
-			path: app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 2
-			path: app/design/adminhtml/default/default/template/customer/tab/newsletter.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 13
-			path: app/design/adminhtml/default/default/template/customer/tab/view/sales.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 8
-			path: app/design/adminhtml/default/default/template/customer/tab/wishlist.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -7671,29 +7486,14 @@ parameters:
 			path: app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/name.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 14
-			path: app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/create/items/renderer/downloadable.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 58
 			path: app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/create/items/renderer/downloadable.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 14
-			path: app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/view/items/renderer/downloadable.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 54
 			path: app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/view/items/renderer/downloadable.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 14
-			path: app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/create/items/renderer/downloadable.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -7701,29 +7501,14 @@ parameters:
 			path: app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/create/items/renderer/downloadable.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 14
-			path: app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/view/items/renderer/downloadable.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 54
 			path: app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/view/items/renderer/downloadable.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 14
-			path: app/design/adminhtml/default/default/template/downloadable/sales/order/view/items/renderer/downloadable.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 63
 			path: app/design/adminhtml/default/default/template/downloadable/sales/order/view/items/renderer/downloadable.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/adminhtml/default/default/template/email/order/items.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -7734,11 +7519,6 @@ parameters:
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 10
 			path: app/design/adminhtml/default/default/template/empty.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 12
-			path: app/design/adminhtml/default/default/template/forgotpassword.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -7817,11 +7597,6 @@ parameters:
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 12
-			path: app/design/adminhtml/default/default/template/login.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 7
 			path: app/design/adminhtml/default/default/template/newsletter/preview/store.phtml
 
@@ -7859,11 +7634,6 @@ parameters:
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 11
 			path: app/design/adminhtml/default/default/template/overlay_popup.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 21
-			path: app/design/adminhtml/default/default/template/page.phtml
 
 		-
 			message: "#^Variable \\$am might not be defined\\.$#"
@@ -8161,11 +7931,6 @@ parameters:
 			path: app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
 
 		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 14
-			path: app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
-
-		-
 			message: "#^Variable \\$userId might not be defined\\.$#"
 			count: 1
 			path: app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
@@ -8266,11 +8031,6 @@ parameters:
 			path: app/design/adminhtml/default/default/template/sales/order/create/items/grid.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 24
-			path: app/design/adminhtml/default/default/template/sales/order/create/items/grid.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 2
 			path: app/design/adminhtml/default/default/template/sales/order/create/js.phtml
@@ -8316,19 +8076,9 @@ parameters:
 			path: app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items/renderer/configurable.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 54
 			path: app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items/renderer/configurable.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items/renderer/default.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -8351,19 +8101,9 @@ parameters:
 			path: app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items/renderer/configurable.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 50
 			path: app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items/renderer/configurable.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items/renderer/default.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -8386,19 +8126,9 @@ parameters:
 			path: app/design/adminhtml/default/default/template/sales/order/invoice/create/items.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/adminhtml/default/default/template/sales/order/invoice/create/items/renderer/configurable.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 52
 			path: app/design/adminhtml/default/default/template/sales/order/invoice/create/items/renderer/configurable.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/adminhtml/default/default/template/sales/order/invoice/create/items/renderer/default.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -8416,19 +8146,9 @@ parameters:
 			path: app/design/adminhtml/default/default/template/sales/order/invoice/view/items.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/adminhtml/default/default/template/sales/order/invoice/view/items/renderer/configurable.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 52
 			path: app/design/adminhtml/default/default/template/sales/order/invoice/view/items/renderer/configurable.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/adminhtml/default/default/template/sales/order/invoice/view/items/renderer/default.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -8584,11 +8304,6 @@ parameters:
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 14
 			path: app/design/adminhtml/default/default/template/sales/order/view/items.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/adminhtml/default/default/template/sales/order/view/items/renderer/default.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -8887,11 +8602,6 @@ parameters:
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 7
-			path: app/design/adminhtml/default/default/template/widget/accordion.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 4
 			path: app/design/adminhtml/default/default/template/widget/breadcrumbs.phtml
 
@@ -8916,21 +8626,6 @@ parameters:
 			path: app/design/adminhtml/default/default/template/widget/form/element/gallery.phtml
 
 		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 1
-			path: app/design/adminhtml/default/default/template/widget/form/renderer/element.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 3
-			path: app/design/adminhtml/default/default/template/widget/form/renderer/fieldset.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 1
-			path: app/design/adminhtml/default/default/template/widget/form/renderer/fieldset/element.phtml
-
-		-
 			message: "#^Method Mage_Adminhtml_Block_Widget_Grid\\:\\:getEmptyCellColspan\\(\\) invoked with 1 parameter, 0 required\\.$#"
 			count: 1
 			path: app/design/adminhtml/default/default/template/widget/grid.phtml
@@ -8941,28 +8636,13 @@ parameters:
 			path: app/design/adminhtml/default/default/template/widget/grid.phtml
 
 		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 4
-			path: app/design/adminhtml/default/default/template/widget/grid/container.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 29
+			message: "#^Call to an undefined method Mage_Adminhtml_Block_Widget_Grid_Massaction\\:\\:canDisplayContainer\\(\\)\\.$#"
+			count: 1
 			path: app/design/adminhtml/default/default/template/widget/grid/massaction.phtml
 
 		-
 			message: "#^File ends with a trailing whitespace\\. This may cause problems when running the code in the web browser\\. Remove the closing \\?\\> mark or remove the whitespace\\.$#"
 			count: 1
-			path: app/design/adminhtml/default/default/template/widget/grid/serializer.phtml
-
-		-
-			message: "#^PHPDoc tag @var does not specify variable name\\.$#"
-			count: 1
-			path: app/design/adminhtml/default/default/template/widget/grid/serializer.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 11
 			path: app/design/adminhtml/default/default/template/widget/grid/serializer.phtml
 
 		-
@@ -8986,16 +8666,6 @@ parameters:
 			path: app/design/adminhtml/default/default/template/widget/view/container.phtml
 
 		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 11
-			path: app/design/adminhtml/default/openmage/template/forgotpassword.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 11
-			path: app/design/adminhtml/default/openmage/template/login.phtml
-
-		-
 			message: "#^Variable \\$minAdminPasswordLength might not be defined\\.$#"
 			count: 2
 			path: app/design/adminhtml/default/openmage/template/resetforgottenpassword.phtml
@@ -9003,11 +8673,6 @@ parameters:
 		-
 			message: "#^Variable \\$resetPasswordLinkToken might not be defined\\.$#"
 			count: 1
-			path: app/design/adminhtml/default/openmage/template/resetforgottenpassword.phtml
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 13
 			path: app/design/adminhtml/default/openmage/template/resetforgottenpassword.phtml
 
 		-
@@ -9046,11 +8711,6 @@ parameters:
 			path: app/design/frontend/base/default/template/bundle/catalog/product/price.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 5
-			path: app/design/frontend/base/default/template/bundle/catalog/product/price.phtml
-
-		-
 			message: "#^Variable \\$_weeeTaxAttributes might not be defined\\.$#"
 			count: 8
 			path: app/design/frontend/base/default/template/bundle/catalog/product/price.phtml
@@ -9063,11 +8723,6 @@ parameters:
 		-
 			message: "#^PHPDoc tag @var has invalid value \\(\\$_catalogHelper Mage_Catalog_Helper_Data\\)\\: Unexpected token \"\\$_catalogHelper\", expected type at offset 9 on line 1$#"
 			count: 1
-			path: app/design/frontend/base/default/template/bundle/catalog/product/view/option_tierprices.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 12
 			path: app/design/frontend/base/default/template/bundle/catalog/product/view/option_tierprices.phtml
 
 		-
@@ -9156,11 +8811,6 @@ parameters:
 			path: app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/options.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/base/default/template/bundle/email/order/items/creditmemo/default.phtml
-
-		-
 			message: "#^Variable \\$_item might not be defined\\.$#"
 			count: 1
 			path: app/design/frontend/base/default/template/bundle/email/order/items/creditmemo/default.phtml
@@ -9174,11 +8824,6 @@ parameters:
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 22
 			path: app/design/frontend/base/default/template/bundle/email/order/items/creditmemo/default.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/base/default/template/bundle/email/order/items/invoice/default.phtml
 
 		-
 			message: "#^Variable \\$_inc might not be defined\\.$#"
@@ -9199,11 +8844,6 @@ parameters:
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 22
 			path: app/design/frontend/base/default/template/bundle/email/order/items/invoice/default.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/base/default/template/bundle/email/order/items/order/default.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -9231,19 +8871,9 @@ parameters:
 			path: app/design/frontend/base/default/template/bundle/rss/catalog/product/price.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 6
-			path: app/design/frontend/base/default/template/bundle/rss/catalog/product/price.phtml
-
-		-
 			message: "#^Variable \\$_weeeTaxAttributes might not be defined\\.$#"
 			count: 8
 			path: app/design/frontend/base/default/template/bundle/rss/catalog/product/price.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/base/default/template/bundle/sales/order/creditmemo/items/renderer.phtml
 
 		-
 			message: "#^Variable \\$_item might not be defined\\.$#"
@@ -9261,11 +8891,6 @@ parameters:
 			path: app/design/frontend/base/default/template/bundle/sales/order/creditmemo/items/renderer.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/base/default/template/bundle/sales/order/invoice/items/renderer.phtml
-
-		-
 			message: "#^Variable \\$_item might not be defined\\.$#"
 			count: 1
 			path: app/design/frontend/base/default/template/bundle/sales/order/invoice/items/renderer.phtml
@@ -9279,11 +8904,6 @@ parameters:
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 173
 			path: app/design/frontend/base/default/template/bundle/sales/order/invoice/items/renderer.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/base/default/template/bundle/sales/order/items/renderer.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -9304,16 +8924,6 @@ parameters:
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 17
 			path: app/design/frontend/base/default/template/callouts/right_col.phtml
-
-		-
-			message: "#^Call to an undefined method Mage_Captcha_Model_Interface\\:\\:getImgSrc\\(\\)\\.$#"
-			count: 1
-			path: app/design/frontend/base/default/template/captcha/zend.phtml
-
-		-
-			message: "#^Call to an undefined method Mage_Captcha_Model_Interface\\:\\:isCaseSensitive\\(\\)\\.$#"
-			count: 1
-			path: app/design/frontend/base/default/template/captcha/zend.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -9408,11 +9018,6 @@ parameters:
 		-
 			message: "#^Left side of && is always true\\.$#"
 			count: 1
-			path: app/design/frontend/base/default/template/catalog/product/price.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 11
 			path: app/design/frontend/base/default/template/catalog/product/price.phtml
 
 		-
@@ -9516,11 +9121,6 @@ parameters:
 			path: app/design/frontend/base/default/template/catalog/product/view/tierprices.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 12
-			path: app/design/frontend/base/default/template/catalog/product/view/tierprices.phtml
-
-		-
 			message: "#^Variable \\$_weeeTaxAttributes might not be defined\\.$#"
 			count: 9
 			path: app/design/frontend/base/default/template/catalog/product/view/tierprices.phtml
@@ -9564,11 +9164,6 @@ parameters:
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 21
 			path: app/design/frontend/base/default/template/catalog/product/widget/new/content/new_list.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 12
-			path: app/design/frontend/base/default/template/catalog/rss/product/price.phtml
 
 		-
 			message: "#^Call to method __\\(\\) on an unknown class Mage_Catalog_Block_Seo_Sitemap_\\.$#"
@@ -9681,11 +9276,6 @@ parameters:
 			path: app/design/frontend/base/default/template/checkout/cart/item/default.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/base/default/template/checkout/cart/item/default.phtml
-
-		-
 			message: "#^Parameter \\#2 \\$visibility of method Mage_Catalog_Helper_Data\\:\\:canApplyMsrp\\(\\) expects int\\|null, string given\\.$#"
 			count: 1
 			path: app/design/frontend/base/default/template/checkout/cart/item/default.phtml
@@ -9713,11 +9303,6 @@ parameters:
 		-
 			message: "#^Method Mage_Checkout_Helper_Data\\:\\:formatPrice\\(\\) invoked with 3 parameters, 1 required\\.$#"
 			count: 6
-			path: app/design/frontend/base/default/template/checkout/cart/sidebar/default.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
 			path: app/design/frontend/base/default/template/checkout/cart/sidebar/default.phtml
 
 		-
@@ -9768,11 +9353,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$product of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects Mage_Catalog_Model_Product, Mage_Sales_Model_Quote_Item given\\.$#"
 			count: 24
-			path: app/design/frontend/base/default/template/checkout/multishipping/overview/item.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
 			path: app/design/frontend/base/default/template/checkout/multishipping/overview/item.phtml
 
 		-
@@ -9883,11 +9463,6 @@ parameters:
 		-
 			message: "#^Method Mage_Checkout_Helper_Data\\:\\:formatPrice\\(\\) invoked with 3 parameters, 1 required\\.$#"
 			count: 12
-			path: app/design/frontend/base/default/template/checkout/onepage/review/item.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
 			path: app/design/frontend/base/default/template/checkout/onepage/review/item.phtml
 
 		-
@@ -10156,11 +9731,6 @@ parameters:
 			path: app/design/frontend/base/default/template/downloadable/checkout/cart/item/default.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/base/default/template/downloadable/checkout/cart/item/default.phtml
-
-		-
 			message: "#^Parameter \\#2 \\$visibility of method Mage_Catalog_Helper_Data\\:\\:canApplyMsrp\\(\\) expects int\\|null, string given\\.$#"
 			count: 1
 			path: app/design/frontend/base/default/template/downloadable/checkout/cart/item/default.phtml
@@ -10181,11 +9751,6 @@ parameters:
 			path: app/design/frontend/base/default/template/downloadable/checkout/onepage/review/item.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/base/default/template/downloadable/checkout/onepage/review/item.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 33
 			path: app/design/frontend/base/default/template/downloadable/checkout/onepage/review/item.phtml
@@ -10196,19 +9761,9 @@ parameters:
 			path: app/design/frontend/base/default/template/downloadable/checkout/success.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/base/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 19
 			path: app/design/frontend/base/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/base/default/template/downloadable/email/order/items/invoice/downloadable.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -10216,39 +9771,19 @@ parameters:
 			path: app/design/frontend/base/default/template/downloadable/email/order/items/invoice/downloadable.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/base/default/template/downloadable/email/order/items/order/downloadable.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 28
 			path: app/design/frontend/base/default/template/downloadable/email/order/items/order/downloadable.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/base/default/template/downloadable/sales/order/creditmemo/items/renderer/downloadable.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 170
 			path: app/design/frontend/base/default/template/downloadable/sales/order/creditmemo/items/renderer/downloadable.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/base/default/template/downloadable/sales/order/invoice/items/renderer/downloadable.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 170
 			path: app/design/frontend/base/default/template/downloadable/sales/order/invoice/items/renderer/downloadable.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/base/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -10271,29 +9806,14 @@ parameters:
 			path: app/design/frontend/base/default/template/email/order/items.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/base/default/template/email/order/items/creditmemo/default.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 16
 			path: app/design/frontend/base/default/template/email/order/items/creditmemo/default.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/base/default/template/email/order/items/invoice/default.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 16
 			path: app/design/frontend/base/default/template/email/order/items/invoice/default.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/base/default/template/email/order/items/order/default.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -10651,11 +10171,6 @@ parameters:
 			path: app/design/frontend/base/default/template/sales/order/creditmemo/items.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/base/default/template/sales/order/creditmemo/items/renderer/default.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 167
 			path: app/design/frontend/base/default/template/sales/order/creditmemo/items/renderer/default.phtml
@@ -10686,11 +10201,6 @@ parameters:
 			path: app/design/frontend/base/default/template/sales/order/invoice/items.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/base/default/template/sales/order/invoice/items/renderer/default.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 167
 			path: app/design/frontend/base/default/template/sales/order/invoice/items/renderer/default.phtml
@@ -10699,11 +10209,6 @@ parameters:
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 18
 			path: app/design/frontend/base/default/template/sales/order/items.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/base/default/template/sales/order/items/renderer/default.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -10946,11 +10451,6 @@ parameters:
 			path: app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle/option/select.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/rwd/default/template/bundle/email/order/items/creditmemo/default.phtml
-
-		-
 			message: "#^Variable \\$_item might not be defined\\.$#"
 			count: 1
 			path: app/design/frontend/rwd/default/template/bundle/email/order/items/creditmemo/default.phtml
@@ -10964,11 +10464,6 @@ parameters:
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 25
 			path: app/design/frontend/rwd/default/template/bundle/email/order/items/creditmemo/default.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/rwd/default/template/bundle/email/order/items/invoice/default.phtml
 
 		-
 			message: "#^Variable \\$_inc might not be defined\\.$#"
@@ -10991,11 +10486,6 @@ parameters:
 			path: app/design/frontend/rwd/default/template/bundle/email/order/items/invoice/default.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/rwd/default/template/bundle/email/order/items/order/default.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 29
 			path: app/design/frontend/rwd/default/template/bundle/email/order/items/order/default.phtml
@@ -11006,49 +10496,9 @@ parameters:
 			path: app/design/frontend/rwd/default/template/bundle/email/order/items/shipment/default.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/rwd/default/template/bundle/sales/order/items/renderer.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 181
 			path: app/design/frontend/rwd/default/template/bundle/sales/order/items/renderer.phtml
-
-		-
-			message: "#^Call to method __\\(\\) on an unknown class Mage_Core_Block_Captcha_Zend\\.$#"
-			count: 3
-			path: app/design/frontend/rwd/default/template/captcha/zend.phtml
-
-		-
-			message: "#^Call to method getCaptchaModel\\(\\) on an unknown class Mage_Core_Block_Captcha_Zend\\.$#"
-			count: 1
-			path: app/design/frontend/rwd/default/template/captcha/zend.phtml
-
-		-
-			message: "#^Call to method getFormId\\(\\) on an unknown class Mage_Core_Block_Captcha_Zend\\.$#"
-			count: 9
-			path: app/design/frontend/rwd/default/template/captcha/zend.phtml
-
-		-
-			message: "#^Call to method getImgHeight\\(\\) on an unknown class Mage_Core_Block_Captcha_Zend\\.$#"
-			count: 1
-			path: app/design/frontend/rwd/default/template/captcha/zend.phtml
-
-		-
-			message: "#^Call to method getRefreshUrl\\(\\) on an unknown class Mage_Core_Block_Captcha_Zend\\.$#"
-			count: 1
-			path: app/design/frontend/rwd/default/template/captcha/zend.phtml
-
-		-
-			message: "#^Call to method getSkinUrl\\(\\) on an unknown class Mage_Core_Block_Captcha_Zend\\.$#"
-			count: 1
-			path: app/design/frontend/rwd/default/template/captcha/zend.phtml
-
-		-
-			message: "#^PHPDoc tag @var for variable \\$this contains unknown class Mage_Core_Block_Captcha_Zend\\.$#"
-			count: 1
-			path: app/design/frontend/rwd/default/template/captcha/zend.phtml
 
 		-
 			message: "#^Call to method escapeUrl\\(\\) on an unknown class Mage_Catalog_Block_Layer_Filter\\.$#"
@@ -11128,11 +10578,6 @@ parameters:
 		-
 			message: "#^Left side of && is always true\\.$#"
 			count: 1
-			path: app/design/frontend/rwd/default/template/catalog/product/price.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 11
 			path: app/design/frontend/rwd/default/template/catalog/product/price.phtml
 
 		-
@@ -11241,11 +10686,6 @@ parameters:
 			path: app/design/frontend/rwd/default/template/checkout/cart/item/default.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/rwd/default/template/checkout/cart/item/default.phtml
-
-		-
 			message: "#^Parameter \\#2 \\$visibility of method Mage_Catalog_Helper_Data\\:\\:canApplyMsrp\\(\\) expects int\\|null, string given\\.$#"
 			count: 1
 			path: app/design/frontend/rwd/default/template/checkout/cart/item/default.phtml
@@ -11258,11 +10698,6 @@ parameters:
 		-
 			message: "#^Method Mage_Checkout_Helper_Data\\:\\:formatPrice\\(\\) invoked with 3 parameters, 1 required\\.$#"
 			count: 6
-			path: app/design/frontend/rwd/default/template/checkout/cart/minicart/default.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
 			path: app/design/frontend/rwd/default/template/checkout/cart/minicart/default.phtml
 
 		-
@@ -11296,11 +10731,6 @@ parameters:
 			path: app/design/frontend/rwd/default/template/checkout/cart/sidebar/default.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/rwd/default/template/checkout/cart/sidebar/default.phtml
-
-		-
 			message: "#^Parameter \\#2 \\$visibility of method Mage_Catalog_Helper_Data\\:\\:canApplyMsrp\\(\\) expects int\\|null, string given\\.$#"
 			count: 1
 			path: app/design/frontend/rwd/default/template/checkout/cart/sidebar/default.phtml
@@ -11331,11 +10761,6 @@ parameters:
 			path: app/design/frontend/rwd/default/template/checkout/multishipping/overview/item.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/rwd/default/template/checkout/multishipping/overview/item.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 18
 			path: app/design/frontend/rwd/default/template/checkout/onepage/payment.phtml
@@ -11353,11 +10778,6 @@ parameters:
 		-
 			message: "#^Method Mage_Checkout_Helper_Data\\:\\:formatPrice\\(\\) invoked with 3 parameters, 1 required\\.$#"
 			count: 12
-			path: app/design/frontend/rwd/default/template/checkout/onepage/review/item.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
 			path: app/design/frontend/rwd/default/template/checkout/onepage/review/item.phtml
 
 		-
@@ -11491,11 +10911,6 @@ parameters:
 			path: app/design/frontend/rwd/default/template/downloadable/checkout/cart/item/default.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/rwd/default/template/downloadable/checkout/cart/item/default.phtml
-
-		-
 			message: "#^Parameter \\#2 \\$visibility of method Mage_Catalog_Helper_Data\\:\\:canApplyMsrp\\(\\) expects int\\|null, string given\\.$#"
 			count: 1
 			path: app/design/frontend/rwd/default/template/downloadable/checkout/cart/item/default.phtml
@@ -11511,19 +10926,9 @@ parameters:
 			path: app/design/frontend/rwd/default/template/downloadable/checkout/onepage/review/item.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/rwd/default/template/downloadable/checkout/onepage/review/item.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 38
 			path: app/design/frontend/rwd/default/template/downloadable/checkout/onepage/review/item.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/rwd/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -11531,29 +10936,14 @@ parameters:
 			path: app/design/frontend/rwd/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/rwd/default/template/downloadable/email/order/items/invoice/downloadable.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 19
 			path: app/design/frontend/rwd/default/template/downloadable/email/order/items/invoice/downloadable.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/rwd/default/template/downloadable/email/order/items/order/downloadable.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 29
 			path: app/design/frontend/rwd/default/template/downloadable/email/order/items/order/downloadable.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/rwd/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -11586,29 +10976,14 @@ parameters:
 			path: app/design/frontend/rwd/default/template/email/order/items.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/rwd/default/template/email/order/items/creditmemo/default.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 17
 			path: app/design/frontend/rwd/default/template/email/order/items/creditmemo/default.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/rwd/default/template/email/order/items/invoice/default.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 17
 			path: app/design/frontend/rwd/default/template/email/order/items/invoice/default.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 8
-			path: app/design/frontend/rwd/default/template/email/order/items/order/default.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"
@@ -11746,11 +11121,6 @@ parameters:
 			path: app/design/frontend/rwd/default/template/sales/order/creditmemo/items.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/rwd/default/template/sales/order/creditmemo/items/renderer/default.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 173
 			path: app/design/frontend/rwd/default/template/sales/order/creditmemo/items/renderer/default.phtml
@@ -11766,11 +11136,6 @@ parameters:
 			path: app/design/frontend/rwd/default/template/sales/order/invoice/items.phtml
 
 		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/rwd/default/template/sales/order/invoice/items/renderer/default.phtml
-
-		-
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 172
 			path: app/design/frontend/rwd/default/template/sales/order/invoice/items/renderer/default.phtml
@@ -11779,11 +11144,6 @@ parameters:
 			message: "#^Variable \\$this might not be defined\\.$#"
 			count: 18
 			path: app/design/frontend/rwd/default/template/sales/order/items.phtml
-
-		-
-			message: "#^Parameter \\#2 \\$compareTo of method Mage_Weee_Helper_Data\\:\\:typeOfDisplay\\(\\) expects array\\|null, int given\\.$#"
-			count: 16
-			path: app/design/frontend/rwd/default/template/sales/order/items/renderer/default.phtml
 
 		-
 			message: "#^Variable \\$this might not be defined\\.$#"

--- a/app/code/core/Mage/Captcha/Block/Captcha/Zend.php
+++ b/app/code/core/Mage/Captcha/Block/Captcha/Zend.php
@@ -71,7 +71,7 @@ class Mage_Captcha_Block_Captcha_Zend extends Mage_Core_Block_Template
     /**
      * Returns captcha model
      *
-     * @return Mage_Captcha_Model_Interface
+     * @return Mage_Captcha_Model_Zend
      */
     public function getCaptchaModel()
     {

--- a/app/code/core/Mage/Weee/Helper/Data.php
+++ b/app/code/core/Mage/Weee/Helper/Data.php
@@ -171,7 +171,7 @@ class Mage_Weee_Helper_Data extends Mage_Core_Helper_Abstract
      * Returns display type for price accordingly to current zone
      *
      * @param Mage_Catalog_Model_Product $product
-     * @param array|null                 $compareTo
+     * @param array|int|null             $compareTo
      * @param string                     $zone
      * @param Mage_Core_Model_Store      $store
      * @return bool|int

--- a/app/design/adminhtml/default/default/template/captcha/zend.phtml
+++ b/app/design/adminhtml/default/default/template/captcha/zend.phtml
@@ -14,7 +14,7 @@
  */
 ?>
 <?php $captcha = $this->getCaptchaModel() ?>
-<?php /** @var Mage_Core_Block_Captcha_Zend $this */ ?>
+<?php /** @var Mage_Captcha_Block_Captcha_Zend $this */ ?>
 <div class="clear"></div>
 <div class="captcha">
     <div class="captcha-input input-box input-left">

--- a/app/design/adminhtml/default/default/template/catalog/category/edit.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/edit.phtml
@@ -15,7 +15,9 @@
 ?>
 <?php
 /**
- * Template for Mage_Adminhtml_Block_Catalog_Category_Cointainer
+ * Template for Mage_Adminhtml_Block_Catalog_Category_Container
+ *
+ * @var Mage_Adminhtml_Block_Catalog_Category_Edit $this
  */
 ?>
 

--- a/app/design/adminhtml/default/default/template/catalog/category/tree.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/tree.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2023 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Catalog_Category_Tree $this */
 ?>
 <div class="categories-side-col">
     <div class="content-header">

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2023 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Catalog_Product_Attribute_Set_Main $this */
 ?>
 <div class="content-header">
     <table cellspacing="0">

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/main.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/main.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Catalog_Product_Attribute_Set_Toolbar_Main $this */
 ?>
 <div class="content-header">
     <table cellspacing="0">

--- a/app/design/adminhtml/default/default/template/catalog/product/edit.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit.phtml
@@ -16,10 +16,10 @@
 <?php
 /**
  * Template for Mage_Adminhtml_Block_Catalog_Product_Edit
+ *
+ * @var Mage_Adminhtml_Block_Catalog_Product_Edit $this
  */
 ?>
-
-
 
 <div class="content-header">
     <h3 class="icon-head head-products"><?php echo $this->getHeader() ?></h3>

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/categories.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/categories.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2023 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Categories $this */
 ?>
 <div class="entry-edit">
     <div class="entry-edit-head">

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Options $this */
 ?>
 <div class="entry-edit custom-options product-custom-options">
     <div id="dynamic-price-warrning" style="display:none">

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2019-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Options_Option $this */
 ?>
 <?php echo $this->getTemplatesHtml() ?>
 

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/date.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/date.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Options_Type_Date $this */
 ?>
 <script type="text/javascript">
 

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/file.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/file.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Options_Type_File $this */
 ?>
 <script type="text/javascript">
 

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/select.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/select.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Options_Type_Select $this */
 ?>
 
 <script type="text/javascript">

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/text.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/text.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Options_Type_Text $this */
 ?>
 <script type="text/javascript">
 //<![CDATA[

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/websites.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/websites.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Websites $this */
 ?>
 <div class="entry-edit">
     <div class="entry-edit-head">

--- a/app/design/adminhtml/default/default/template/catalog/product/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/js.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Js $this */
 ?>
 <script type="text/javascript">
 //<![CDATA[

--- a/app/design/adminhtml/default/default/template/catalog/product/price.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/price.phtml
@@ -23,11 +23,11 @@
  */
 ?>
 <?php
-    /** @var $_coreHelper Mage_Core_Helper_Data */
+    /** @var Mage_Core_Helper_Data $_coreHelper */
     $_coreHelper        = $this->helper('core');
-    /** @var $_weeeHelper Mage_Weee_Helper_Data */
+    /** @var Mage_Weee_Helper_Data $_weeeHelper */
     $_weeeHelper        = $this->helper('weee');
-    /** @var $_taxHelper Mage_Tax_Helper_Data */
+    /** @var Mage_Tax_Helper_Data $_taxHelper */
     $_taxHelper         = $this->helper('tax');
 
     $_product           = $this->getProduct();

--- a/app/design/adminhtml/default/default/template/catalog/product/tab/inventory.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/tab/inventory.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2020-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Inventory $this */
 ?>
 <?php if ($this->isReadonly()):?>
 <?php $_readonly = ' disabled="disabled" ';?>
@@ -34,7 +36,7 @@
             </select>
             <input type="hidden" id="inventory_manage_stock_default" value="<?php echo $this->getDefaultConfigValue('manage_stock'); ?>" />
 
-            <?php $_checked = ($this->getFieldValue('use_config_manage_stock') || $this->IsNew()) ? 'checked="checked"' : '' ?>
+            <?php $_checked = ($this->getFieldValue('use_config_manage_stock') || $this->isNew()) ? 'checked="checked"' : '' ?>
             <input type="checkbox" id="inventory_use_config_manage_stock" name="<?php echo $this->getFieldSuffix() ?>[stock_data][use_config_manage_stock]" value="1" <?php echo $_checked ?> onclick="toggleValueElements(this, this.parentNode);" class="checkbox" <?php echo $_readonly;?>/>
             <label for="inventory_use_config_manage_stock" class="normal"><?php echo Mage::helper('catalog')->__('Use Config Settings') ?></label>
             <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements($('inventory_use_config_manage_stock'), $('inventory_use_config_manage_stock').parentNode);</script><?php endif ?></td>
@@ -57,7 +59,7 @@
             <td class="label"><label for="inventory_min_qty"><?php echo Mage::helper('catalog')->__('Qty for Item\'s Status to Become Out of Stock') ?></label></td>
             <td class="value"><input type="text" class="input-text validate-number" id="inventory_min_qty" name="<?php echo $this->getFieldSuffix() ?>[stock_data][min_qty]" value="<?php echo $this->getFieldValue('min_qty')*1 ?>" <?php echo $_readonly;?>/>
 
-            <?php $_checked = ($this->getFieldValue('use_config_min_qty') || $this->IsNew()) ? 'checked="checked"' : '' ?>
+            <?php $_checked = ($this->getFieldValue('use_config_min_qty') || $this->isNew()) ? 'checked="checked"' : '' ?>
             <input type="checkbox" id="inventory_use_config_min_qty" name="<?php echo $this->getFieldSuffix() ?>[stock_data][use_config_min_qty]" value="1" <?php echo $_checked ?> onclick="toggleValueElements(this, this.parentNode);" <?php echo $_readonly;?> />
             <label for="inventory_use_config_min_qty" class="normal"><?php echo Mage::helper('catalog')->__('Use Config Settings') ?></label>
             <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements($('inventory_use_config_min_qty'), $('inventory_use_config_min_qty').parentNode);</script><?php endif ?></td>
@@ -68,7 +70,7 @@
             <td class="label"><label for="inventory_min_sale_qty"><?php echo Mage::helper('catalog')->__('Minimum Qty Allowed in Shopping Cart') ?></label></td>
             <td class="value"><input type="text" class="input-text validate-number" id="inventory_min_sale_qty" name="<?php echo $this->getFieldSuffix() ?>[stock_data][min_sale_qty]" value="<?php echo (bool)$this->getProduct()->getId() ? $this->getFieldValue('min_sale_qty')*1 : Mage::helper('catalog/product')->getDefaultProductValue('min_sale_qty', $this->getProduct()->getTypeId()) ?>" <?php echo $_readonly ?>/>
 
-            <?php $_checked = ($this->getFieldValue('use_config_min_sale_qty') || $this->IsNew()) ? 'checked="checked"' : '' ?>
+            <?php $_checked = ($this->getFieldValue('use_config_min_sale_qty') || $this->isNew()) ? 'checked="checked"' : '' ?>
             <input type="checkbox" id="inventory_use_config_min_sale_qty" name="<?php echo $this->getFieldSuffix() ?>[stock_data][use_config_min_sale_qty]" value="1" <?php echo $_checked ?> onclick="toggleValueElements(this, this.parentNode);" class="checkbox" <?php echo $_readonly;?> />
             <label for="inventory_use_config_min_sale_qty" class="normal"><?php echo Mage::helper('catalog')->__('Use Config Settings') ?></label>
             <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements($('inventory_use_config_min_sale_qty'), $('inventory_use_config_min_sale_qty').parentNode);</script><?php endif ?></td>
@@ -79,7 +81,7 @@
             <td class="label"><label for="inventory_max_sale_qty"><?php echo Mage::helper('catalog')->__('Maximum Qty Allowed in Shopping Cart') ?></label></td>
             <td class="value"><input type="text" class="input-text validate-number" id="inventory_max_sale_qty" name="<?php echo $this->getFieldSuffix() ?>[stock_data][max_sale_qty]" value="<?php echo $this->getFieldValue('max_sale_qty')*1 ?>" <?php echo $_readonly;?> />
 
-            <?php $_checked = ($this->getFieldValue('use_config_max_sale_qty') || $this->IsNew()) ? 'checked="checked"' : '' ?>
+            <?php $_checked = ($this->getFieldValue('use_config_max_sale_qty') || $this->isNew()) ? 'checked="checked"' : '' ?>
             <input type="checkbox" id="inventory_use_config_max_sale_qty" name="<?php echo $this->getFieldSuffix() ?>[stock_data][use_config_max_sale_qty]" value="1" <?php echo $_checked ?> onclick="toggleValueElements(this, this.parentNode);" class="checkbox" <?php echo $_readonly;?> />
             <label for="inventory_use_config_max_sale_qty" class="normal"><?php echo Mage::helper('catalog')->__('Use Config Settings') ?></label>
             <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements($('inventory_use_config_max_sale_qty'), $('inventory_use_config_max_sale_qty').parentNode);</script><?php endif ?></td>
@@ -120,7 +122,7 @@
             <?php endforeach ?>
             </select>
 
-            <?php $_checked = ($this->getFieldValue('use_config_backorders') || $this->IsNew()) ? 'checked="checked"' : '' ?>
+            <?php $_checked = ($this->getFieldValue('use_config_backorders') || $this->isNew()) ? 'checked="checked"' : '' ?>
             <input type="checkbox" id="inventory_use_config_backorders" name="<?php echo $this->getFieldSuffix() ?>[stock_data][use_config_backorders]" value="1" <?php echo $_checked ?> onclick="toggleValueElements(this, this.parentNode);" class="checkbox" <?php echo $_readonly;?> />
             <label for="inventory_use_config_backorders" class="normal"><?php echo Mage::helper('catalog')->__('Use Config Settings') ?></label>
             <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements($('inventory_use_config_backorders'), $('inventory_use_config_backorders').parentNode);</script><?php endif ?></td>
@@ -130,7 +132,7 @@
             <td class="label"><label for="inventory_notify_stock_qty"><?php echo Mage::helper('catalog')->__('Notify for Quantity Below') ?></label></td>
             <td class="value"><input type="text" class="input-text validate-number" id="inventory_notify_stock_qty" name="<?php echo $this->getFieldSuffix() ?>[stock_data][notify_stock_qty]" value="<?php echo $this->getFieldValue('notify_stock_qty')*1 ?>" <?php echo $_readonly;?>/>
 
-            <?php $_checked = ($this->getFieldValue('use_config_notify_stock_qty') || $this->IsNew()) ? 'checked="checked"' : '' ?>
+            <?php $_checked = ($this->getFieldValue('use_config_notify_stock_qty') || $this->isNew()) ? 'checked="checked"' : '' ?>
             <input type="checkbox" id="inventory_use_config_notify_stock_qty" name="<?php echo $this->getFieldSuffix() ?>[stock_data][use_config_notify_stock_qty]" value="1" <?php echo $_checked ?> onclick="toggleValueElements(this, this.parentNode);" class="checkbox" <?php echo $_readonly;?>/>
             <label for="inventory_use_config_notify_stock_qty" class="normal"><?php echo Mage::helper('catalog')->__('Use Config Settings') ?></label>
             <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements($('inventory_use_config_notify_stock_qty'), $('inventory_use_config_notify_stock_qty').parentNode);</script><?php endif ?></td>
@@ -145,7 +147,7 @@
             </select>
             <input type="hidden" id="inventory_enable_qty_increments_default" value="<?php echo $this->getDefaultConfigValue('enable_qty_increments'); ?>" />
 
-            <?php $_checked = ($this->getFieldValue('use_config_enable_qty_increments') || $this->IsNew()) ? 'checked="checked"' : '' ?>
+            <?php $_checked = ($this->getFieldValue('use_config_enable_qty_increments') || $this->isNew()) ? 'checked="checked"' : '' ?>
             <input type="checkbox" id="inventory_use_config_enable_qty_increments" name="<?php echo $this->getFieldSuffix() ?>[stock_data][use_config_enable_qty_increments]" value="1" <?php echo $_checked ?> onclick="toggleValueElements(this, this.parentNode);" class="checkbox" <?php echo $_readonly;?>/>
             <label for="inventory_use_config_enable_qty_increments" class="normal"><?php echo Mage::helper('catalog')->__('Use Config Settings') ?></label>
             <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements($('inventory_use_config_enable_qty_increments'), $('inventory_use_config_enable_qty_increments').parentNode);</script><?php endif ?></td>
@@ -155,7 +157,7 @@
             <td class="label"><label for="inventory_qty_increments"><?php echo Mage::helper('catalog')->__('Qty Increments') ?></label></td>
             <td class="value">
                 <input type="text" class="input-text validate-digits" id="inventory_qty_increments" name="<?php echo $this->getFieldSuffix() ?>[stock_data][qty_increments]" value="<?php echo $this->getFieldValue('qty_increments')*1 ?>" <?php echo $_readonly;?>/>
-                <?php $_checked = ($this->getFieldValue('use_config_qty_increments') || $this->IsNew()) ? 'checked="checked"' : '' ?>
+                <?php $_checked = ($this->getFieldValue('use_config_qty_increments') || $this->isNew()) ? 'checked="checked"' : '' ?>
                 <input type="checkbox" id="inventory_use_config_qty_increments" name="<?php echo $this->getFieldSuffix() ?>[stock_data][use_config_qty_increments]" value="1" <?php echo $_checked ?> onclick="toggleValueElements(this, this.parentNode);" class="checkbox" <?php echo $_readonly;?>/>
                 <label for="inventory_use_config_qty_increments" class="normal"><?php echo Mage::helper('catalog')->__('Use Config Settings') ?></label>
                 <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements($('inventory_use_config_qty_increments'), $('inventory_use_config_qty_increments').parentNode);</script><?php endif ?></td>

--- a/app/design/adminhtml/default/default/template/customer/edit/tab/account/form/renderer/group.phtml
+++ b/app/design/adminhtml/default/default/template/customer/edit/tab/account/form/renderer/group.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Customer_Edit_Renderer_Attribute_Group $this */
 ?>
 <?php
 $_element = $this->getElement();

--- a/app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2017-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Customer_Edit_Tab_Addresses $this */
 ?>
 <!-- Addresses list -->
 <table cellspacing="0" class="form-edit">

--- a/app/design/adminhtml/default/default/template/customer/tab/newsletter.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/newsletter.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Customer_Edit_Tab_Newsletter $this */
 ?>
 <div class="entry-edit">
 <?php echo $this->getFormObject()->getHtml() ?>

--- a/app/design/adminhtml/default/default/template/customer/tab/view/sales.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/view/sales.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Customer_Edit_Tab_View_Sales $this */
 ?>
 <div class="entry-edit">
     <div class="entry-edit-head"><h4 class="icon-head head-customer-sales-statistics"><?php echo Mage::helper('customer')->__('Sales Statistics') ?></h4></div>

--- a/app/design/adminhtml/default/default/template/customer/tab/wishlist.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/wishlist.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Customer_Edit_Tab_Wishlist $this */
 ?>
 <?php echo $this->getGridParentHtml() ?>
 <?php if($this->canDisplayContainer()): ?>

--- a/app/design/adminhtml/default/default/template/forgotpassword.phtml
+++ b/app/design/adminhtml/default/default/template/forgotpassword.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2020-2024 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Template $this */
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/app/design/adminhtml/default/default/template/login.phtml
+++ b/app/design/adminhtml/default/default/template/login.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2020-2024 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Template $this */
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/app/design/adminhtml/default/default/template/page.phtml
+++ b/app/design/adminhtml/default/default/template/page.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2023 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Page $this */
 ?>
 <?php /*{
     "label":"Root page layout",

--- a/app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
+++ b/app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Template $this */
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/app/design/adminhtml/default/default/template/widget/accordion.phtml
+++ b/app/design/adminhtml/default/default/template/widget/accordion.phtml
@@ -16,6 +16,8 @@
 <?php
 /**
  * Template for Mage_Adminhtml_Block_Widget_Accordion
+ *
+ * @var Mage_Adminhtml_Block_Customer_Edit_Tab_View_Accordion $this
  */
 ?>
 <dl id="tab_content_<?php echo $this->getHtmlId() ?>" name="tab_content_<?php echo $this->getHtmlId() ?>" class="accordion">

--- a/app/design/adminhtml/default/default/template/widget/form/renderer/element.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/renderer/element.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Widget_Form_Renderer_Element $this */
 ?>
 <?php $_element = $this->getElement() ?>
 <?php if($_element->getNoSpan() !== true): ?>

--- a/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Widget_Form_Renderer_Fieldset $this */
 ?>
 <?php $_element = $this->getElement() ?>
 <?php if ($_element->getFieldsetContainerId()): ?>

--- a/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset/element.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset/element.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Widget_Form_Renderer_Fieldset_Element $this */
 ?>
 <?php
 $_element = $this->getElement();

--- a/app/design/adminhtml/default/default/template/widget/grid/container.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/container.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Widget_Grid_Container $this */
 ?>
 <div class="content-header">
     <table cellspacing="0">

--- a/app/design/adminhtml/default/default/template/widget/grid/massaction.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/massaction.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2021-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Widget_Grid_Massaction $this */
 ?>
 <div id="<?php echo $this->getHtmlId() ?>">
 <table cellspacing="0" cellpadding="0" class="massaction">

--- a/app/design/adminhtml/default/default/template/widget/grid/serializer.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/serializer.phtml
@@ -15,7 +15,7 @@
 ?>
 <?php
 /**
- * @var Mage_Adminhtml_Block_Widget_Grid_Serializer
+ * @var Mage_Adminhtml_Block_Widget_Grid_Serializer $this
  */
 ?>
 <?php $_id = 'id_' . md5(microtime()) ?>

--- a/app/design/adminhtml/default/openmage/template/forgotpassword.phtml
+++ b/app/design/adminhtml/default/openmage/template/forgotpassword.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2020-2024 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Template $this */
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/app/design/adminhtml/default/openmage/template/login.phtml
+++ b/app/design/adminhtml/default/openmage/template/login.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2020-2024 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Template $this */
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/app/design/adminhtml/default/openmage/template/resetforgottenpassword.phtml
+++ b/app/design/adminhtml/default/openmage/template/resetforgottenpassword.phtml
@@ -12,6 +12,8 @@
  * @copyright   Copyright (c) 2020-2024 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Adminhtml_Block_Template $this */
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/app/design/frontend/rwd/default/template/captcha/zend.phtml
+++ b/app/design/frontend/rwd/default/template/captcha/zend.phtml
@@ -13,9 +13,8 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<?php /** @var Mage_Core_Block_Captcha_Zend $this */ ?>
-
-<?php /* @var $captcha Mage_Core_Model_Captcha_Zend */ ?>
+<?php /** @var Mage_Captcha_Block_Captcha_Zend $this */ ?>
+<?php /** @var Mage_Captcha_Model_Zend $captcha */ ?>
 <?php $captcha = $this->getCaptchaModel() ?>
 <li class="captcha-input-container" id="captcha-input-box-<?php echo $this->getFormId()?>">
     <label for="captcha_<?php echo $this->getFormId() ?>" class="required"><em>*</em><?php echo $this->__('Please type the letters below')?></label>

--- a/composer.json
+++ b/composer.json
@@ -136,7 +136,8 @@
     "scripts": {
         "php-cs-fixer:test": "vendor/bin/php-cs-fixer fix --dry-run --diff",
         "php-cs-fixer:fix": "vendor/bin/php-cs-fixer fix",
-        "phpstan": "vendor/bin/phpstan analyze",
+        "phpstan": "XDEBUG_MODE=off php vendor/bin/phpstan analyze",
+        "phpstan:baseline": "XDEBUG_MODE=off php vendor/bin/phpstan analyze -b .phpstan.dist.baseline.neon",
         "phpunit:test": "XDEBUG_MODE=off php vendor/bin/phpunit --no-coverage --testdox",
         "phpunit:coverage": "XDEBUG_MODE=coverage php vendor/bin/phpunit --testdox",
         "phpunit:coverage-local": "XDEBUG_MODE=coverage php vendor/bin/phpunit --coverage-html build/coverage --testdox",
@@ -147,6 +148,7 @@
         "php-cs-fixer:test": "Run php-cs-fixer",
         "php-cs-fixer:fix": "Run php-cs-fixer and fix issues",
         "phpstan": "Run phpstan",
+        "phpstan:baseline": "Run phpstan and update baseline",
         "phpunit:test": "Run PHPUnit",
         "phpunit:coverage": "Run PHPUnit with code coverage (requires XDEBUG enabled)",
         "phpunit:coverage-local": "Run PHPUnit with local HTML code coverage (requires XDEBUG enabled)",


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

IDE can now link blocks /w template files.

Added composer short-cut to generate phpostan basline

```
conposer run phpstan:baseline
```