### PR TITLE
Remove the usage of the {@link ...} inline annotation in PHP files

### DIFF
--- a/lib/Varien/Db/Select.php
+++ b/lib/Varien/Db/Select.php
@@ -239,7 +239,8 @@ class Varien_Db_Select extends Zend_Db_Select
     }
 
     /**
-     * Populate the {@link $_parts} 'join' key
+     * Populate the $_parts 'join' key
+     * @see $_parts
      *
      * Does the dirty work of populating the join key.
      *

--- a/lib/Varien/File/Uploader.php
+++ b/lib/Varien/File/Uploader.php
@@ -390,7 +390,8 @@ class Varien_File_Uploader
     }
 
     /**
-     * Used to set {@link _allowCreateFolders} value
+     * Used to set the _allowCreateFolders value
+     * @see _allowCreateFolders
      *
      * @param mixed $flag
      * @access public
@@ -403,7 +404,8 @@ class Varien_File_Uploader
     }
 
     /**
-     * Used to set {@link _allowRenameFiles} value
+     * Used to set the _allowRenameFiles value
+     * @see _allowRenameFiles
      *
      * @param mixed $flag
      * @access public
@@ -416,7 +418,8 @@ class Varien_File_Uploader
     }
 
     /**
-     * Used to set {@link _enableFilesDispersion} value
+     * Used to set the _enableFilesDispersion value
+     * @see _enableFilesDispersion
      *
      * @param mixed $flag
      * @access public

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -310,7 +310,8 @@ class Varien_Io_File extends Varien_Io_Abstract
     }
 
     /**
-     * Used to set {@link _allowCreateFolders} value
+     * Used to set the _allowCreateFolders value
+     * @see _allowCreateFolders
      *
      * @param bool $flag
      * @access public


### PR DESCRIPTION
The proposed change is not intended to solve a specific issue related to Rector, but rather to modernize and simplify the PHPDoc in the code, by removing a syntax that no longer brings additional benefits in the current context.

The {@link ...} syntax is indeed part of phpDocumentor, as you can check here

https://manual.phpdoc.org/HTMLSmartyConverter/HandS/phpDocumentor/tutorial_tags.inlinelink.pkg.html

but in the files I modified, it was not used to reference URLs or classes, only for properties, which does not have a significant impact on the generated documentation. Additionally, removing this type of annotation reduces confusion and potential incompatibilities with other tools, including Rector, even if there are no errors at the moment.

I asked ChatGPT about this issue and the answer is that the {@link ...} statement is still valid, but recommends replacing it with @see. 

For example:

```php
/**
 * Sets the value of _allowRenameFiles.
 * @see _allowRenameFiles
 *  ...
 */
```

The change is limited to a few files and does not affect the functionality of the code, only the documentation, bringing a more modern and clear form. It's a minor adjustment, but beneficial for maintenance and consistency

These updates improve compatibility with Rector and other PHPDoc tooling by ensuring all comments conform to supported annotation formats. Please note that this is only applicable to PHP files, not JavaScript files.

No business logic or code functionality was changed, only docblock comments were updated for clarity and compatibility.