### PR TITLE
Remove FlyingMana from mentions of maintainership

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See: https://docs.openmage.org/
 
 ## Sponsorship
 
-* [opencollective](https://opencollective.com/openmage) (maintained by [Daniel Fahlke](https://github.com/Flyingmana) and [Colin Mollenhour](https://github.com/colinmollenhour))
+* [opencollective](https://opencollective.com/openmage) [Colin Mollenhour](https://github.com/colinmollenhour))
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
         {
             "name": "Daniel Fahlke aka Flyingmana",
             "email": "flyingmana@googlemail.com",
-            "role": "Maintainer"
+            "role": "retired Maintainer"
         },
         {
             "name": "David Robinson",


### PR DESCRIPTION
as many already noticed, I retired as a maintainer mid of 2024.
And while Iam still available to do payed work in this area, I dont plan to come back as a Maintainer to this Project.

Therefore its time to remove the places where I am listed as one.