### PR TITLE
Fix issue #4312 add `is_iterable()` check in grid.

### DIFF
--- a/app/design/adminhtml/default/default/template/widget/grid.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid.phtml
@@ -146,7 +146,7 @@ $numColumns = count($this->getColumns());
 
             <?php endforeach ?>
             </tr>
-            <?php if ($_multipleRows = $this->getMultipleRows($_item)):?>
+            <?php if (is_iterable($_multipleRows = $this->getMultipleRows($_item))):?>
                 <?php foreach ($_multipleRows as $_i):?>
                 <tr>
                     <?php $i=0;foreach ($this->getMultipleRowColumns($_i) as $_column): ?>


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
See issue #4312 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
- fixes OpenMage/magento-lts#4312

