### PR TITLE
php 8.3: fix catch for empty sitemap filename

### DIFF
--- a/app/code/core/Mage/Sitemap/Model/Observer.php
+++ b/app/code/core/Mage/Sitemap/Model/Observer.php
@@ -68,7 +68,7 @@ class Mage_Sitemap_Model_Observer
 
             try {
                 $sitemap->generateXml();
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 $errors[] = $e->getMessage();
             }
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
With PHP 7.4 this catch will catch empty filename exception. With PHP 8.3, empty filename escapes the catch, because it is type of `ValueError` which does not inherit from `Exception`. This PR fixes the catch, that PHP 8.3 behavior is the same as PHP 7.4

full PHP 8.3 error that escapes the catch
```
PHP Fatal error:  Uncaught ValueError: Path cannot be empty in /srv/www/scooterdiscounter/public/lib/Varien/Io/File.php:139
```

### Manual testing scenarios (*)
1. create sitemap with empty filename (using script or manipulate in database)
2. execute cronjob `sitemap_generate`

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
