### PR TITLE
chore: downgrade `symplify/vendor-patches`

### DIFF
--- a/.ddev/commands/web/vendor-patches
+++ b/.ddev/commands/web/vendor-patches
@@ -4,4 +4,4 @@
 ## Usage: vendor-patches
 ## Example: ddev vendor-patches
 
-php vendor/bin/vendor-patches generate --patches-folder=.vendor-patches "$@"
+php vendor/bin/vendor-patches generate --patches-file=patches.json --patches-folder=.vendor-patches "$@"

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "phpunit/phpunit": "^9.6",
         "rector/rector": "^2.1.12",
         "squizlabs/php_codesniffer": "^3.7",
-        "symplify/vendor-patches": "^12.0"
+        "symplify/vendor-patches": "^12.0, !=12.0.5, !=12.0.6"
     },
     "replace": {
         "symfony/polyfill-ctype": "*",
@@ -141,19 +141,6 @@
         }
     },
     "extra": {
-        "patches": {
-            "shardj/zf1-future": {
-                "MAG-1.9.3.0": "https://raw.githubusercontent.com/OpenMage/magento-lts/de83e28a673e3c1a249b51433abf6dc93e59063c/.vendor-patches/MAG-1.9.3.0.patch",
-                "MAG-1.9.3.7 - SUPEE-10415": "https://raw.githubusercontent.com/OpenMage/magento-lts/de83e28a673e3c1a249b51433abf6dc93e59063c/.vendor-patches/MAG-1.9.3.7.patch",
-                "OM-918 - Add runtime cache to Zend_Locale_Data": "https://raw.githubusercontent.com/OpenMage/magento-lts/f28ab75b1df7d1497ed775e33b77d7957c9b85c4/.vendor-patches/OM-918.patch",
-                "OM-1081 - Not detecting HTTPS behind a proxy": "https://raw.githubusercontent.com/OpenMage/magento-lts/de83e28a673e3c1a249b51433abf6dc93e59063c/.vendor-patches/OM-1081.patch",
-                "OM-2047 - Pass delimiter char to preg_quote": "https://raw.githubusercontent.com/OpenMage/magento-lts/5479577ef5207ace4f5842a2f1a636f689db9194/.vendor-patches/OM-2047.patch",
-                "OM-2050 - Prevent checking known date codes": "https://raw.githubusercontent.com/OpenMage/magento-lts/de83e28a673e3c1a249b51433abf6dc93e59063c/.vendor-patches/OM-2050.patch"
-            },
-            "magento-ecg/coding-standard": {
-                "ECG-72 - Fix LoopSniff": "https://raw.githubusercontent.com/OpenMage/magento-lts/de83e28a673e3c1a249b51433abf6dc93e59063c/.vendor-patches/ECG-72.patch"
-            }
-        },
         "magento-root-dir": ".",
         "magento-deploystrategy": "copy",
         "magento-deploystrategy-dev": "symlink",
@@ -195,7 +182,7 @@
         "rector:test": "vendor/bin/rector process --config .rector.php --dry-run",
         "rector:test:debug": "vendor/bin/rector process --config .rector.php --dry-run --debug",
         "rector:fix": "vendor/bin/rector process --config .rector.php",
-        "vendor:patch": "vendor/bin/vendor-patches generate --patches-folder=.vendor-patches",
+        "vendor:patch": "vendor/bin/vendor-patches generate --patches-file=patches.json --patches-folder=.vendor-patches",
         "test": [
             "@php-cs-fixer:test",
             "@phpstan",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c47c7697fdbb17ecb01f597954d972e",
+    "content-hash": "416833ac523a8f6849aea118fa0c1c2b",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -9500,20 +9500,20 @@
         },
         {
             "name": "symplify/vendor-patches",
-            "version": "12.0.6",
+            "version": "12.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/vendor-patches.git",
-                "reference": "096aaab56bcea39e25468f538601fda00c1024bb"
+                "reference": "157ddf6b8d992a2e3adbd9bc16264a6e95d91f6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/vendor-patches/zipball/096aaab56bcea39e25468f538601fda00c1024bb",
-                "reference": "096aaab56bcea39e25468f538601fda00c1024bb",
+                "url": "https://api.github.com/repos/symplify/vendor-patches/zipball/157ddf6b8d992a2e3adbd9bc16264a6e95d91f6b",
+                "reference": "157ddf6b8d992a2e3adbd9bc16264a6e95d91f6b",
                 "shasum": ""
             },
             "require": {
-                "cweagans/composer-patches": "^1.7.3 || ^2.0",
+                "cweagans/composer-patches": "^1.7 || ^2.0",
                 "php": ">=7.2"
             },
             "bin": [
@@ -9527,7 +9527,7 @@
             "description": "Generate vendor patches for packages with single command",
             "support": {
                 "issues": "https://github.com/symplify/vendor-patches/issues",
-                "source": "https://github.com/symplify/vendor-patches/tree/12.0.6"
+                "source": "https://github.com/symplify/vendor-patches/tree/12.0.1"
             },
             "funding": [
                 {
@@ -9539,7 +9539,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-03T10:18:03+00:00"
+            "time": "2025-11-19T09:19:07+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/patches.json
+++ b/patches.json
@@ -1,0 +1,15 @@
+{
+    "patches": {
+        "shardj/zf1-future": {
+            "MAG-1.9.3.0": "https://raw.githubusercontent.com/OpenMage/magento-lts/de83e28a673e3c1a249b51433abf6dc93e59063c/.vendor-patches/MAG-1.9.3.0.patch",
+            "MAG-1.9.3.7 - SUPEE-10415": "https://raw.githubusercontent.com/OpenMage/magento-lts/de83e28a673e3c1a249b51433abf6dc93e59063c/.vendor-patches/MAG-1.9.3.7.patch",
+            "OM-918 - Add runtime cache to Zend_Locale_Data": "https://raw.githubusercontent.com/OpenMage/magento-lts/f28ab75b1df7d1497ed775e33b77d7957c9b85c4/.vendor-patches/OM-918.patch",
+            "OM-1081 - Not detecting HTTPS behind a proxy": "https://raw.githubusercontent.com/OpenMage/magento-lts/de83e28a673e3c1a249b51433abf6dc93e59063c/.vendor-patches/OM-1081.patch",
+            "OM-2047 - Pass delimiter char to preg_quote": "https://raw.githubusercontent.com/OpenMage/magento-lts/5479577ef5207ace4f5842a2f1a636f689db9194/.vendor-patches/OM-2047.patch",
+            "OM-2050 - Prevent checking known date codes": "https://raw.githubusercontent.com/OpenMage/magento-lts/de83e28a673e3c1a249b51433abf6dc93e59063c/.vendor-patches/OM-2050.patch"
+        },
+        "magento-ecg/coding-standard": {
+            "ECG-72 - Fix LoopSniff": "https://raw.githubusercontent.com/OpenMage/magento-lts/de83e28a673e3c1a249b51433abf6dc93e59063c/.vendor-patches/ECG-72.patch"
+        }
+    }
+}

--- a/patches.lock.json
+++ b/patches.lock.json
@@ -1,5 +1,5 @@
 {
-    "_hash": "884e5f42330374f25da0de5a0a8eb339285d9d2c154ab842982bb699f1ebda7a",
+    "_hash": "c574e774d540e0016437a71525053a3767c30d41bfe15fb42e41e6b75f381530",
     "patches": {
         "shardj/zf1-future": [
             {
@@ -9,7 +9,7 @@
                 "sha256": "02e8483ded77ceff2deaf0e1e68276dfd5f4427a2577867fc378b3e5851fc386",
                 "depth": 1,
                 "extra": {
-                    "provenance": "root"
+                    "provenance": "patches-file:patches.json"
                 }
             },
             {
@@ -19,7 +19,7 @@
                 "sha256": "ab35564f6d49993021efa816157d276621ed116e9040b8a9b727149f6a935624",
                 "depth": 1,
                 "extra": {
-                    "provenance": "root"
+                    "provenance": "patches-file:patches.json"
                 }
             },
             {
@@ -29,7 +29,7 @@
                 "sha256": "6e9394e95639941d096e6c80cf2106234d864b26d2eee3bb44fa159295629f43",
                 "depth": 1,
                 "extra": {
-                    "provenance": "root"
+                    "provenance": "patches-file:patches.json"
                 }
             },
             {
@@ -39,7 +39,7 @@
                 "sha256": "a3d0e71e9c5593d86acd478aaca5a2148ba74ceacc27c644e4eaa60d2c7ec904",
                 "depth": 1,
                 "extra": {
-                    "provenance": "root"
+                    "provenance": "patches-file:patches.json"
                 }
             },
             {
@@ -49,7 +49,7 @@
                 "sha256": "e5398fd3b9cdbe2ccad2fa68b71d34daee0e5f7ae392b3db950326d5a61ec06a",
                 "depth": 1,
                 "extra": {
-                    "provenance": "root"
+                    "provenance": "patches-file:patches.json"
                 }
             },
             {
@@ -59,7 +59,7 @@
                 "sha256": "417fcce2d3e5162ee701dcbcf5fc4e30628f07a5833381b7d29d6ebc8dbc5d30",
                 "depth": 1,
                 "extra": {
-                    "provenance": "root"
+                    "provenance": "patches-file:patches.json"
                 }
             }
         ],
@@ -71,7 +71,7 @@
                 "sha256": "c24c480d3e5a0257d75650ec13841594c1d3fa7f80d9adfcd4e95e5aeab2e139",
                 "depth": 1,
                 "extra": {
-                    "provenance": "root"
+                    "provenance": "patches-file:patches.json"
                 }
             }
         ]


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Downgraded `symplify/vendor-patches` as latest version are broken.

- see https://github.com/symplify/vendor-patches/issues/57
- moved pathes from composer.json to patches.json