### PR TITLE
fix: Argument #1 ($client) must be of type `?Mage_Usa_Model_Shipping_Carrier_Usps_Rest_Client`

### DIFF
--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/AbstractService.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/AbstractService.php
@@ -21,7 +21,7 @@ use Monolog\Level;
  */
 abstract class Mage_Usa_Model_Shipping_Carrier_Usps_AbstractService
 {
-    protected ?Mage_Usa_Model_Shipping_Carrier_Usps_Rest_Client $_client = null;
+    protected null|array|Mage_Usa_Model_Shipping_Carrier_Usps_Rest_Client $_client = null;
 
     protected bool $_debug = false;
 
@@ -30,7 +30,7 @@ abstract class Mage_Usa_Model_Shipping_Carrier_Usps_AbstractService
      */
     protected string $_debugPrefix = 'USPS Service';
 
-    public function __construct(?Mage_Usa_Model_Shipping_Carrier_Usps_Rest_Client $client = null)
+    public function __construct($client = null)
     {
         $this->_client = $client;
         $this->_debug = Mage::getStoreConfigFlag('carriers/usps/debug');

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Label/Service.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Label/Service.php
@@ -38,7 +38,7 @@ class Mage_Usa_Model_Shipping_Carrier_Usps_Label_Service extends Mage_Usa_Model_
     /**
      * Constructor
      */
-    public function __construct(?Mage_Usa_Model_Shipping_Carrier_Usps_Rest_Client $client = null)
+    public function __construct($client = null)
     {
         parent::__construct($client);
         $this->_loadConfig();

--- a/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Address/ServiceTest.php
+++ b/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Address/ServiceTest.php
@@ -38,6 +38,7 @@ final class ServiceTest extends OpenMageTest
      */
     public function testIsEnabled(): void
     {
+        $result = self::$subject->isEnabled();
         self::markTestSkipped('');
     }
 }

--- a/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Address/ServiceTest.php
+++ b/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Address/ServiceTest.php
@@ -37,7 +37,7 @@ final class ServiceTest extends OpenMageTest
      */
     public function testIsEnabled(): void
     {
-        $result = self::$subject->isEnabled();
+        self::$subject->isEnabled();
         self::markTestSkipped('');
     }
 }

--- a/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Address/ServiceTest.php
+++ b/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Address/ServiceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
+ * @package    OpenMage_Tests
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Usa\Model\Shipping\Carrier\Usps\Adress;
+
+use Mage;
+use Mage_Usa_Model_Shipping_Carrier_Usps_Address_Service as Subject;
+use Override;
+use OpenMage\Tests\Unit\OpenMageTest;
+use OpenMage\Tests\Unit\Traits\DataProvider\Mage\Usa\Model\Shipping\Carrier\Usps\Address\ServiceTrait;
+
+final class ServiceTest extends OpenMageTest
+{
+    use ServiceTrait;
+
+    private static Subject $subject;
+
+    #[Override]
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::$subject = Mage::getModel('usa/shipping_carrier_usps_address_service');
+        self::markTestSkipped('');
+    }
+
+    /**
+     * @covers \Mage_Usa_Model_Shipping_Carrier_Usps_Address_Service::isEnabled()
+     * @group Model
+     * @group test
+     */
+    public function testIsEnabled(): void
+    {
+        self::markTestSkipped('');
+    }
+}

--- a/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Address/ServiceTest.php
+++ b/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Address/ServiceTest.php
@@ -28,7 +28,6 @@ final class ServiceTest extends OpenMageTest
     {
         parent::setUpBeforeClass();
         self::$subject = Mage::getModel('usa/shipping_carrier_usps_address_service');
-        self::markTestSkipped('');
     }
 
     /**

--- a/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Address/ServiceTest.php
+++ b/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Address/ServiceTest.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace OpenMage\Tests\Unit\Mage\Usa\Model\Shipping\Carrier\Usps\Adress;
+namespace OpenMage\Tests\Unit\Mage\Usa\Model\Shipping\Carrier\Usps\Address;
 
 use Mage;
 use Mage_Usa_Model_Shipping_Carrier_Usps_Address_Service as Subject;

--- a/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Label/ServiceTest.php
+++ b/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Label/ServiceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
+ * @package    OpenMage_Tests
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Usa\Model\Shipping\Carrier\Usps\Label;
+
+use Mage;
+use Mage_Usa_Model_Shipping_Carrier_Usps_Label_Service as Subject;
+use Override;
+use OpenMage\Tests\Unit\OpenMageTest;
+use OpenMage\Tests\Unit\Traits\DataProvider\Mage\Usa\Model\Shipping\Carrier\Usps\Label\ServiceTrait;
+
+final class ServiceTest extends OpenMageTest
+{
+    use ServiceTrait;
+
+    private static Subject $subject;
+
+    #[Override]
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::$subject = Mage::getModel('usa/shipping_carrier_usps_label_service');
+        self::markTestSkipped('');
+    }
+
+    /**
+     * @covers \Mage_Usa_Model_Shipping_Carrier_Usps_Label_Service::isEnabled()
+     * @group Model
+     * @group test
+     */
+    public function testIsEnabled(): void
+    {
+        self::markTestSkipped('');
+    }
+}

