### PR TITLE
Translate "is confirmed" select options in customer/edit (account information).

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
@@ -173,11 +173,14 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_Account extends Mage_Adminhtml_Bloc
                         $confirmationKey = $customer->getRandomConfirmationKey();
                     }
 
-                    $element = $fieldset->addField('confirmation', 'select', [
+                    $fieldset->addField('confirmation', 'select', [
                         'name'  => 'confirmation',
                         'label' => Mage::helper('customer')->__($confirmationAttribute->getFrontendLabel()),
                     ])->setEntityAttribute($confirmationAttribute)
-                        ->setValues(['' => 'Confirmed', $confirmationKey => 'Not confirmed']);
+                        ->setValues([
+                            '' => Mage::helper('customer')->__('Confirmed'),
+                            $confirmationKey => Mage::helper('customer')->__('Not confirmed'),
+                        ]);
 
                     // Prepare send welcome email checkbox if customer is not confirmed
                     // no need to add it, if website ID is empty

--- a/app/locale/en_US/Mage_Customer.csv
+++ b/app/locale/en_US/Mage_Customer.csv
@@ -262,6 +262,7 @@
 "No customer collections found","No customer collections found"
 "No item specified.","No item specified."
 "Not Sent","Not Sent"
+"Not confirmed","Not confirmed"
 "Not confirmed, can login","Not confirmed, can login"
 "Not confirmed, cannot login","Not confirmed, cannot login"
 "Number of Lines in a Street Address ","Number of Lines in a Street Address "


### PR DESCRIPTION
### Description (*)
The select options couldn't be translated.

### Related Pull Requests
-

### Fixed Issues (if relevant)
-

### Manual testing scenarios (*)
Add a non English translation for `Confirmed` and `Not confirmed` in Mage_Customer.csv

### Questions or comments
-

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
