### PR TITLE
Fix products duplicate across pagination when they have the same posi…

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
@@ -1520,7 +1520,7 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
             // optimize if using cat index
             $filters = $this->_productLimitationFilters;
             if (isset($filters['category_id']) || isset($filters['visibility'])) {
-                $this->getSelect()->order('cat_index.position ' . $dir);
+                $this->getSelect()->order(['cat_index.position ' . $dir, 'e.entity_id ' . $dir]);
             } else {
                 $this->getSelect()->order('e.entity_id ' . $dir);
             }


### PR DESCRIPTION
## Bug Description
### Issue #4749 
When filtering products in a category with pagination enabled, some products can appear duplicated across different pages if they have the same value in the "position" field.

## Steps to Reproduce
1. Have multiple products in a category with the same position value (typically 0)
2. Apply a filter to the category 
3. Navigate between pages 1 and 2
4. Notice that some products (in my case, product ID 5034) appear on multiple pages

## Expected Behavior
Each product should appear exactly once in the paginated listing.

## Actual Behavior
The same product appears on multiple pages when browsing through the pagination, specifically when sorting by position and multiple products have the same position value.

## Proposed Solution
Modify the `addAttributeToSort` method to include entity_id as a tiebreaker criterion:

```php
if ($attribute == 'position') {
    if (isset($this->_productLimitationFilters['category_id'])) {
        $this->getSelect()->order(['cat_index.position ' . $dir, 'e.entity_id ASC']);
    }
    return $this;
}
```

Instead of only ordering by position. This would ensure a deterministic order even when multiple products have the same position value.

## Environment
- OpenMage version: [your version]
- PHP version: [your version]
- MySQL version: [your version]