### PR TITLE
Re-add DDEV files to composer installs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 # Make packagist / composer download smaller
-/.ddev export-ignore
 /.github export-ignore
 /dev export-ignore
 /docs export-ignore


### PR DESCRIPTION
Custom DDEV commands should also be available for composer install.