### PR TITLE
Fix bug on unable to clear date and datetime attribute.

### DIFF
--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Date.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Date.php
@@ -93,12 +93,11 @@ class Mage_Eav_Model_Attribute_Data_Date extends Mage_Eav_Model_Attribute_Data_A
      */
     public function compactValue($value)
     {
-        if ($value !== false) {
-            if (empty($value)) {
-                $value = null;
-            }
-            $this->getEntity()->setDataUsingMethod($this->getAttribute()->getAttributeCode(), $value);
+        if (empty($value)) {
+            $value = null;
         }
+        $this->getEntity()->setDataUsingMethod($this->getAttribute()->getAttributeCode(), $value);
+
         return $this;
     }
 


### PR DESCRIPTION
### Description (*)
See issue #4604

### Fixed Issues (if relevant)
- fixes OpenMage/magento-lts#4604

### Manual testing scenarios (*)
1. Clear the DOB field on the customer page in backend and save
2. Without this PR, the DOB cannot be cleared


