### PR TITLE
Fix media gallery actions on duplicate and product deletion procedures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@
 /app/etc/modules/Cm_RedisSession.xml
 /lib/Credis
 
+# MM Ignition
+/app/code/community/MM
+/app/etc/modules/MM_Ignition.xml
+
 # ChartJs library
 /js/lib/chartjs
 

--- a/app/code/community/MM/Ignition
+++ b/app/code/community/MM/Ignition
@@ -1,1 +1,0 @@
-../../../../vendor/empiricompany/openmage_ignition/app/code/community/MM/Ignition

--- a/app/etc/modules/MM_Ignition.xml
+++ b/app/etc/modules/MM_Ignition.xml
@@ -1,1 +1,0 @@
-../../../vendor/empiricompany/openmage_ignition/app/etc/modules/MM_Ignition.xml


### PR DESCRIPTION


### Description (*)
Use cases:

> A product with 3 images is being duplicated 10 times. This will result in extra 10 products that all of them use the original product's images, even though the images are being copied. So there are going to be 30 residual images that are not used anywhere.

> When a product gets deleted, it's image files are not being deleted. (probably because of the above in fear)

This commit does:

- [fix] media gallery to properly propagate store view data
- [fix] use new (copied) images on product duplication
- [feature] on product deletion the images will be deleted. Since the product duplication flow uses new images this is now safe. For compatibility, images that are used by other products since this change, will not be affected.


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
For [fix] parts do the same with/without this commit:
1. Spin up ddev environment with sample data.
2. Duplicate a product.
3. Check the new product's image,thumb,small attributes + whole gallery.
4. Check `<root>/media/catalog/product/<path_to_image(s)>`

For [feature] part (before this commit):
1. Spin up ddev environment with sample data.
2. Duplicate product. (new product will use same images)
3. Apply this commit.
4. Duplicate product. (new product will use new copied images)
5. Delete the duplicated products.
6. Check old product's images that are still there and that the 2nd duplicated product's images are removed.

### Questions or comments
Feedback I guess?
