### PR TITLE
add missing quotation mark in multiselect form element

### DIFF
--- a/lib/Varien/Data/Form/Element/Multiselect.php
+++ b/lib/Varien/Data/Form/Element/Multiselect.php
@@ -63,7 +63,7 @@ class Varien_Data_Form_Element_Multiselect extends Varien_Data_Form_Element_Abst
             name="' . $this->getName() . '"
             data-test="' . $this->getTestId() . '"
             ' . $this->serialize($this->getHtmlAttributes()) . '
-            multiple="multiple
+            multiple="multiple"
             >'
             . "\n";
 


### PR DESCRIPTION
### Description (*)
The character was missing after the last change, breaking the first option.

### Related Pull Requests
-

### Fixed Issues (if relevant)
-

### Manual testing scenarios (*)
inspect the html of a multiselect in the configuration.

### Questions or comments
-

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
