### PR TITLE
rector: `UnwrapSprintfOneArgumentRector`

### DIFF
--- a/.rector.php
+++ b/.rector.php
@@ -57,7 +57,6 @@ try {
             CodeQuality\For_\ForRepeatedCountToOwnVariableRector::class, # todo: TMP
             CodeQuality\Foreach_\ForeachItemsAssignToEmptyArrayToAssignRector::class, # todo: TMP
             CodeQuality\FuncCall\SimplifyRegexPatternRector::class, # todo: TMP
-            CodeQuality\FuncCall\UnwrapSprintfOneArgumentRector::class, # todo: TMP
             CodeQuality\FunctionLike\SimplifyUselessVariableRector::class, # todo: TMP
             CodeQuality\Identical\FlipTypeControlToUseExclusiveTypeRector::class, # todo: TMP
             CodeQuality\Identical\SimplifyBoolIdenticalTrueRector::class, # todo: TMP

--- a/lib/Varien/Io/Sftp.php
+++ b/lib/Varien/Io/Sftp.php
@@ -46,7 +46,7 @@ class Varien_Io_Sftp extends Varien_Io_Abstract implements Varien_Io_Interface
         }
         $this->_connection = new \phpseclib3\Net\SFTP($host, $port, $args['timeout']);
         if (!$this->_connection->login($args['username'], $args['password'])) {
-            throw new Exception(sprintf(__('Unable to open SFTP connection as %s@%s', $args['username'], $args['host'])));
+            throw new Exception(__('Unable to open SFTP connection as %s@%s', $args['username'], $args['host']));
         }
     }
 


### PR DESCRIPTION
- see https://getrector.com/rule-detail/remove-unused-private-property-rector
