### PR TITLE
DRAFT: Fix/environment loader

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
@@ -380,6 +380,7 @@ class Mage_Adminhtml_Block_System_Config_Form extends Mage_Adminhtml_Block_Widge
                     'name'                  => $name,
                     'label'                 => $label,
                     'comment'               => $comment,
+                    'disabled'              => $this->isDisabled($path),
                     'tooltip'               => $tooltip,
                     'hint'                  => $hint,
                     'value'                 => $data,
@@ -627,6 +628,20 @@ class Mage_Adminhtml_Block_System_Config_Form extends Mage_Adminhtml_Block_Widge
         }
 
         return $scope;
+    }
+
+    /**
+     * Render element as disabled, if overwritten by ENV variable
+     *
+     * @param string $data
+     * @return bool
+     */
+    public function isDisabled($path): bool
+    {
+        /** @var Mage_Core_Helper_EnvironmentConfigLoader $environmentConfigLoaderHelper */
+        $environmentConfigLoaderHelper = Mage::helper('core/environmentConfigLoader');
+        $path = $this->getScope() . '/' . $path;
+        return $environmentConfigLoaderHelper->hasPath($path);
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Model/Config/Data.php
+++ b/app/code/core/Mage/Adminhtml/Model/Config/Data.php
@@ -349,6 +349,13 @@ class Mage_Adminhtml_Model_Config_Data extends Varien_Object
                 $config[$data->getPath()] = $data->getValue();
             }
         }
+
+        if (!$full) {
+            /** @var Mage_Core_Helper_EnvironmentConfigLoader $environmentConfigLoaderHelper */
+            $environmentConfigLoaderHelper = Mage::helper('core/environmentConfigLoader');
+            $envConfig = $environmentConfigLoaderHelper->getAsArray($scope = $this->getScope());
+            $config = array_merge($config, $envConfig);
+        }
         return $config;
     }
 

--- a/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
+++ b/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
@@ -105,6 +105,42 @@ class Mage_Core_Helper_EnvironmentConfigLoader extends Mage_Core_Helper_Abstract
         }
     }
 
+    public function getAsArray(string $wantedScope): array
+    {
+        $env = $this->getEnv();
+        $config = [];
+
+        foreach ($env as $configKey => $value) {
+            if (!$this->isConfigKeyValid($configKey)) {
+                continue;
+            }
+
+            list($configKeyParts, $scope) = $this->getConfigKey($configKey);
+            if (strtolower($scope) !== strtolower($wantedScope)) {
+                continue;
+            }
+
+            switch ($scope) {
+                case static::CONFIG_KEY_DEFAULT:
+                    list($unused1, $unused2, $section, $group, $field) = $configKeyParts;
+                    $path = $this->buildPath($section, $group, $field);
+                    $config[$path] = $value;
+                    break;
+
+                case static::CONFIG_KEY_WEBSITES:
+                case static::CONFIG_KEY_STORES:
+                    list($unused1, $unused2, $storeCode, $section, $group, $field) = $configKeyParts;
+                    $path = $this->buildPath($section, $group, $field);
+                    $storeCode = strtolower($storeCode);
+                    $scope = strtolower($scope);
+                    $config[$path] = $value;
+                    break;
+            }
+        }
+
+        return $config;
+    }
+
     /**
      * @internal method mostly for mocking
      */

--- a/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
+++ b/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
@@ -105,6 +105,39 @@ class Mage_Core_Helper_EnvironmentConfigLoader extends Mage_Core_Helper_Abstract
         }
     }
 
+    public function hasPath(string $wantedPath): bool
+    {
+        $env = $this->getEnv();
+        $config = [];
+
+        foreach ($env as $configKey => $value) {
+            if (!$this->isConfigKeyValid($configKey)) {
+                continue;
+            }
+
+            list($configKeyParts, $scope) = $this->getConfigKey($configKey);
+
+            switch ($scope) {
+                case static::CONFIG_KEY_DEFAULT:
+                    list($unused1, $unused2, $section, $group, $field) = $configKeyParts;
+                    $path = $this->buildPath($section, $group, $field);
+                    $nodePath = $this->buildNodePath($scope, $path);
+                    $config[$nodePath] = $value;
+                    break;
+
+                case static::CONFIG_KEY_WEBSITES:
+                case static::CONFIG_KEY_STORES:
+                    list($unused1, $unused2, $storeCode, $section, $group, $field) = $configKeyParts;
+                    $path = $this->buildPath($section, $group, $field);
+                    $nodePath = $this->buildNodePath($scope, $path);
+                    $config[$nodePath] = $value;
+                    break;
+            }
+        }
+        $hasConfig = array_key_exists($wantedPath, $config);
+        return $hasConfig;
+    }
+
     public function getAsArray(string $wantedScope): array
     {
         $env = $this->getEnv();
@@ -131,8 +164,6 @@ class Mage_Core_Helper_EnvironmentConfigLoader extends Mage_Core_Helper_Abstract
                 case static::CONFIG_KEY_STORES:
                     list($unused1, $unused2, $storeCode, $section, $group, $field) = $configKeyParts;
                     $path = $this->buildPath($section, $group, $field);
-                    $storeCode = strtolower($storeCode);
-                    $scope = strtolower($scope);
                     $config[$path] = $value;
                     break;
             }

