### PR TITLE
New PHPStan Plugin Test

### DIFF
--- a/.phpstan.dist.neon
+++ b/.phpstan.dist.neon
@@ -1,9 +1,11 @@
 includes:
-    - vendor/macopedia/phpstan-magento1/extension.neon
+    - vendor/mahocommerce/maho-phpstan-plugin/extension.neon
     - .phpstan.dist.baseline.neon
     - phar://phpstan.phar/conf/bleedingEdge.neon
 parameters:
     magentoRootPath: %currentWorkingDirectory%
+    bootstrapFiles:
+        - app/Mage.php
     fileExtensions:
       - php
       - phtml

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -278,7 +278,7 @@ final class Mage
             if ($graceful) {
                 return;
             }
-            self::throwException('Mage registry key "' . $key . '" already exists');
+            self::throwException("Mage registry key $key already exists");
         }
         self::$_registry[$key] = $value;
     }
@@ -331,7 +331,7 @@ final class Mage
         if (is_dir($appRoot) && is_readable($appRoot)) {
             self::$_appRoot = $appRoot;
         } else {
-            self::throwException($appRoot . ' is not a directory or not readable by this user');
+            self::throwException("$appRoot is not a directory or not readable by this user");
         }
     }
 
@@ -493,13 +493,17 @@ final class Mage
      * @param callback $callback
      * @param array $data
      * @param string $observerName
-     * @param string $observerClass
+     * @param class-string|'' $observerClass
      * @return Varien_Event_Collection
+     * @throws Mage_Core_Exception
      */
     public static function addObserver($eventName, $callback, $data = [], $observerName = '', $observerClass = '')
     {
         if ($observerClass == '') {
             $observerClass = 'Varien_Event_Observer';
+        }
+        if (!class_exists($observerClass)) {
+            self::throwException("Invalid observer class: $observerClass");
         }
         $observer = new $observerClass();
         $observer->setName($observerName)->addData($data)->setEventName($eventName)->setCallback($callback);
@@ -524,71 +528,129 @@ final class Mage
     }
 
     /**
-     * Retrieve model object
+     * Retrieve helper singleton by alias
      *
-     * @link    Mage_Core_Model_Config::getModelInstance
-     * @param   string $modelClass
-     * @param   array|string|object $arguments
-     * @return  Mage_Core_Model_Abstract|false
-     */
-    public static function getModel($modelClass = '', $arguments = [])
-    {
-        return self::getConfig()->getModelInstance($modelClass, $arguments);
-    }
-
-    /**
-     * Retrieve model object singleton
+     * ```php
+     * $helper = Mage::helper('core'); // Mage_Core_Helper_Data
+     * $helper = Mage::helper('core/url'); // Mage_Core_Helper_Url
+     * ```
      *
-     * @param   string $modelClass
-     * @return  Mage_Core_Model_Abstract|false
+     * @param string $helperAlias
+     * @return Mage_Core_Helper_Abstract|false
      */
-    public static function getSingleton($modelClass = '', array $arguments = [])
+    public static function helper($helperAlias)
     {
-        $registryKey = '_singleton/' . $modelClass;
+        $registryKey = '_helper/' . $helperAlias;
         if (!isset(self::$_registry[$registryKey])) {
-            self::register($registryKey, self::getModel($modelClass, $arguments));
+            self::register($registryKey, self::getConfig()->getHelperInstance($helperAlias));
         }
         return self::$_registry[$registryKey];
     }
 
     /**
-     * Retrieve object of resource model
+     * Retrieve model instance by alias
      *
-     * @param   string $modelClass
-     * @param   array $arguments
-     * @return  Mage_Core_Model_Resource_Db_Collection_Abstract|false
+     * ```php
+     * $model = Mage::getModel('core/store'); // Mage_Core_Model_Store
+     * ```
+     *
+     * @param string $modelAlias
+     * @param array|string|object $arguments
+     * @return Mage_Core_Model_Abstract|false
      */
