### PR TITLE
fix: wrong rate limit check

### DIFF
--- a/app/code/core/Mage/Sales/Helper/Guest.php
+++ b/app/code/core/Mage/Sales/Helper/Guest.php
@@ -109,7 +109,7 @@ class Mage_Sales_Helper_Guest extends Mage_Core_Helper_Data
             return true;
         }
 
-        if (!Mage::helper('core')->isRateLimitExceeded(true, false)) {
+        if ($errors || Mage::helper('core')->isRateLimitExceeded(true, false)) {
             Mage::getSingleton('core/session')->addError($this->__($errorMessage));
         }
 


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Rate limit check is negated and always wrong.

https://demo.openmage.org/sales/guest/form/

### Related Pull Requests
<!-- related pull request placeholder -->
- see https://github.com/OpenMage/magento-lts/commit/2a2a2fb504247e8966f8ffc2e17d614be5d43128
- see https://github.com/OpenMage/magento-lts/releases/tag/v20.1.1

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
- fixes https://github.com/OpenMage/magento-lts/issues/5514

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. sample data
2. try to view a an order (valid input)

