### PR TITLE
Fixed null deprecation in Mage_Eav_Model_Attribute_Data_Text

### DIFF
--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
@@ -37,7 +37,7 @@ class Mage_Eav_Model_Attribute_Data_Text extends Mage_Eav_Model_Attribute_Data_A
      * Validate data
      * Return true or array of errors
      *
-     * @param array|string $value
+     * @param string|bool|null $value
      * @return bool|array
      */
     public function validateValue($value)
@@ -51,7 +51,7 @@ class Mage_Eav_Model_Attribute_Data_Text extends Mage_Eav_Model_Attribute_Data_A
             $value = $this->getEntity()->getDataUsingMethod($attribute->getAttributeCode());
         }
 
-        if ($attribute->getIsRequired() && strlen($value) == 0) {
+        if ($attribute->getIsRequired() && strlen((string) $value) === 0) {
             $errors[] = Mage::helper('eav')->__('"%s" is a required value.', $label);
         }
 
@@ -60,7 +60,7 @@ class Mage_Eav_Model_Attribute_Data_Text extends Mage_Eav_Model_Attribute_Data_A
         }
 
         // validate length
-        $length = Mage::helper('core/string')->strlen(trim($value));
+        $length = Mage::helper('core/string')->strlen(trim((string) $value));
 
         $validateRules = $attribute->getValidateRules();
         if (!empty($validateRules['min_text_length']) && $length < $validateRules['min_text_length']) {

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
@@ -51,7 +51,7 @@ class Mage_Eav_Model_Attribute_Data_Text extends Mage_Eav_Model_Attribute_Data_A
             $value = $this->getEntity()->getDataUsingMethod($attribute->getAttributeCode());
         }
 
-        if ($attribute->getIsRequired() && strlen((string) $value) === 0) {
+        if ($attribute->getIsRequired() && (string) $value === '') {
             $errors[] = Mage::helper('eav')->__('"%s" is a required value.', $label);
         }
 


### PR DESCRIPTION
### Description (*)
```
    [type] => 8192:E_DEPRECATED
    [message] => trim(): Passing null to parameter #1 ($string) of type string is deprecated
    [file] => .../app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
    [line] => 62
    [uri] => /checkout/onepage/saveBilling/
```
