### PR TITLE
Fix: create empty SimpleXMLElement

### DIFF
--- a/app/code/core/Mage/AdminNotification/Model/Feed.php
+++ b/app/code/core/Mage/AdminNotification/Model/Feed.php
@@ -169,7 +169,7 @@ class Mage_AdminNotification_Model_Feed extends Mage_Core_Model_Abstract
             $data = $this->getFeedData();
             $xml  = new SimpleXMLElement($data);
         } catch (Exception $e) {
-            $xml  = new SimpleXMLElement('<?xml version="1.0" encoding="utf-8" ?>');
+            $xml  = new SimpleXMLElement('<?xml version="1.0" encoding="utf-8" ?><feed />');
         }
 
         return $xml;


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This causes a fatal error, because its no valid xml (no root element)

```php
new SimpleXMLElement('<?xml version="1.0" encoding="utf-8" ?>');
```