-    public static function getResourceModel($modelClass, $arguments = [])
+    public static function getModel($modelAlias, $arguments = [])
     {
-        return self::getConfig()->getResourceModelInstance($modelClass, $arguments);
+        return self::getConfig()->getModelInstance($modelAlias, $arguments);
+    }
+
+    /**
+     * Retrieve model singleton by alias
+     *
+     * ```php
+     * $model = Mage::getModel('core/session'); // Mage_Core_Model_Session
+     * ```
+     *
+     * @param string $modelAlias
+     * @return Mage_Core_Model_Abstract|false
+     */
+    public static function getSingleton($modelAlias, array $arguments = [])
+    {
+        $registryKey = '_singleton/' . $modelAlias;
+        if (!isset(self::$_registry[$registryKey])) {
+            self::register($registryKey, self::getModel($modelAlias, $arguments));
+        }
+        return self::$_registry[$registryKey];
+    }
+
+    /**
+     * Retrieve resource model by alias
+     *
+     * ```php
+     * $model = Mage::getResourceModel('core/store_collection'); // Mage_Core_Model_Resource_Store_Collection
+     * ```
+     *
+     * @param string $modelAlias
+     * @param array $arguments
+     * @return Mage_Core_Model_Resource_Db_Collection_Abstract|false
+     */
+    public static function getResourceModel($modelAlias, $arguments = [])
+    {
+        return self::getConfig()->getResourceModelInstance($modelAlias, $arguments);
+    }
+
+    /**
+     * Retrieve resource model singleton by alias
+     *
+     * ```php
+     * $model = Mage::getResourceSingleton('core/session'); // Mage_Core_Model_Resource_Session
+     * ```
+     *
+     * @param string $modelAlias
+     * @return Mage_Core_Model_Resource_Db_Collection_Abstract|false
+     */
+    public static function getResourceSingleton($modelAlias, array $arguments = [])
+    {
+        $registryKey = '_resource_singleton/' . $modelAlias;
+        if (!isset(self::$_registry[$registryKey])) {
+            self::register($registryKey, self::getResourceModel($modelAlias, $arguments));
+        }
+        return self::$_registry[$registryKey];
+    }
+
+    /**
+     * Retrieve resource helper model singleton
+     *
+     * ```php
+     * $model = Mage::getResourceHelper('core'); // Mage_Core_Model_Resource_Helper_Mysql4
+     * ```
+     *
+     * @param string $moduleAlias
+     * @return Mage_Core_Model_Resource_Helper_Abstract|false
+     */
+    public static function getResourceHelper($moduleAlias)
+    {
+        $registryKey = '_resource_helper/' . $moduleAlias;
+        if (!isset(self::$_registry[$registryKey])) {
+            self::register($registryKey, self::getConfig()->getResourceHelperInstance($moduleAlias));
+        }
+        return self::$_registry[$registryKey];
     }
 
     /**
      * Retrieve Controller instance by ClassName
      *
-     * @param string $class
+     * @param class-string $class
      * @param Mage_Core_Controller_Request_Http $request
      * @param Mage_Core_Controller_Response_Http $response
      * @return Mage_Core_Controller_Front_Action
+     * @throws Mage_Core_Exception
      */
     public static function getControllerInstance($class, $request, $response, array $invokeArgs = [])
     {
-        return new $class($request, $response, $invokeArgs);
-    }
-
-    /**
-     * Retrieve resource vodel object singleton
-     *
-     * @param   string $modelClass
-     * @return  object
-     */
-    public static function getResourceSingleton($modelClass = '', array $arguments = [])
-    {
-        $registryKey = '_resource_singleton/' . $modelClass;
-        if (!isset(self::$_registry[$registryKey])) {
-            self::register($registryKey, self::getResourceModel($modelClass, $arguments));
+        if (!class_exists($class)) {
+            self::throwException("Invalid controller class: $class");
         }
-        return self::$_registry[$registryKey];
+        return new $class($request, $response, $invokeArgs);
     }
 
     /**
@@ -604,48 +666,19 @@ final class Mage
     }
 
     /**
-     * Retrieve helper object
-     *
-     * @param string $name the helper name
-     * @return Mage_Core_Helper_Abstract
-     */
-    public static function helper($name)
-    {
-        $registryKey = '_helper/' . $name;
-        if (!isset(self::$_registry[$registryKey])) {
-            $helperClass = self::getConfig()->getHelperClassName($name);
-            self::register($registryKey, new $helperClass());
-        }
-        return self::$_registry[$registryKey];
-    }
-
-    /**
-     * Retrieve resource helper object
-     *
-     * @param string $moduleName
-     * @return Mage_Core_Model_Resource_Helper_Abstract
-     */
-    public static function getResourceHelper($moduleName)
-    {
-        $registryKey = '_resource_helper/' . $moduleName;
-        if (!isset(self::$_registry[$registryKey])) {
-            $helperClass = self::getConfig()->getResourceHelper($moduleName);
-            self::register($registryKey, $helperClass);
-        }
-        return self::$_registry[$registryKey];
-    }
-
-    /**
      * Return new exception by module to be thrown
      *
-     * @param string $module
+     * @param string $moduleName
      * @param string $message
      * @param integer $code
      * @return Mage_Core_Exception
      */
-    public static function exception($module = 'Mage_Core', $message = '', $code = 0)
+    public static function exception($moduleName = 'Mage_Core', $message = '', $code = 0)
     {
-        $className = $module . '_Exception';
+        $className = $moduleName . '_Exception';
+        if (!class_exists($className)) {
+            $className = 'Mage_Core_Exception';
+        }
         return new $className($message, $code);
     }
 
@@ -654,6 +687,7 @@ final class Mage
      *
      * @param string $message
      * @param string $messageStorage
+     * @return never
      * @throws Mage_Core_Exception
      */
     public static function throwException($message, $messageStorage = null)

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -784,8 +784,8 @@ final class Mage
      */
     private static function _setIsInstalled($options = [])
     {
-        if (isset($options['is_installed']) && $options['is_installed']) {
-            self::$_isInstalled = true;
+        if (isset($options['is_installed'])) {
+            self::$_isInstalled = (bool) $options['is_installed'];
         }
     }
 

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -13,8 +13,9 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-define('DS', DIRECTORY_SEPARATOR);
-define('PS', PATH_SEPARATOR);
+defined('DS') || define('DS', DIRECTORY_SEPARATOR);
+defined('PS') || define('PS', PATH_SEPARATOR);
+
 define('BP', dirname(__DIR__));
 
 Mage::register('original_include_path', get_include_path());

--- a/app/code/core/Mage/Core/Controller/Varien/Front.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Front.php
@@ -18,7 +18,7 @@
  * @category   Mage
  * @package    Mage_Core
  *
- * @method Mage_Core_Controller_Varien_Action getAction()
+ * @method Mage_Core_Controller_Varien_Action|null getAction()
  * @method $this setAction(Mage_Core_Controller_Varien_Action $value)
  * @method bool getNoRender()
  */

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -1165,31 +1165,6 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     }
 
     /**
-     * Get module setup class instance.
-     *
-     * Defaults to Mage_Core_Setup
-     *
-     * @param string|Mage_Core_Model_Config_Element $module
-     * @return object
-     */
-    public function getModuleSetup($module = '')
-    {
-        $className = 'Mage_Core_Setup';
-        if ($module !== '') {
-            if (is_string($module)) {
-                $module = $this->getModuleConfig($module);
-            }
-            if (isset($module->setup)) {
-                $moduleClassName = $module->setup->getClassName();
-                if (!empty($moduleClassName)) {
-                    $className = $moduleClassName;
-                }
-            }
-        }
-        return new $className($module);
-    }
-
-    /**
      * Get base filesystem directory. depends on $type
      *
      * If $moduleName is specified retrieves specific value for the module.
@@ -1332,20 +1307,48 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     }
 
     /**
+     * Retrieve class name from config.xml node
+     */
+    public function getNodeClassName(string $path): string
+    {
+        $config = Mage::getConfig()->getNode($path);
+        if (!$config) {
+            return false;
+        }
+        return $config->getClassName();
+    }
+
+    /**
+     * Retrieve class instance from config.xml node
+     *
+     * @param string $path
+     * @return Mage_Core_Model_Abstract|false
+     */
+    public function getNodeClassInstance($path)
+    {
+        $className = $this->getNodeClassName($path);
+        if ($className === false || !class_exists($className)) {
+            return false;
+        }
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
+        return new $className();
+    }
+
+    /**
      * Retrieve class name by class group
      *
      * @param   string $groupType currently supported model, block, helper
-     * @param   string $classId slash separated class identifier, ex. group/class
+     * @param   string $classAlias slash separated class identifier, ex. group/class
      * @param   string $groupRootNode optional config path for group config
      * @return  string
      */
-    public function getGroupedClassName($groupType, $classId, $groupRootNode = null)
+    public function getGroupedClassName($groupType, $classAlias, $groupRootNode = null)
     {
         if (empty($groupRootNode)) {
             $groupRootNode = 'global/' . $groupType . 's';
         }
 
-        $classArr = explode('/', trim($classId));
+        $classArr = explode('/', trim($classAlias));
         $group = $classArr[0];
         $class = !empty($classArr[1]) ? $classArr[1] : null;
 
@@ -1397,8 +1400,8 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     /**
      * Retrieve block class name
      *
-     * @param   string $blockType
-     * @return  string
+     * @param string $blockType
+     * @return string
      */
     public function getBlockClassName($blockType)
     {
@@ -1411,109 +1414,144 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     /**
      * Retrieve helper class name
      *
-     * @param   string $helperName
-     * @return  string
+     * @param string $helperAlias
+     * @return string
      */
-    public function getHelperClassName($helperName)
+    public function getHelperClassName($helperAlias)
     {
-        if (!str_contains($helperName, '/')) {
-            $helperName .= '/data';
+        if (!str_contains($helperAlias, '/')) {
+            $helperAlias .= '/data';
         }
-        return $this->getGroupedClassName('helper', $helperName);
+        return $this->getGroupedClassName('helper', $helperAlias);
+    }
+
+    /**
+     * Retrieve helper instance
+     */
+    public function getHelperInstance(string $helperAlias): Mage_Core_Helper_Abstract|false
+    {
+        $className = $this->getHelperClassName($helperAlias);
+        if (!class_exists($className)) {
+            return false;
+        }
+        Varien_Profiler::start('CORE::create_object_of::' . $className);
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
+        $obj = new $className();
+        Varien_Profiler::stop('CORE::create_object_of::' . $className);
+        return $obj;
+    }
+
+    /**
+     * Retrieve model class name
+     *
+     * @param string $modelAlias
+     * @return string
+     */
+    public function getModelClassName($modelAlias)
+    {
+        $modelAlias = trim($modelAlias);
+        if (!str_contains($modelAlias, '/')) {
+            return $modelAlias;
+        }
+        return $this->getGroupedClassName('model', $modelAlias);
+    }
+
+    /**
+     * Retrieve model instance
+     *
+     * @param string $modelAlias
+     * @param array|object $constructArguments
+     * @return Mage_Core_Model_Abstract|false
+     */
+    public function getModelInstance($modelAlias, $constructArguments = [])
+    {
+        $className = $this->getModelClassName($modelAlias);
+        if (!class_exists($className)) {
+            return false;
+        }
+        Varien_Profiler::start('CORE::create_object_of::' . $className);
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
+        $obj = new $className($constructArguments);
+        Varien_Profiler::stop('CORE::create_object_of::' . $className);
+        return $obj;
+    }
+
+    /**
+     * Retrieve resource model class name
+     *
+     * @param string $modelAlias
+     * @return string|false
+     */
+    public function getResourceModelClassName($modelAlias)
+    {
+        $factoryName = $this->_getResourceModelFactoryClassName($modelAlias);
+        if ($factoryName) {
+            return $this->getModelClassName($factoryName);
+        }
+        return false;
+    }
+
+    /**
+     * Retrieve resource model instance
+     *
+     * @param string $modelAlias
+     * @param array $constructArguments
+     * @return Mage_Core_Model_Resource_Db_Collection_Abstract|false
+     */
+    public function getResourceModelInstance($modelAlias, $constructArguments = [])
+    {
+        $className = $this->getResourceModelClassName($modelAlias);
+        if ($className === false || !class_exists($className)) {
+            return false;
+        }
+        Varien_Profiler::start('CORE::create_object_of::' . $className);
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
+        $obj = new $className($constructArguments);
+        Varien_Profiler::stop('CORE::create_object_of::' . $className);
+        return $obj;
+    }
+
+    /**
+     * Retrieve resource helper class name
+     */
+    public function getResourceHelperClassName(string $moduleAlias): string|false
+    {
+        $connectionModel = $this->_getResourceConnectionModel($moduleAlias);
+        $modelClass = sprintf('%s/helper_%s', $moduleAlias, $connectionModel);
+
+        return $this->getResourceModelClassName($modelClass);
     }
 
     /**
      * Retrieve resource helper instance
      *
-     * Example:
-     * $config->getResourceHelper('cms')
-     * will instantiate Mage_Cms_Model_Resource_Helper_<db_adapter_name>
-     *
-     * @param string $moduleName
+     * @param string $moduleAlias
      * @return Mage_Core_Model_Resource_Helper_Abstract|false
      */
-    public function getResourceHelper($moduleName)
+    public function getResourceHelperInstance(string $moduleAlias): Mage_Core_Model_Resource_Helper_Abstract|false
     {
-        $connectionModel = $this->_getResourceConnectionModel($moduleName);
-        $helperClass     = sprintf('%s/helper_%s', $moduleName, $connectionModel);
-        $helperClassName = $this->_getResourceModelFactoryClassName($helperClass);
-        if ($helperClassName) {
-            return $this->getModelInstance($helperClassName, $moduleName);
-        }
-
-        return false;
-    }
-
-    /**
-     * Retrieve module class name
-     *
-     * @param   string $modelClass
-     * @return  string
-     */
-    public function getModelClassName($modelClass)
-    {
-        $modelClass = trim($modelClass);
-        if (!str_contains($modelClass, '/')) {
-            return $modelClass;
-        }
-        return $this->getGroupedClassName('model', $modelClass);
-    }
-
-    /**
-     * Get model class instance.
-     *
-     * Example:
-     * $config->getModelInstance('catalog/product')
-     *
-     * Will instantiate Mage_Catalog_Model_Resource_Product
-     *
-     * @param string $modelClass
-     * @param array|object $constructArguments
-     * @return Mage_Core_Model_Abstract|false
-     * @see Mage_Catalog_Model_Resource_Product
-     */
-    public function getModelInstance($modelClass = '', $constructArguments = [])
-    {
-        $className = $this->getModelClassName($modelClass);
-        if (class_exists($className)) {
-            Varien_Profiler::start('CORE::create_object_of::' . $className);
-            $obj = new $className($constructArguments);
-            Varien_Profiler::stop('CORE::create_object_of::' . $className);
-            return $obj;
-        } else {
+        $className = $this->getResourceHelperClassName($moduleAlias);
+        if ($className === false || !class_exists($className)) {
             return false;
         }
+        Varien_Profiler::start('CORE::create_object_of::' . $className);
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
+        $obj = new $className();
+        Varien_Profiler::stop('CORE::create_object_of::' . $className);
+        return $obj;
     }
 
     /**
-     * @param string $path
-     * @return bool
-     */
-    public function getNodeClassInstance($path)
-    {
-        $config = Mage::getConfig()->getNode($path);
-        if (!$config) {
-            return false;
-        } else {
-            $className = $config->getClassName();
-            return new $className();
-        }
-    }
-
-    /**
-     * Get resource model object by alias
+     * Retrieve resource helper instance
      *
-     * @param   string $modelClass
-     * @param   array $constructArguments
-     * @return Mage_Core_Model_Resource_Db_Collection_Abstract|false
+     * @param string $moduleAlias
+     * @return Mage_Core_Model_Resource_Helper_Abstract|false
+     * @deprecated Use getResourceHelperInstance() method instead
+     * @see Mage_Core_Model_Config::getResourceHelperInstance()
      */
-    public function getResourceModelInstance($modelClass = '', $constructArguments = [])
+    public function getResourceHelper($moduleAlias)
     {
-        $factoryName = $this->_getResourceModelFactoryClassName($modelClass);
-        if (!$factoryName) {
-            return false;
-        }
-        return $this->getModelInstance($factoryName, $constructArguments);
+        return $this->getResourceHelperInstance($moduleAlias);
     }
 
     /**
@@ -1774,21 +1812,6 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
         }
 
         return $resourceModel . '/' . $model;
-    }
-
-    /**
-     * Get a resource model class name
-     *
-     * @param string $modelClass
-     * @return string|false
-     */
-    public function getResourceModelClassName($modelClass)
-    {
-        $factoryName = $this->_getResourceModelFactoryClassName($modelClass);
-        if ($factoryName) {
-            return $this->getModelClassName($factoryName);
-        }
-        return false;
     }
 
     /**

--- a/app/code/core/Mage/Core/Model/Layout.php
+++ b/app/code/core/Mage/Core/Model/Layout.php
@@ -443,17 +443,21 @@ class Mage_Core_Model_Layout extends Varien_Simplexml_Config
     /**
      * Block Factory
      *
-     * @param     string $type
-     * @param     string|null $name
-     * @return    Mage_Core_Block_Abstract|false
+     * @param string|Mage_Core_Block_Abstract $type
+     * @param string $name
+     * @return Mage_Core_Block_Abstract|false
      */
     public function createBlock($type, $name = '', array $attributes = [])
     {
-        try {
-            $block = $this->_getBlockInstance($type, $attributes);
-        } catch (Exception $e) {
-            Mage::logException($e);
-            return false;
+        if ($type instanceof Mage_Core_Block_Abstract) {
+            $block = $type;
+        } else {
+            try {
+                $block = $this->_getBlockInstance($type, $attributes);
+            } catch (Exception $e) {
+                Mage::logException($e);
+                return false;
+            }
         }
 
         if (empty($name) || $name[0] === '.') {
@@ -462,8 +466,6 @@ class Mage_Core_Model_Layout extends Varien_Simplexml_Config
                 $block->setAnonSuffix(substr($name, 1));
             }
             $name = 'ANONYMOUS_' . count($this->_blocks);
-        } elseif (isset($this->_blocks[$name]) && Mage::getIsDeveloperMode()) {
-            //Mage::throwException(Mage::helper('core')->__('Block with name "%s" already exists', $name));
         }
 
         $block->setType($type);
@@ -491,24 +493,20 @@ class Mage_Core_Model_Layout extends Varien_Simplexml_Config
     /**
      * Create block object instance based on block type
      *
-     * @param string $block
+     * @param string $type
      * @return Mage_Core_Block_Abstract
+     * @throws Mage_Core_Exception
      */
     protected function _getBlockInstance($block, array $attributes = [])
     {
-        if (is_string($block)) {
-            if (str_contains($block, '/')) {
-                if (!$block = Mage::getConfig()->getBlockClassName($block)) {
-                    Mage::throwException(Mage::helper('core')->__('Invalid block type: %s', $block));
-                }
-            }
-            if (class_exists($block, false) || mageFindClassFile($block)) {
-                // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
-                $block = new $block($attributes);
-            }
+        $className = Mage::getConfig()->getBlockClassName($type);
+        if ($className === false || !class_exists($className)) {
+            Mage::throwException(Mage::helper('core')->__('Invalid block type: %s', $type));
         }
+        // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
+        $block = new $className($attributes);
         if (!$block instanceof Mage_Core_Block_Abstract) {
-            Mage::throwException(Mage::helper('core')->__('Invalid block type: %s', $block));
+            Mage::throwException(Mage::helper('core')->__('Invalid block type: %s', $type));
         }
         return $block;
     }
@@ -592,23 +590,14 @@ class Mage_Core_Model_Layout extends Varien_Simplexml_Config
     /**
      * @param string $type
      * @return Mage_Core_Block_Abstract
+     * @throws Mage_Core_Exception
      */
     public function getBlockSingleton($type)
     {
         if (!isset($this->_helpers[$type])) {
-            $className = Mage::getConfig()->getBlockClassName($type);
-            if (!$className) {
-                Mage::throwException(Mage::helper('core')->__('Invalid block type: %s', $type));
-            }
-
-            // phpcs:ignore Ecg.Classes.ObjectInstantiation.DirectInstantiation
-            $helper = new $className();
-            if ($helper) {
-                if ($helper instanceof Mage_Core_Block_Abstract) {
-                    $helper->setLayout($this);
-                }
-                $this->_helpers[$type] = $helper;
-            }
+            $helper = $this->_getBlockInstance($type);
+            $helper->setLayout($this);
+            $this->_helpers[$type] = $helper;
         }
         return $this->_helpers[$type];
     }
@@ -622,7 +611,7 @@ class Mage_Core_Model_Layout extends Varien_Simplexml_Config
     public function helper($name)
     {
         $helper = Mage::helper($name);
-        if (!$helper) {
+        if ($helper === false) {
             return false;
         }
         return $helper->setLayout($this);

--- a/app/code/core/Mage/Sales/Model/Config.php
+++ b/app/code/core/Mage/Sales/Model/Config.php
@@ -24,7 +24,7 @@ class Mage_Sales_Model_Config
 
     /**
      * @param string $type
-     * @return bool
+     * @return Mage_Core_Model_Abstract|false
      */
     public function getQuoteRuleConditionInstance($type)
     {
@@ -33,7 +33,7 @@ class Mage_Sales_Model_Config
 
     /**
      * @param string $type
-     * @return bool
+     * @return Mage_Core_Model_Abstract|false
      */
     public function getQuoteRuleActionInstance($type)
     {

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,9 @@
         "AFL-3.0"
     ],
     "type": "magento-source",
+    "repositories": [
+        { "type": "git", "url": "https://github.com/justinbeaty/maho-phpstan-plugin.git" }
+    ],
     "require": {
         "php": ">=7.4 <8.5",
         "ext-ctype": "*",
@@ -47,8 +50,8 @@
         "composer/composer": "^2.7",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
         "friendsofphp/php-cs-fixer": "^3.4",
-        "macopedia/phpstan-magento1": "^1.0.5",
         "magento-ecg/coding-standard": "^4.5",
+        "mahocommerce/maho-phpstan-plugin": "dev-topic-v3",
         "openmage/dev-meta-package": "^1.0.5",
         "perftools/php-profiler": "^1.1",
         "phpcompatibility/php-compatibility": "^9.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af2f1a89f41c33d8f756c32152ac217d",
+    "content-hash": "ca62c6b13e386b963f57e1f2ca1f6631",
     "packages": [
         {
             "name": "colinmollenhour/cache-backend-redis",
@@ -3515,45 +3515,6 @@
             "time": "2024-11-25T00:39:24+00:00"
         },
         {
-            "name": "macopedia/phpstan-magento1",
-            "version": "v1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/macopedia/phpstan-magento1.git",
-                "reference": "01418cc9a536ffbf298fdf7ea3b9fac1f87a0508"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/macopedia/phpstan-magento1/zipball/01418cc9a536ffbf298fdf7ea3b9fac1f87a0508",
-                "reference": "01418cc9a536ffbf298fdf7ea3b9fac1f87a0508",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">= 7.4",
-                "phpstan/phpstan": "^1.12.11 | ^2.0.2"
-            },
-            "replace": {
-                "inviqa/phpstan-magento1": "0.1.5",
-                "vianetz/phpstan-magento1": "0.1.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPStanMagento1\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Extension for PHPStan to allow analysis of Magento 1 code.",
-            "support": {
-                "issues": "https://github.com/macopedia/phpstan-magento1/issues",
-                "source": "https://github.com/macopedia/phpstan-magento1/tree/v1.1.0"
-            },
-            "time": "2024-11-19T10:50:38+00:00"
-        },
-        {
             "name": "magento-ecg/coding-standard",
             "version": "4.5.4",
             "source": {
@@ -3589,6 +3550,40 @@
                 "source": "https://github.com/magento-ecg/coding-standard/tree/v4.5.2"
             },
             "time": "2023-07-05T15:24:16+00:00"
+        },
+        {
+            "name": "mahocommerce/maho-phpstan-plugin",
+            "version": "dev-topic-v3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/justinbeaty/maho-phpstan-plugin.git",
+                "reference": "21667ad6c3a67850e5b68cdb86c0dd72847669f4"
+            },
+            "require": {
+                "php": ">= 8.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Maho\\PHPStanPlugin\\": "src/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "Extension for PHPStan to allow static analysis of Maho projects.",
+            "time": "2024-12-09T16:14:18+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -7339,7 +7334,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "mahocommerce/maho-phpstan-plugin": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
### Description (*)
This is test to use a new PHPStan plugin with OM instead of radically changing the macopedia one. Presumably you'd fork the module into a new namespace.

I also cleaned up a lot of the `Mage::getModel()` etc methods in `app/Mage.php`, `Mage_Core_Model_Config`, `Mage_Core_Model_Layout`, etc classes. I did change the ordering of some of those methods, so please use split diff view.

Some notable changes:

`Mage::helper('foo')` now returns `false` instead of throwing an error. This is technically a breaking change, but in reality it's okay because you'd just get an error on the next line of code where you try to call some method on that helper. This is in line with all of the other methods like `Mage::getModel()` which can return false.

I removed `Mage_Core_Model_Config::getModuleSetup()` method. It was from a really old Magento version and not applicable anymore.

I removed some empty string default params, so `Mage::getModel($modelClass = '', $arguments = [])` is now `Mage::getModel($modelClass, $arguments = [])`. Because calling getModel with no value just returns false.

I added some `@throws` annotations.

### Related Pull Requests
https://github.com/macopedia/phpstan-magento1/pull/6

### Manual testing scenarios (*)
1. Checkout the branch and composer install. Then run phpstan.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->