### PR TITLE
warning - fix undefined array key labels

### DIFF
--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
@@ -384,7 +384,7 @@ class Mage_ConfigurableSwatches_Helper_Productimg extends Mage_Core_Helper_Abstr
 
         if (!isset($this->_productImageFilters[$product->getId()])) {
             $mapping = call_user_func_array('array_merge_recursive', array_values($product->getChildAttributeLabelMapping()));
-            $filters = array_unique($mapping['labels']);
+            $filters = isset($mapping['labels']) ? array_unique($mapping['labels']) : [];
             $filters = array_merge($filters, array_map(function ($label) {
                 return $label . Mage_ConfigurableSwatches_Helper_Productimg::SWATCH_LABEL_SUFFIX;
             }, $filters));


### PR DESCRIPTION
## Bug Description
Analyzing system.log i found
Warning: Undefined array key "labels"  in /var/www/html/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php on line 387

## Proposed Solution
Modify the `addAttributeToSort` method to include entity_id as a tiebreaker criterion:
chang this 
```php
$filters = array_unique($mapping['labels']) ;
```
for
```php
$filters = isset($mapping['labels']) ? array_unique($mapping['labels']) : [];
```
