### PR TITLE
Rector: set methods to private in `Mage.php`

### DIFF
--- a/.rector.php
+++ b/.rector.php
@@ -39,4 +39,23 @@ return RectorConfig::configure()
         DeadCode\ClassMethod\RemoveUselessReturnTagRector::class,
         DeadCode\Property\RemoveUselessVarTagRector::class,
         TypeDeclaration\ClassMethod\ReturnNeverTypeRector::class,
-    ]);
+    ])
+    ->withPreparedSets(
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+    );

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -781,7 +781,7 @@ final class Mage
      *
      * @param array $options
      */
-    protected static function _setIsInstalled($options = [])
+    private static function _setIsInstalled($options = [])
     {
         if (isset($options['is_installed']) && $options['is_installed']) {
             self::$_isInstalled = true;
@@ -793,7 +793,7 @@ final class Mage
      *
      * @param array $options
      */
-    protected static function _setConfigModel($options = [])
+    private static function _setConfigModel($options = [])
     {
         if (isset($options['config_model']) && class_exists($options['config_model'])) {
             $alternativeConfigModelName = $options['config_model'];


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

`_setIsInstalled()` & `_setConfigModel()`  are only called in `Mage::run()` itself.