### PR TITLE
Hotfix:  `core_store.store_id` can be `null`

### DIFF
--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -2466,11 +2466,6 @@ parameters:
 			path: app/code/core/Mage/Catalog/Model/Resource/Product.php
 
 		-
-			message: "#^Parameter \\#1 \\$expression of class Zend_Db_Expr constructor expects string, int given\\.$#"
-			count: 2
-			path: app/code/core/Mage/Catalog/Model/Resource/Product.php
-
-		-
 			message: "#^Method Mage_Catalog_Model_Resource_Product_Attribute_Backend_Media\\:\\:insertGallery\\(\\) should return int but returns string\\.$#"
 			count: 1
 			path: app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Media.php
@@ -3964,11 +3959,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$url of method Mage_Core_Controller_Response_Http\\:\\:setRedirect\\(\\) expects string, bool given\\.$#"
 			count: 1
 			path: app/code/core/Mage/Customer/Model/Session.php
-
-		-
-			message: "#^Parameter \\#3 \\$storeId of method Mage_Customer_Model_Customer\\:\\:sendNewAccountEmail\\(\\) expects string, int given\\.$#"
-			count: 3
-			path: app/code/core/Mage/Customer/controllers/AccountController.php
 
 		-
 			message: "#^Method Mage_Dataflow_Model_Batch\\:\\:setParams\\(\\) should return Mage_Dataflow_Model_Batch_Abstract but returns \\$this\\(Mage_Dataflow_Model_Batch\\)\\.$#"

--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -691,11 +691,6 @@ parameters:
 			path: app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
 
 		-
-			message: "#^Parameter \\#3 \\$storeId of method Mage_Customer_Model_Customer\\:\\:sendNewAccountEmail\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
-
-		-
 			message: "#^Variable \\$billingAddress might not be defined\\.$#"
 			count: 2
 			path: app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
@@ -3116,11 +3111,6 @@ parameters:
 			path: app/code/core/Mage/Checkout/Model/Type/Onepage.php
 
 		-
-			message: "#^Parameter \\#3 \\$storeId of method Mage_Customer_Model_Customer\\:\\:sendNewAccountEmail\\(\\) expects string, int given\\.$#"
-			count: 2
-			path: app/code/core/Mage/Checkout/Model/Type/Onepage.php
-
-		-
 			message: "#^Property Mage_Checkout_Model_Type_Onepage\\:\\:\\$_quote \\(Mage_Sales_Model_Quote\\) on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: app/code/core/Mage/Checkout/Model/Type/Onepage.php
@@ -5133,11 +5123,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$message of static method Mage\\:\\:throwException\\(\\) expects string, array given\\.$#"
 			count: 1
-			path: app/code/core/Mage/Paypal/Model/Express/Checkout.php
-
-		-
-			message: "#^Parameter \\#3 \\$storeId of method Mage_Customer_Model_Customer\\:\\:sendNewAccountEmail\\(\\) expects string, int given\\.$#"
-			count: 2
 			path: app/code/core/Mage/Paypal/Model/Express/Checkout.php
 
 		-

--- a/app/code/core/Mage/Catalog/Model/Resource/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product.php
@@ -397,7 +397,7 @@ class Mage_Catalog_Model_Resource_Product extends Mage_Catalog_Model_Resource_Ab
 
             $selectFields = [
                 't_v_default.entity_id',
-                new Zend_Db_Expr($storeId),
+                new Zend_Db_Expr((string)$storeId),
                 $adapter->getCheckSql('t_v.value_id > 0', 't_v.value', 't_v_default.value'),
             ];
 
@@ -426,7 +426,7 @@ class Mage_Catalog_Model_Resource_Product extends Mage_Catalog_Model_Resource_Ab
 
             $selectFields = [
                 new Zend_Db_Expr($productId),
-                new Zend_Db_Expr($storeId),
+                new Zend_Db_Expr((string)$storeId),
                 $adapter->getCheckSql('t_v.value_id > 0', 't_v.value', 't_v_default.value')
             ];
 

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -703,8 +703,8 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
      */
     public function getId()
     {
-        $data = $this->_getData('store_id');
-        return is_null($data) ? null : (int)$data;
+        $storeId = $this->_getData('store_id');
+        return is_null($storeId) ? null : (int)$storeId;
     }
 
     /**

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -699,11 +699,12 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
     /**
      * Get store identifier
      *
-     * @return int
+     * @return int|null
      */
     public function getId()
     {
-        return (int)$this->_getData('store_id');
+        $data = $this->_getData('store_id');
+        return is_null($data) ? null : (int)$data;
     }
 
     /**

--- a/app/code/core/Mage/Customer/Model/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Customer.php
@@ -717,7 +717,7 @@ class Mage_Customer_Model_Customer extends Mage_Core_Model_Abstract
      *
      * @param string $type
      * @param string $backUrl
-     * @param string $storeId
+     * @param string|int $storeId
      * @param string $password
      * @throws Mage_Core_Exception
      * @return $this

--- a/app/code/core/Mage/Customer/controllers/AccountController.php
+++ b/app/code/core/Mage/Customer/controllers/AccountController.php
@@ -334,7 +334,7 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
             $customer->sendNewAccountEmail(
                 'confirmation',
                 $session->getBeforeAuthUrl(),
-                (string)$store->getId(),
+                $store->getId(),
                 $this->getRequest()->getPost('password')
             );
             /** @var Helper $customerHelper */
