### PR TITLE
Fix invalid XML when UPS returns "Too Many Requests" error

### DIFF
--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
@@ -848,6 +848,7 @@ XMLRequest;
         $costArr = [];
         $priceArr = [];
         if (strlen(trim($xmlResponse)) > 0) {
+            $xmlResponse = str_replace('<?xmlversion="1.0"?>', '<?xml version="1.0"?>', $xmlResponse);
             $xml = new Varien_Simplexml_Config();
             $xml->loadString($xmlResponse);
             $arr = $xml->getXpath('//RatingServiceSelectionResponse/Response/ResponseStatusCode/text()');


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
During checkout (or cart page) when asking UPS for rates, there are times where I get a "Too Many Requests" error. I've replicated that [API call through Postman](https://.postman.co/workspace/LuzCommerce~b73b762e-b1cb-42d1-83bd-d03ce415acdd/request/27490266-0b423415-419b-46cb-9862-b914c474ce06?action=share&creator=27490266&ctx=documentation).

When that happens, their XML response doesn't have a space in it. That includes the space in `<?xml version="1.0"?>`. They sent it as `<?xmlversion="1.0"?>` which throws an error.
<img width="1283" height="803" alt="image" src="https://github.com/user-attachments/assets/aaa393bd-2e05-49da-872e-e90a149c9e6c" />

<img width="1128" height="712" alt="image" src="https://github.com/user-attachments/assets/f8f9a0e5-2064-419b-ae86-5b2fd501d431" />

### Manual testing scenarios (*)
1. Do a checkout and get UPS rates.
Sorry, this error doesn't happen in our live production. Maybe it only happens in my country (Philippines)?


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
