### PR TITLE
Fixed incorrect OAuth nonce_used error when it should be error on inc…

### DIFF
--- a/app/code/core/Mage/Oauth/Model/Server.php
+++ b/app/code/core/Mage/Oauth/Model/Server.php
@@ -463,6 +463,7 @@ class Mage_Oauth_Model_Server
         $nonceObj->load($nonce, 'nonce');
 
         if ($nonceObj->getTimestamp() == $timestamp) {
+            $this->_initConsumer();
             $this->_throwException('', self::ERR_NONCE_USED);
         }
         $nonceObj->setNonce($nonce)


### PR DESCRIPTION
…orrect consumer key.

### Description (*)
Incorrect error message leads the developer astray and can waste hours on the wrong thing. This PR fixes such a bug.

### Manual testing scenarios (*)
I use [openmage-shooter](https://github.com/kiatng/openmage-shooter) to test. 
1. [OpenMage OAuth Server] Add a consumer if none exist.
2. [DDEV] Install [openmage-shooter](https://github.com/kiatng/openmage-shooter) in your DDEV environment.
3. [Browser] Open https://openmage.ddev.site/shooter/rest
   * Fill in the OAuth params, on _Consumer Key_, enter a wrong key.
   * Click save. 
   * Error nonce_used:
![image](https://github.com/user-attachments/assets/5323fe00-7ca9-439e-800c-216c402c02cf)
   * Try again with this PR, error: _Could not retrieve a valid Token response from Token URL: oauth_problem=consumer_key_rejected_
