### PR TITLE
Fixed explode(): Passing `null` in `sales_order_afterPlace` observer

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -27,7 +27,7 @@
  * @method $this setAdjustmentNegative(float $value)
  * @method float getAdjustmentPositive()
  * @method $this setAdjustmentPositive(float $value)
- * @method string getAppliedRuleIds()
+ * @method string|null getAppliedRuleIds()
  * @method $this setAppliedRuleIds(string $value)
  * @method array getAppliedTaxes()
  * @method $this setAppliedTaxes(array $value)

--- a/app/code/core/Mage/Sales/Model/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Item.php
@@ -42,7 +42,7 @@
  * @method $this setName(string $value)
  * @method string getDescription()
  * @method $this setDescription(string $value)
- * @method string getAppliedRuleIds()
+ * @method string|null getAppliedRuleIds()
  * @method $this setAppliedRuleIds(string $value)
  * @method string getAdditionalData()
  * @method $this setAdditionalData(string $value)

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Item.php
@@ -16,7 +16,7 @@
  *
  * @method string getAdditionalData()
  * @method $this setAdditionalData(string $value)
- * @method string getAppliedRuleIds()
+ * @method string|null getAppliedRuleIds()
  * @method $this setAppliedRuleIds(string $value)
  *
  * @method float getBaseCost()

--- a/app/code/core/Mage/Sales/Model/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item.php
@@ -18,7 +18,7 @@
  *
  * @method string getAdditionalData()
  * @method $this setAdditionalData(string $value)
- * @method string getAppliedRuleIds()
+ * @method string|null getAppliedRuleIds()
  * @method $this setAppliedRuleIds(string $value)
  *
  * @method $this setBackorders(float $value)

--- a/app/code/core/Mage/SalesRule/Model/Observer.php
+++ b/app/code/core/Mage/SalesRule/Model/Observer.php
@@ -57,6 +57,7 @@ class Mage_SalesRule_Model_Observer
      *
      * @param Varien_Event_Observer $observer
      * @return $this
+     * @throws Throwable
      * @SuppressWarnings("PHPMD.CamelCaseMethodName")
      */
     // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
@@ -69,20 +70,14 @@ class Mage_SalesRule_Model_Observer
             return $this;
         }
 
-        $appliedRuleIds = $order->getAppliedRuleIds();
-        if (empty($appliedRuleIds)) {
-            return $this;
-        }
-
-        // lookup rule ids
-        $ruleIds = explode(',', $appliedRuleIds);
-        $ruleIds = array_unique($ruleIds);
-
-        $ruleCustomer = null;
         $customerId = $order->getCustomerId();
 
         // use each rule (and apply to customer, if applicable)
         if ($order->getDiscountAmount() != 0) {
+            // lookup rule ids
+            $ruleIds = explode(',', (string) $order->getAppliedRuleIds());
+            $ruleIds = array_unique($ruleIds);
+
             foreach ($ruleIds as $ruleId) {
                 if (!$ruleId) {
                     continue;


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR resolves the deprecated warning "Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /var/www/html/app/code/core/Mage/SalesRule/Model/Observer.php on line 72"

### Manual testing scenarios (*)
1. Just need to created a order or dispatch manually the event 'sales_order_place_after' for an order that has not applied rules on it

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
