### PR TITLE
Expand Purifier functionality. First step toward using HTMLPurifier in more places.

### DIFF
--- a/app/code/core/Mage/Core/Helper/Purifier.php
+++ b/app/code/core/Mage/Core/Helper/Purifier.php
@@ -8,34 +8,64 @@
  */
 
 /**
- * @package    Mage_Core
+ * A Helper for purifying HTML strings.
+ *
+ * "Purify" in this context means to sanitize HTML in order to prevent
+ * vulnerabilities and/or broken HTML. It is also a reference to the
+ * HTMLPurifier library that is used as a dependency in the original
+ * implementation.
+ *
+ * @package Mage_Core
  */
 class Mage_Core_Helper_Purifier extends Mage_Core_Helper_Abstract
 {
+    /**
+     * @deprecated Don't create your own {@link \HTMLPurifier}. Use
+     *             {@link \Mage_Core_Model_Purifier} via
+     *             `Mage::getModel('core/purifier', $options);`
+     * @var string
+     */
     public const CACHE_DEFINITION = 'Cache.DefinitionImpl';
 
+    /**
+     * @deprecated No longer used. See {@link static::$defaultPurifier}.
+     * @see        static::$defaultPurifier
+     */
     protected ?HTMLPurifier $purifier;
+
+    /** @var \Mage_Core_Model_Purifier */
+    protected $defaultPurifier;
 
     /**
      * Purifier Constructor Call
+     *
+     * @param null|\HTMLPurifier $purifier **Deprecated:** Unused
      */
-    public function __construct(
-        ?HTMLPurifier $purifier = null
-    ) {
-        $config = HTMLPurifier_Config::createDefault();
-        $config->set(self::CACHE_DEFINITION, null);
-
-        $this->purifier = $purifier ?? new HTMLPurifier($config);
+    public function __construct(?HTMLPurifier $purifier = null)
+    {
+        $this->purifier = $purifier;
+        $this->defaultPurifier = Mage::getModel('core/purifier');
     }
 
     /**
      * Purify Html Content
      *
-     * @param  array|string $content
-     * @return array|string
+     * @template T of string[]|string
+     * @param  T $content
+     * @return T
      */
     public function purify($content)
     {
-        return is_array($content) ? $this->purifier->purifyArray($content) : $this->purifier->purify($content);
+        if (is_array($content)) {
+            $purified = [];
+
+            foreach ($content as $html) {
+                $purified[] = $this->defaultPurifier->purify($html);
+            }
+
+            return $purified;
+        }
+
+        return $this->defaultPurifier->purify($content);
     }
 }

--- a/app/code/core/Mage/Core/Helper/Purifier.php
+++ b/app/code/core/Mage/Core/Helper/Purifier.php
@@ -16,6 +16,8 @@
  * implementation.
  *
  * @package Mage_Core
+ * @see Mage_Core_Model_Purifier_Interface
+ * @see Mage_Core_Model_Purifier
  */
 class Mage_Core_Helper_Purifier extends Mage_Core_Helper_Abstract
 {
@@ -33,18 +35,19 @@ class Mage_Core_Helper_Purifier extends Mage_Core_Helper_Abstract
      */
     protected ?HTMLPurifier $purifier;
 
-    /** @var \Mage_Core_Model_Purifier */
-    protected $defaultPurifier;
+    protected Mage_Core_Model_Purifier_Interface $defaultPurifier;
 
     /**
      * Purifier Constructor Call
      *
-     * @param null|\HTMLPurifier $purifier **Deprecated:** Unused
+     * @param null|HTMLPurifier $purifier **Deprecated:** Unused
      */
     public function __construct(?HTMLPurifier $purifier = null)
     {
         $this->purifier = $purifier;
-        $this->defaultPurifier = Mage::getModel('core/purifier');
+        /** @var Mage_Core_Model_Purifier $defaultPurifier */
+        $defaultPurifier = Mage::getModel('core/purifier');
+        $this->defaultPurifier = $defaultPurifier;
     }
 
     /**

--- a/app/code/core/Mage/Core/Helper/Purifier/Config.php
+++ b/app/code/core/Mage/Core/Helper/Purifier/Config.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
+ * @package    Mage_Core
+ */
+
+declare(strict_types=1);
+
+/**
+ * @package Mage_Core
+ */
+class Mage_Core_Helper_Purifier_Config
+{
+    /** @var null|string */
+    protected const DEFINITION_CACHE_MODEL_CLASS = 'core/purifier_definitionCache';
+
+    /** @var null|class-string */
+    protected ?string $cacheDefinitionImpl;
+
+    public function __construct()
+    {
+        if (static::DEFINITION_CACHE_MODEL_CLASS === null) {
+            $cacheDefinitionImpl = null;
+        } else {
+            $cacheModelClassName = Mage::getConfig()->getModelClassName(
+                static::DEFINITION_CACHE_MODEL_CLASS,
+            );
+            if (!class_exists($cacheModelClassName)) {
+                throw new RuntimeException(
+                    'Invalid Mage Model class alias: '
+                    . '"' . static::DEFINITION_CACHE_MODEL_CLASS . '"',
+                );
+            }
+
+            // Using a short key is not necessary and increases collision risk
+            $cacheDefinitionImpl = $cacheModelClassName;
+
+            HTMLPurifier_DefinitionCacheFactory::instance()->register(
+                $cacheDefinitionImpl,
+                $cacheModelClassName,
+            );
+        }
+
+        $this->cacheDefinitionImpl = $cacheDefinitionImpl;
+    }
+
+    /**
+     * @return null|class-string
+     */
+    public function getCacheDefinitionImpl(): ?string
+    {
+        return $this->cacheDefinitionImpl;
+    }
+}

--- a/app/code/core/Mage/Core/Helper/Purifier/DefinitionCache.php
+++ b/app/code/core/Mage/Core/Helper/Purifier/DefinitionCache.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 /**
  * @package Mage_Core
  */
-class Mage_Core_Helper_Purifier_Config
+class Mage_Core_Helper_Purifier_DefinitionCache
 {
     /** @var null|string */
     protected const DEFINITION_CACHE_MODEL_CLASS = 'core/purifier_definitionCache';

--- a/app/code/core/Mage/Core/Model/Purifier.php
+++ b/app/code/core/Mage/Core/Model/Purifier.php
@@ -19,4 +19,30 @@ declare(strict_types=1);
  * @see Mage_Core_Model_Purifier_Abstract
  * @package Mage_Core
  */
-class Mage_Core_Model_Purifier extends Mage_Core_Model_Purifier_Abstract implements Mage_Core_Model_Purifier_Interface {}
+class Mage_Core_Model_Purifier extends Mage_Core_Model_Purifier_Abstract implements Mage_Core_Model_Purifier_Interface
+{
+    /**
+     * @inheritDoc
+     */
+    final public const OPTION_ALLOWED_ATTRIBUTES = parent::OPTION_ALLOWED_ATTRIBUTES;
+
+    /**
+     * @inheritDoc
+     */
+    final public const OPTION_ALLOWED_CLASSES = parent::OPTION_ALLOWED_CLASSES;
+
+    /**
+     * @inheritDoc
+     */
+    final public const OPTION_ALLOWED_ELEMENTS = parent::OPTION_ALLOWED_ELEMENTS;
+
+    /**
+     * @inheritDoc
+     */
+    final public const OPTION_ALLOWED_STYLE_PROPERTIES = parent::OPTION_ALLOWED_STYLE_PROPERTIES;
+
+    /**
+     * @inheritDoc
+     */
+    final public const OPTION_ESCAPE_INVALID_TAGS = parent::OPTION_ESCAPE_INVALID_TAGS;
+}

--- a/app/code/core/Mage/Core/Model/Purifier.php
+++ b/app/code/core/Mage/Core/Model/Purifier.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
+ * @package    Mage_Core
+ */
+
+declare(strict_types=1);
+
+/**
+ * A model for purifying HTML strings.
+ *
+ * "Purify" in this context means to sanitize HTML in order to prevent
+ * vulnerabilities and/or broken HTML. It is also a reference to the
+ * HTMLPurifier library that is used as a dependency in the original
+ * implementation.
+ *
+ * @package Mage_Core
+ */
+class Mage_Core_Model_Purifier
+{
+    protected const CONFIG_CACHE_DEFINITION_IMPL = 'Cache.DefinitionImpl';
+
+    protected const CONFIG_CORE_ESCAPE_INVALID_TAGS = 'Core.EscapeInvalidTags';
+
+    protected const CONFIG_HTML_ALLOWED_ELEMENTS = 'HTML.AllowedElements';
+
+    /** @var \HTMLPurifier */
+    protected $purifier;
+
+    /**
+     * Mage model constructor.
+     *
+     * NOTE: If inheriting from this class, note that the
+     * {@link HTMLPurifier_Config} instance is finalized upon first *read*
+     * operation on it, which often occurs on the first call of
+     * {@link HTMLPurifier::purify()} or {@link HTMLPurifier::purifyArray()}.
+     * Therefore, more configuration *can* happen after construction via
+     * `$this->purifier->config->set('key', 'value');` calls, though this should
+     * not be considered to be guaranteed behavior or part of the official API
+     * of the class.
+     *
+     * The {@link $options}:
+     * | Key              | Description                                                                                            | Default |
+     * |------------------|--------------------------------------------------------------------------------------------------------|---------|
+     * | allowedElements  | `null` to allow all valid HTML elements, or an array of allowed element names, e.g., `['b', 'i', 'u']` | `null`  |
+     * | escapeInvalidTags| `true` to include invalid and forbidden tags as literal text, `false` to strip the tag                 | `false` |
+     *
+     * @param array{
+     *     allowedElements?: string[],
+     *     escapeInvalidTags?: bool,
+     * } $options
+     */
+    public function __construct($options = [])
+    {
+        $allowedElements = $options['allowedElements'] ?? null;
+        $escapeInvalidTags = $options['escapeInvalidTags'] ?? false;
+
+        /** @var \Mage_Core_Helper_Purifier_Config $configHelper */
+        $configHelper = Mage::helper('core/purifier_config');
+
+        $config = HTMLPurifier_Config::createDefault();
+        // Allow <a> target attribute (when <a> is allowed)
+        $config->set('Attr.AllowedFrameTargets', ['_self', '_blank', '_parent', '_top']);
+        // Allow <a> rel attribute (when <a> is allowed)
+        $config->set('Attr.AllowedRel', ['nofollow', 'noopener', 'noreferrer']);
+        // Don't "fix" deprecated HTML
+        $config->set('HTML.TidyLevel', 'none');
+        // Use custom cache for HTMLPurifier definitions
+        $config->set(static::CONFIG_CACHE_DEFINITION_IMPL, $configHelper->getCacheDefinitionImpl());
+        // Optionally set an allowlist for HTML elements
+        $config->set(static::CONFIG_HTML_ALLOWED_ELEMENTS, $allowedElements);
+        // Write invalid tags as escaped text instead of removing the content
+        $config->set(static::CONFIG_CORE_ESCAPE_INVALID_TAGS, $escapeInvalidTags);
+
+        $this->purifier = new HTMLPurifier($config);
+    }
+
+    /**
+     * @return null|string[]
+     */
+    public function getAllowedElements()
+    {
+        return $this->purifier->config->get(static::CONFIG_HTML_ALLOWED_ELEMENTS);
+    }
+
+    /**
+     * @return bool
+     */
+    public function getEscapeInvalidTags()
+    {
+        return $this->purifier->config->get(static::CONFIG_CORE_ESCAPE_INVALID_TAGS);
+    }
+
+    /**
+     * Purify Html Content
+     *
+     * @param  string $html
+     * @return string
+     */
+    public function purify($html)
+    {
+        if (!str_contains($html, '<')) {
+            $decoded = html_entity_decode($html, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            return htmlspecialchars($decoded, ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        }
+
+        return $this->purifier->purify($html);
+    }
+}

--- a/app/code/core/Mage/Core/Model/Purifier.php
+++ b/app/code/core/Mage/Core/Model/Purifier.php
@@ -10,103 +10,13 @@
 declare(strict_types=1);
 
 /**
- * A model for purifying HTML strings.
+ * De facto model implementation of {@link Mage_Core_Model_Purifier_Interface}.
  *
- * "Purify" in this context means to sanitize HTML in order to prevent
- * vulnerabilities and/or broken HTML. It is also a reference to the
- * HTMLPurifier library that is used as a dependency in the original
- * implementation.
+ * NOTE: Instances of this model are somewhat heavy, so it's best to cache
+ * instances that use identical configurations.
  *
+ * @see Mage_Core_Model_Purifier_Interface
+ * @see Mage_Core_Model_Purifier_Abstract
  * @package Mage_Core
  */
-class Mage_Core_Model_Purifier
-{
-    protected const CONFIG_CACHE_DEFINITION_IMPL = 'Cache.DefinitionImpl';
-
-    protected const CONFIG_CORE_ESCAPE_INVALID_TAGS = 'Core.EscapeInvalidTags';
-
-    protected const CONFIG_HTML_ALLOWED_ELEMENTS = 'HTML.AllowedElements';
-
-    /** @var \HTMLPurifier */
-    protected $purifier;
-
-    /**
-     * Mage model constructor.
-     *
-     * NOTE: If inheriting from this class, note that the
-     * {@link HTMLPurifier_Config} instance is finalized upon first *read*
-     * operation on it, which often occurs on the first call of
-     * {@link HTMLPurifier::purify()} or {@link HTMLPurifier::purifyArray()}.
-     * Therefore, more configuration *can* happen after construction via
-     * `$this->purifier->config->set('key', 'value');` calls, though this should
-     * not be considered to be guaranteed behavior or part of the official API
-     * of the class.
-     *
-     * The {@link $options}:
-     * | Key              | Description                                                                                            | Default |
-     * |------------------|--------------------------------------------------------------------------------------------------------|---------|
-     * | allowedElements  | `null` to allow all valid HTML elements, or an array of allowed element names, e.g., `['b', 'i', 'u']` | `null`  |
-     * | escapeInvalidTags| `true` to include invalid and forbidden tags as literal text, `false` to strip the tag                 | `false` |
-     *
-     * @param array{
-     *     allowedElements?: string[],
-     *     escapeInvalidTags?: bool,
-     * } $options
-     */
-    public function __construct($options = [])
-    {
-        $allowedElements = $options['allowedElements'] ?? null;
-        $escapeInvalidTags = $options['escapeInvalidTags'] ?? false;
-
-        /** @var \Mage_Core_Helper_Purifier_Config $configHelper */
-        $configHelper = Mage::helper('core/purifier_config');
-
-        $config = HTMLPurifier_Config::createDefault();
-        // Allow <a> target attribute (when <a> is allowed)
-        $config->set('Attr.AllowedFrameTargets', ['_self', '_blank', '_parent', '_top']);
-        // Allow <a> rel attribute (when <a> is allowed)
-        $config->set('Attr.AllowedRel', ['nofollow', 'noopener', 'noreferrer']);
-        // Don't "fix" deprecated HTML
-        $config->set('HTML.TidyLevel', 'none');
-        // Use custom cache for HTMLPurifier definitions
-        $config->set(static::CONFIG_CACHE_DEFINITION_IMPL, $configHelper->getCacheDefinitionImpl());
-        // Optionally set an allowlist for HTML elements
-        $config->set(static::CONFIG_HTML_ALLOWED_ELEMENTS, $allowedElements);
-        // Write invalid tags as escaped text instead of removing the content
-        $config->set(static::CONFIG_CORE_ESCAPE_INVALID_TAGS, $escapeInvalidTags);
-
-        $this->purifier = new HTMLPurifier($config);
-    }
-
-    /**
-     * @return null|string[]
-     */
-    public function getAllowedElements()
-    {
-        return $this->purifier->config->get(static::CONFIG_HTML_ALLOWED_ELEMENTS);
-    }
-
-    /**
-     * @return bool
-     */
-    public function getEscapeInvalidTags()
-    {
-        return $this->purifier->config->get(static::CONFIG_CORE_ESCAPE_INVALID_TAGS);
-    }
-
-    /**
-     * Purify Html Content
-     *
-     * @param  string $html
-     * @return string
-     */
-    public function purify($html)
-    {
-        if (!str_contains($html, '<')) {
-            $decoded = html_entity_decode($html, ENT_QUOTES | ENT_HTML5, 'UTF-8');
-            return htmlspecialchars($decoded, ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
-        }
-
-        return $this->purifier->purify($html);
-    }
-}
+class Mage_Core_Model_Purifier extends Mage_Core_Model_Purifier_Abstract implements Mage_Core_Model_Purifier_Interface {}

--- a/app/code/core/Mage/Core/Model/Purifier/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Purifier/Abstract.php
@@ -194,10 +194,10 @@ abstract class Mage_Core_Model_Purifier_Abstract implements Mage_Core_Model_Puri
      * shapes may cause unexpected results.
      *
      * @param array{
-     *     allowedElements?: string[],
-     *     allowedAttributes?: string[],
-     *     allowedClasses?: string[],
-     *     allowedStyleProperties?: string[],
+     *     allowedElements?: null|string[],
+     *     allowedAttributes?: null|string[],
+     *     allowedClasses?: null|string[],
+     *     allowedStyleProperties?: null|string[],
      *     escapeInvalidTags?: bool,
      * } $options
      */

--- a/app/code/core/Mage/Core/Model/Purifier/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Purifier/Abstract.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
+ * @package    Mage_Core
+ */
+
+declare(strict_types=1);
+
+/**
+ * Default implementation of {@link Mage_Core_Model_Purifier_Interface}.
+ *
+ * This abstract class provides a standard, configurable, implementation of
+ * {@link Mage_Core_Model_Purifier_Interface}. Derived classes can only
+ * customize the purification behavior by passing options to the constructor.
+ * If further customization is needed, consider using a different
+ * implementation of {@link Mage_Core_Model_Purifier_Interface}.
+ *
+ * The implementation of this class contains no mutable state, but derived
+ * classes may or may not be immutable.
+ *
+ * The de facto model class for this implementation is
+ * {@link Mage_Core_Model_Purifier}. That can be used for ad-hoc purifier
+ * instances. However, instances of this class can be somewhat heavy in memory
+ * consumption and have an amortized cost of generating internal parsing rules
+ * once per instance. It can be wise to create model subclasses with zero
+ * argument constructors that always pass exactly the same options to the parent
+ * constructor. Such a class is a good candidate for `Mage::getSingleton()` use.
+ *
+ * @see Mage_Core_Model_Purifier_Interface
+ * @see Mage_Core_Model_Purifier
+ * @package Mage_Core
+ */
+abstract class Mage_Core_Model_Purifier_Abstract implements Mage_Core_Model_Purifier_Interface
+{
+    private const CONFIG_CACHE_DEFINITION_IMPL = 'Cache.DefinitionImpl';
+
+    private const CONFIG_CORE_ESCAPE_INVALID_TAGS = 'Core.EscapeInvalidTags';
+
+    private const CONFIG_HTML_ALLOWED_ELEMENTS = 'HTML.AllowedElements';
+
+    private readonly HTMLPurifier $purifier;
+
+    /**
+     * Mage model constructor.
+     *
+     * The {@link $options}:
+     * | Key              | Description                                                                                            | Default |
+     * |------------------|--------------------------------------------------------------------------------------------------------|---------|
+     * | allowedElements  | `null` to allow all valid HTML elements, or an array of allowed element names, e.g., `['b', 'i', 'u']` | `null`  |
+     * | escapeInvalidTags| `true` to include invalid and forbidden tags as literal text, `false` to strip the tag                 | `false` |
+     *
+     * @param array{
+     *     allowedElements?: string[],
+     *     escapeInvalidTags?: bool,
+     * } $options
+     */
+    public function __construct(array $options = [])
+    {
+        $allowedElements = $options['allowedElements'] ?? null;
+        $escapeInvalidTags = $options['escapeInvalidTags'] ?? false;
+
+        /** @var Mage_Core_Helper_Purifier_Config $configHelper */
+        $configHelper = Mage::helper('core/purifier_config');
+
+        $config = HTMLPurifier_Config::createDefault();
+        // Allow <a> target attribute (when <a> is allowed)
+        $config->set('Attr.AllowedFrameTargets', ['_self', '_blank', '_parent', '_top']);
+        // Allow <a> rel attribute (when <a> is allowed)
+        $config->set('Attr.AllowedRel', ['nofollow', 'noopener', 'noreferrer']);
+        // Don't "fix" deprecated HTML
+        $config->set('HTML.TidyLevel', 'none');
+        // Use custom cache for HTMLPurifier definitions
+        $config->set(self::CONFIG_CACHE_DEFINITION_IMPL, $configHelper->getCacheDefinitionImpl());
+        // Optionally set an allowlist for HTML elements
+        $config->set(self::CONFIG_HTML_ALLOWED_ELEMENTS, $allowedElements);
+        // Write invalid tags as escaped text instead of removing the content
+        $config->set(self::CONFIG_CORE_ESCAPE_INVALID_TAGS, $escapeInvalidTags);
+
+        $this->purifier = new HTMLPurifier($config);
+    }
+
+    /**
+     * @return null|string[]
+     */
+    final public function getAllowedElements(): ?array
+    {
+        return $this->purifier->config->get(self::CONFIG_HTML_ALLOWED_ELEMENTS);
+    }
+
+    final public function getEscapeInvalidTags(): bool
+    {
+        return $this->purifier->config->get(self::CONFIG_CORE_ESCAPE_INVALID_TAGS);
+    }
+
+    /**
+     * Purify Html Content
+     */
+    final public function purify(string $html): string
+    {
+        // As an optimization, we know that a string that has no '<' character
+        // is text content, so we can avoid the overhead of HTMLPurifier. The
+        // specific calls and flag parameters were chosen to exactly match the
+        // output from HTMLPurifier being called with the same text, so that
+        // the output is identical with or without the optimization.
+
+        if (!str_contains($html, '<')) {
+            $decoded = html_entity_decode($html, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            return htmlspecialchars($decoded, ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        }
+
+        return (string) $this->purifier->purify($html);
+    }
+}

--- a/app/code/core/Mage/Core/Model/Purifier/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Purifier/Abstract.php
@@ -35,35 +35,182 @@ declare(strict_types=1);
  */
 abstract class Mage_Core_Model_Purifier_Abstract implements Mage_Core_Model_Purifier_Interface
 {
+    /**
+     * Options key.
+     *
+     * *Value Type:* `null|string[]`
+     *
+     * *Default Value:* `null`
+     *
+     * *Description:* Provides a list of HTML attributes. Any attribute not
+     *                present in the list will be stripped from the purified
+     *                HTML. If unset or `null`, almost all standard attributes
+     *                are allowed except for those considered to be "unsafe",
+     *                such anything that allows JavaScript execution (e.g.,
+     *                `onclick`) as well as the `id` attribute. The syntax for
+     *                entries in this list is `'tag.attr'`, where `'*.attr'` is
+     *                used for global attributes. The presence of an attribute
+     *                in this list does not imply that its *values* will not be
+     *                modified or removed. Note that `'*.id'` is never allowed,
+     *                even when included in this list.
+     */
+    protected const OPTION_ALLOWED_ATTRIBUTES = 'allowedAttributes';
+
+    /**
+     * Options key.
+     *
+     * *Value Type:* `null|string[]`
+     *
+     * *Default Value:* `null`
+     *
+     * *Description:* Provides a list of CSS classes to allow as values for the
+     *                global `class` HTML attribute. Any class not present in
+     *                the list will be stripped from the purified HTML. If
+     *                unset or `null`, all classes are allowed. The entries in
+     *                this list are individual, case-sensitive, CSS class names.
+     *                Note that this option has no effect if the `class`
+     *                attribute is forbidden (see
+     *                {@link static::OPTION_ALLOWED_ATTRIBUTES}).
+     *
+     * @see static::OPTION_ALLOWED_ATTRIBUTES
+     */
+    protected const OPTION_ALLOWED_CLASSES = 'allowedClasses';
+
+    /**
+     * Options key.
+     *
+     * *Value Type:* `null|string[]`
+     *
+     * *Default Value:* `null`
+     *
+     * *Description:* Provides a list of HTML elements. Any element not present
+     *                in the list will be either stripped from the purified
+     *                HTML, or rendered as literal text content, depending on
+     *                the value of the
+     *                {@link static::OPTION_ESCAPE_INVALID_TAGS} option. If
+     *                unset or `null`, a liberal default list is used that
+     *                includes all standard HTML elements except for those
+     *                considered to be "unsafe" from malicious input (e.g.,
+     *                `<script>`). The entries in this list are HTML element
+     *                names with no extra syntax (e.g., no '<', '>'
+     *                characters). Note that the aforementioned "unsafe"
+     *                elements are never allowed, even when included in this
+     *                list.
+     *
+     * @see static::OPTION_ESCAPE_INVALID_TAGS
+     */
+    protected const OPTION_ALLOWED_ELEMENTS = 'allowedElements';
+
+    /**
+     * Options key.
+     *
+     * *Value Type:* `null|string[]`
+     *
+     * *Default Value:* `null`
+     *
+     * *Description:* Provides a list of CSS properties to allow as values for
+     *                the global `style` HTML attribute. Any CSS property not
+     *                present in the list will be stripped from the purified
+     *                HTML. If unset or `null`, a default list is used that
+     *                includes all standard CSS properties except for those
+     *                considered to be "unsafe" from CSS injection. The
+     *                entries in this list are individual, case-sensitive, CSS
+     *                property names. Note that the aforementioned "unsafe"
+     *                properties are never allowed, even when included in this
+     *                list. Note that this option has no effect if the
+     *                `style` attribute is forbidden (see
+     *                {@link static::OPTION_ALLOWED_ATTRIBUTES}). Note that
+     *                this option *only* applies to inline `style` attributes
+     *                in the HTML text and not to any styling done by
+     *                stylesheets.
+     *
+     * @see static::OPTION_ALLOWED_ATTRIBUTES
+     */
+    protected const OPTION_ALLOWED_STYLE_PROPERTIES = 'allowedStyleProperties';
+
+    /**
+     * Options key.
+     *
+     * *Value Type:* `bool`
+     *
+     * *Default Value:* `false`
+     *
+     * *Description:* Determines whether forbidden elements (see
+     *                {@link static::OPTION_ALLOWED_ELEMENTS}) are removed
+     *                from the purified output or included as literal text
+     *                content. This has no affect on parts of the input that
+     *                are already written as text content.
+     *
+     * @see static::OPTION_ALLOWED_ELEMENTS
+     */
+    protected const OPTION_ESCAPE_INVALID_TAGS = 'escapeInvalidTags';
+
+    private const CONFIG_ATTR_ALLOWED_CLASSES = 'Attr.AllowedClasses';
+
     private const CONFIG_CACHE_DEFINITION_IMPL = 'Cache.DefinitionImpl';
 
     private const CONFIG_CORE_ESCAPE_INVALID_TAGS = 'Core.EscapeInvalidTags';
 
+    private const CONFIG_CSS_ALLOWED_PROPERTIES = 'CSS.AllowedProperties';
+
     private const CONFIG_HTML_ALLOWED_ELEMENTS = 'HTML.AllowedElements';
+
+    private const CONFIG_HTML_ALLOWED_ATTRIBUTES = 'HTML.AllowedAttributes';
 
     private readonly HTMLPurifier $purifier;
 
     /**
-     * Mage model constructor.
+     * Constructor.
      *
-     * The {@link $options}:
-     * | Key              | Description                                                                                            | Default |
-     * |------------------|--------------------------------------------------------------------------------------------------------|---------|
-     * | allowedElements  | `null` to allow all valid HTML elements, or an array of allowed element names, e.g., `['b', 'i', 'u']` | `null`  |
-     * | escapeInvalidTags| `true` to include invalid and forbidden tags as literal text, `false` to strip the tag                 | `false` |
+     * For detailed descriptions of the options and their effects, see:
+     * - {@link self::OPTION_ALLOWED_ELEMENTS}
+     * - {@link self::OPTION_ALLOWED_ATTRIBUTES}
+     * - {@link self::OPTION_ALLOWED_CLASSES}
+     * - {@link self::OPTION_ALLOWED_STYLE_PROPERTIES}
+     * - {@link self::OPTION_ESCAPE_INVALID_TAGS}
+     *
+     * Notes and Suggestions:
+     * - The defaults should be fine for most use cases that just want to
+     * sanitize arbitrary HTML. **However**, do note that the defaults allow
+     * for a lot of freedom in styling. Supplied input may set any `class` and
+     * may set `style` attributes that mess up intended layout/formatting by,
+     * e.g., setting strange margins or font sizes.
+     * - Be careful when customizing `allowedAttributes`. It's easy to forget
+     * legitimate attributes like `'a.href'`, without which `<a>` tags are
+     * essentially useless. It's also not usually necessary (see below). It
+     * may occasionally be desirable to set it to `[]` for very restrictive
+     * contexts, but again, one must make sure to not accidentally break the
+     * functionality of the `allowedElements`.
+     * - A simple way to disable all styling without having to craft a custom
+     * `allowedAttributes` list is to simply set `allowedClasses` and
+     * `allowedStyleProperties` to `[]`. This will strip all values from the
+     * `class` and `style` attributes, and since the purifier already strips
+     * empty `class` and `style` attributes from the output, this results in
+     * all `class` and `style` attributes being removed.
+     *
+     * **WARNING:**
+     * All options that expect a list of strings (`string[]`) are expected to
+     * have only numeric keys, starting from 0 with no gaps ("dense"). Other
+     * shapes may cause unexpected results.
      *
      * @param array{
      *     allowedElements?: string[],
+     *     allowedAttributes?: string[],
+     *     allowedClasses?: string[],
+     *     allowedStyleProperties?: string[],
      *     escapeInvalidTags?: bool,
      * } $options
      */
     public function __construct(array $options = [])
     {
-        $allowedElements = $options['allowedElements'] ?? null;
-        $escapeInvalidTags = $options['escapeInvalidTags'] ?? false;
+        $allowedElements = $options[static::OPTION_ALLOWED_ELEMENTS] ?? null;
+        $allowedAttributes = $options[static::OPTION_ALLOWED_ATTRIBUTES] ?? null;
+        $allowedClasses = $options[static::OPTION_ALLOWED_CLASSES] ?? null;
+        $allowedStyleProperties = $options[static::OPTION_ALLOWED_STYLE_PROPERTIES] ?? null;
+        $escapeInvalidTags = $options[static::OPTION_ESCAPE_INVALID_TAGS] ?? false;
 
-        /** @var Mage_Core_Helper_Purifier_Config $configHelper */
-        $configHelper = Mage::helper('core/purifier_config');
+        /** @var Mage_Core_Helper_Purifier_DefinitionCache $definitionCacheHelper */
+        $definitionCacheHelper = Mage::helper('core/purifier_definitionCache');
 
         $config = HTMLPurifier_Config::createDefault();
         // Allow <a> target attribute (when <a> is allowed)
@@ -73,9 +220,15 @@ abstract class Mage_Core_Model_Purifier_Abstract implements Mage_Core_Model_Puri
         // Don't "fix" deprecated HTML
         $config->set('HTML.TidyLevel', 'none');
         // Use custom cache for HTMLPurifier definitions
-        $config->set(self::CONFIG_CACHE_DEFINITION_IMPL, $configHelper->getCacheDefinitionImpl());
+        $config->set(self::CONFIG_CACHE_DEFINITION_IMPL, $definitionCacheHelper->getCacheDefinitionImpl());
         // Optionally set an allowlist for HTML elements
         $config->set(self::CONFIG_HTML_ALLOWED_ELEMENTS, $allowedElements);
+        // Optionally set an allowlist for HTML element attributes
+        $config->set(self::CONFIG_HTML_ALLOWED_ATTRIBUTES, $allowedAttributes);
+        // Optionally set an allowlist for class attributes
+        $config->set(self::CONFIG_ATTR_ALLOWED_CLASSES, $allowedClasses);
+        // Optionally set an allowlist for CSS properties allowed in style attributes
+        $config->set(self::CONFIG_CSS_ALLOWED_PROPERTIES, $allowedStyleProperties);
         // Write invalid tags as escaped text instead of removing the content
         $config->set(self::CONFIG_CORE_ESCAPE_INVALID_TAGS, $escapeInvalidTags);
 
@@ -85,9 +238,33 @@ abstract class Mage_Core_Model_Purifier_Abstract implements Mage_Core_Model_Puri
     /**
      * @return null|string[]
      */
+    final public function getAllowedAttributes(): ?array
+    {
+        return $this->purifier->config->get(self::CONFIG_HTML_ALLOWED_ATTRIBUTES);
+    }
+
+    /**
+     * @return null|string[]
+     */
     final public function getAllowedElements(): ?array
     {
         return $this->purifier->config->get(self::CONFIG_HTML_ALLOWED_ELEMENTS);
+    }
+
+    /**
+     * @return null|string[]
+     */
+    final public function getAllowedClasses(): ?array
+    {
+        return $this->purifier->config->get(self::CONFIG_ATTR_ALLOWED_CLASSES);
+    }
+
+    /**
+     * @return null|string[]
+     */
+    final public function getAllowedStyleProperties(): ?array
+    {
+        return $this->purifier->config->get(self::CONFIG_CSS_ALLOWED_PROPERTIES);
     }
 
     final public function getEscapeInvalidTags(): bool

--- a/app/code/core/Mage/Core/Model/Purifier/DefinitionCache.php
+++ b/app/code/core/Mage/Core/Model/Purifier/DefinitionCache.php
@@ -1,0 +1,416 @@
+<?php
+
+/**
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
+ * @package    Mage_Core
+ */
+
+declare(strict_types=1);
+
+/**
+ * HTMLPurifier definition cache implementation using Magento's cache system.
+ *
+ * This allows HTMLPurifier to cache parsed definitions using whatever cache
+ * backend Magento is configured to use (File, Memcached, APC, Redis, etc.),
+ * rather than requiring a separate file-based cache.
+ *
+ * This Model class is not intended to be instantiated by Magento. Its
+ * fully-qualified class name is registered to the HTMLPurifier library, which
+ * will instantiate instance(s) as it sees fit. That said, the constructor *is*
+ * compatible with the {@link Mage::getModel()} factory.
+ *
+ * @package Mage_Core
+ */
+class Mage_Core_Model_Purifier_DefinitionCache extends HTMLPurifier_DefinitionCache
+{
+    /**
+     * Cache tag for all HTMLPurifier entries, enabling bulk invalidation.
+     */
+    public const MAGE_CACHE_TAG = 'HTMLPURIFIER';
+
+    /**
+     * Cache ID prefix to namespace HTMLPurifier entries.
+     */
+    protected const MAGE_CACHE_ID_PREFIX = 'htmlpurifier_def';
+
+    /**
+     * Cache lifetime in seconds (1 week). Definitions rarely change.
+     */
+    protected const MAGE_CACHE_LIFETIME = 604800;
+
+    protected string $signingKey;
+
+    /**
+     * @param array{type: string}|string $type          type of definition objects this instance of
+     *                                                  the cache will handle
+     * @param null|string                $encryptionKey Magento's core encryption key (or a suitable
+     *                                                  substitute). Used to derive a key to
+     *                                                  authenticate cache entries.
+     */
+    public function __construct($type = '', $encryptionKey = null)
+    {
+        if (!is_string($type)) {
+            $type = ((array) $type)['type'] ?? '';
+        }
+
+        parent::__construct($type);
+
+        $encryptionKey ??= (string) Mage::getConfig()->getNode('global/crypt/key');
+        if ($encryptionKey === '') {
+            throw new RuntimeException('Missing Magento encryption key');
+        }
+
+        $this->signingKey = hash_hkdf('sha256', $encryptionKey, info: 'htmlpurifier-cache-signing');
+    }
+
+    /**
+     * Generates a unique identifier for a particular configuration
+     *
+     * Note: If you must override this method, then you likely need to also
+     * override {@link static::isOld()}.
+     *
+     * @param  HTMLPurifier_Config $config Instance of HTMLPurifier_Config
+     * @return string
+     */
+    public function generateKey($config)
+    {
+        $version = str_replace('.', '_', $config->version);
+        $hash = $config->getBatchSerial($this->type);
+        $revision = $config->get($this->type . '.DefinitionRev');
+        return self::MAGE_CACHE_ID_PREFIX . "__{$version}__{$hash}__$revision";
+    }
+
+    /**
+     * Tests whether or not a key is old with respect to the configuration's
+     * version and revision number.
+     *
+     * Note: If you must override this method, then you likely need to also
+     * override {@link static::generateKey()}.
+     *
+     * @param  string              $key    Key to test
+     * @param  HTMLPurifier_Config $config Instance of HTMLPurifier_Config to
+     *                                     test against
+     * @return bool
+     */
+    public function isOld($key, $config)
+    {
+        $parts = explode('__', $key, 5);
+        if (count($parts) !== 4) {
+            return true;
+        }
+
+        [, $version, $hash, $revision] = $parts;
+
+        // Be conservative: any version mismatch counts as "old"
+        if (version_compare($version, $config->version) !== 0) {
+            return true;
+        }
+
+        if ($hash !== $config->getBatchSerial($this->type)) {
+            return true;
+        }
+
+        // Revisions are ints, but string comparison might be future-proof
+        if ($revision < $config->get($this->type . '.DefinitionRev')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  HTMLPurifier_Definition $def
+     * @param  HTMLPurifier_Config     $config
+     * @return bool
+     */
+    public function add($def, $config)
+    {
+        if (!$this->checkDefType($def)) {
+            return false;
+        }
+
+        $cache = $this->getMageCache();
+
+        $id = $this->generateKey($config);
+
+        // Only add if not already cached
+        if ($cache->test($id) !== false) {
+            return false;
+        }
+
+        return $cache->save(
+            $this->encode($def),
+            $id,
+            $this->getMageCacheTags(),
+            self::MAGE_CACHE_LIFETIME,
+        );
+    }
+
+    /**
+     * @param  HTMLPurifier_Definition $def
+     * @param  HTMLPurifier_Config     $config
+     * @return bool
+     */
+    public function set($def, $config)
+    {
+        if (!$this->checkDefType($def)) {
+            return false;
+        }
+
+        $cache = $this->getMageCache();
+
+        $id = $this->generateKey($config);
+
+        return $cache->save(
+            $this->encode($def),
+            $id,
+            $this->getMageCacheTags(),
+            self::MAGE_CACHE_LIFETIME,
+        );
+    }
+
+    /**
+     * @param  HTMLPurifier_Definition $def
+     * @param  HTMLPurifier_Config     $config
+     * @return bool
+     */
+    public function replace($def, $config)
+    {
+        if (!$this->checkDefType($def)) {
+            return false;
+        }
+
+        $cache = $this->getMageCache();
+
+        $id = $this->generateKey($config);
+
+        // Only replace if already cached
+        if ($cache->test($id) === false) {
+            return false;
+        }
+
+        return $cache->save(
+            $this->encode($def),
+            $id,
+            $this->getMageCacheTags(),
+            self::MAGE_CACHE_LIFETIME,
+        );
+    }
+
+    /**
+     * @param  HTMLPurifier_Config           $config
+     * @return false|HTMLPurifier_Definition
+     */
+    public function get($config)
+    {
+        $id = $this->generateKey($config);
+
+        $data = $this->getMageCache()->load($id);
+        if (!is_string($data)) {
+            return false;
+        }
+
+        /*
+         * NOTE: Upstream's Serializer DefinitionCache does NOT check for
+         * staleness in its implementation. Presumably for performance reasons.
+         */
+
+        return $this->decode($data);
+    }
+
+    /**
+     * @param  HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function remove($config)
+    {
+        $id = $this->generateKey($config);
+        return $this->getMageCache()->remove($id);
+    }
+
+    /**
+     * Clears all HTMLPurifier definition cache entries.
+     *
+     * @param  HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function flush($config)
+    {
+        return $this->getMageCache()->clean(
+            Zend_Cache::CLEANING_MODE_MATCHING_TAG,
+            $this->getMageCacheTags(),
+        );
+    }
+
+    /**
+     * Clears old and invalid/corrupted entries.
+     *
+     * @param  HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function cleanup($config)
+    {
+        $cache = $this->getMageCache();
+        $ids = $cache->getIdsMatchingTags($this->getMageCacheTags());
+        foreach ($ids as $id) {
+            $data = $cache->load($id);
+
+            // No longer in cache
+            if ($data === false) {
+                continue;
+            }
+
+            // Corrupted
+            if (!is_string($data)) {
+                $cache->remove($id);
+                continue;
+            }
+
+            $def = $this->decode($data);
+
+            // Corrupted
+            if ($def === false) {
+                $cache->remove($id);
+                continue;
+            }
+
+            // Old/stale
+            if ($this->isOld($id, $config)) {
+                $cache->remove($id);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Encodes the definition object to be stored in cache.
+     *
+     * Note: If you must override this method, then you likely need to also
+     * override {@link static::decode()}.
+     *
+     * @param  HTMLPurifier_Definition $def
+     * @return string
+     */
+    protected function encode($def)
+    {
+        $serialized = $this->serialize($def);
+        $signature = $this->generateSignature($serialized);
+        return "$signature:$serialized";
+    }
+
+    /**
+     * Decodes the definition object from the encoded value.
+     *
+     * Note: If you must override this method, then you likely need to also
+     * override {@link static::encode()}.
+     *
+     * @param  string                        $encoded
+     * @return false|HTMLPurifier_Definition
+     */
+    protected function decode($encoded)
+    {
+        $parts = explode(':', $encoded, 2);
+        if (count($parts) !== 2) {
+            return false;
+        }
+
+        [$signature, $serialized] = $parts;
+
+        if (!$this->signatureMatches($signature, $serialized)) {
+            return false;
+        }
+
+        return $this->deserialize($serialized);
+    }
+
+    /**
+     * Serializes the definition object to be stored in cache.
+     *
+     * Note: If you must override this method, then you likely need to also
+     * override {@link static::deserialize()}.
+     *
+     * @param  HTMLPurifier_Definition $def
+     * @return string
+     */
+    protected function serialize($def)
+    {
+        return serialize($def);
+    }
+
+    /**
+     * Deserializes the definition object to be stored in cache.
+     *
+     * **WARNING:** The base implementation, {@link self::deserialize()}, calls
+     * {@link \unserialize()} without an explicit 'allowed_classes' option.
+     * Therefore, {@link self::deserialize()} should *never* be called on data
+     * that has not been authenticated (i.e., by confirming that
+     * {@link static::signatureMatches()} returns `true`).
+     *
+     * Note: If you must override this method, then you likely need to also
+     * override {@link static::serialize()}.
+     *
+     * @param  string                        $serialized
+     * @return false|HTMLPurifier_Definition
+     */
+    protected function deserialize($serialized)
+    {
+        $def = unserialize($serialized);
+        if ($def instanceof HTMLPurifier_Definition) {
+            return $def;
+        }
+
+        return false;
+    }
+
+    /**
+     * Generates cryptographic signature for the serialized data.
+     *
+     * Note: If you must override this method, then you likely need to also
+     * override {@link static::signatureMatches()}.
+     *
+     * @param  string $serialized
+     * @return string
+     * @see static::signatureMatches()
+     */
+    protected function generateSignature($serialized)
+    {
+        return hash_hmac('sha256', $serialized, $this->signingKey);
+    }
+
+    /**
+     * Check cryptographic signature for the serialized data.
+     *
+     * Note: If you must override this method, then you likely need to also
+     * override {@link static::generateSignature()}.
+     *
+     * @param  string $signature
+     * @param  string $serialized
+     * @return bool
+     * @see static::generateSignature()
+     */
+    protected function signatureMatches($signature, $serialized)
+    {
+        return hash_equals($signature, $this->generateSignature($serialized));
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getMageCacheTags()
+    {
+        return [self::MAGE_CACHE_TAG, $this->type];
+    }
+
+    /**
+     * Gets the Magento cache instance.
+     *
+     * @return Zend_Cache_Core
+     */
+    protected function getMageCache()
+    {
+        return Mage::app()->getCache();
+    }
+}

--- a/app/code/core/Mage/Core/Model/Purifier/DefinitionCache.php
+++ b/app/code/core/Mage/Core/Model/Purifier/DefinitionCache.php
@@ -12,8 +12,7 @@ declare(strict_types=1);
 /**
  * HTMLPurifier definition cache implementation using Magento's cache system.
  *
- * This allows HTMLPurifier to cache parsed definitions using whatever cache
- * backend Magento is configured to use (File, Memcached, APC, Redis, etc.),
+ * This allows HTMLPurifier to cache parsed definitions using Magento's cache
  * rather than requiring a separate file-based cache.
  *
  * This Model class is not intended to be instantiated by Magento. Its

--- a/app/code/core/Mage/Core/Model/Purifier/Interface.php
+++ b/app/code/core/Mage/Core/Model/Purifier/Interface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
+ * @package    Mage_Core
+ */
+
+declare(strict_types=1);
+
+/**
+ * A model for purifying HTML strings.
+ *
+ * "Purify" in this context means to sanitize HTML in order to prevent
+ * vulnerabilities and/or broken HTML. It is also a reference to the
+ * HTMLPurifier library that is used as a dependency in the default
+ * implementation.
+ *
+ * @package Mage_Core
+ */
+interface Mage_Core_Model_Purifier_Interface
+{
+    /**
+     * Purify Html Content
+     */
+    public function purify(string $html): string;
+}

--- a/tests/unit/Mage/Core/Model/Purifier/DefinitionCacheTest.php
+++ b/tests/unit/Mage/Core/Model/Purifier/DefinitionCacheTest.php
@@ -1,0 +1,343 @@
+<?php
+
+/**
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
+ * @package    OpenMage_Tests
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Core\Model\Purifier;
+
+use HTMLPurifier_Config;
+use HTMLPurifier_DefinitionCacheFactory;
+use Mage;
+use Mage_Core_Model_Purifier_DefinitionCache as Subject;
+use OpenMage\Tests\Unit\OpenMageTest;
+use Zend_Cache;
+use Zend_Cache_Backend;
+use Zend_Cache_Backend_ExtendedInterface;
+
+final class DefinitionCacheTest extends OpenMageTest
+{
+    private const CACHE_DEFINITION_IMPL = self::class;
+
+    /** @var Zend_Cache_Backend&Zend_Cache_Backend_ExtendedInterface */
+    private static $cacheBackend;
+
+    /** @var null|Zend_Cache_Backend */
+    private static $originalBackend;
+
+    /** @var bool */
+    private static $originalCachingOption;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::$originalCachingOption = Mage::getConfig()->getCache()->getOption('caching');
+        // @phpstan-ignore assign.propertyType (Doc types don't match between cache backend getter and setter)
+        self::$originalBackend = Mage::getConfig()->getCache()->getBackend();
+
+        self::$cacheBackend = new class extends Zend_Cache_Backend implements Zend_Cache_Backend_ExtendedInterface {
+            /** @var array<string, array{value: string, tags: string[]}> */
+            private array $entries = [];
+
+            /**
+             * Tag to ids map
+             *
+             * @var array<string, string[]>
+             */
+            private array $tags = [];
+
+            /**
+             * @return string[]
+             */
+            public function getIds()
+            {
+                return array_keys($this->entries);
+            }
+
+            /**
+             * @return string[]
+             */
+            public function getTags()
+            {
+                return array_keys($this->tags);
+            }
+
+            /**
+             * @param  string[] $tags
+             * @return string[]
+             */
+            public function getIdsMatchingTags($tags = [])
+            {
+                $ids = [];
+                foreach ($this->entries as $id => $entry) {
+                    if (array_diff($tags, $entry['tags']) === []) {
+                        $ids[] = $id;
+                    }
+                }
+
+                return $ids;
+            }
+
+            /**
+             * @param  string[] $tags
+             * @return string[]
+             */
+            public function getIdsNotMatchingTags($tags = [])
+            {
+                $ids = [];
+                foreach ($this->entries as $id => $entry) {
+                    if (array_diff($tags, $entry['tags']) !== []) {
+                        $ids[] = $id;
+                    }
+                }
+
+                return $ids;
+            }
+
+            /**
+             * @param  string[] $tags
+             * @return string[]
+             */
+            public function getIdsMatchingAnyTags($tags = [])
+            {
+                $ids = [];
+                foreach ($tags as $tag) {
+                    $ids = array_merge($ids, $this->tags[$tag] ?? []);
+                }
+
+                return array_unique($ids);
+            }
+
+            /**
+             * @return int
+             */
+            public function getFillingPercentage()
+            {
+                return 0;
+            }
+
+            /**
+             * @param  string      $id
+             * @return array|false
+             */
+            public function getMetadatas($id)
+            {
+                $entry = $this->entries[$id] ?? false;
+                if ($entry === false) {
+                    return false;
+                }
+
+                return [
+                    'expire' => PHP_INT_MAX,
+                    'tags' => $entry['tags'],
+                    'mtime' => 0,
+                ];
+            }
+
+            /**
+             * @param  string $id
+             * @param  int    $extraLifetime
+             * @return bool
+             */
+            public function touch($id, $extraLifetime)
+            {
+                return array_key_exists($id, $this->entries);
+            }
+
+            /**
+             * @return array
+             */
+            public function getCapabilities()
+            {
+                return [
+                    'automatic_cleaning' => false,
+                    'tags' => true,
+                    'expired_read' => false,
+                    'priority' => false,
+                    'infinite_lifetime' => false,
+                    'get_list' => true,
+                ];
+            }
+
+            /**
+             * @param array $directives
+             */
+            public function setDirectives($directives) {}
+
+            /**
+             * @param  string       $id
+             * @param  bool         $doNotTestCacheValidity
+             * @return false|string
+             */
+            public function load($id, $doNotTestCacheValidity = false)
+            {
+                $entry = $this->entries[$id] ?? false;
+                if ($entry === false) {
+                    return false;
+                }
+
+                return $entry['value'];
+            }
+
+            /**
+             * @param  string    $id
+             * @return false|int
+             */
+            public function test($id)
+            {
+                if (array_key_exists($id, $this->entries)) {
+                    return 0;
+                }
+
+                return false;
+            }
+
+            /**
+             * @param  string         $data
+             * @param  string         $id
+             * @param  string[]       $tags
+             * @param  null|false|int $specificLifetime
+             * @return bool
+             */
+            public function save($data, $id, $tags = [], $specificLifetime = false)
+            {
+                $oldTags = ($this->entries[$id] ?? ['tags' => []])['tags'];
+                $removedTags = array_diff($oldTags, $tags);
+                $addedTags = array_diff($tags, $oldTags);
+
+                foreach ($removedTags as $removedTag) {
+                    $this->tags[$removedTag] = array_diff($this->tags[$removedTag], [$id]);
+                }
+
+                foreach ($addedTags as $addedTag) {
+                    $this->tags[$addedTag][] = $id;
+                }
+
+                $this->entries[$id] = [
+                    'value' => $data,
+                    'tags' => $tags,
+                ];
+
+                return true;
+            }
+
+            /**
+             * @param  string $id
+             * @return bool
+             */
+            public function remove($id)
+            {
+                $entry = $this->entries[$id] ?? false;
+                if ($entry !== false) {
+                    $tags = $entry['tags'];
+                    foreach ($tags as $tag) {
+                        $this->tags[$tag] = array_diff($this->tags[$tag], [$id]);
+                    }
+
+                    unset($this->entries[$id]);
+                }
+
+                return true;
+            }
+
+            /**
+             * @param  string   $mode
+             * @param  string[] $tags
+             * @return bool
+             */
+            public function clean($mode = Zend_Cache::CLEANING_MODE_ALL, $tags = [])
+            {
+                switch ($mode) {
+                    case Zend_Cache::CLEANING_MODE_ALL:
+                        $this->entries = [];
+                        $this->tags = [];
+
+                        break;
+                    case Zend_Cache::CLEANING_MODE_OLD:
+                        break;
+                    case Zend_Cache::CLEANING_MODE_MATCHING_TAG:
+                        foreach ($this->getIdsMatchingTags($tags) as $id) {
+                            $this->remove($id);
+                        }
+
+                        break;
+                    case Zend_Cache::CLEANING_MODE_NOT_MATCHING_TAG:
+                        foreach ($this->getIdsNotMatchingTags($tags) as $id) {
+                            $this->remove($id);
+                        }
+
+                        break;
+                    case Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG:
+                        foreach ($this->getIdsMatchingAnyTags($tags) as $id) {
+                            $this->remove($id);
+                        }
+
+                        break;
+                }
+
+                return true;
+            }
+        };
+
+        Mage::getConfig()->getCache()->setOption('caching', true);
+        Mage::getConfig()->getCache()->setBackend(self::$cacheBackend);
+
+        HTMLPurifier_DefinitionCacheFactory::instance()->register(
+            self::CACHE_DEFINITION_IMPL,
+            Subject::class,
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Mage::getConfig()->getCache()->setOption('caching', self::$originalCachingOption);
+        Mage::getConfig()->getCache()->setBackend(self::$originalBackend);
+
+        HTMLPurifier_DefinitionCacheFactory::instance()->register(
+            self::CACHE_DEFINITION_IMPL,
+            // @phpstan-ignore argument.type (Doc type is wrong, null is fine)
+            null,
+        );
+
+        parent::tearDownAfterClass();
+    }
+
+    protected function tearDown(): void
+    {
+        self::$cacheBackend->clean();
+    }
+
+    /**
+     * Tests that the cache is populated by calls to HTMLPurifier.
+     *
+     * @group Model
+     */
+    public function testCacheIsPopulatedByPurifier(): void
+    {
+        $config = HTMLPurifier_Config::createDefault();
+        $config->set('Cache.DefinitionImpl', self::CACHE_DEFINITION_IMPL);
+
+        $purifier = new \HTMLPurifier($config);
+
+        self::assertEmpty(self::$cacheBackend->getIds(), 'Cache should be empty at start of test');
+        self::assertEmpty(self::$cacheBackend->getTags(), 'Cache should be empty at start of test');
+
+        $purifier->purify(
+            <<<'HTML'
+            <h1>Title</h1>
+            <p>Here is some text.</p>
+            <madeup class="foo"></madeup>
+            <a href="http://localhost:8080"></a>
+            HTML,
+        );
+
+        self::assertNotEmpty(self::$cacheBackend->getIds(), 'Cache should contain definition entries after purifying');
+        self::assertNotEmpty(self::$cacheBackend->getTags(), 'Cache should contain tags after purifying');
+    }
+}

--- a/tests/unit/Mage/Core/Model/Purifier/DefinitionCacheTest.php
+++ b/tests/unit/Mage/Core/Model/Purifier/DefinitionCacheTest.php
@@ -11,8 +11,10 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Core\Model\Purifier;
 
+use HTMLPurifier;
 use HTMLPurifier_Config;
 use HTMLPurifier_DefinitionCacheFactory;
+use InvalidArgumentException;
 use Mage;
 use Mage_Core_Model_Purifier_DefinitionCache as Subject;
 use OpenMage\Tests\Unit\OpenMageTest;
@@ -279,6 +281,8 @@ final class DefinitionCacheTest extends OpenMageTest
                         }
 
                         break;
+                    default:
+                        throw new InvalidArgumentException('Invalid cleaning mode');
                 }
 
                 return true;
@@ -323,7 +327,7 @@ final class DefinitionCacheTest extends OpenMageTest
         $config = HTMLPurifier_Config::createDefault();
         $config->set('Cache.DefinitionImpl', self::CACHE_DEFINITION_IMPL);
 
-        $purifier = new \HTMLPurifier($config);
+        $purifier = new HTMLPurifier($config);
 
         self::assertEmpty(self::$cacheBackend->getIds(), 'Cache should be empty at start of test');
         self::assertEmpty(self::$cacheBackend->getTags(), 'Cache should be empty at start of test');

--- a/tests/unit/Mage/Core/Model/PurifierTest.php
+++ b/tests/unit/Mage/Core/Model/PurifierTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
+ * @package    OpenMage_Tests
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Core\Model;
+
+use Mage;
+use Mage_Core_Model_Purifier as Subject;
+use OpenMage\Tests\Unit\OpenMageTest;
+use OpenMage\Tests\Unit\Traits\DataProvider\Mage\Core\Model\PurifierTrait;
+
+final class PurifierTest extends OpenMageTest
+{
+    use PurifierTrait;
+
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+    }
+
+    /**
+     * @dataProvider provideGetters
+     * @group Model
+     */
+    public function testGetters($allowedElements, $escapeInvalidTags): void
+    {
+        /** @var Subject $subject */
+        $subject = Mage::getModel('core/purifier', [
+            'allowedElements' => $allowedElements,
+            'escapeInvalidTags' => $escapeInvalidTags,
+        ]);
+
+        self::assertSame(gettype($allowedElements), gettype($subject->getAllowedElements()));
+        self::assertSame(gettype($escapeInvalidTags), gettype($subject->getEscapeInvalidTags()));
+    }
+
+    /**
+     * @dataProvider providePurify
+     * @group Model
+     */
+    public function testPurify(string $expected, string $input, array $options = []): void
+    {
+        /** @var Subject $subject */
+        $subject = Mage::getModel('core/purifier', $options);
+        self::assertSame($expected, $subject->purify($input));
+    }
+}

--- a/tests/unit/Mage/Core/Model/PurifierTest.php
+++ b/tests/unit/Mage/Core/Model/PurifierTest.php
@@ -76,7 +76,7 @@ final class PurifierTest extends OpenMageTest
      * @dataProvider provideGetEscapeInvalidTags
      * @group Model
      */
-    public function testGetters($escapeInvalidTags): void
+    public function testGetEscapeInvalidTags($escapeInvalidTags): void
     {
         $subject = $this->getSubject([
             Subject::OPTION_ESCAPE_INVALID_TAGS => $escapeInvalidTags,

--- a/tests/unit/Mage/Core/Model/PurifierTest.php
+++ b/tests/unit/Mage/Core/Model/PurifierTest.php
@@ -20,25 +20,73 @@ final class PurifierTest extends OpenMageTest
 {
     use PurifierTrait;
 
-
-    public static function setUpBeforeClass(): void
-    {
-        parent::setUpBeforeClass();
-    }
-
     /**
-     * @dataProvider provideGetters
+     * @dataProvider provideGetAllowedAttributes
      * @group Model
      */
-    public function testGetters($allowedElements, $escapeInvalidTags): void
+    public function testGetAllowedAttributes(?array $allowedAttributes): void
     {
         /** @var Subject $subject */
         $subject = Mage::getModel('core/purifier', [
-            'allowedElements' => $allowedElements,
-            'escapeInvalidTags' => $escapeInvalidTags,
+            Subject::OPTION_ALLOWED_ATTRIBUTES => $allowedAttributes,
+        ]);
+
+        self::assertSame(gettype($allowedAttributes), gettype($subject->getAllowedAttributes()));
+    }
+
+    /**
+     * @dataProvider provideGetAllowedElements
+     * @group Model
+     */
+    public function testGetAllowedElements(?array $allowedElements): void
+    {
+        /** @var Subject $subject */
+        $subject = Mage::getModel('core/purifier', [
+            Subject::OPTION_ALLOWED_ELEMENTS => $allowedElements,
         ]);
 
         self::assertSame(gettype($allowedElements), gettype($subject->getAllowedElements()));
+    }
+
+    /**
+     * @dataProvider provideGetAllowedClasses
+     * @group Model
+     */
+    public function testGetAllowedClasses(?array $allowedClasses): void
+    {
+        /** @var Subject $subject */
+        $subject = Mage::getModel('core/purifier', [
+            Subject::OPTION_ALLOWED_CLASSES => $allowedClasses,
+        ]);
+
+        self::assertSame(gettype($allowedClasses), gettype($subject->getAllowedClasses()));
+    }
+
+    /**
+     * @dataProvider provideGetAllowedStyleProperties
+     * @group Model
+     */
+    public function testGetAllowedStyleProperties(?array $allowedStyleProperties): void
+    {
+        /** @var Subject $subject */
+        $subject = Mage::getModel('core/purifier', [
+            Subject::OPTION_ALLOWED_STYLE_PROPERTIES => $allowedStyleProperties,
+        ]);
+
+        self::assertSame(gettype($allowedStyleProperties), gettype($subject->getAllowedStyleProperties()));
+    }
+
+    /**
+     * @dataProvider provideGetEscapeInvalidTags
+     * @group Model
+     */
+    public function testGetters($escapeInvalidTags): void
+    {
+        /** @var Subject $subject */
+        $subject = Mage::getModel('core/purifier', [
+            Subject::OPTION_ESCAPE_INVALID_TAGS => $escapeInvalidTags,
+        ]);
+
         self::assertSame(gettype($escapeInvalidTags), gettype($subject->getEscapeInvalidTags()));
     }
 

--- a/tests/unit/Mage/Core/Model/PurifierTest.php
+++ b/tests/unit/Mage/Core/Model/PurifierTest.php
@@ -26,8 +26,7 @@ final class PurifierTest extends OpenMageTest
      */
     public function testGetAllowedAttributes(?array $allowedAttributes): void
     {
-        /** @var Subject $subject */
-        $subject = Mage::getModel('core/purifier', [
+        $subject = $this->getSubject([
             Subject::OPTION_ALLOWED_ATTRIBUTES => $allowedAttributes,
         ]);
 
@@ -40,8 +39,7 @@ final class PurifierTest extends OpenMageTest
      */
     public function testGetAllowedElements(?array $allowedElements): void
     {
-        /** @var Subject $subject */
-        $subject = Mage::getModel('core/purifier', [
+        $subject = $this->getSubject([
             Subject::OPTION_ALLOWED_ELEMENTS => $allowedElements,
         ]);
 
@@ -54,8 +52,7 @@ final class PurifierTest extends OpenMageTest
      */
     public function testGetAllowedClasses(?array $allowedClasses): void
     {
-        /** @var Subject $subject */
-        $subject = Mage::getModel('core/purifier', [
+        $subject = $this->getSubject([
             Subject::OPTION_ALLOWED_CLASSES => $allowedClasses,
         ]);
 
@@ -68,8 +65,7 @@ final class PurifierTest extends OpenMageTest
      */
     public function testGetAllowedStyleProperties(?array $allowedStyleProperties): void
     {
-        /** @var Subject $subject */
-        $subject = Mage::getModel('core/purifier', [
+        $subject = $this->getSubject([
             Subject::OPTION_ALLOWED_STYLE_PROPERTIES => $allowedStyleProperties,
         ]);
 
@@ -82,8 +78,7 @@ final class PurifierTest extends OpenMageTest
      */
     public function testGetters($escapeInvalidTags): void
     {
-        /** @var Subject $subject */
-        $subject = Mage::getModel('core/purifier', [
+        $subject = $this->getSubject([
             Subject::OPTION_ESCAPE_INVALID_TAGS => $escapeInvalidTags,
         ]);
 
@@ -96,8 +91,14 @@ final class PurifierTest extends OpenMageTest
      */
     public function testPurify(string $expected, string $input, array $options = []): void
     {
+        $subject = $this->getSubject($options);
+        self::assertSame($expected, $subject->purify($input));
+    }
+
+    private function getSubject(array $options): Subject
+    {
         /** @var Subject $subject */
         $subject = Mage::getModel('core/purifier', $options);
-        self::assertSame($expected, $subject->purify($input));
+        return $subject;
     }
 }

--- a/tests/unit/Traits/DataProvider/Mage/Core/Model/PurifierTrait.php
+++ b/tests/unit/Traits/DataProvider/Mage/Core/Model/PurifierTrait.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Traits\DataProvider\Mage\Core\Model;
+
+use Generator;
+
+trait PurifierTrait
+{
+    public function provideGetters(): Generator
+    {
+        yield 'allow all elements, no escape' => [null, false];
+        yield 'allow all elements, yes escape' => [null, true];
+        yield 'allow some elements, no escape' => [['b', 'i', 'u'], false];
+        yield 'allow some elements, yes escape' => [['b', 'i', 'u'], true];
+        yield 'allow no elements, no escape' => [[], false];
+        yield 'allow no elements, yes escape' => [[], true];
+    }
+
+    public function providePurify(): Generator
+    {
+        yield 'empty string' => [
+            '',
+            '',
+        ];
+
+        yield 'plain text' => [
+            'hello world',
+            'hello world',
+        ];
+
+        yield 'double quotes preserved' => [
+            'He said "hello"',
+            'He said "hello"',
+        ];
+
+        yield 'single quotes preserved' => [
+            "it's fine",
+            "it's fine",
+        ];
+
+        yield 'both quotes preserved' => [
+            'She said "it\'s OK"',
+            'She said "it\'s OK"',
+        ];
+
+        yield 'bare ampersand encoded' => [
+            'a &amp; b',
+            'a & b',
+        ];
+
+        yield '&amp; entity round-trips' => [
+            'a &amp; b',
+            'a &amp; b',
+        ];
+
+        yield '&lt; entity round-trips' => [
+            '1 &lt; 2',
+            '1 &lt; 2',
+        ];
+
+        yield '&gt; entity round-trips' => [
+            '2 &gt; 1',
+            '2 &gt; 1',
+        ];
+
+        yield 'bare > encoded' => [
+            'value &gt; 0',
+            'value > 0',
+        ];
+
+        yield '&quot; entity decoded' => [
+            '"hello"',
+            '&quot;hello&quot;',
+        ];
+
+        yield '&#039; entity decoded' => [
+            "'hello'",
+            '&#039;hello&#039;',
+        ];
+
+        yield '&copy; named entity decoded' => [
+            "\u{00A9} 2024",
+            '&copy; 2024',
+        ];
+
+        yield '&nbsp; named entity decoded' => [
+            "hello\u{00A0}world",
+            'hello&nbsp;world',
+        ];
+
+        yield 'double-encoded &amp;amp; preserves one level' => [
+            '&amp;amp;',
+            '&amp;amp;',
+        ];
+
+        yield 'fast path used regardless of escapeInvalidTags' => [
+            'He said "it\'s fine"',
+            'He said "it\'s fine"',
+            ['escapeInvalidTags' => true],
+        ];
+
+        yield 'fast path used regardless of allowedElements' => [
+            'He said "it\'s fine"',
+            'He said "it\'s fine"',
+            ['allowedElements' => []],
+        ];
+
+        yield 'fast path used with both options' => [
+            'He said "it\'s fine"',
+            'He said "it\'s fine"',
+            ['escapeInvalidTags' => true, 'allowedElements' => []],
+        ];
+
+        yield 'allowed tag preserved' => [
+            '<b>bold</b>',
+            '<b>bold</b>',
+        ];
+
+        yield 'script tag stripped' => [
+            '',
+            '<script>alert("xss")</script>',
+        ];
+
+        yield 'forbidden tag stripped when escapeInvalidTags=false' => [
+            'bold',
+            '<b>bold</b>',
+            ['allowedElements' => []],
+        ];
+
+        yield 'forbidden tag escaped when escapeInvalidTags=true' => [
+            '&lt;b&gt;bold&lt;/b&gt;',
+            '<b>bold</b>',
+            ['escapeInvalidTags' => true, 'allowedElements' => []],
+        ];
+    }
+}

--- a/tests/unit/Traits/DataProvider/Mage/Core/Model/PurifierTrait.php
+++ b/tests/unit/Traits/DataProvider/Mage/Core/Model/PurifierTrait.php
@@ -16,30 +16,30 @@ trait PurifierTrait
 {
     public function provideGetAllowedAttributes(): Generator
     {
-        yield 'allow all' => [null];
-        yield 'allow some' => [['a.href', '*.class']];
-        yield 'allow none' => [[]];
+        yield 'allow all attributes' => [null];
+        yield 'allow some attributes' => [['a.href', '*.class']];
+        yield 'allow no attributes' => [[]];
     }
 
     public function provideGetAllowedElements(): Generator
     {
-        yield 'allow all' => [null];
-        yield 'allow some' => [['b', 'i', 'u']];
-        yield 'allow none' => [[]];
+        yield 'allow all elements' => [null];
+        yield 'allow some elements' => [['b', 'i', 'u']];
+        yield 'allow no elements' => [[]];
     }
 
     public function provideGetAllowedClasses(): Generator
     {
-        yield 'allow all' => [null];
-        yield 'allow some' => [['foo-bar__baz']];
-        yield 'allow none' => [[]];
+        yield 'allow all classes' => [null];
+        yield 'allow some classes' => [['foo-bar__baz']];
+        yield 'allow no classes' => [[]];
     }
 
     public function provideGetAllowedStyleProperties(): Generator
     {
-        yield 'allow all' => [null];
-        yield 'allow some' => [['margin', 'font-size']];
-        yield 'allow none' => [[]];
+        yield 'allow all style properties' => [null];
+        yield 'allow some style properties' => [['margin', 'font-size']];
+        yield 'allow no style properties' => [[]];
     }
 
     public function provideGetEscapeInvalidTags(): Generator

--- a/tests/unit/Traits/DataProvider/Mage/Core/Model/PurifierTrait.php
+++ b/tests/unit/Traits/DataProvider/Mage/Core/Model/PurifierTrait.php
@@ -14,14 +14,38 @@ use Generator;
 
 trait PurifierTrait
 {
-    public function provideGetters(): Generator
+    public function provideGetAllowedAttributes(): Generator
     {
-        yield 'allow all elements, no escape' => [null, false];
-        yield 'allow all elements, yes escape' => [null, true];
-        yield 'allow some elements, no escape' => [['b', 'i', 'u'], false];
-        yield 'allow some elements, yes escape' => [['b', 'i', 'u'], true];
-        yield 'allow no elements, no escape' => [[], false];
-        yield 'allow no elements, yes escape' => [[], true];
+        yield 'allow all' => [null];
+        yield 'allow some' => [['a.href', '*.class']];
+        yield 'allow none' => [[]];
+    }
+
+    public function provideGetAllowedElements(): Generator
+    {
+        yield 'allow all' => [null];
+        yield 'allow some' => [['b', 'i', 'u']];
+        yield 'allow none' => [[]];
+    }
+
+    public function provideGetAllowedClasses(): Generator
+    {
+        yield 'allow all' => [null];
+        yield 'allow some' => [['foo-bar__baz']];
+        yield 'allow none' => [[]];
+    }
+
+    public function provideGetAllowedStyleProperties(): Generator
+    {
+        yield 'allow all' => [null];
+        yield 'allow some' => [['margin', 'font-size']];
+        yield 'allow none' => [[]];
+    }
+
+    public function provideGetEscapeInvalidTags(): Generator
+    {
+        yield 'false' => [false];
+        yield 'true' => [true];
     }
 
     public function providePurify(): Generator


### PR DESCRIPTION
* Add configurable models, allowing different filtering/escaping rules.
* Add HTMLPurifier cache implementation that uses Magento's cache.
* Change Mage_Core_Helper_Purifier to use a default model instance.

### Description (*)
This PR is related to feature request: #5277. It adds a Mage_Core_Model_Purifier with ~~two~~ several configurable options ~~: an optional allowlist of HTML tags (null -> allow all), and a boolean option to switch between escaping invalid/disallowed tags or stripping them~~.

~~The PR isn't ready to merge yet. I have tests that we've used in our app that I'd have to port over, and~~ I'd like to discuss several things about the actual design as well as code style.

1. Note that HTMLPurifier requires registering a DefinitionCache class name with a singleton factory instance, so I put that code in ~~Mage_Core_Helper_Purifier_Config~~Mage_Core_Helper_Purifier_DefinitionCache, which then provides the registered cache class setting to be used by the Mage_Core_Model_Purifier constructor. Then, the cache is only registered once per request, but is used by every model instance. If there is a more appropriate way to go about this, please advise.
2. I'm not 100% confident in the default configuration, nor am I confident that the ~~two~~ options I designed into the model class are enough. I don't think it would be wise to fully expose the internal dependency on HTMLPurifier_Config. Rather, we should choose our own API for our use case and only work with native types or types we define. Magento devs should not need the "full power" of HTMLPurifier, and the more options we expose, the more locked in we get for future changes (including changes to HTMLPurifier). So, keeping the configuration options minimal at first seems wise.
3. What are the current guidelines/rules on native type hints? HTMLPurifier, itself, doesn't use native type hints and just uses the PHPDoc type hints, so I just used those in places where interfacing with the library. Similarly, the older Mage calls are not type hinted, so I didn't put them either for things like `Mage_Core_Model_Purifier_DefinitionCache::getMageCache()`, because *technically* that method can't promise more than the method it calls through to. EDIT: Though, I did add native type hints to the model/interface methods even though the library does not use them. I decided it was unlikely to cause errors now or in the future, and the benefits to having real types for a new core API outweighs whatever small risk that the library might sometimes lie about what it's returning.
4. ~~Are `final` classes/methods used/allowed at all? I assumed not, so I was careful to consider the non-public API of each class so that it was safe/useful for inheritance.~~
5. Honestly, the way I did this, we could probably also deprecate everything on `Mage_Core_Helper_Purifier`, and/or turn it into a factory for model instances that caches the different configs.
6. We could also consider pulling part of this out to lib/Mage or lib/Magento (what's the difference?). Maybe even just the DefinitionCache adapter, since it doesn't *really* seem like a typical Magento model (then again, neither do Mage_Core_Model_Logger, Mage_Core_Model_Cache, Mage_Core_Model_App, etc, etc...).

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
#5277 

### Manual testing scenarios (*)
Nothing, yet. The only theoretically observable change from this code is that the Malicious code filtering (the only place that Mage_Core_Helper_Purifier is used) will have slightly different results because of the non-default settings I've chosen for us, whereas the old code used exactly HTMLPurifier's default config. Neither result is more or less safe than the other, but they can be slightly different (e.g., I allow `<a>` tags to use the `target` and `rel` attributes, which default HTMLPurifier does not).

### Questions or comments
Eh... see above. I didn't look ahead to see this section when I wrote the description... :p

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
