### PR TITLE
Fix issue with double port in error pages base URL

### DIFF
--- a/errors/processor.php
+++ b/errors/processor.php
@@ -185,6 +185,9 @@ class Error_Processor
         if (!empty($_SERVER['SERVER_PORT'])
             && preg_match('/\d+/', $_SERVER['SERVER_PORT'])
             && !in_array($_SERVER['SERVER_PORT'], [80, 433])
+            && (strlen($host) <= strlen(':' . $_SERVER['SERVER_PORT'])
+                || substr_compare($host, ':' . $_SERVER['SERVER_PORT'], -strlen(':' . $_SERVER['SERVER_PORT'])) !== 0
+            )
         ) {
             $url .= ':' . $_SERVER['SERVER_PORT'];
         }

--- a/errors/processor.php
+++ b/errors/processor.php
@@ -185,12 +185,11 @@ class Error_Processor
         if (!empty($_SERVER['SERVER_PORT'])
             && preg_match('/\d+/', $_SERVER['SERVER_PORT'])
             && !in_array($_SERVER['SERVER_PORT'], [80, 433])
-            && (strlen($host) <= strlen(':' . $_SERVER['SERVER_PORT'])
-                || substr_compare($host, ':' . $_SERVER['SERVER_PORT'], -strlen(':' . $_SERVER['SERVER_PORT'])) !== 0
-            )
+            && !str_ends_with($host, ':' . $_SERVER['SERVER_PORT'])
         ) {
             $url .= ':' . $_SERVER['SERVER_PORT'];
         }
+
         return  $url;
     }
 


### PR DESCRIPTION

### Description (*)
This fixes an issue where the base URL injected into the error page HTML HEAD includes the port twice, and breaks the CSS and image imports. This happens because the code uses HTTP_HOST server variable that already includes the port if the browser URL has a port.

### Manual testing scenarios (*)
1.  Deploy OpenMage in a server on a port other than 80 or 443, for example `http://localhost:8080`
2. Go to an error page, such as `http://localhost:8080/errors/404.php`
3. You will notice in the HTML, the `<head>` the `<base>` element has a URL like `http://localhost:8080:8080/errors/default/`

### Questions or comments
The code uses `substr_compare` instead of `str_ends_with` for php 7 compatibility.

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All automated tests passed successfully (all builds are green)
