### PR TITLE
PHP8: Handle null and empty string values in _prepareValue

### DIFF
--- a/app/code/core/Mage/Api2/Model/Renderer/Xml.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Xml.php
@@ -110,7 +110,7 @@ class Mage_Api2_Model_Renderer_Xml implements Mage_Api2_Model_Renderer_Interface
      */
     protected function _prepareValue($value)
     {
-        if ($value === null || $value === '') {
+        if ($value === null) {
             return '';
         }
 


### PR DESCRIPTION
> str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated

1. dev mode ON
2. sample data installed
3. guest permissions for rest api
4. https://magento-lts.ddev.site/api/rest/products/ace000