### PR TITLE
Improve CMS Page URL Key comment with implications for reference updates

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Main.php
@@ -57,7 +57,7 @@ class Mage_Adminhtml_Block_Cms_Page_Edit_Tab_Main extends Mage_Adminhtml_Block_W
             'title'     => Mage::helper('cms')->__('URL Key'),
             'required'  => true,
             'class'     => 'validate-identifier',
-            'note'      => Mage::helper('cms')->__('Relative to Website Base URL'),
+            'note'      => Mage::helper('cms')->__('Relative to Website Base URL. Please note this change may require updating references in CMS blocks, widgets, layouts, templates, external/internal links, and any custom extensions or modules.'),
             'disabled'  => $isElementDisabled,
         ]);
 

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Main.php
@@ -57,7 +57,7 @@ class Mage_Adminhtml_Block_Cms_Page_Edit_Tab_Main extends Mage_Adminhtml_Block_W
             'title'     => Mage::helper('cms')->__('URL Key'),
             'required'  => true,
             'class'     => 'validate-identifier',
-            'note'      => Mage::helper('cms')->__('Relative to Website Base URL. Please note this change may require updating references in CMS blocks, widgets, layouts, templates, external/internal links, and any custom extensions or modules.'),
+            'note'      => Mage::helper('cms')->__('Relative to Website Base URL'),
             'disabled'  => $isElementDisabled,
         ]);
 

--- a/app/locale/en_US/Mage_Cms.csv
+++ b/app/locale/en_US/Mage_Cms.csv
@@ -125,3 +125,4 @@
 "Unable to find a page to delete.","Unable to find a page to delete."
 "WYSIWYG Options","WYSIWYG Options"
 "px.","px."
+"Relative to Website Base URL. Please note this change may require updating references in CMS blocks, widgets, layouts, templates, external/internal links, and any custom extensions or modules.","Relative to Website Base URL. Please note this change may require updating references in CMS blocks, widgets, layouts, templates, external/internal links, and any custom extensions or modules."

--- a/app/locale/en_US/Mage_Cms.csv
+++ b/app/locale/en_US/Mage_Cms.csv
@@ -94,7 +94,7 @@
 "Pages","Pages"
 "Product Tax Class Information","Product Tax Class Information"
 "Redirect to CMS-page if Cookies are Disabled","Redirect to CMS-page if Cookies are Disabled"
-"Relative to Website Base URL","Relative to Website Base URL"
+"Relative to Website Base URL","Relative to Website Base URL. Please note this change may require updating references in CMS blocks, widgets, layouts, templates, external/internal links, and any custom extensions or modules."
 "Save Block","Save Block"
 "Save Page","Save Page"
 "Save Process","Save Process"
@@ -125,4 +125,3 @@
 "Unable to find a page to delete.","Unable to find a page to delete."
 "WYSIWYG Options","WYSIWYG Options"
 "px.","px."
-"Relative to Website Base URL. Please note this change may require updating references in CMS blocks, widgets, layouts, templates, external/internal links, and any custom extensions or modules.","Relative to Website Base URL. Please note this change may require updating references in CMS blocks, widgets, layouts, templates, external/internal links, and any custom extensions or modules."


### PR DESCRIPTION
## What does this PR improve?

This PR enhances the comment shown for the "URL Key" field in the CMS Page admin form. The new note informs administrators that changing the URL Key may require updating all references to the page in CMS blocks, widgets, layouts, templates, external/internal links, and any custom extensions or modules.

## Why was this change made?

Previously, the only help text was "Relative to Website Base URL," which is technically accurate but does not warn about breaking references elsewhere in the site or custom code. Modifying the URL Key for a CMS Page can cause broken links or missing content if the identifier is used in:
- CMS blocks (e.g. `{{page url="identifier"}}`)
- Widgets
- Layout XML or templates
- External/internal links (emails, SEO, documentation)
- Custom extensions or modules

Adding this note helps administrators understand the potential impact and avoid unintended issues after changing the URL Key.

## Before

<img width="1024" height="741" alt="before" src="https://github.com/user-attachments/assets/eedd1fd7-89c8-4697-a830-ccac8cd35222" />

## After

<img width="1021" height="646" alt="after" src="https://github.com/user-attachments/assets/5a7321bc-d920-4f87-8047-06fe415a96b8" />