### PR TITLE
Fix: error in admin edit cart rule

### DIFF
--- a/app/code/core/Mage/Rule/Model/Action/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Action/Abstract.php
@@ -254,17 +254,19 @@ abstract class Mage_Rule_Model_Action_Abstract extends Varien_Object implements 
      */
     public function getAttributeElement()
     {
-        $renderer = Mage::getBlockSingleton('rule/editable');
-        if ($renderer instanceof Varien_Data_Form_Element_Renderer_Interface) {
-            $this->getForm()::setFieldsetRenderer($renderer);
-        }
-
-        return $this->getForm()->addField('action:' . $this->getId() . ':attribute', 'select', [
+        $element = $this->getForm()->addField('action:' . $this->getId() . ':attribute', 'select', [
             'name' => 'rule[actions][' . $this->getId() . '][attribute]',
             'values' => $this->getAttributeSelectOptions(),
             'value' => $this->getAttribute(),
             'value_name' => $this->getAttributeName(),
         ]);
+
+        $renderer = Mage::getBlockSingleton('rule/editable');
+        if ($renderer instanceof Varien_Data_Form_Element_Renderer_Interface) {
+            $element->setRenderer($renderer);
+        }
+
+        return $element;
     }
 
     /**
@@ -272,17 +274,19 @@ abstract class Mage_Rule_Model_Action_Abstract extends Varien_Object implements 
      */
     public function getOperatorElement()
     {
-        $renderer = Mage::getBlockSingleton('rule/editable');
-        if ($renderer instanceof Varien_Data_Form_Element_Renderer_Interface) {
-            $this->getForm()::setFieldsetRenderer($renderer);
-        }
-
-        return $this->getForm()->addField('action:' . $this->getId() . ':operator', 'select', [
+        $element = $this->getForm()->addField('action:' . $this->getId() . ':operator', 'select', [
             'name' => 'rule[actions][' . $this->getId() . '][operator]',
             'values' => $this->getOperatorSelectOptions(),
             'value' => $this->getOperator(),
             'value_name' => $this->getOperatorName(),
         ]);
+
+        $renderer = Mage::getBlockSingleton('rule/editable');
+        if ($renderer instanceof Varien_Data_Form_Element_Renderer_Interface) {
+            $element->setRenderer($renderer);
+        }
+
+        return $element;
     }
 
     /**
@@ -290,16 +294,18 @@ abstract class Mage_Rule_Model_Action_Abstract extends Varien_Object implements 
      */
     public function getValueElement()
     {
-        $renderer = Mage::getBlockSingleton('rule/editable');
-        if ($renderer instanceof Varien_Data_Form_Element_Renderer_Interface) {
-            $this->getForm()::setFieldsetRenderer($renderer);
-        }
-
-        return $this->getForm()->addField('action:' . $this->getId() . ':value', 'text', [
+        $element = $this->getForm()->addField('action:' . $this->getId() . ':value', 'text', [
             'name' => 'rule[actions][' . $this->getId() . '][value]',
             'value' => $this->getValue(),
             'value_name' => $this->getValueName(),
         ]);
+
+        $renderer = Mage::getBlockSingleton('rule/editable');
+        if ($renderer instanceof Varien_Data_Form_Element_Renderer_Interface) {
+            $element->setRenderer($renderer);
+        }
+
+        return $element;
     }
 
     /**

--- a/app/code/core/Mage/Rule/Model/Action/Collection.php
+++ b/app/code/core/Mage/Rule/Model/Action/Collection.php
@@ -108,16 +108,18 @@ class Mage_Rule_Model_Action_Collection extends Mage_Rule_Model_Action_Abstract
      */
     public function getNewChildElement()
     {
-        $renderer = Mage::getBlockSingleton('rule/newchild');
-        if ($renderer instanceof Varien_Data_Form_Element_Renderer_Interface) {
-            $this->getForm()::setFieldsetRenderer($renderer);
-        }
-
-        return $this->getForm()->addField('action:' . $this->getId() . ':new_child', 'select', [
+        $element = $this->getForm()->addField('action:' . $this->getId() . ':new_child', 'select', [
             'name' => 'rule[actions][' . $this->getId() . '][new_child]',
             'values' => $this->getNewChildSelectOptions(),
             'value_name' => $this->getNewChildName(),
         ]);
+
+        $renderer = Mage::getBlockSingleton('rule/newchild');
+        if ($renderer instanceof Varien_Data_Form_Element_Renderer_Interface) {
+            $element->setRenderer($renderer);
+        }
+
+        return $element;
     }
 
     /**

--- a/app/code/core/Mage/Rule/Model/Condition/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Abstract.php
@@ -509,17 +509,19 @@ abstract class Mage_Rule_Model_Condition_Abstract extends Varien_Object implemen
             }
         }
 
-        $renderer = Mage::getBlockSingleton('rule/editable');
-        if ($renderer instanceof Varien_Data_Form_Element_Renderer_Interface) {
-            $this->getForm()::setFieldsetRenderer($renderer);
-        }
-
-        return $this->getForm()->addField($this->getPrefix() . '__' . $this->getId() . '__attribute', 'select', [
+        $element = $this->getForm()->addField($this->getPrefix() . '__' . $this->getId() . '__attribute', 'select', [
             'name'       => 'rule[' . $this->getPrefix() . '][' . $this->getId() . '][attribute]',
             'values'     => $this->getAttributeSelectOptions(),
             'value'      => $this->getAttribute(),
             'value_name' => $this->getAttributeName(),
         ]);
+
+        $renderer = Mage::getBlockSingleton('rule/editable');
+        if ($renderer instanceof Varien_Data_Form_Element_Renderer_Interface) {
+            $element->setRenderer($renderer);
+        }
+
+        return $element;
     }
 
     /**

--- a/app/code/core/Mage/Rule/Model/Condition/Combine.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Combine.php
@@ -147,17 +147,19 @@ class Mage_Rule_Model_Condition_Combine extends Mage_Rule_Model_Condition_Abstra
             }
         }
 
-        $renderer = Mage::getBlockSingleton('rule/editable');
-        if ($renderer instanceof Varien_Data_Form_Element_Renderer_Interface) {
-            $this->getForm()::setFieldsetRenderer($renderer);
-        }
-
-        return $this->getForm()->addField($this->getPrefix() . '__' . $this->getId() . '__aggregator', 'select', [
+        $element = $this->getForm()->addField($this->getPrefix() . '__' . $this->getId() . '__aggregator', 'select', [
             'name' => 'rule[' . $this->getPrefix() . '][' . $this->getId() . '][aggregator]',
             'values' => $this->getAggregatorSelectOptions(),
             'value' => $this->getAggregator(),
             'value_name' => $this->getAggregatorName(),
         ]);
+
+        $renderer = Mage::getBlockSingleton('rule/editable');
+        if ($renderer instanceof Varien_Data_Form_Element_Renderer_Interface) {
+            $element->setRenderer($renderer);
+        }
+
+        return $element;
     }
     /* end aggregator methods */
 
@@ -308,16 +310,18 @@ class Mage_Rule_Model_Condition_Combine extends Mage_Rule_Model_Condition_Abstra
      */
     public function getNewChildElement()
     {
-        $renderer = Mage::getBlockSingleton('rule/newchild');
-        if ($renderer instanceof Varien_Data_Form_Element_Renderer_Interface) {
-            $this->getForm()::setFieldsetRenderer($renderer);
-        }
-
-        return $this->getForm()->addField($this->getPrefix() . '__' . $this->getId() . '__new_child', 'select', [
+        $element = $this->getForm()->addField($this->getPrefix() . '__' . $this->getId() . '__new_child', 'select', [
             'name' => 'rule[' . $this->getPrefix() . '][' . $this->getId() . '][new_child]',
             'values' => $this->getNewChildSelectOptions(),
             'value_name' => $this->getNewChildName(),
         ]);
+
+        $renderer = Mage::getBlockSingleton('rule/newchild');
+        if ($renderer instanceof Varien_Data_Form_Element_Renderer_Interface) {
+            $element->setRenderer($renderer);
+        }
+
+        return $element;
     }
 
     /**


### PR DESCRIPTION
### Description (*)
After #4487, my coworkers found another problem. This time it's the page for cart rules.

![Image](https://github.com/user-attachments/assets/203755ca-03e0-4687-8de9-6b8c31d83b3c)

The problem originates from these changes in v20.12.0:

```diff
--- a/app/code/core/Mage/Rule/Model/Action/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Action/Abstract.php
@@ -254,12 +254,17 @@ public function getTypeElement()
      */
     public function getAttributeElement()
     {
+        $renderer = Mage::getBlockSingleton('rule/editable');
+        if ($renderer instanceof Varien_Data_Form_Element_Renderer_Interface) {
+            $this->getForm()::setFieldsetRenderer($renderer);
+        }
+
         return $this->getForm()->addField('action:' . $this->getId() . ':attribute', 'select', [
             'name' => 'rule[actions][' . $this->getId() . '][attribute]',
             'values' => $this->getAttributeSelectOptions(),
             'value' => $this->getAttribute(),
             'value_name' => $this->getAttributeName(),
-        ])->setRenderer(Mage::getBlockSingleton('rule/editable'));
+        ]);
     }
```

`$this->getForm()->addField(...)` creates a new form field **and returns the newly created field**. Previously, `->setRenderer(...)` was called on this newly created form field. With your changes in v20.12.0, setFieldsetRenderer() is now called on the form, not on the form field.


### Manual testing scenarios (*)
1. Go to Promotions -> Shopping Cart Price Rules
2. Open any rule
3. See the tab switcher being messed up.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
