### PR TITLE
Update email type handling to cast type as integer

### DIFF
--- a/app/code/core/Mage/Core/Model/Email/Queue.php
+++ b/app/code/core/Mage/Core/Model/Email/Queue.php
@@ -192,7 +192,7 @@ class Mage_Core_Model_Email_Queue extends Mage_Core_Model_Abstract
                 $mailer = new Zend_Mail('utf-8');
                 foreach ($message->getRecipients() as $recipient) {
                     [$email, $name, $type] = $recipient;
-                    match ($type) {
+                    match ((int) $type) {
                         self::EMAIL_TYPE_BCC => $mailer->addBcc($email),
                         default => $mailer->addTo($email, $this->getBase64EncodedString($name)),
                     };


### PR DESCRIPTION
### Related Pull Requests
<!-- related pull request placeholder -->
- see OpenMage/magento-lts#4835

### Fixed Issues (if relevant)
- fixes OpenMage/magento-lts#4932

### Manual testing scenarios (*)

```php
<?

$v = '1';

$bug = match ($v) {
	1 => true,
	default => false
};
var_dump($bug); #false

$fix = match ((int) $v) {
	1 => true,
	default => false
};
var_dump($fix); #true

switch ($v) {
	case 1:
		$old = true;
		break;
	default:
		$old = false;
}
var_dump($old); #true
```