### PR TITLE
Suggest n98-magerun in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -146,6 +146,9 @@
         },
         "sort-packages": true
     },
+    "suggest": {
+        "n98/magerun": "The n98 magerun cli tools provides some handy tools to work with Magento from command line."
+    },
     "scripts": {
         "php-cs-fixer:test": "vendor/bin/php-cs-fixer fix --dry-run --diff",
         "php-cs-fixer:fix": "vendor/bin/php-cs-fixer fix",

--- a/composer.lock
+++ b/composer.lock
@@ -7128,5 +7128,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
I dont want to reinvent the wheel and add better CLI support like started in https://github.com/OpenMage/magento-lts/pull/2955.

Better use [n98-magerun](https://github.com/netz98/n98-magerun).

It provides a lot of helpfull commands and easy ways to add you own. See https://magerun.net/introducting-the-new-n98-magerun-module-system/.

Note: atm - until v3 release, that should be available soon, you can use its develop-branch to run it with php8.