### PR TITLE
Cache store in API2 for performance.

### DIFF
--- a/app/code/core/Mage/Api2/Model/Resource.php
+++ b/app/code/core/Mage/Api2/Model/Resource.php
@@ -173,6 +173,11 @@ abstract class Mage_Api2_Model_Resource
     protected $_multicall;
 
     /**
+     * @var Mage_Core_Model_Store
+     */
+    protected $_store;
+
+    /**
      * Dispatch
      * To implement the functionality, you must create a method in the parent one.
      *
@@ -1029,6 +1034,9 @@ abstract class Mage_Api2_Model_Resource
      */
     protected function _getStore()
     {
+        if ($this->_store) {
+            return $this->_store;
+        }
         $store = $this->getRequest()->getParam('store');
         try {
             if ($this->getUserType() != Mage_Api2_Model_Auth_User_Admin::USER_TYPE) {
@@ -1049,6 +1057,7 @@ abstract class Mage_Api2_Model_Resource
             // store does not exist
             $this->_critical('Requested store is invalid', Mage_Api2_Model_Server::HTTP_BAD_REQUEST);
         }
+        $this->_store = $store;
         return $store;
     }
 }


### PR DESCRIPTION
### Description (*)
While testing PR #4511, I discovered that `_getStore()` was called 6 times in retrieving a product by API2. This PR cache the store object for performance.

### Related Pull Requests
<!-- related pull request placeholder -->
- see OpenMage/magento-lts#4511

### Manual testing scenarios (*)
 I use https://github.com/kiatng/openmage-shooter.

