### PR TITLE
Replace `trigger_error`, which is deprecated in PHP 8.4.

### DIFF
--- a/lib/Varien/Db/Adapter/Interface.php
+++ b/lib/Varien/Db/Adapter/Interface.php
@@ -50,6 +50,7 @@ interface Varien_Db_Adapter_Interface
      * Error message for DDL query in transactions
      */
     public const ERROR_DDL_MESSAGE = 'DDL statements are not allowed in transactions';
+    public const ERROR_TRANSACTION_NOT_COMMITTED = 'Some transactions have not been committed or rolled back';
 
     /**
      * Begin new DB transaction for connection

--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -464,7 +464,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
             if (in_array($startSql, $this->_ddlRoutines)
                 && (preg_match($this->_tempRoutines, $sql) !== 1)
             ) {
-                trigger_error(Varien_Db_Adapter_Interface::ERROR_DDL_MESSAGE, E_USER_ERROR);
+                throw new Varien_Db_Exception(Varien_Db_Adapter_Interface::ERROR_DDL_MESSAGE);
             }
         }
     }
@@ -4094,7 +4094,7 @@ class Varien_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql implements V
     public function __destruct()
     {
         if ($this->_transactionLevel > 0) {
-            trigger_error('Some transactions have not been committed or rolled back', E_USER_ERROR);
+            throw new RuntimeException(Varien_Db_Adapter_Interface::ERROR_TRANSACTION_NOT_COMMITTED);
         }
     }
 }


### PR DESCRIPTION
### Description (*)

Ref https://www.php.net/manual/en/function.trigger-error.php
> Warning
Passing [E_USER_ERROR](https://www.php.net/manual/en/errorfunc.constants.php#constant.e-user-error) as the error_level is now deprecated. Throw an [Exception](https://www.php.net/manual/en/class.exception.php) or call [exit()](https://www.php.net/manual/en/function.exit.php) instead.

