### PR TITLE
No Layout on Redirect in CatalogSearch AdvancedController

### DIFF
--- a/app/code/core/Mage/CatalogSearch/controllers/AdvancedController.php
+++ b/app/code/core/Mage/CatalogSearch/controllers/AdvancedController.php
@@ -42,6 +42,7 @@ class Mage_CatalogSearch_AdvancedController extends Mage_Core_Controller_Front_A
                     ->setQueryParams($this->getRequest()->getQuery())
                     ->getUrl('*/*/'),
             );
+            return;
         }
         $this->_initLayoutMessages('catalog/session');
         $this->renderLayout();


### PR DESCRIPTION
On _redirectError, it shouldn't return a body

<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
- fixes OpenMage/magento-lts#3389

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
