### PR TITLE
Fix php8.2 compatibility on V19.

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Quote/Discount.php
+++ b/app/code/core/Mage/SalesRule/Model/Quote/Discount.php
@@ -145,7 +145,7 @@ class Mage_SalesRule_Model_Quote_Discount extends Mage_Sales_Model_Quote_Address
 
         if ($amount != 0) {
             $description = $address->getDiscountDescription();
-            if (strlen($description)) {
+            if (is_string($description) && strlen($description)) {
                 $title = Mage::helper('sales')->__('Discount (%s)', $description);
             } else {
                 $title = Mage::helper('sales')->__('Discount');


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->
-  https://github.com/OpenMage/magento-lts/pull/4293/

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
### Manual testing scenarios (*)

### Questions or comments

I discover this issue when user report error on cart page after upgrade PHP from 7.4 to 8.2 on Openmage 19.5.3

Openmage 19.5.3 should support PHP 8.2 and I also see that it should already resolve by https://github.com/OpenMage/magento-lts/pull/4293/ maybe we can backport portion of that code?

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
