### PR TITLE
Add profiler stop call in EAV config loading

### DIFF
--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -151,6 +151,7 @@ class Mage_Eav_Model_Config
 
         if ($this->_isCacheEnabled() && $this->_loadFromCache($storeId)) {
             $this->_storeInitialized[$storeId] = true;
+            Varien_Profiler::stop('EAV: ' . __METHOD__);
             return;
         }
 


### PR DESCRIPTION
Added a missing profiler stop call to improve performance tracking:

```[INVALID NESTING!] Found: CORE::create_object_of:: ... | Expecting: EAV: Mage_Eav_Model_Config::_initializeStore```


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
