### PR TITLE
[Catalog] normalize CRLF before text-option length check (#4448)

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Text.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Text.php
@@ -34,6 +34,10 @@ class Mage_Catalog_Model_Product_Option_Type_Text extends Mage_Catalog_Model_Pro
         $option = $this->getOption();
         $value = trim($this->getUserValue());
 
+        // Match the JS validator, which counts each line break as a single character.
+        // Browsers post textarea content with CRLF line endings, but readers see LF.
+        $value = str_replace(["\r\n", "\r"], "\n", $value);
+
         // Check requires option to have some value
         if (strlen($value) == 0 && $option->getIsRequire() && !$this->getSkipCheckRequiredOption()) {
             $this->setIsValid(false);

--- a/tests/unit/Mage/Catalog/Model/Product/Option/Type/TextTest.php
+++ b/tests/unit/Mage/Catalog/Model/Product/Option/Type/TextTest.php
@@ -15,6 +15,7 @@ use Override;
 use Mage;
 use Mage_Catalog_Model_Product_Option;
 use Mage_Catalog_Model_Product_Option_Type_Text as Subject;
+use Mage_Core_Exception;
 use OpenMage\Tests\Unit\OpenMageTest;
 use OpenMage\Tests\Unit\Traits\DataProvider\Mage\Catalog\Model\Product\Option\Type\TextTrait;
 
@@ -60,5 +61,44 @@ final class TextTest extends OpenMageTest
     public function testGetDefaultAttributeSetId(): void
     {
         self::assertIsString(self::$subject->getFormattedOptionValue(''));
+    }
+
+    /**
+     * Browsers post textarea content with CRLF; the JS validator counts each
+     * line break as one character. The server must agree, otherwise input that
+     * passed client-side validation is rejected with "The text is too long".
+     *
+     * @group Model
+     * @group runInSeparateProcess
+     * @runInSeparateProcess
+     */
+    public function testValidateUserValueNormalizesCrlfWithinMaxLength(): void
+    {
+        $option = new Mage_Catalog_Model_Product_Option();
+        $option->setId('opt');
+        $option->setMaxCharacters(7);
+
+        self::$subject->setOption($option);
+        self::$subject->validateUserValue(['opt' => "abcd\r\nef"]);
+
+        self::assertTrue(self::$subject->getIsValid());
+        self::assertSame("abcd\nef", self::$subject->getUserValue());
+    }
+
+    /**
+     * @group Model
+     * @group runInSeparateProcess
+     * @runInSeparateProcess
+     */
+    public function testValidateUserValueRejectsOverMaxAfterCrlfNormalization(): void
+    {
+        $option = new Mage_Catalog_Model_Product_Option();
+        $option->setId('opt');
+        $option->setMaxCharacters(5);
+
+        self::$subject->setOption($option);
+
+        $this->expectException(Mage_Core_Exception::class);
+        self::$subject->validateUserValue(['opt' => "abcd\r\nef"]);
     }
 }


### PR DESCRIPTION
> ⚠️ **AI-generated PR (testing)**
>
> This PR was authored by Claude (Anthropic), running as @colinmollenhour's local Claude Code agent, to dogfood a new set of OpenMage-specific Skills. It addresses a bug from the issue tracker; the diff is small and targeted, but reviewers should treat it with the usual caution applied to AI work — it has had no human pre-review beyond the author noticing the change.
>
> **Skills loaded during this work:**
> - `mage-product-types` — Mage_Catalog product-type and custom-option model context (used to orient on `Mage_Catalog_Model_Product_Option_Type_Text` and the validate-vs-prepareForCart flow).

## Summary

Fixes #4448.

When a customer enters text into a `textfield` / `textarea` custom option whose total length (with `\n` counted as 1) sits exactly at the per-option max, the JS validator passes but the server-side validator throws *"The text is too long"*.

Root cause: the browser submits textarea content with **CRLF** line endings, while the JS validator measured `value.length` against a value where line breaks are **LF**. Each line break therefore counted as 2 characters server-side.

Fix: normalize `\r\n` (and bare `\r`) to `\n` after `trim()` and before the length check / value persistence. Stored value is now also LF-only, which matches what `getFormattedOptionValue()` rendered to the customer in cart anyway.

## Test plan
- [ ] Add a configurable text option with `max_characters = 10` to a product.
- [ ] In a textarea-like input (or a textfield with `\n` injected), submit a value of exactly 10 chars including `\n` characters.
- [ ] Pre-fix: server rejects with "The text is too long".
- [ ] Post-fix: add-to-cart succeeds, cart shows the value with line breaks.
- [ ] Re-test required-option validation: empty input still rejected with the *required* message, not the *too long* message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)