### PR TITLE
rector: `TernaryEmptyArrayArrayDimFetchToCoalesceRector`

### DIFF
--- a/.rector.php
+++ b/.rector.php
@@ -134,7 +134,6 @@ try {
             CodeQuality\If_\SimplifyIfElseToTernaryRector::class,
             CodeQuality\Include_\AbsolutizeRequireAndIncludePathRector::class, # todo: TMP
             CodeQuality\Isset_\IssetOnPropertyObjectToPropertyExistsRector::class, # todo: TMP
-            CodeQuality\Ternary\TernaryEmptyArrayArrayDimFetchToCoalesceRector::class, # todo: TMP
             CodingStyle\ClassMethod\FuncGetArgsToVariadicParamRector::class, # todo: TMP
             CodingStyle\Encapsed\EncapsedStringsToSprintfRector::class, # todo: TMP
             CodingStyle\FuncCall\StrictArraySearchRector::class, # todo: TMP


### PR DESCRIPTION
- see https://getrector.com/rule-detail/ternary-empty-array-array-dim-fetch-to-coalesce-rector

(already fix in other rules)