### PR TITLE
Allow ACL settings for system config "groups"

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
@@ -592,7 +592,12 @@ class Mage_Adminhtml_Block_System_Config_Form extends Mage_Adminhtml_Block_Widge
     protected function _canShowField($field)
     {
         $ifModuleEnabled = trim((string)$field->if_module_enabled);
-        if ($ifModuleEnabled && !Mage::helper('Core')->isModuleEnabled($ifModuleEnabled)) {
+        if ($ifModuleEnabled && !Mage::helper('core')->isModuleEnabled($ifModuleEnabled)) {
+            return false;
+        }
+
+        $aclResource = trim((string)$field->acl_rescource);
+        if ($aclResource && !Mage::getSingleton('admin/session')->isAllowed($aclResource)) {
             return false;
         }
 

--- a/app/code/core/Mage/Sitemap/etc/adminhtml.xml
+++ b/app/code/core/Mage/Sitemap/etc/adminhtml.xml
@@ -43,6 +43,24 @@
                                 <children>
                                     <sitemap translate="title" module="shipping">
                                         <title>Google Sitemap</title>
+                                        <children>
+                                            <category translate="title">
+                                                <title>Categories Options</title>
+                                                <sort_order>10</sort_order>
+                                            </category>
+                                            <product translate="title">
+                                                <title>Products Options</title>
+                                                <sort_order>20</sort_order>
+                                            </product>
+                                            <page translate="title">
+                                                <title>CMS Pages Options</title>
+                                                <sort_order>30</sort_order>
+                                            </page>
+                                            <generate translate="title">
+                                                <title>Generation Settings</title>
+                                                <sort_order>40</sort_order>
+                                            </generate>
+                                        </children>
                                     </sitemap>
                                 </children>
                             </config>

--- a/app/code/core/Mage/Sitemap/etc/system.xml
+++ b/app/code/core/Mage/Sitemap/etc/system.xml
@@ -30,6 +30,7 @@
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
+                    <acl_resource>system/config/sitemap/category</acl_resource>
                     <fields>
                         <changefreq translate="label">
                             <label>Frequency</label>
@@ -69,6 +70,7 @@
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
+                    <acl_resource>system/config/sitemap/product</acl_resource>
                     <fields>
                         <changefreq translate="label">
                             <label>Frequency</label>
@@ -108,6 +110,7 @@
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
+                    <acl_resource>system/config/sitemap/page</acl_resource>
                     <fields>
                         <changefreq translate="label">
                             <label>Frequency</label>
@@ -147,6 +150,7 @@
                     <show_in_default>1</show_in_default>
                     <show_in_website>0</show_in_website>
                     <show_in_store>0</show_in_store>
+                    <acl_resource>system/config/generate/page</acl_resource>
                     <fields>
                         <enabled translate="label">
                             <label>Enabled</label>


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. See https://github.com/OpenMage/magento-lts/pull/3451#issuecomment-1728982076

Adds `acl_resource` node for system.xml config groups. Add a path to your acl_resource (in adminhtml.xml). E.g. 

```xml
<acl_resource>system/config/sitemap/category</acl_resource>
```