### PR TITLE
Deprecate Date_Short and removed strftime 

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Date/Short.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Date/Short.php
@@ -17,6 +17,7 @@
 /**
  * @category   Mage
  * @package    Mage_Adminhtml
+ * @deprecated
  */
 class Mage_Adminhtml_Model_System_Config_Source_Date_Short
 {
@@ -24,10 +25,10 @@ class Mage_Adminhtml_Model_System_Config_Source_Date_Short
     {
         $arr = [];
         $arr[] = ['label' => '', 'value' => ''];
-        $arr[] = ['label' => strftime('MM/DD/YY (%m/%d/%y)'), 'value' => '%m/%d/%y'];
-        $arr[] = ['label' => strftime('MM/DD/YYYY (%m/%d/%Y)'), 'value' => '%m/%d/%Y'];
-        $arr[] = ['label' => strftime('DD/MM/YY (%d/%m/%y)'), 'value' => '%d/%m/%y'];
-        $arr[] = ['label' => strftime('DD/MM/YYYY (%d/%m/%Y)'), 'value' => '%d/%m/%Y'];
+        $arr[] = ['label' => sprintf('MM/DD/YY (%s)', date('m/d/y')), 'value' => '%m/%d/%y'];
+        $arr[] = ['label' => sprintf('MM/DD/YYYY (%s)', date('m/d/Y')), 'value' => '%m/%d/%Y'];
+        $arr[] = ['label' => sprintf('DD/MM/YY (%s)', date('d/m/y')), 'value' => '%d/%m/%y'];
+        $arr[] = ['label' => sprintf('DD/MM/YYYY (%s)', date('d/m/Y')), 'value' => '%d/%m/%Y'];
         return $arr;
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Deprecated Mage_Adminhtml_Model_System_Config_Source_Date_Short because it uses strftime format strings as values.
Replaced strftime with date

### Related Pull Requests
<!-- related pull request placeholder -->
- see OpenMage/magento-lts#<issue_number>

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
- fixes OpenMage/magento-lts#4398

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
