### PR TITLE
Use sameSite setting in the session cookie

### DIFF
--- a/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
@@ -106,6 +106,7 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
             'domain'   => $cookie->getConfigDomain(),
             'secure'   => $cookie->isSecure(),
             'httponly' => $cookie->getHttponly(),
+            'samesite' => $cookie->getSameSite(),
         ];
 
         if (!$cookieParams['httponly']) {
@@ -122,7 +123,7 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
             $cookieParams['domain'] = $cookie->getDomain();
         }
 
-        call_user_func_array('session_set_cookie_params', array_values($cookieParams));
+        session_set_cookie_params($cookieParams);
 
         if (!empty($sessionName)) {
             $this->setSessionName($sessionName);


### PR DESCRIPTION
Session cookies should contain the samesite setting from the configuration

### Manual testing scenarios (*)
1. Open frontend page and check the cookies of the server response

### SonarQube Note
SonarQube may flag the use of insecure cookie settings in this PR. However, these are configuration options—not hardcoded values. Actual security enforcement depends on how the store is configured. These warnings are considered false positives in this context.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
