### PR TITLE
fix boolean logic whith 'not one of' condition

### DIFF
--- a/app/code/core/Mage/Rule/Model/Resource/Rule/Condition/SqlBuilder.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Rule/Condition/SqlBuilder.php
@@ -91,7 +91,7 @@ class Mage_Rule_Model_Resource_Rule_Condition_SqlBuilder
             foreach ($value as $v) {
                 $results[] = $this->_adapter->quoteInto("{$selectOperator}", $v);
             }
-            $result = implode(in_array($operator, ['()', '!()']) ? ' OR ' : ' AND ', $results);
+            $result = implode($operator == '()' ? ' OR ' : ' AND ', $results);
         } else {
             $result = $this->_adapter->quoteInto("{$field}{$selectOperator}", $value);
         }


### PR DESCRIPTION
# Description
When using condition "not one of" on multiple categories, products are matched when absent of just one of the categories.
 
pre-fix where condition : 
```
" ((NOT FIND_IN_SET('5',`ccp`.`category_id`) OR NOT FIND_IN_SET('55',`ccp`.`category_id`) OR NOT FIND_IN_SET('80',`ccp`.`category_id`) OR NOT FIND_IN_SET('148',`ccp`.`category_id`))) "
```


post-fix where condition : 
```
" ((NOT FIND_IN_SET('5',`ccp`.`category_id`) AND NOT FIND_IN_SET('55',`ccp`.`category_id`) AND NOT FIND_IN_SET('80',`ccp`.`category_id`) AND NOT FIND_IN_SET('148',`ccp`.`category_id`))) "
```

# Step to reproduce
- Try to apply a promotion on all products but those in two categories
- Products in the two categories are excluded
- Products in only one category are not