### PR TITLE
Fix duplicate block rendering with getSortedChildren()

### DIFF
--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -464,6 +464,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
 
         $block->setParentBlock($this);
         $block->setBlockAlias($alias);
+        $this->unsetChild($alias);
         $this->_children[$alias] = $block;
         return $this;
     }
@@ -482,7 +483,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
             unset($this->_children[$alias]);
             $key = array_search($name, $this->_sortedChildren);
             if ($key !== false) {
-                unset($this->_sortedChildren[$key]);
+                array_splice($this->_sortedChildren, $key, 1);
             }
         }
 
@@ -741,7 +742,6 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      */
     public function sortChildren($force = false)
     {
-        $this->_sortedChildren = array_values($this->_sortedChildren); // reset indexes which might have gaps after unsetting blocks
         foreach ($this->_sortInstructions as $name => $list) {
             list($siblingName, $after, $exists) = $list;
             if ($exists && !$force) {

--- a/composer.lock
+++ b/composer.lock
@@ -287,20 +287,20 @@
         },
         {
             "name": "ezyang/htmlpurifier",
-            "version": "v4.17.0",
+            "version": "v4.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ezyang/htmlpurifier.git",
-                "reference": "bbc513d79acf6691fa9cf10f192c90dd2957f18c"
+                "reference": "cb56001e54359df7ae76dc522d08845dc741621b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/bbc513d79acf6691fa9cf10f192c90dd2957f18c",
-                "reference": "bbc513d79acf6691fa9cf10f192c90dd2957f18c",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/cb56001e54359df7ae76dc522d08845dc741621b",
+                "reference": "cb56001e54359df7ae76dc522d08845dc741621b",
                 "shasum": ""
             },
             "require": {
-                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0"
+                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "require-dev": {
                 "cerdic/css-tidy": "^1.7 || ^2.0",
@@ -342,9 +342,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ezyang/htmlpurifier/issues",
-                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.17.0"
+                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.18.0"
             },
-            "time": "2023-11-17T15:01:25+00:00"
+            "time": "2024-11-01T03:51:45+00:00"
         },
         {
             "name": "flyingmana/composer-config-reader",

--- a/tests/unit/Mage/Core/Block/Text/ListTest.php
+++ b/tests/unit/Mage/Core/Block/Text/ListTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   OpenMage
+ * @package    OpenMage_Tests
+ * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Core\Block\Text;
+
+use Mage;
+use PHPUnit\Framework\TestCase;
+
+class ListTest extends TestCase
+{
+    public function setUp(): void
+    {
+        Mage::app();
+    }
+
+    /**
+     * @group Mage_Core
+     * @group Mage_Core_Block
+     */
+    public function testDuplicateBlockName(): void
+    {
+        $layout = Mage::getModel('core/layout');
+
+        $parentBlock = $layout->createBlock('core/text_list', 'parent');
+
+        $childBlockA = $layout->createBlock('core/text', 'child_a')->setText('A1');
+        $parentBlock->append($childBlockA);
+
+        $childBlockA = $layout->createBlock('core/text', 'child_a')->setText('A2');
+        $parentBlock->append($childBlockA);
+
+        $this->assertSame('A2', $parentBlock->toHtml());
+    }
+
+    /**
+     * @group Mage_Core
+     * @group Mage_Core_Block
+     */
+    public function testDuplicateBlockNameOrdering(): void
+    {
+        $layout = Mage::getModel('core/layout');
+
+        $parentBlock = $layout->createBlock('core/text_list', 'parent');
+
+        $childBlockA = $layout->createBlock('core/text', 'child_a')->setText('A');
+        $parentBlock->append($childBlockA);
+
+        $childBlockB = $layout->createBlock('core/text', 'child_b')->setText('B');
+        $parentBlock->append($childBlockB);
+
+        $childBlockC = $layout->createBlock('core/text', 'child_c')->setText('C');
+        $parentBlock->append($childBlockC);
+
+        $parentBlock->unsetChild('child_b');
+
+        $childBlockB = $layout->createBlock('core/text', 'child_b')->setText('B');
+        $parentBlock->insert($childBlockB, 'child_c', false);
+
+        $this->assertSame('ABC', $parentBlock->toHtml());
+    }
+
+    /**
+     * @group Mage_Core
+     * @group Mage_Core_Block
+     */
+    public function testUniqueBlockNameOrdering(): void
+    {
+        $layout = Mage::getModel('core/layout');
+
+        $parentBlock = $layout->createBlock('core/text_list', 'parent');
+
+        $childBlockD = $layout->createBlock('core/text', 'child_d')->setText('D');
+        $parentBlock->insert($childBlockD, 'child_c', true);
+
+        $childBlockC = $layout->createBlock('core/text', 'child_c')->setText('C');
+        $parentBlock->insert($childBlockC, 'child_b', true);
+
+        $childBlockA = $layout->createBlock('core/text', 'child_a')->setText('A');
+        $parentBlock->insert($childBlockC, 'child_b', false);
+
+        $childBlockB = $layout->createBlock('core/text', 'child_b')->setText('B');
+        $parentBlock->insert($childBlockC, 'child_a', true);
+
+        $parentBlock->unsetChild('child_a');
+        $parentBlock->unsetChild('child_b');
+
+        $this->assertSame('CD', $parentBlock->toHtml());
+    }
+}


### PR DESCRIPTION
### Description (*)

If you try to add a block to a `core/text_list`, you'll get unexpected behavior if another block has been defined with the same name or alias. I consider this a bug because it's not that both blocks are rendered, but the second block is rendered twice.

For example, this renders "ÄÄ":
```xml
<block type="core/text_list" name="test">
    <block type="core/text" name="test_a">
        <action method="setText"><text>A</text></action>
    </block>
    <block type="core/text" name="test_a">
        <action method="setText"><text>Ä</text></action>
    </block>
</block>
```

While the first block will be overwritten by `$this->_children[$alias] = $block;`, a duplicate array element will be added to `$this->_sortedChildren`. 

Then when we loop through the sorted children in `Mage_Core_Block_Text_List`, we will encounter the block name `test_a` twice, call `getBlock('test_a')` twice, and run `toHtml()` twice.

https://github.com/OpenMage/magento-lts/blob/ca4f3217b7a0cb8d0b5b00df7c519922f55d99f3/app/code/core/Mage/Core/Block/Text/List.php#L27-L38

You could just not add duplicate block names, but it's actually useful if you want to override a block in a more specific handle without having to add `<action method="unsetChild">`.

I also replaced `unset()` with `array_splice()` in the `unsetChild` method. This seems like a better solution than the solution merged from PR #1108 which I reverted.

### Related Pull Requests
#1108

### Manual testing scenarios (*)
Add the following into your local.xml:

```xml
<?xml version="1.0"?>
<layout version="0.1.0">
    <default>
        <reference name="content">

            <block type="core/text" name="test_1_title">
                <action method="setText"><text><![CDATA[<h5>Test 1</h5>]]></text></action>
            </block>
            <block type="core/text_list" name="test_1">
                <block type="core/text" name="test_1_a">
                    <action method="setText"><text>A</text></action>
                </block>
                <block type="core/text" name="test_1_a">
                    <action method="setText"><text>Ä</text></action>
                </block>
            </block>

            <block type="core/text" name="test_2_title">
                <action method="setText"><text><![CDATA[<h5>Test 2</h5>]]></text></action>
            </block>
            <block type="core/text_list" name="test_2">
                <block type="core/text" name="test_2_a">
                    <action method="setText"><text>A</text></action>
                </block>
                <block type="core/text" name="test_2_b">
                    <action method="setText"><text>B</text></action>
                </block>
                <block type="core/text" name="test_2_c">
                    <action method="setText"><text>C</text></action>
                </block>
                <action method="unsetChild">
                    <name>test_2_b</name>
                </action>
                <block type="core/text" name="test_2_b" before="test_2_c">
                    <action method="setText"><text>B</text></action>
                </block>
            </block>

            <block type="core/text" name="test_3_title">
                <action method="setText"><text><![CDATA[<h5>Test 3</h5>]]></text></action>
            </block>
            <block type="core/text_list" name="test_3">
                <block type="core/text" name="test_3_c" after="test_3_b">
                    <action method="setText"><text>C</text></action>
                </block>
                <block type="core/text" name="test_3_a" before="test_3_b">
                    <action method="setText"><text>A</text></action>
                </block>
                <block type="core/text" name="test_3_b" after="test_3_a">
                    <action method="setText"><text>B</text></action>
                </block>
                <action method="unsetChild">
                    <name>test_3_a</name>
                </action>
            </block>

            <block type="core/text" name="test_4_title">
                <action method="setText"><text><![CDATA[<h5>Test 4</h5>]]></text></action>
            </block>
            <block type="core/text_list" name="test_4">
                <block type="core/text" name="test_4_d" after="test_4_c">
                    <action method="setText"><text>D</text></action>
                </block>
                <block type="core/text" name="test_4_c" after="test_4_b">
                    <action method="setText"><text>C</text></action>
                </block>
                <block type="core/text" name="test_4_a" before="test_4_b">
                    <action method="setText"><text>A</text></action>
                </block>
                <block type="core/text" name="test_4_b" after="test_4_a">
                    <action method="setText"><text>B</text></action>
                </block>
                <action method="unsetChild">
                    <name>test_4_a</name>
                </action>
                <action method="unsetChild">
                    <name>test_4_b</name>
                </action>
            </block>

        </reference>
    </default>
</layout>
```

### Results:

![image](https://github.com/user-attachments/assets/66700667-2b03-4141-a4a7-c149f8ab4481)


### Questions or comments
I think I correctly replicated the issue in #1108, but if there's another test case please let me know. Ping @lemundo-team and @sreichel.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->