### PR TITLE
cypress: allow no message on error/success/warning check

### DIFF
--- a/cypress/support/openmage/_utils/validation.js
+++ b/cypress/support/openmage/_utils/validation.js
@@ -134,7 +134,11 @@ cy.openmage.validation = {
             options.match = 'include.text';
         }
 
-        cy.get(element).should(options.match, message);
+        if (message === undefined) {
+            cy.get(element).should('exist');
+        } else {
+            cy.get(element).should(options.match, message);
+        }
 
         if (options.screenshot === true && options.filename) {
             cy.openmage.utils.screenshot(cy.openmage.validation._messagesContainer, options.filename);


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Allow check for error/waring/success w/o checking message content.