### PR TITLE
Fix PHP 8.5 using null as an array offset is deprecated

### DIFF
--- a/app/code/core/Mage/Wishlist/Model/Item.php
+++ b/app/code/core/Mage/Wishlist/Model/Item.php
@@ -146,13 +146,15 @@ class Mage_Wishlist_Model_Item extends Mage_Core_Model_Abstract implements Mage_
      *
      * @param  Mage_Wishlist_Model_Item_Option $option
      * @return $this
+     * @throws Mage_Core_Exception
      */
     protected function _addOptionCode($option)
     {
-        if (!isset($this->_optionsByCode[$option->getCode()])) {
-            $this->_optionsByCode[$option->getCode()] = $option;
+        $code = (string) $option->getCode();
+        if (!isset($this->_optionsByCode[$code])) {
+            $this->_optionsByCode[$code] = $option;
         } else {
-            Mage::throwException(Mage::helper('sales')->__('An item option with code %s already exists.', $option->getCode()));
+            Mage::throwException(Mage::helper('sales')->__('An item option with code %s already exists.', $code));
         }
 
         return $this;
@@ -655,6 +657,7 @@ class Mage_Wishlist_Model_Item extends Mage_Core_Model_Abstract implements Mage_
      */
     public function getOptionByCode($code)
     {
+        $code = (string) $code;
         if (isset($this->_optionsByCode[$code]) && !$this->_optionsByCode[$code]->isDeleted()) {
             return $this->_optionsByCode[$code];
         }

--- a/app/code/core/Mage/Wishlist/Model/Item/Option.php
+++ b/app/code/core/Mage/Wishlist/Model/Item/Option.php
@@ -13,7 +13,7 @@
  * @package    Mage_Wishlist
  *
  * @method Mage_Wishlist_Model_Resource_Item_Option            _getResource()
- * @method string                                              getCode()
+ * @method null|string                                         getCode()
  * @method Mage_Wishlist_Model_Resource_Item_Option_Collection getCollection()
  * @method int                                                 getProductId()
  * @method Mage_Wishlist_Model_Resource_Item_Option            getResource()


### PR DESCRIPTION
PHP Deprecated:  Using null as an array offset is deprecated, use an empty string instead in

- app/code/core/Mage/Wishlist/Model/Item.php on line 658
- app/code/core/Mage/Wishlist/Model/Item.php on line 152
- app/code/core/Mage/Wishlist/Model/Item.php on line 153

(https://github.com/OpenMage/magento-lts/actions/runs/23358136437/job/67955409410)
