### PR TITLE
chore: docblock correction and strlen in loop micro optimisation in Mage_Sales PDF

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
@@ -257,7 +257,7 @@ abstract class Mage_Sales_Model_Order_Pdf_Abstract extends Varien_Object
      * Insert order to pdf page
      *
      * @param Zend_Pdf_Page          $page
-     * @param Mage_Sales_Model_Order $obj
+     * @param Mage_Sales_Model_Order|Mage_Sales_Model_Order_Shipment $obj
      * @param bool                   $putOrderId
      */
     protected function insertOrder(&$page, $obj, $putOrderId = true)

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
@@ -82,12 +82,12 @@ abstract class Mage_Sales_Model_Order_Pdf_Abstract extends Varien_Object
      */
     public function widthForStringUsingFontSize($string, $font, $fontSize)
     {
-        $drawingString = '"libiconv"' == ICONV_IMPL
+        $drawingString = '"libiconv"' === ICONV_IMPL
             ? iconv('UTF-8', 'UTF-16BE//IGNORE', $string)
             : @iconv('UTF-8', 'UTF-16BE', $string);
 
         $characters = [];
-        for ($i = 0; $i < strlen($drawingString); $i++) {
+        for ($i = 0, $lenMax = strlen($drawingString); $i < $lenMax; $i++) {
             $characters[] = (ord($drawingString[$i++]) << 8) | ord($drawingString[$i]);
         }
 

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
@@ -256,9 +256,9 @@ abstract class Mage_Sales_Model_Order_Pdf_Abstract extends Varien_Object
     /**
      * Insert order to pdf page
      *
-     * @param Zend_Pdf_Page          $page
+     * @param Zend_Pdf_Page                                          $page
      * @param Mage_Sales_Model_Order|Mage_Sales_Model_Order_Shipment $obj
-     * @param bool                   $putOrderId
+     * @param bool                                                   $putOrderId
      */
     protected function insertOrder(&$page, $obj, $putOrderId = true)
     {


### PR DESCRIPTION
### Description (*)
 - Widen `insertOrder()` docblock to show `$obj` accepts `Mage_Sales_Model_Order_Shipment` in addition to
  `Mage_Sales_Model_Order`
 - Use strict comparison (`===`) for `ICONV_IMPL` string check in `widthForStringUsingFontSize()`
 - Hoist `strlen()` out of the `for` loop to avoid redundant calls per iteration

### Manual testing scenarios (*)
No behavioural changes, micro optimisation and documentation only.

### Contribution checklist (*)
 - [*] Pull request has a meaningful description of its purpose
 - [*] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
