### PR TITLE
Fix PHPDoc {@link ...} Annotations for Rector Compatibility

### DIFF
--- a/lib/Varien/Db/Select.php
+++ b/lib/Varien/Db/Select.php
@@ -239,7 +239,7 @@ class Varien_Db_Select extends Zend_Db_Select
     }
 
     /**
-     * Populate the {@link $_parts} 'join' key
+     * Populate the $_parts 'join' key
      *
      * Does the dirty work of populating the join key.
      *

--- a/lib/Varien/File/Uploader.php
+++ b/lib/Varien/File/Uploader.php
@@ -390,7 +390,7 @@ class Varien_File_Uploader
     }
 
     /**
-     * Used to set {@link _allowCreateFolders} value
+     * Used to set the _allowCreateFolders} value
      *
      * @param mixed $flag
      * @access public
@@ -403,7 +403,7 @@ class Varien_File_Uploader
     }
 
     /**
-     * Used to set {@link _allowRenameFiles} value
+     * Used to set the _allowRenameFiles} value
      *
      * @param mixed $flag
      * @access public
@@ -416,7 +416,7 @@ class Varien_File_Uploader
     }
 
     /**
-     * Used to set {@link _enableFilesDispersion} value
+     * Used to set the _enableFilesDispersion value
      *
      * @param mixed $flag
      * @access public

--- a/lib/Varien/File/Uploader.php
+++ b/lib/Varien/File/Uploader.php
@@ -390,7 +390,7 @@ class Varien_File_Uploader
     }
 
     /**
-     * Used to set the _allowCreateFolders} value
+     * Used to set the _allowCreateFolders value
      *
      * @param mixed $flag
      * @access public
@@ -403,7 +403,7 @@ class Varien_File_Uploader
     }
 
     /**
-     * Used to set the _allowRenameFiles} value
+     * Used to set the _allowRenameFiles value
      *
      * @param mixed $flag
      * @access public

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -310,7 +310,7 @@ class Varien_Io_File extends Varien_Io_Abstract
     }
 
     /**
-     * Used to set {@link _allowCreateFolders} value
+     * Used to set the _allowCreateFolders} value
      *
      * @param bool $flag
      * @access public

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -310,7 +310,7 @@ class Varien_Io_File extends Varien_Io_Abstract
     }
 
     /**
-     * Used to set the _allowCreateFolders} value
+     * Used to set the _allowCreateFolders value
      *
      * @param bool $flag
      * @access public


### PR DESCRIPTION
This pull request updates PHPDoc comments in the affected file(s) to remove usages of the {@link ...} inline annotation, which are not fully supported by Rector and may cause issues during automated refactoring or code analysis.

All docblocks previously containing {@link ...} are now rewritten using standard PHPDoc syntax with plain references and correct grammar, e.g.:

- Changed: Used to set {@link _allowCreateFolders} value
- To: Used to set the _allowCreateFolders value.

These updates improve compatibility with Rector and other PHPDoc tooling by ensuring all comments conform to supported annotation formats.

No business logic or code functionality was changed—only docblock comments were updated for clarity and compatibility.