### PR TITLE
[Tax] add FK to tax/sales_order_tax again

### DIFF
--- a/app/code/core/Mage/Tax/etc/config.xml
+++ b/app/code/core/Mage/Tax/etc/config.xml
@@ -17,7 +17,7 @@
 <config>
     <modules>
         <Mage_Tax>
-            <version>1.6.0.4</version>
+            <version>1.6.0.5</version>
         </Mage_Tax>
     </modules>
     <global>

--- a/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.4-1.6.0.5.php
@@ -9,7 +9,7 @@
  * @category   Mage
  * @package    Mage_Tax
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
- * @copyright  Copyright (c) 2020-2022 The OpenMage Contributors (https://www.openmage.org)
+ * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://www.openmage.org)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -26,7 +26,10 @@ $this->getConnection()->addForeignKey(
     $taxTable,
     'order_id',
     $orderTable,
-    'entity_id'
+    'entity_id',
+    Varien_Db_Adapter_Interface::FK_ACTION_CASCADE,
+    Varien_Db_Adapter_Interface::FK_ACTION_CASCADE,
+    true
 );
 
 $this->endSetup();

--- a/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.4-1.6.0.5.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   Mage
+ * @package    Mage_Tax
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
+ * @copyright  Copyright (c) 2020-2022 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Tax_Model_Resource_Setup $this */
+
+$this->startSetup();
+
+$taxTable = $this->getTable('tax/sales_order_tax');
+$orderTable = $this->getTable('sales/order');
+
+// adds FK_SALES_ORDER_TAX_ORDER back again
+
+$this->getConnection()->addForeignKey(
+    $this->getFkName($taxTable, 'order_id', $orderTable, 'entity_id'),
+    $taxTable, 'order_id', $orderTable, 'entity_id'
+);
+
+$this->endSetup();

--- a/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.4-1.6.0.5.php
@@ -21,10 +21,12 @@ $taxTable = $this->getTable('tax/sales_order_tax');
 $orderTable = $this->getTable('sales/order');
 
 // adds FK_SALES_ORDER_TAX_ORDER back again
-
 $this->getConnection()->addForeignKey(
     $this->getFkName($taxTable, 'order_id', $orderTable, 'entity_id'),
-    $taxTable, 'order_id', $orderTable, 'entity_id'
+    $taxTable,
+    'order_id',
+    $orderTable,
+    'entity_id'
 );
 
 $this->endSetup();


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This Fixes the Missing FK between `sales_order_tax` and `sales_flat_order`

Right now, when an order gets deleted, the cascade deletes the `sales_flat_order_item`
and then the cascade deletes `sales_order_tax_item`,
but `sales_order_tax` stays with now the order_id pointing to an order that doesn't exist anymore.

That could cause in the wrong taxes to be displayed.

The FK existed before as `FK_SALES_ORDER_TAX_ORDER`, but got removed ages [ago](https://github.com/OpenMage/magento-lts/blob/main/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.3.9-1.4.0.php).

The only other tables that misses the FK are these ones, but they are referenced via creditmemo/invoice/shipment:
* sales_flat_creditmemo_grid
* sales_flat_invoice_grid
* sales_flat_shipment_grid
* sales_flat_shipment_track

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->