### PR TITLE
[SalesRule] optimize getActiveAttributes slow query (#4979)

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule.php
@@ -239,12 +239,12 @@ class Mage_SalesRule_Model_Resource_Rule extends Mage_Rule_Model_Resource_Abstra
     public function getActiveAttributes($websiteId, $customerGroupId)
     {
         $read = $this->_getReadAdapter();
+        $distinctAttributeIds = $read->select()
+            ->distinct(true)
+            ->from($this->getTable('salesrule/product_attribute'), 'attribute_id');
         $select = $read->select()
-            ->from(
-                ['a' => $this->getTable('salesrule/product_attribute')],
-                new Zend_Db_Expr('DISTINCT ea.attribute_code'),
-            )
-            ->joinInner(['ea' => $this->getTable('eav/attribute')], 'ea.attribute_id = a.attribute_id', []);
+            ->from(['ea' => $this->getTable('eav/attribute')], ['attribute_code'])
+            ->joinInner(['a' => $distinctAttributeIds], 'ea.attribute_id = a.attribute_id', []);
         return $read->fetchAll($select);
     }
 


### PR DESCRIPTION
> ⚠️ **AI-generated PR (testing)**
>
> This PR was authored by Claude (Anthropic), running as @colinmollenhour's local Claude Code agent, to dogfood a new set of OpenMage-specific Skills. It addresses a bug from the issue tracker; the diff is small and targeted, but reviewers should treat it with the usual caution applied to AI work — it has had no human pre-review beyond the author noticing the change.
>
> **Skills loaded during this work:**
> - `mage-promotions` — Mage_SalesRule / Mage_CatalogRule / Mage_Rule context (used to confirm `salesrule/product_attribute` ↔ `eav/attribute` semantics for `getActiveAttributes`).

## Summary

Fixes #4979.

`Mage_SalesRule_Model_Resource_Rule::getActiveAttributes()` previously joined `salesrule_product_attribute` to `eav_attribute` and applied `DISTINCT` against the joined result. With even a moderate number of rules and attributes, MySQL must materialize the join and sort to deduplicate.

This change deduplicates `attribute_id` first against `salesrule_product_attribute` (where the column is part of the primary key, so the dedup is index-only), then joins the unique set to `eav_attribute`. Reporter measured this as faster.

The two unused parameters (`$websiteId`, `$customerGroupId`) are left in place — this is a public API on a resource model, and the only in-repo caller (`Mage_SalesRule_Model_Observer::addProductAttributes`) passes them.

## Test plan
- [ ] Confirm the rendered SQL no longer DISTINCTs over the joined result (run with profiling on).
- [ ] Sanity-check that `addProductAttributes` observer still populates the `quote_item_collection_select_after` attribute set correctly on a quote with at least one active sales rule.
- [ ] Spot-check store-front cart totals collection isn't affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)