--- a/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Label/ServiceTest.php
+++ b/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Label/ServiceTest.php
@@ -38,6 +38,7 @@ final class ServiceTest extends OpenMageTest
      */
     public function testIsEnabled(): void
     {
+        $result = self::$subject->isEnabled();
         self::markTestSkipped('');
     }
 }

--- a/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Label/ServiceTest.php
+++ b/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Label/ServiceTest.php
@@ -37,7 +37,7 @@ final class ServiceTest extends OpenMageTest
      */
     public function testIsEnabled(): void
     {
-        $result = self::$subject->isEnabled();
+        self::$subject->isEnabled();
         self::markTestSkipped('');
     }
 }

--- a/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Label/ServiceTest.php
+++ b/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Label/ServiceTest.php
@@ -28,7 +28,6 @@ final class ServiceTest extends OpenMageTest
     {
         parent::setUpBeforeClass();
         self::$subject = Mage::getModel('usa/shipping_carrier_usps_label_service');
-        self::markTestSkipped('');
     }
 
     /**

--- a/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Service/StandardsTest.php
+++ b/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Service/StandardsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
+ * @package    OpenMage_Tests
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Mage\Usa\Model\Shipping\Carrier\Usps\Service;
+
+use Mage;
+use Mage_Usa_Model_Shipping_Carrier_Usps_Service_Standards as Subject;
+use Override;
+use OpenMage\Tests\Unit\OpenMageTest;
+use OpenMage\Tests\Unit\Traits\DataProvider\Mage\Usa\Model\Shipping\Carrier\Usps\Service\StandardsTrait;
+
+final class StandardsTest extends OpenMageTest
+{
+    use StandardsTrait;
+
+    private static Subject $subject;
+
+    #[Override]
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::$subject = Mage::getModel('usa/shipping_carrier_usps_service_standards');
+        self::markTestSkipped('');
+    }
+
+    /**
+     * @covers \Mage_Usa_Model_Shipping_Carrier_Usps_Service_Standards::isEnabled()
+     * @group Model
+     * @group test
+     */
+    public function testIsEnabled(): void
+    {
+        self::markTestSkipped('');
+    }
+}

--- a/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Service/StandardsTest.php
+++ b/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Service/StandardsTest.php
@@ -38,6 +38,7 @@ final class StandardsTest extends OpenMageTest
      */
     public function testIsEnabled(): void
     {
+        $result = self::$subject->isEnabled();
         self::markTestSkipped('');
     }
 }

--- a/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Service/StandardsTest.php
+++ b/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Service/StandardsTest.php
@@ -37,7 +37,7 @@ final class StandardsTest extends OpenMageTest
      */
     public function testIsEnabled(): void
     {
-        $result = self::$subject->isEnabled();
+        self::$subject->isEnabled();
         self::markTestSkipped('');
     }
 }

--- a/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Service/StandardsTest.php
+++ b/tests/unit/Mage/Usa/Model/Shipping/Carrier/Usps/Service/StandardsTest.php
@@ -28,7 +28,6 @@ final class StandardsTest extends OpenMageTest
     {
         parent::setUpBeforeClass();
         self::$subject = Mage::getModel('usa/shipping_carrier_usps_service_standards');
-        self::markTestSkipped('');
     }
 
     /**

--- a/tests/unit/Traits/DataProvider/Mage/Usa/Model/Shipping/Carrier/Usps/Address/ServiceTrait.php
+++ b/tests/unit/Traits/DataProvider/Mage/Usa/Model/Shipping/Carrier/Usps/Address/ServiceTrait.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
+ * @package    OpenMage_Tests
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Traits\DataProvider\Mage\Usa\Model\Shipping\Carrier\Usps\Address;
+
+trait ServiceTrait {}

--- a/tests/unit/Traits/DataProvider/Mage/Usa/Model/Shipping/Carrier/Usps/Label/ServiceTrait.php
+++ b/tests/unit/Traits/DataProvider/Mage/Usa/Model/Shipping/Carrier/Usps/Label/ServiceTrait.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
+ * @package    OpenMage_Tests
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Traits\DataProvider\Mage\Usa\Model\Shipping\Carrier\Usps\Label;
+
+trait ServiceTrait {}

--- a/tests/unit/Traits/DataProvider/Mage/Usa/Model/Shipping/Carrier/Usps/Service/StandardsTrait.php
+++ b/tests/unit/Traits/DataProvider/Mage/Usa/Model/Shipping/Carrier/Usps/Service/StandardsTrait.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright  For copyright and license information, read the COPYING.txt file.
+ * @link       /COPYING.txt
+ * @license    Open Software License (OSL 3.0)
+ * @package    OpenMage_Tests
+ */
+
+declare(strict_types=1);
+
+namespace OpenMage\Tests\Unit\Traits\DataProvider\Mage\Usa\Model\Shipping\Carrier\Usps\Service;
+
+trait StandardsTrait {}


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Checkout is broken.

New release at the weekend.

>  Mage_Usa_Model_Shipping_Carrier_Usps_AbstractService::__construct(): Argument #1 ($client) must be of type ?Mage_Usa_Model_Shipping_Carrier_Usps_Rest_Client, array given

### Related Pull Requests
<!-- related pull request placeholder -->
- see OpenMage/magento-lts#5258