### PR TITLE
FEAT: disable advanced search on storeview scope

### DIFF
--- a/app/code/core/Mage/Catalog/Helper/Search.php
+++ b/app/code/core/Mage/Catalog/Helper/Search.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   Mage
+ * @package    Mage_Catalog
+ * @copyright  Copyright (c) 2025 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Catalog search helper
+ *
+ * @category   Mage
+ * @package    Mage_Catalog
+ */
+class Mage_Catalog_Helper_Search extends Mage_Core_Helper_Abstract
+{
+    protected $_moduleName = 'Mage_Catalog';
+
+    /**
+     * @SuppressWarnings("PHPMD.StaticAccess")
+     */
+    public function isNotEnabled(): bool
+    {
+        return !Mage::getStoreConfigFlag('catalog/search/enable_advanced_search');
+    }
+
+    /**
+     * @SuppressWarnings("PHPMD.StaticAccess")
+     */
+    public function getNoRoutePath(): string
+    {
+        return $this->_getUrl(Mage::getStoreConfig('web/default/cms_no_route'));
+    }
+}

--- a/app/code/core/Mage/Catalog/Model/Observer/DisableAdvancedSearch.php
+++ b/app/code/core/Mage/Catalog/Model/Observer/DisableAdvancedSearch.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available at https://opensource.org/license/osl-3-0-php
+ *
+ * @category   Mage
+ * @package    Mage_Catalog
+ * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://www.magento.com)
+ * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Catalog Observer
+ *
+ * @category   Mage
+ * @package    Mage_Catalog
+ */
+class Mage_Catalog_Model_Observer_DisableAdvancedSearch
+{
+    /**
+     * Disable Advanced Search at storeview scope
+     *
+     * @SuppressWarnings("PHPMD.StaticAccess")
+     */
+    public function execute(Varien_Event_Observer $observer): void
+    {
+        /** @var Mage_Catalog_Helper_Search $helper */
+        $helper = Mage::helper('catalog/search');
+        if ($helper->isNotEnabled()) {
+            $observer->getControllerAction()->getResponse()->setRedirect($helper->getNoRoutePath());
+        }
+    }
+}

--- a/app/code/core/Mage/Catalog/etc/config.xml
+++ b/app/code/core/Mage/Catalog/etc/config.xml
@@ -711,6 +711,22 @@
                     </catalog>
                 </observers>
             </sales_convert_quote_item_to_order_item>
+            <controller_action_predispatch_catalogsearch_advanced_index>
+                <observers>
+                    <stackexchange_disable_advancedsearch_index>
+                        <class>catalog/observer_disableAdvancedSearch</class>
+                        <method>execute</method>
+                    </stackexchange_disable_advancedsearch_index>
+                </observers>
+            </controller_action_predispatch_catalogsearch_advanced_index>
+            <controller_action_predispatch_catalogsearch_advanced_result>
+                <observers>
+                    <stackexchange_disable_advancedsearch_results>
+                        <class>catalog/observer_disableAdvancedSearch</class>
+                        <method>execute</method>
+                    </stackexchange_disable_advancedsearch_results>
+                </observers>
+            </controller_action_predispatch_catalogsearch_advanced_result>
         </events>
         <translate>
             <modules>
@@ -821,6 +837,9 @@
                 <interval_division_limit>9</interval_division_limit>
                 <display_product_count>1</display_product_count>
             </layered_navigation>
+            <search>
+                <enable_advanced_search>1</enable_advanced_search>
+            </search>
         </catalog>
         <system>
             <media_storage_configuration>

--- a/app/code/core/Mage/Catalog/etc/system.xml
+++ b/app/code/core/Mage/Catalog/etc/system.xml
@@ -474,6 +474,20 @@
                     </fields>
                 </layer>
 -->
+
+                <search>
+                    <fields>
+                        <enable_advanced_search translate="label">
+                            <label>Enable Advanced Search</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
+                            <sort_order>800</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </enable_advanced_search>
+                    </fields>
+                </search>
             </groups>
         </catalog>
         <design>

--- a/app/locale/en_US/Mage_Catalog.csv
+++ b/app/locale/en_US/Mage_Catalog.csv
@@ -284,6 +284,7 @@
 "Email","Email"
 "Email to a Friend","Email to a Friend"
 "Empty","Empty"
+"Enable Advanced Search","Enable Advanced Search"
 "Enable MAP","Enable MAP"
 "Enable Qty Increments","Enable Qty Increments"
 "Enable WYSIWYG","Enable WYSIWYG"


### PR DESCRIPTION
This is a port of one of my extensions. It has only 265 downloads for M1, but 30k for Magento2. Worth to add 2 observers?

For me it was usefull as many stores dont have well configured attributes that gave advanced search a bad UX. It was better to disable it.

Note: i followed M2s SRP (single-responsibility principle) for observers and created a new class with only one `excetute`-method. The interface for that will come in a seperate PR.

