### PR TITLE
Core: add Conditional return types to escapeHtml and jsQuoteEscape

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
@@ -171,7 +171,7 @@ class Mage_Adminhtml_Catalog_Product_AttributeController extends Mage_Adminhtml_
 
             if (!empty($data['option']) && !empty($data['option']['value']) && is_array($data['option']['value'])) {
                 $allowableTags = isset($data['is_html_allowed_on_front']) && $data['is_html_allowed_on_front']
-                    ? sprintf('<%s>', implode('><', $this->_getAllowedTags())) : null;
+                    ? $this->_getAllowedTags() : null;
                 foreach ($data['option']['value'] as $key => $values) {
                     foreach ($values as $storeId => $storeLabel) {
                         $data['option']['value'][$key][$storeId]

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -187,7 +187,7 @@ abstract class Mage_Core_Helper_Abstract
      */
     public function escapeHtml($data, $allowedTags = null)
     {
-        if (is_null($data) || $data === '') {
+        if ($data === '' || !is_array($data) && !is_string($data)) {
             $result = $data;
         } elseif (is_array($data)) {
             $result = [];
@@ -195,6 +195,7 @@ abstract class Mage_Core_Helper_Abstract
                 $result[] = $this->escapeHtml($item);
             }
         } elseif (is_array($allowedTags) && $allowedTags !== []) {
+            // TODO to preg_quote the allowed tags
             $allowed = implode('|', $allowedTags);
             $result = preg_replace('/<([\/\s\r\n]*)(' . $allowed . ')([\/\s\r\n]*)>/si', '##$1$2$3##', $data);
             if ($result !== null) {

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -192,7 +192,7 @@ abstract class Mage_Core_Helper_Abstract
             foreach ($data as $item) {
                 $result[] = $this->escapeHtml($item);
             }
-        } elseif (is_string($data) && strlen($data) > 0) {
+        } elseif (is_string($data) && $data !== '') {
             // process single item
             if (is_array($allowedTags) && $allowedTags !== []) {
                 $allowed = implode('|', $allowedTags);

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -197,8 +197,10 @@ abstract class Mage_Core_Helper_Abstract
             if (is_array($allowedTags) && $allowedTags !== []) {
                 $allowed = implode('|', $allowedTags);
                 $result = preg_replace('/<([\/\s\r\n]*)(' . $allowed . ')([\/\s\r\n]*)>/si', '##$1$2$3##', $data);
-                $result = htmlspecialchars($result, ENT_COMPAT, 'UTF-8', false);
-                $result = preg_replace('/##([\/\s\r\n]*)(' . $allowed . ')([\/\s\r\n]*)##/si', '<$1$2$3>', $result);
+                if ($result !== null) {
+                    $result = htmlspecialchars($result, ENT_COMPAT, 'UTF-8', false);
+                    $result = preg_replace('/##([\/\s\r\n]*)(' . $allowed . ')([\/\s\r\n]*)##/si', '<$1$2$3>', $result);
+                }
             } else {
                 $result = htmlspecialchars($data, ENT_COMPAT, 'UTF-8', false);
             }

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -187,25 +187,22 @@ abstract class Mage_Core_Helper_Abstract
      */
     public function escapeHtml($data, $allowedTags = null)
     {
-        if (is_array($data)) {
+        if (is_null($data) || $data === '') {
+            $result = $data;
+        } elseif (is_array($data)) {
             $result = [];
             foreach ($data as $item) {
                 $result[] = $this->escapeHtml($item);
             }
-        } elseif (is_string($data) && $data !== '') {
-            // process single item
-            if (is_array($allowedTags) && $allowedTags !== []) {
-                $allowed = implode('|', $allowedTags);
-                $result = preg_replace('/<([\/\s\r\n]*)(' . $allowed . ')([\/\s\r\n]*)>/si', '##$1$2$3##', $data);
-                if ($result !== null) {
-                    $result = htmlspecialchars($result, ENT_COMPAT, 'UTF-8', false);
-                    $result = preg_replace('/##([\/\s\r\n]*)(' . $allowed . ')([\/\s\r\n]*)##/si', '<$1$2$3>', $result);
-                }
-            } else {
-                $result = htmlspecialchars($data, ENT_COMPAT, 'UTF-8', false);
+        } elseif (is_array($allowedTags) && $allowedTags !== []) {
+            $allowed = implode('|', $allowedTags);
+            $result = preg_replace('/<([\/\s\r\n]*)(' . $allowed . ')([\/\s\r\n]*)>/si', '##$1$2$3##', $data);
+            if ($result !== null) {
+                $result = htmlspecialchars($result, ENT_COMPAT, 'UTF-8', false);
+                $result = preg_replace('/##([\/\s\r\n]*)(' . $allowed . ')([\/\s\r\n]*)##/si', '<$1$2$3>', $result);
             }
         } else {
-            $result = $data;
+            $result = htmlspecialchars($data, ENT_COMPAT, 'UTF-8', false);
         }
 
         return $result;

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -243,6 +243,9 @@ abstract class Mage_Core_Helper_Abstract
         }
 
         $result = strip_tags($data, $allowableTags);
+        if (is_string($allowableTags)) {
+            $allowableTags = [$allowableTags];
+        }
         return $escape ? $this->escapeHtml($result, $allowableTags) : $result;
     }
 

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -309,15 +309,6 @@ abstract class Mage_Core_Helper_Abstract
      */
     public function jsQuoteEscape($data, $quote = "'")
     {
-        if (is_array($data)) {
-            $result = [];
-            foreach ($data as $item) {
-                $result[] = str_replace($quote, '\\' . $quote, $item);
-            }
-
-            return $result;
-        }
-
         return str_replace($quote, '\\' . $quote, $data);
     }
 

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -192,7 +192,7 @@ abstract class Mage_Core_Helper_Abstract
             foreach ($data as $item) {
                 $result[] = $this->escapeHtml($item);
             }
-        } elseif (is_string($data) && strlen($data)) {
+        } elseif (is_string($data) && strlen($data) > 0) {
             // process single item
             if (is_array($allowedTags) && $allowedTags !== []) {
                 $allowed = implode('|', $allowedTags);

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -243,9 +243,11 @@ abstract class Mage_Core_Helper_Abstract
         }
 
         $result = strip_tags($data, $allowableTags);
+
         if (is_string($allowableTags)) {
             $allowableTags = [$allowableTags];
         }
+
         return $escape ? $this->escapeHtml($result, $allowableTags) : $result;
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This adds [Conditional return types](https://phpstan.org/writing-php-code/phpdoc-types#conditional-return-types) to escapeHtml and jsQuoteEscape.

### Related Pull Requests
<!-- related pull request placeholder -->
- see OpenMage/magento-lts#5258

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
- fixes OpenMage/magento-lts#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [x] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