--- a/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
+++ b/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
@@ -73,8 +73,10 @@ class Mage_Core_Helper_EnvironmentConfigLoader extends Mage_Core_Helper_Abstract
                     $nodePath = $this->buildNodePath($scope, $path);
                     $xmlConfig->setNode($nodePath, $value);
                     try {
-                        $store = Mage::app()->getStore(0);
-                        $this->setCache($store, $value, $path);
+                        foreach (['0', 'admin'] as $store) {
+                            $store = Mage::app()->getStore($store);
+                            $this->setCache($store, $value, $path);
+                        }
                     } catch (Throwable $exception) {
                         Mage::logException($exception);
                     }
@@ -90,8 +92,10 @@ class Mage_Core_Helper_EnvironmentConfigLoader extends Mage_Core_Helper_Abstract
                     $xmlConfig->setNode($nodePath, $value);
                     try {
                         if (!str_contains($nodePath, 'websites')) {
-                            $store = Mage::app()->getStore($storeCode);
-                            $this->setCache($store, $value, $path);
+                            foreach ([$storeCode, 'admin'] as $store) {
+                                $store = Mage::app()->getStore($store);
+                                $this->setCache($store, $value, $path);
+                            }
                         }
                     } catch (Throwable $exception) {
                         Mage::logException($exception);

--- a/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
+++ b/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
@@ -70,15 +70,32 @@ class Mage_Core_Helper_EnvironmentConfigLoader extends Mage_Core_Helper_Abstract
                 case static::CONFIG_KEY_DEFAULT:
                     list($unused1, $unused2, $section, $group, $field) = $configKeyParts;
                     $path = $this->buildPath($section, $group, $field);
-                    $xmlConfig->setNode($this->buildNodePath($scope, $path), $value);
+                    $nodePath = $this->buildNodePath($scope, $path);
+                    $xmlConfig->setNode($nodePath, $value);
+                    try {
+                        $store = Mage::app()->getStore(0);
+                        $this->setCache($store, $value, $path);
+                    } catch (Throwable $exception) {
+                        Mage::logException($exception);
+                    }
                     break;
 
                 case static::CONFIG_KEY_WEBSITES:
                 case static::CONFIG_KEY_STORES:
-                    list($unused1, $unused2, $code, $section, $group, $field) = $configKeyParts;
+                    list($unused1, $unused2, $storeCode, $section, $group, $field) = $configKeyParts;
                     $path = $this->buildPath($section, $group, $field);
-                    $nodePath = sprintf('%s/%s/%s', strtolower($scope), strtolower($code), $path);
+                    $storeCode = strtolower($storeCode);
+                    $scope = strtolower($scope);
+                    $nodePath = sprintf('%s/%s/%s', $scope, $storeCode, $path);
                     $xmlConfig->setNode($nodePath, $value);
+                    try {
+                        if (!str_contains($nodePath, 'websites')) {
+                            $store = Mage::app()->getStore($storeCode);
+                            $this->setCache($store, $value, $path);
+                        }
+                    } catch (Throwable $exception) {
+                        Mage::logException($exception);
+                    }
                     break;
             }
         }
@@ -98,6 +115,16 @@ class Mage_Core_Helper_EnvironmentConfigLoader extends Mage_Core_Helper_Abstract
             $this->envStore = getenv();
         }
         return $this->envStore;
+    }
+
+    protected function setCache(Mage_Core_Model_Store $store, $value, string $path): void
+    {
+        $refObject = new ReflectionObject($store);
+        $refProperty = $refObject->getProperty('_configCache');
+        $refProperty->setAccessible(true);
+        $configCache = $refProperty->getValue($store);
+        $configCache[$path] = $value;
+        $refProperty->setValue($store, $configCache);
     }
 
     protected function getConfigKey(string $configKey): array

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -344,6 +344,9 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
         }
 
         $config = Mage::getConfig();
+        /** @var Mage_Core_Helper_EnvironmentConfigLoader $environmentConfigLoaderHelper */
+        $environmentConfigLoaderHelper = Mage::helper('core/environmentConfigLoader');
+        $environmentConfigLoaderHelper->overrideEnvironment($config);
 
         $fullPath = 'stores/' . $this->getCode() . '/' . $path;
         $data = $config->getNode($fullPath);


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR attempts to fix the incomplete attempt for config values to be overwritten from ENV variables.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Relates to issue https://github.com/OpenMage/magento-lts/issues/4257#issuecomment-2599524399

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Variables from the ENV should now be disabled for editing on the backend, but still shown.
2. Variables from the ENV should be available from `Mage::getStoreConfig`.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
Please give feedback to this WIP solution. 
Maybe in the future we can add a reasoning of "why" the field in the backend is disabled for edits. Such as give a "warning" sign and show that this field is overwritten by a environment variable.
I feel that this is out of scope for now, for I think that the feature should first work the best it can.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
