### PR TITLE
Fix incorrect regex for files in errors/ and return 404 for index.php

### DIFF
--- a/dev/openmage/nginx-admin.conf
+++ b/dev/openmage/nginx-admin.conf
@@ -101,7 +101,7 @@ server {
     }
     location /errors/ {
         root /var/www/html;
-        location ~* \.(!(css|jpg|jpeg|gif|png|ico|webp))$ { return 404; }
+        location ~* \.(?!(css|jpg|jpeg|gif|png|ico|webp)$)[a-z]+$ { return 404; }
     }
     location /api/ {
         rewrite ^/api/(.+?)/(.+)$ /api.php?type=$1&$args last;

--- a/dev/openmage/nginx-frontend.conf
+++ b/dev/openmage/nginx-frontend.conf
@@ -144,14 +144,13 @@ server {
     }
     location /errors/ {
         root /var/www/html;
-        location ~* \.(!(css|jpg|jpeg|gif|png|ico|webp))$ { return 404; }
+        location ~* \.(?!(css|jpg|jpeg|gif|png|ico|webp)$)[a-z]+$ { return 404; }
     }
 
     # Non-rewritten URLs, Admin and API are disabled for frontend
     location /index.php/ { return 404; }
     location ~ ^/admin(?:/(.*))?$ { return 404; }
     location /api/ { return 404; }
-    location /api.php { return 404; }
 
     # Clients use the frontend to call API
     #location /api {
@@ -166,8 +165,10 @@ server {
     location ~ /\. { return 404; }
 
     # Ignore the files that are needed only for Apache
+    location = /api.php { return 404; }
     location = /get.php { return 404; }
     location = /install.php { return 404; }
+    location = /index.php { return 404; }
 
     # Custom error handlers
     error_page 404 = @php-404;


### PR DESCRIPTION
This fixes two problems with the nginx config in dev/openmage:

- The negative lookahead regex for files in errors/ was not working, allowing .php or .xml files stored there to be downloaded
- The index.php file was not explicitly located as 404

These files were added in #1210 to support Apache and are not needed for nginx but any files added to pub/ should be excluded via the config (this kinda defeats the purpose of having a separate directory for pub files but it is what it is).

### Manual testing scenarios (*)

These urls should return a 404:

http://localhost/errors/report.php
http://localhost/index.php
