### PR TITLE
Fixed null deprecation in `Mage_Catalog_Model_Product_Option_Type_Text::validateUserValue()`

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Default.php
@@ -54,9 +54,12 @@ class Mage_Catalog_Model_Product_Option_Type_Default extends Varien_Object
      */
     protected $_formattedOptionValue = null;
 
-    public function getUserValue(): string
+    /**
+     * @return string|array
+     */
+    public function getUserValue()
     {
-        return (string) $this->getDataByKey('user_value');
+        return $this->getDataByKey('user_value') ?? '';
     }
 
     /**

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Default.php
@@ -25,6 +25,7 @@
  * @method string getProcessMode()
  * @method $this setProcessMode(string $value)
  * @method $this setQuoteItem(Mage_Sales_Model_Quote_Item $value)
+ * @method array|int getUserValue()
  * @method $this setRequest(Varien_Object $value)
  * @method $this setUserValue(array|int $value)
  */
@@ -53,14 +54,6 @@ class Mage_Catalog_Model_Product_Option_Type_Default extends Varien_Object
      * @var string|null
      */
     protected $_formattedOptionValue = null;
-
-    /**
-     * @return string|array
-     */
-    public function getUserValue()
-    {
-        return $this->getDataByKey('user_value') ?? '';
-    }
 
     /**
      * Option Instance setter

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Default.php
@@ -25,7 +25,6 @@
  * @method string getProcessMode()
  * @method $this setProcessMode(string $value)
  * @method $this setQuoteItem(Mage_Sales_Model_Quote_Item $value)
- * @method array|int getUserValue()
  * @method $this setRequest(Varien_Object $value)
  * @method $this setUserValue(array|int $value)
  */
@@ -54,6 +53,11 @@ class Mage_Catalog_Model_Product_Option_Type_Default extends Varien_Object
      * @var string|null
      */
     protected $_formattedOptionValue = null;
+
+    public function getUserValue(): string
+    {
+        return (string) $this->getDataByKey('user_value');
+    }
 
     /**
      * Option Instance setter

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Text.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Text.php
@@ -33,7 +33,7 @@ class Mage_Catalog_Model_Product_Option_Type_Text extends Mage_Catalog_Model_Pro
         parent::validateUserValue($values);
 
         $option = $this->getOption();
-        $value = trim($this->getUserValue());
+        $value = is_null($this->getUserValue()) ? '' : trim($this->getUserValue());
 
         // Check requires option to have some value
         if (strlen($value) == 0 && $option->getIsRequire() && !$this->getSkipCheckRequiredOption()) {

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Text.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Text.php
@@ -33,7 +33,7 @@ class Mage_Catalog_Model_Product_Option_Type_Text extends Mage_Catalog_Model_Pro
         parent::validateUserValue($values);
 
         $option = $this->getOption();
-        $value = is_null($this->getUserValue()) ? '' : trim($this->getUserValue());
+        $value = trim($this->getUserValue());
 
         // Check requires option to have some value
         if (strlen($value) == 0 && $option->getIsRequire() && !$this->getSkipCheckRequiredOption()) {


### PR DESCRIPTION
```
    [type] => 8192:E_DEPRECATED
    [message] => trim(): Passing null to parameter #1 ($string) of type string is deprecated
    [file] => .../app/code/core/Mage/Catalog/Model/Product/Option/Type/Text.php
    [line] => 36
```