### PR TITLE
fix(security): Remove phantom checkbox behavior in ACL role editor

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesedit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesedit.php
@@ -15,15 +15,6 @@
 class Mage_Adminhtml_Block_Permissions_Tab_Rolesedit extends Mage_Adminhtml_Block_Widget_Form implements Mage_Adminhtml_Block_Widget_Tab_Interface
 {
     /**
-     * Retrieve an instance of the fallback helper
-     * @return Mage_Admin_Helper_Rules_Fallback
-     */
-    protected function _getFallbackHelper()
-    {
-        return Mage::helper('admin/rules_fallback');
-    }
-
-    /**
      * Get tab label
      *
      * @return string
@@ -86,20 +77,6 @@ class Mage_Adminhtml_Block_Permissions_Tab_Rolesedit extends Mage_Adminhtml_Bloc
                     $resources[$itemResourceId]['checked'] = true;
                     $selrids[] = $itemResourceId;
                 }
-            }
-        }
-
-        $resourcesPermissionsMap = $rules->getResourcesPermissionsArray();
-        $undefinedResources = array_diff(array_keys($resources), array_keys($resourcesPermissionsMap));
-
-        foreach ($undefinedResources as $undefinedResourceId) {
-            // Fallback resource permissions
-            $permissions = $this->_getFallbackHelper()->fallbackResourcePermissions(
-                $resourcesPermissionsMap,
-                $undefinedResourceId,
-            );
-            if ($permissions == Mage_Admin_Model_Rules::RULE_PERMISSION_ALLOWED) {
-                $selrids[] = $undefinedResourceId;
             }
         }
 


### PR DESCRIPTION
When new ACL resources are added to the system, roles without explicit rules for those resources would show them as "checked" in the UI based on parent permission inheritance. However, the actual runtime permission check uses different logic (falls back to null/root), so users may not actually have access.

This creates a security risk: when an admin edits a role and saves it without unchecking these phantom checkboxes, the permissions get explicitly granted - potentially giving users access to features they were never intended to have.

The fix removes the fallback inheritance logic in the UI. New resources will now appear unchecked by default, requiring explicit selection by the admin. This prevents accidental permission grants.