### PR TITLE
Fix SQL syntax error when catalog rule has empty condition values

### DIFF
--- a/app/code/core/Mage/Rule/Model/Condition/Combine.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Combine.php
@@ -38,7 +38,7 @@ class Mage_Rule_Model_Condition_Combine extends Mage_Rule_Model_Condition_Abstra
         $wheres = [];
         foreach ($this->getConditions() as $condition) {
             $conditionSql = $condition->prepareConditionSql();
-            if (!empty($conditionSql)) {
+            if ($conditionSql !== '') {
                 $wheres[] = '(' . $conditionSql . ')';
             }
         }


### PR DESCRIPTION
### Description (*)
This PR fixes a SQL syntax error that occurs when a catalog rule contains a condition (e.g., category) with no selected values. The issue was in Mage_Rule_Model_Condition_Combine::prepareConditionSql() which would wrap empty condition SQL in parentheses, generating invalid SQL like AND ()).

The fix adds a check to only include conditions that return non-empty SQL, preventing malformed queries when conditions have empty values (e.g., category condition with no selected categories).

### Manual testing scenarios (*)
1. Create a new catalog rule
2. Add a "Category" condition but don't select any categories
3. Save and apply the rule
4. Edit an existing product in admin to trigger catalog rule validation.

**Note SQL include an empty AND ()**
```
SELECT DISTINCT p.entity_id FROM `catalog_product_entity` AS `p`
 INNER JOIN `catalog_product_flat_1` AS `cpf` ON cpf.entity_id = p.entity_id
 LEFT JOIN `catalog_category_product` AS `ccp` ON ccp.product_id = p.entity_id WHERE ( ((`ccp`.`category_id` IN ('142') AND `ccp`.`category_id` IN ('156') AND `ccp`.`category_id` IN ('169') AND `ccp`.`category_id` IN ('159') AND `ccp`.`category_id` IN ('170') AND `ccp`.`category_id` IN ('171')) AND ()) ) AND (p.entity_id = '183') LIMIT 1
```
**Full stack trace:**
```
Next Zend_Db_Statement_Exception: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')) ) AND (p.entity_id = '183') LIMIT 1' at line 3, query was: SELECT DISTINCT p.entity_id FROM `catalog_product_entity` AS `p`
 INNER JOIN `catalog_product_flat_1` AS `cpf` ON cpf.entity_id = p.entity_id
 LEFT JOIN `catalog_category_product` AS `ccp` ON ccp.product_id = p.entity_id WHERE ( ((`ccp`.`category_id` IN ('142') AND `ccp`.`category_id` IN ('156') AND `ccp`.`category_id` IN ('169') AND `ccp`.`category_id` IN ('159') AND `ccp`.`category_id` IN ('170') AND `ccp`.`category_id` IN ('171')) AND ()) ) AND (p.entity_id = '183') LIMIT 1 in vendor/shardj/zf1-future/library/Zend/Db/Statement/Pdo.php:235
Stack trace:
#0 lib/Varien/Db/Statement/Pdo/Mysql.php(98): Zend_Db_Statement_Pdo->_execute(Array)
#1 vendor/shardj/zf1-future/library/Zend/Db/Statement.php(303): Varien_Db_Statement_Pdo_Mysql->_execute(Array)
#2 vendor/shardj/zf1-future/library/Zend/Db/Adapter/Abstract.php(480): Zend_Db_Statement->execute(Array)
#3 vendor/shardj/zf1-future/library/Zend/Db/Adapter/Pdo/Abstract.php(267): Zend_Db_Adapter_Abstract->query('SELECT DISTINCT...', Array)
#4 lib/Varien/Db/Adapter/Pdo/Mysql.php(487): Zend_Db_Adapter_Pdo_Abstract->query('SELECT DISTINCT...', Array)
#5 vendor/shardj/zf1-future/library/Zend/Db/Adapter/Abstract.php(831): Varien_Db_Adapter_Pdo_Mysql->query('SELECT DISTINCT...', Array)
#6 app/code/core/Mage/CatalogRule/Model/Resource/Rule.php(167): Zend_Db_Adapter_Abstract->fetchOne(Object(Varien_Db_Select))
#7 app/code/core/Mage/CatalogRule/Model/Resource/Rule.php(758): Mage_CatalogRule_Model_Resource_Rule->validateProduct(Object(Mage_CatalogRule_Model_Rule), Object(Mage_Catalog_Model_Product), Array)
#8 app/code/core/Mage/CatalogRule/Model/Rule.php(332): Mage_CatalogRule_Model_Resource_Rule->applyToProduct(Object(Mage_CatalogRule_Model_Rule), Object(Mage_Catalog_Model_Product), Array)
#9 app/code/core/Mage/CatalogRule/Model/Observer.php(54): Mage_CatalogRule_Model_Rule->applyAllRulesToProduct(Object(Mage_Catalog_Model_Product))
#10 app/code/core/Mage/Core/Model/App.php(1447): Mage_CatalogRule_Model_Observer->applyAllRulesOnProduct(Object(Varien_Event_Observer))
#11 app/code/core/Mage/Core/Model/App.php(1425): Mage_Core_Model_App->_callObserverMethod(Object(Mage_CatalogRule_Model_Observer), 'applyAllRulesOn...', Object(Varien_Event_Observer), 'catalogrule')
#12 app/Mage.php(521): Mage_Core_Model_App->dispatchEvent('catalog_product...', Array)
#13 app/code/core/Mage/Core/Model/Abstract.php(404): Mage::dispatchEvent('catalog_product...', Array)
#14 app/code/core/Mage/Catalog/Model/Product.php(2345): Mage_Core_Model_Abstract->afterCommitCallback()
#15 app/code/core/Mage/Core/Model/Resource/Abstract.php(100): Mage_Catalog_Model_Product->afterCommitCallback()
#16 app/code/core/Mage/Core/Model/Abstract.php(384): Mage_Core_Model_Resource_Abstract->commit()
#17 app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php(749): Mage_Core_Model_Abstract->save()
#18 app/code/core/Mage/Core/Controller/Varien/Action.php(418): Mage_Adminhtml_Catalog_ProductController->saveAction()
#19 app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(256): Mage_Core_Controller_Varien_Action->dispatch('save')
#20 app/code/core/Mage/Core/Controller/Varien/Front.php(182): Mage_Core_Controller_Varien_Router_Standard->match(Object(Mage_Core_Controller_Request_Http))
#21 app/code/core/Mage/Core/Model/App.php(357): Mage_Core_Controller_Varien_Front->dispatch()
#22 app/Mage.php(749): Mage_Core_Model_App->run(Array)
#23 index.php(61): Mage::run('', 'store')
#24 {main}

```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
