### PR TITLE
php8.3: fix passing null to `str_replace()`

### DIFF
--- a/lib/Varien/Object.php
+++ b/lib/Varien/Object.php
@@ -589,7 +589,7 @@ class Varien_Object implements ArrayAccess
         } else {
             preg_match_all('/\{\{([a-z0-9_]+)\}\}/is', $format, $matches);
             foreach ($matches[1] as $var) {
-                $format = str_replace('{{' . $var . '}}', $this->getData($var), $format);
+                $format = str_replace('{{' . $var . '}}', $this->getData($var) ?: '', $format);
             }
             $str = $format;
         }

--- a/tests/unit/Varien/ObjectTest.php
+++ b/tests/unit/Varien/ObjectTest.php
@@ -166,15 +166,32 @@ class ObjectTest extends TestCase
     }
 
     /**
+     * @dataProvider provideToString
      * @group Varien_Object
      */
-    public function testToString(): void
+    public function testToString(string $expectedResult, string $format): void
     {
-        $this->subject->setString1('open');
-        $this->subject->setString2('mage');
-        $this->assertSame('open, mage', $this->subject->toString());
-        $this->assertSame('openmage', $this->subject->toString('{{string1}}{{string2}}'));
-        $this->assertSame('open', $this->subject->toString('{{string1}}{{string_not_exists}}'));
+        $this->subject->setString1('one');
+        $this->subject->setString2('two');
+        $this->subject->setString3('three');
+
+        $this->assertSame($expectedResult, $this->subject->toString($format));
+    }
+
+    public function provideToString(): Generator
+    {
+        yield 'no format' => [
+            'one, two, three',
+            '',
+        ];
+        yield 'valid' => [
+            'one two',
+            '{{string1}} {{string2}}',
+        ];
+        yield 'invalid' => [
+            'three  one',
+            '{{string3}} {{string_not_exists}} {{string1}}',
+        ];
     }
 
     /**


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

...