### PR TITLE
Bugfix: `Mage_Adminhtml_Helper_Dashboard_Data->countStores()` on null

### DIFF
--- a/app/code/core/Mage/Adminhtml/Helper/Dashboard/Data.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Dashboard/Data.php
@@ -29,7 +29,7 @@ class Mage_Adminhtml_Helper_Dashboard_Data extends Mage_Core_Helper_Data
     /**
      * Retrieve stores configured in system.
      *
-     * @return array
+     * @return Mage_Core_Model_Resource_Store_Collection
      */
     public function getStores()
     {
@@ -47,7 +47,7 @@ class Mage_Adminhtml_Helper_Dashboard_Data extends Mage_Core_Helper_Data
      */
     public function countStores()
     {
-        return count($this->_stores->getItems());
+        return count($this->getStores()->getItems());
     }
 
     /**


### PR DESCRIPTION
Part of https://github.com/OpenMage/magento-lts/pull/4340.
```
Fatal error:  Uncaught Error: Call to a member function getItems() on null in /var/www/html/app/code/core/Mage/Adminhtml/Helper/Dashboard/Data.php:50
Stack trace:
#0 /var/www/html/test.php(68): Mage_Adminhtml_Helper_Dashboard_Data->countStores()
#1 /var/www/html/test.php(79): test4340()
```

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->

```php
$test = Mage::helper('adminhtml/dashboard_data');
var_dump($test->countStores());
```