### PR TITLE
PHP8: Allow null hash in validateHashByVersion method

### DIFF
--- a/app/code/core/Mage/Core/Model/Encryption.php
+++ b/app/code/core/Mage/Core/Model/Encryption.php
@@ -143,7 +143,7 @@ class Mage_Core_Model_Encryption
      */
     public function validateHashByVersion($password, $hash, $version = self::HASH_VERSION_MD5)
     {
-        if (is_null($hash)) {
+        if ($hash === null) {
             $hash = '';
         }
 


### PR DESCRIPTION
> Exception: Deprecated functionality: password_verify(): Passing null to parameter #2 ($hash) of type string is deprecated  in /var/www/html/app/code/core/Mage/Core/Model/Encryption.php on line 147

Found in unit tests.