### PR TITLE
Allow empty qty-item field when creating a shipment

### DIFF
--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/items.phtml
@@ -125,8 +125,7 @@ function validQtyItems() {
     var valid = true;
     var errorMessage = '<?php echo Mage::helper('core')->jsQuoteEscape($this->helper('sales')->__('Invalid value(s) for Qty to Ship')) ?>';
     $$('.qty-item').each(function(item) {
-        var val = parseFloat(item.value);
-        if (isNaN(val) || val < 0) {
+        if (isNaN(item.value) || parseFloat(item.value) < 0) {
             valid = false;
             alert(errorMessage);
             throw $break;


### PR DESCRIPTION
While creating a shipment, one has to put a `0` into every order line that is out of scope for this shipment, empty values are blocked by JS, while the PHP code can take empty values without issue.

This PR allows simply clearing the `qty-item` field.

### Manual testing scenarios (*)
1. Try and see if there are any logs, errors, or functional bugs