@@ -576,7 +576,7 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
         $customer->sendNewAccountEmail(
             $isJustConfirmed ? 'confirmed' : 'registered',
             '',
-            (string)Mage::app()->getStore()->getId(),
+            Mage::app()->getStore()->getId(),
             $this->getRequest()->getPost('password')
         );
 
@@ -666,7 +666,7 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
                     throw new Exception('');
                 }
                 if ($customer->getConfirmation()) {
-                    $customer->sendNewAccountEmail('confirmation', '', (string)Mage::app()->getStore()->getId());
+                    $customer->sendNewAccountEmail('confirmation', '', Mage::app()->getStore()->getId());
                     $this->_getSession()->addSuccess($this->__('Please, check your email for confirmation key.'));
                 } else {
                     $this->_getSession()->addSuccess($this->__('This email does not require confirmation.'));

--- a/app/code/core/Mage/Customer/controllers/AccountController.php
+++ b/app/code/core/Mage/Customer/controllers/AccountController.php
@@ -334,7 +334,7 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
             $customer->sendNewAccountEmail(
                 'confirmation',
                 $session->getBeforeAuthUrl(),
-                $store->getId(),
+                (string)$store->getId(),
                 $this->getRequest()->getPost('password')
             );
             /** @var Helper $customerHelper */
@@ -576,7 +576,7 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
         $customer->sendNewAccountEmail(
             $isJustConfirmed ? 'confirmed' : 'registered',
             '',
-            Mage::app()->getStore()->getId(),
+            (string)Mage::app()->getStore()->getId(),
             $this->getRequest()->getPost('password')
         );
 
@@ -666,7 +666,7 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
                     throw new Exception('');
                 }
                 if ($customer->getConfirmation()) {
-                    $customer->sendNewAccountEmail('confirmation', '', Mage::app()->getStore()->getId());
+                    $customer->sendNewAccountEmail('confirmation', '', (string)Mage::app()->getStore()->getId());
                     $this->_getSession()->addSuccess($this->__('Please, check your email for confirmation key.'));
                 } else {
                     $this->_getSession()->addSuccess($this->__('This email does not require confirmation.'));

--- a/tests/unit/Mage/Core/Model/StoreTest.php
+++ b/tests/unit/Mage/Core/Model/StoreTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   OpenMage
+ * @package    OpenMage_Tests
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Core\Model;
+
+use Generator;
+use Mage;
+use Mage_Core_Model_Store;
+use PHPUnit\Framework\TestCase;
+
+class StoreTest extends TestCase
+{
+    public Mage_Core_Model_Store $subject;
+
+    public function setUp(): void
+    {
+        Mage::app();
+        $this->subject = Mage::getModel('core/store');
+    }
+
+    /**
+     * @dataProvider provideGetId
+     * @group Mage_Core
+     * @group Mage_Core_Model
+     * @group pr-4236
+     */
+    public function testGetId(?int $expectedResult, ?string $withStore): void
+    {
+        if ($withStore) {
+            $this->subject->setData('store_id', $withStore);
+        }
+        $this->assertSame($expectedResult, $this->subject->getId());
+    }
+
+    public function provideGetId(): Generator
+    {
+        yield 'store id' => [
+            1,
+            '1',
+        ];
+        yield 'no store id' => [
+            null,
+            null,
+        ];
+    }
+}

--- a/tests/unit/Mage/Core/Model/StoreTest.php
+++ b/tests/unit/Mage/Core/Model/StoreTest.php
@@ -33,6 +33,7 @@ class StoreTest extends TestCase
     }
 
     /**
+     * @covers Mage_Core_Model_Store::getId()
      * @dataProvider provideGetId
      * @group Mage_Core
      * @group Mage_Core_Model

--- a/tests/unit/Mage/Core/Model/StoreTest.php
+++ b/tests/unit/Mage/Core/Model/StoreTest.php
@@ -36,7 +36,6 @@ class StoreTest extends TestCase
      * @dataProvider provideGetId
      * @group Mage_Core
      * @group Mage_Core_Model
-     * @group pr-4236
      */
     public function testGetId(?int $expectedResult, ?string $withStore): void
     {


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

- Main branch-only. Not in released versions.

I made an error in ... that changes core_store table when creating a new storeview and break whole backend/store.

https://github.com/OpenMage/magento-lts/blob/main/app/code/core/Mage/Core/Model/Store.php#L699-L707

### Related Pull Requests

1. see https://github.com/OpenMage/magento-lts/pull/4236#discussion_r1792821735

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. create new store view
2. its written to store_id 0 (admin store)
3. ...
