### PR TITLE
Fix MySQL connection for DDEV setup

### DIFF
--- a/.ddev/commands/web/openmage-admin
+++ b/.ddev/commands/web/openmage-admin
@@ -29,14 +29,14 @@ fi
 RANDOM_STRING=$({ tr -dc A-Za-z0-9 </dev/urandom | head -c 32 ; })
 
 if [[ "${ACTION}" =~ ^(update|u) ]]; then
-  if mysql -u db -h db db -e "UPDATE "${TABLE_PREFIX}"admin_user SET password=CONCAT(MD5('"${RANDOM_STRING}""${ADMIN_PASSWORD}"'),':"${RANDOM_STRING}"') WHERE username='"${ADMIN_USER}"'"; then
+  if mysql -u db -pdb -h db db -e "UPDATE "${TABLE_PREFIX}"admin_user SET password=CONCAT(MD5('"${RANDOM_STRING}""${ADMIN_PASSWORD}"'),':"${RANDOM_STRING}"') WHERE username='"${ADMIN_USER}"'"; then
     echo "If the account "${ADMIN_USER}" exists it has been updated."
   else
     exit 1
   fi
 elif [[ "${ACTION}" =~ ^(create|c) ]]; then
-  if mysql -u db -h db db -e "INSERT INTO "${TABLE_PREFIX}"admin_user (firstname, lastname, email, username, password) VALUES ('"${ADMIN_FIRSTNAME}"', '"${ADMIN_LASTNAME}"', '"${ADMIN_EMAIL}"', '"${ADMIN_USER}"', CONCAT(MD5('"${RANDOM_STRING}""${ADMIN_PASSWORD}"'), ':"${RANDOM_STRING}"'))"; then
-    mysql -u db -h db db -e "INSERT INTO "${TABLE_PREFIX}"admin_role(parent_id, tree_level, sort_order, role_type, user_id, role_name)
+  if mysql -u db -pdb -h db db -e "INSERT INTO "${TABLE_PREFIX}"admin_user (firstname, lastname, email, username, password) VALUES ('"${ADMIN_FIRSTNAME}"', '"${ADMIN_LASTNAME}"', '"${ADMIN_EMAIL}"', '"${ADMIN_USER}"', CONCAT(MD5('"${RANDOM_STRING}""${ADMIN_PASSWORD}"'), ':"${RANDOM_STRING}"'))"; then
+    mysql -u db -pdb -h db db -e "INSERT INTO "${TABLE_PREFIX}"admin_role(parent_id, tree_level, sort_order, role_type, user_id, role_name)
     VALUES (1, 2, 0, 'U',(SELECT user_id FROM "${TABLE_PREFIX}"admin_user WHERE username = '"${ADMIN_USER}"'),'"${ADMIN_FIRSTNAME}"')"
     echo "The account "$ADMIN_USER" has been created."
   else

--- a/.ddev/commands/web/openmage-install
+++ b/.ddev/commands/web/openmage-install
@@ -53,7 +53,7 @@ if [ -f "${LOCALXML}" ]; then
   fi
 
   if [[ "${DELETE}" =~ ^(yes|y) ]]; then
-    mysql -u db -h db -e "DROP SCHEMA IF EXISTS db; CREATE SCHEMA db;";
+    mysql -u db -pdb -h db -e "DROP SCHEMA IF EXISTS db; CREATE SCHEMA db;";
     rm "${LOCALXML}"
   else
     exit 1
@@ -96,7 +96,7 @@ if [[ $INSTALL_SAMPLE_DATA =~ ^(yes|y) ]]; then
   rm -rf "${ROOT}"/"${DDEV_DOCROOT}/var/cache/"*
 
   echo "Importing Sample Data into the database..."
-  mysql -u db -h db db < "${SAMPLE_DATA_DIRECTORY}"/magento-sample-data-1.9.2.4/magento_sample_data_for_1.9.2.4.sql
+  mysql -u db -pdb -h db db < "${SAMPLE_DATA_DIRECTORY}"/magento-sample-data-1.9.2.4/magento_sample_data_for_1.9.2.4.sql
 
   # remove sample data
   if [[ "${SAMPLE_DATA_KEEP_FLAG}" ]]; then


### PR DESCRIPTION
### Description (*)

`ddev openmage-admin` doesn't import sample data because DDEV don't use `MYSQL_PWD` anymore:

- https://github.com/ddev/ddev/pull/6887

```
$ ddev openmage-install -q
...
Importing Sample Data into the database...
ERROR 1045 (28000): Access denied for user 'db'@'172.19.0.2' (using password: YES)
...
```

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Use DDEV quickstart for OpenMage from:

- https://github.com/ddev/ddev/pull/7091

Sample data should be successfully imported.