### PR TITLE
Improved error message for CMS page delete

### DIFF
--- a/app/code/core/Mage/Cms/Helper/Page.php
+++ b/app/code/core/Mage/Cms/Helper/Page.php
@@ -175,7 +175,7 @@ class Mage_Cms_Helper_Page extends Mage_Core_Helper_Abstract
         return $searchPaths;
     }
 
-    public static function getConfigNameFromPath(string $paths): string
+    public static function getConfigLabelFromConfigPath(string $paths): string
     {
         return match ($paths) {
             self::XML_PATH_NO_ROUTE_PAGE => Mage::helper('cms')->__('No Route Page'),
@@ -189,7 +189,7 @@ class Mage_Cms_Helper_Page extends Mage_Core_Helper_Abstract
      * @param Mage_Adminhtml_Block_System_Config_Form::SCOPE_* $scope
      * @throws Mage_Core_Exception
      */
-    public static function getConfigStoreFromScope(string $scope, string $scopeId): string
+    public static function getScopeInfoFromConfigScope(string $scope, string $scopeId): string
     {
         return match ($scope) {
             Mage_Adminhtml_Block_System_Config_Form::SCOPE_DEFAULT => Mage::helper('cms')->__('Default Config'),
@@ -224,12 +224,12 @@ class Mage_Cms_Helper_Page extends Mage_Core_Helper_Abstract
         foreach ($data as $path => $items) {
             $scopes = [];
             foreach ($items as $item) {
-                $scopes[] = self::getConfigStoreFromScope($item['scope'], $item['scope_id']);
+                $scopes[] = self::getScopeInfoFromConfigScope($item['scope'], $item['scope_id']);
             }
 
             $messages[] = sprintf(
                 '"%s" (%s)',
-                self::getConfigNameFromPath($path),
+                self::getConfigLabelFromConfigPath($path),
                 implode(', ', $scopes),
             );
         }

--- a/app/code/core/Mage/Cms/Helper/Page.php
+++ b/app/code/core/Mage/Cms/Helper/Page.php
@@ -176,15 +176,15 @@ class Mage_Cms_Helper_Page extends Mage_Core_Helper_Abstract
     }
 
     /**
-     * @param self::XML_PATH_* $paths
+     * @param self::XML_PATH_* $path
      */
-    public static function getConfigLabelFromConfigPath(string $paths): string
+    public static function getConfigLabelFromConfigPath(string $path): string
     {
-        return match ($paths) {
+        return match ($path) {
             self::XML_PATH_NO_ROUTE_PAGE => Mage::helper('cms')->__('No Route Page'),
             self::XML_PATH_NO_COOKIES_PAGE => Mage::helper('cms')->__('No Cookies Page'),
             self::XML_PATH_HOME_PAGE => Mage::helper('cms')->__('Home Page'),
-            default => $paths,
+            default => $path,
         };
     }
 

--- a/app/code/core/Mage/Cms/Helper/Page.php
+++ b/app/code/core/Mage/Cms/Helper/Page.php
@@ -175,6 +175,9 @@ class Mage_Cms_Helper_Page extends Mage_Core_Helper_Abstract
         return $searchPaths;
     }
 
+    /**
+     * @param self::XML_PATH_* $paths
+     */
     public static function getConfigLabelFromConfigPath(string $paths): string
     {
         return match ($paths) {

--- a/app/code/core/Mage/Cms/Model/Resource/Page.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Page.php
@@ -39,8 +39,8 @@ class Mage_Cms_Model_Resource_Page extends Mage_Core_Model_Resource_Db_Abstract
                 $object->setId(null);
                 Mage::throwException(
                     Mage::helper('cms')->__(
-                        'Cannot delete page, it is used in "%s".',
-                        implode(', ', $isUsedInConfig->getColumnValues('path')),
+                        'Cannot delete page, it is used in %s.',
+                        Mage_Cms_Helper_Page::getDeleteErrorMessage($isUsedInConfig),
                     ),
                 );
             }

--- a/app/code/core/Mage/Cms/etc/system.xml
+++ b/app/code/core/Mage/Cms/etc/system.xml
@@ -17,7 +17,7 @@
                             <label>CMS Home Page</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_cms_page</source_model>
-                            <sort_order>1</sort_order>
+                            <sort_order>21</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -26,7 +26,7 @@
                             <label>CMS No Route Page</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_cms_page</source_model>
-                            <sort_order>2</sort_order>
+                            <sort_order>22</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -35,7 +35,7 @@
                             <label>CMS No Cookies Page</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_cms_page</source_model>
-                            <sort_order>3</sort_order>
+                            <sort_order>23</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -44,7 +44,7 @@
                             <label>Show Breadcrumbs for CMS Pages</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>5</sort_order>
+                            <sort_order>25</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>

--- a/cypress/e2e/openmage/backend/cms/page.cy.js
+++ b/cypress/e2e/openmage/backend/cms/page.cy.js
@@ -1,4 +1,5 @@
 const route = cy.testRoutes.backend.cms.page;
+const validation = cy.openmage.validation;
 
 describe(`Checks admin system "${route.h3}"`, () => {
     beforeEach('Log in the user', () => {
@@ -8,5 +9,32 @@ describe(`Checks admin system "${route.h3}"`, () => {
 
     it(`tests classes and title`, () => {
         cy.adminTestRoute(route);
+    });
+
+    it('tests to disable a CMS page that is used in config', () => {
+        cy.log('Select a CMS page');
+        cy.get(route._gridTable)
+            .contains('td', 'no-route')
+            .click();
+
+        cy.log('Disable the CMS page');
+        cy.get('#page_is_active')
+            .select('Disabled');
+
+        validation.saveAction(route._buttonSaveAndContinue);
+        cy.get(validation._warningMessage).should('include.text', 'Cannot disable page, it is used in configuration');
+        cy.get(validation._successMessage).should('include.text', 'The page has been saved.');
+        //cy.get('#messages').screenshot('error-disable-active-page', { overwrite: true});
+    });
+
+    it('tests to delete a CMS page that is used in config', () => {
+        cy.log('Select a CMS page');
+        cy.get(route._gridTable)
+            .contains('td', 'no-route')
+            .click();
+
+        validation.saveAction(route._buttonDelete);
+        cy.get(validation._errorMessage).should('include.text', 'Cannot delete page');
+        //cy.get('#messages').screenshot('error-delete-active-page', { overwrite: true});
     });
 });

--- a/cypress/support/openmage.js
+++ b/cypress/support/openmage.js
@@ -82,7 +82,7 @@ cy.openmage = {
         },
         saveAction: (selector) => {
             cy.log('Clicking on Save button');
-            cy.get(selector).click({force: true, multiple: true});
+            cy.get(selector).first().click({force: true, multiple: false});
         },
         validateFields: (fields, validation) =>{
             cy.log('Checking for error messages');

--- a/cypress/support/openmage/config/paths.js
+++ b/cypress/support/openmage/config/paths.js
@@ -73,6 +73,11 @@ cy.testRoutes = {
                 url: 'cms_page/index',
                 h3: 'Manage Pages',
                 _h3: adminPage._h3,
+                _gridTable: '#cmsPageGrid_table',
+                _buttonDelete: '.form-buttons button[title="Delete Page"]',
+                _buttonReset: '.form-buttons button[title="Rest"]',
+                _buttonSave: '.form-buttons button[title="Save Page"]',
+                _buttonSaveAndContinue: '.form-buttons button[title="Save and Continue Edit"]',
             },
             widget: {
                 _id_parent: adminNav.cms,

--- a/tests/unit/Mage/Cms/Helper/PageTest.php
+++ b/tests/unit/Mage/Cms/Helper/PageTest.php
@@ -27,4 +27,13 @@ final class PageTest extends OpenMageTest
     {
         self::assertSame($expectedResult, Subject::getUsedInStoreConfigPaths($path));
     }
+
+    /**
+     * @dataProvider provideGetConfigStoreFromScope
+     * @group Helper
+     */
+    public function testGetConfigStoreFromScope(string $expectedResult, string $scope, string $scopeId): void
+    {
+        self::assertStringStartsWith($expectedResult, Subject::getConfigStoreFromScope($scope, $scopeId));
+    }
 }

--- a/tests/unit/Mage/Cms/Helper/PageTest.php
+++ b/tests/unit/Mage/Cms/Helper/PageTest.php
@@ -20,6 +20,7 @@ final class PageTest extends OpenMageTest
     use CmsTrait;
 
     /**
+     * @covers Mage_Cms_Helper_Page::getUsedInStoreConfigPaths()
      * @dataProvider provideGetUsedInStoreConfigPaths
      * @group Helper
      */
@@ -29,11 +30,22 @@ final class PageTest extends OpenMageTest
     }
 
     /**
-     * @dataProvider provideGetConfigStoreFromScope
+     * @covers Mage_Cms_Helper_Page::getConfigLabelFromConfigPath()
+     * @dataProvider provideGetConfigLabelFromConfigPath
      * @group Helper
      */
-    public function testGetConfigStoreFromScope(string $expectedResult, string $scope, string $scopeId): void
+    public function testGetConfigLabelFromConfigPath(string $expectedResult, string $paths): void
     {
-        self::assertStringStartsWith($expectedResult, Subject::getConfigStoreFromScope($scope, $scopeId));
+        self::assertSame($expectedResult, Subject::getConfigLabelFromConfigPath($paths));
+    }
+
+    /**
+     * @covers Mage_Cms_Helper_Page::getScopeInfoFromConfigScope()
+     * @dataProvider provideGetScopeInfoFromConfigScope
+     * @group Helper
+     */
+    public function testGetScopeInfoFromConfigScope(string $expectedResult, string $scope, string $scopeId): void
+    {
+        self::assertStringStartsWith($expectedResult, Subject::getScopeInfoFromConfigScope($scope, $scopeId));
     }
 }

--- a/tests/unit/Traits/DataProvider/Mage/Cms/CmsTrait.php
+++ b/tests/unit/Traits/DataProvider/Mage/Cms/CmsTrait.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace OpenMage\Tests\Unit\Traits\DataProvider\Mage\Cms;
 
 use Generator;
+use Mage_Adminhtml_Block_System_Config_Form;
 use Mage_Cms_Helper_Page;
 
 trait CmsTrait
@@ -42,6 +43,27 @@ trait CmsTrait
         yield 'custom paths' => [
             array_merge($default, $custom),
             $custom,
+        ];
+    }
+
+    public function provideGetConfigStoreFromScope(): Generator
+    {
+        yield 'default' => [
+            'Default Config',
+            Mage_Adminhtml_Block_System_Config_Form::SCOPE_DEFAULT,
+            '1',
+        ];
+
+        yield 'websites' => [
+            'Website',
+            Mage_Adminhtml_Block_System_Config_Form::SCOPE_WEBSITES,
+            '1',
+        ];
+
+        yield 'stores' => [
+            'Store View',
+            Mage_Adminhtml_Block_System_Config_Form::SCOPE_STORES,
+            '1',
         ];
     }
 

--- a/tests/unit/Traits/DataProvider/Mage/Cms/CmsTrait.php
+++ b/tests/unit/Traits/DataProvider/Mage/Cms/CmsTrait.php
@@ -46,7 +46,25 @@ trait CmsTrait
         ];
     }
 
-    public function provideGetConfigStoreFromScope(): Generator
+    public function provideGetConfigLabelFromConfigPath(): Generator
+    {
+        yield 'home page' => [
+            'Home Page',
+            Mage_Cms_Helper_Page::XML_PATH_HOME_PAGE,
+        ];
+
+        yield 'no cookie page' => [
+            'No Cookies Page',
+            Mage_Cms_Helper_Page::XML_PATH_NO_COOKIES_PAGE,
+        ];
+
+        yield 'no route page' => [
+            'No Route Page',
+            Mage_Cms_Helper_Page::XML_PATH_NO_ROUTE_PAGE,
+        ];
+    }
+
+    public function provideGetScopeInfoFromConfigScope(): Generator
     {
         yield 'default' => [
             'Default Config',


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

@addison74 thanks for working on all the CMS page related issue, but we should do it step by step ....

### What are the issues we have?

- it is incomplete
  - disable page (works)
  - change url key (needs to be checked)
  - un-asign stores(needs to be checked)
  - asign disabled page in config(needs to be checked)
  - asign page with invalid store setting (test!?)
- error message should be improved (confirmed)

This PR ...

- improves error message
- fixes sort order in admin config
- adds some cypress/unit tests

### Related Pull Requests
<!-- related pull request placeholder -->
- see OpenMage/magento-lts#4968

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. get to Admin - CMS - Page
2. try delete "no-route" page
3. ...
