### PR TITLE
fix Incomplete multi-character sanitization leads Improper Input Validation (RXSS)

### DIFF
--- a/js/prototype/prototype.js
+++ b/js/prototype/prototype.js
@@ -621,7 +621,13 @@ Object.extend(String.prototype, (function() {
   }
 
   function stripTags() {
-    return this.replace(/<\w+(\s+("[^"]*"|'[^']*'|[^>'"])+)?\s*("[^">]*|'[^'>])?(\/)?>|<\/\w+>/gi, '');
+    var previous;
+    var input = this;
+    do {
+      previous = input;
+      input = input.replace(/<\w+(\s+("[^"]*"|'[^']*'|[^>'"])+)?\s*("[^">]*|'[^'>])?(\/)?>|<\/\w+>/gi, '');
+    } while (input !== previous);
+    return input;
   }
 
   function stripScripts() {


### PR DESCRIPTION
https://github.com/OpenMage/magento-lts/blob/591aedbf65df5680b8a59edb94e9309cf06d9456/js/prototype/prototype.js#L624-L624

fix the problem ensure that all instances of the targeted patterns are removed, even if they appear consecutively or in a nested manner. One effective way to achieve this is to apply the regular expression replacement repeatedly until no more replacements can be performed. This approach ensures that all instances of the targeted patterns are removed, effectively sanitizing the input. modify the `stripTags` function to repeatedly apply the regular expression replacement until the input no longer changes. This will ensure that all HTML tags are removed, even if they are nested or malformed.

Sanitizing untrusted input is a common technique for preventing injection attacks and other security vulnerabilities. Regular expressions are often used to perform this sanitization. However, when the regular expression matches multiple consecutive characters, replacing it just once can result in the unsafe text reappearing in the sanitized input. Attackers can exploit this issue by crafting inputs that, when sanitized with an ineffective regular expression, still contain malicious code or content. This can lead to code execution, data exposure, or other vulnerabilities.

## POC
Consider the following JavaScript code that aims to remove all HTML comment start and end tags:
```js
str.replace(/<!--|--!?>/g, "");   
```
Given the input string "<!<!--- comment --->>", the output will be "<!-- comment -->", which still contains an HTML comment. One possible fix for this issue is to apply the regular expression replacement repeatedly until no more replacements can be performed. This ensures that the unsafe text does not re-appear in the sanitized input, effectively removing all instances of the targeted pattern:
```js
function removeHtmlComments(input) {  
  let previous;  
  do {  
    previous = input;  
    input = input.replace(/<!--|--!?>/g, "");  
  } while (input !== previous);  
  return input;  
}  
```
Another vulnerable is the following regular expression intended to remove script tags:
```js
str.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/g, "");  
```
If the input string is `<scrip<script>is removed</script>t>alert(123)</script>`, the output will be `<script>alert(123)</script>`, which still contains a script tag. A fix for this issue is to rewrite the regular expression to match single characters ("<" and ">") instead of the entire unsafe text. This simplifies the sanitization process and ensures that all potentially unsafe characters are removed:
```js
function removeAllHtmlTags(input) {  
  return input.replace(/<|>/g, "");  
}
```
Another potential fix is to use the popular `sanitize-html` npm library. It keeps most of the safe HTML tags while removing all unsafe tags and attributes.
```js
const sanitizeHtml = require("sanitize-html");
function removeAllHtmlTags(input) {  
  return sanitizeHtml(input);  
}
```


The regular expression attempts to strip out all occurences of `/../` from str. This will not work as expected: for the string `/./.././`, it will remove the single occurrence of `/../` in the middle, but the remainder of the string then becomes `/../`, which is another instance of the substring we were trying to remove. A possible fix for this issue is to use the "sanitize-filename" npm library for path sanitization. This library is specifically designed to handle path sanitization, and should handle all corner cases and ensure effective sanitization:
```js
const sanitize = require("sanitize-filename");  
  
function sanitizePath(input) {  
  return sanitize(input);  
}  
```
## References
[A1 Injection](https://www.owasp.org/index.php/Top_10-2017_A1-Injection)
[Removing all script tags from HTML with JS regular expression](https://stackoverflow.com/questions/6659351/removing-all-script-tags-from-html-with-js-regular-expression)
[CWE-20](https://cwe.mitre.org/data/definitions/20.html)
[CWE-80](https://cwe.mitre.org/data/definitions/80.html)
[CWE-116](https://cwe.mitre.org/data/definitions/116.html)


