### PR TITLE
[FIX] Extract CMS page identifier retrieval logic to helper function

### DIFF
--- a/app/code/core/Mage/Catalog/Helper/Search.php
+++ b/app/code/core/Mage/Catalog/Helper/Search.php
@@ -31,6 +31,6 @@ class Mage_Catalog_Helper_Search extends Mage_Core_Helper_Abstract
      */
     public function getNoRoutePath(): string
     {
-        return $this->_getUrl(Mage::helper('cms/page')->getIdentifierPageFromConfigPath(Mage_Cms_Helper_Page::XML_PATH_NO_ROUTE_PAGE));
+        return $this->_getUrl(Mage::helper('cms/page')->getIdentifierFromConfigPath(Mage_Cms_Helper_Page::XML_PATH_NO_ROUTE_PAGE));
     }
 }

--- a/app/code/core/Mage/Cms/Block/Page.php
+++ b/app/code/core/Mage/Cms/Block/Page.php
@@ -54,8 +54,8 @@ class Mage_Cms_Block_Page extends Mage_Core_Block_Abstract
         // show breadcrumbs
         if (Mage::getStoreConfig('web/default/show_cms_breadcrumbs')
             && ($breadcrumbs = $this->getLayout()->getBlock('breadcrumbs'))
-            && ($page->getIdentifier() !== $helper->getIdentifierPageFromConfigPath(Mage_Cms_Helper_Page::XML_PATH_HOME_PAGE))
-            && ($page->getIdentifier() !== $helper->getIdentifierPageFromConfigPath(Mage_Cms_Helper_Page::XML_PATH_NO_ROUTE_PAGE))
+            && ($page->getIdentifier() !== $helper->getIdentifierFromConfigPath(Mage_Cms_Helper_Page::XML_PATH_HOME_PAGE))
+            && ($page->getIdentifier() !== $helper->getIdentifierFromConfigPath(Mage_Cms_Helper_Page::XML_PATH_NO_ROUTE_PAGE))
         ) {
             $breadcrumbsArray[] = [
                 'crumbName' => 'home',
@@ -144,9 +144,9 @@ class Mage_Cms_Block_Page extends Mage_Core_Block_Abstract
         $helper = Mage::helper('cms/page');
 
         // Handle special pages differently
-        $homePageId = $helper->getIdentifierPageFromConfigPath(Mage_Cms_Helper_Page::XML_PATH_HOME_PAGE);
-        $noRoutePageId = $helper->getIdentifierPageFromConfigPath(Mage_Cms_Helper_Page::XML_PATH_NO_ROUTE_PAGE);
-        $noCookiesPageId = $helper->getIdentifierPageFromConfigPath(Mage_Cms_Helper_Page::XML_PATH_NO_COOKIES_PAGE);
+        $homePageId = $helper->getIdentifierFromConfigPath(Mage_Cms_Helper_Page::XML_PATH_HOME_PAGE);
+        $noRoutePageId = $helper->getIdentifierFromConfigPath(Mage_Cms_Helper_Page::XML_PATH_NO_ROUTE_PAGE);
+        $noCookiesPageId = $helper->getIdentifierFromConfigPath(Mage_Cms_Helper_Page::XML_PATH_NO_COOKIES_PAGE);
 
         // For homepage, use base URL
         if ($identifier === $homePageId) {

--- a/app/code/core/Mage/Cms/Helper/Page.php
+++ b/app/code/core/Mage/Cms/Helper/Page.php
@@ -248,9 +248,11 @@ class Mage_Cms_Helper_Page extends Mage_Core_Helper_Abstract
     }
 
     /**
+     * Get CMS page identifier without trailing page ID
+     *
      * @param Mage_Cms_Helper_Page::XML_PATH_* $path
      */
-    public function getIdentifierPageFromConfigPath(string $path): string
+    public function getIdentifierFromConfigPath(string $path): string
     {
         return explode('|', (string) Mage::getStoreConfig($path))[0];
     }


### PR DESCRIPTION
## Context
In the default CMS page configuration (e.g., web/default/cms_home_page), when the value is modified via the admin panel, the identifier is stored in the format identifier|page_id (e.g., home|15). Currently, the code directly compares the configuration value with the page identifier, which fails because the stored value includes the CMS page ID suffix.
This affects:

Breadcrumbs display in Mage_Cms_Block_Page::_prepareLayout()
Logic for handling special pages (home, no-route, no-cookies)

## Problem
Direct comparisons between $page->getIdentifier() and Mage::getStoreConfig('web/default/cms_home_page') fail because the configuration value may include a |page_id suffix.
Solution
A new method getIndentifierPageFromConfigPath() has been added to Mage_Cms_Helper_Page to extract the page identifier from the configuration value using explode('|', $value)[0]. This method is now used in Mage_Cms_Block_Page to ensure comparisons are made only against the identifier, not the full value.
Changes Made

New method in Mage_Cms_Helper_Page:
```php

public function getIndentifierPageFromConfigPath(string $path): string
{
    return explode('|', Mage::getStoreConfig($path))[0];
}
```


Usage in Mage_Cms_Block_Page:

Replaced direct calls to Mage::getStoreConfig() with calls to the new helper method for the following paths:

web/default/cms_home_page
web/default/cms_no_route
web/default/cms_no_cookies


## Impact

Bug Fix: Identifier comparisons now work correctly, even if the configuration value has been modified via the admin panel.
Maintainability: The identifier extraction logic is centralized in a helper, avoiding code duplication.
Compatibility: No behavioral changes for unmodified configurations (without the |page_id suffix).
Testing

Verified that breadcrumbs display correctly for pages other than home/no-route.
Verified that special page handling logic (home, no-route, no-cookies) works as expected.
Additional Notes

This change is backward compatible and requires no data migration.
The helper method is generic and can be reused for other similar configuration paths.
