### PR TITLE
[SalesRule] count coupon usage for free-shipping-only rules (#4757)

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Observer.php
+++ b/app/code/core/Mage/SalesRule/Model/Observer.php
@@ -95,9 +95,9 @@ class Mage_SalesRule_Model_Observer
                         $ruleCustomer->setTimesUsed($ruleCustomer->getTimesUsed() + 1);
                     } else {
                         $ruleCustomer
-                        ->setCustomerId($customerId)
-                        ->setRuleId($ruleId)
-                        ->setTimesUsed(1);
+                            ->setCustomerId($customerId)
+                            ->setRuleId($ruleId)
+                            ->setTimesUsed(1);
                     }
 
                     // phpcs:ignore Ecg.Performance.Loop.ModelLSD

--- a/app/code/core/Mage/SalesRule/Model/Observer.php
+++ b/app/code/core/Mage/SalesRule/Model/Observer.php
@@ -73,46 +73,43 @@ class Mage_SalesRule_Model_Observer
 
         $customerId = $order->getCustomerId();
 
-        // use each rule (and apply to customer, if applicable)
-        if ($order->getDiscountAmount() != 0) {
-            // lookup rule ids
-            $ruleIds = array_map(intval(...), explode(',', (string) $order->getAppliedRuleIds()));
-            $ruleIds = array_unique($ruleIds);
+        // lookup rule ids — applied rules can produce zero discount (e.g. free-shipping-only rules)
+        $ruleIds = array_unique(array_filter(
+            array_map(intval(...), explode(',', (string) $order->getAppliedRuleIds())),
+        ));
 
-            foreach ($ruleIds as $ruleId) {
-                if (!$ruleId) {
-                    continue;
-                }
-
-                $rule = Mage::getModel('salesrule/rule');
+        foreach ($ruleIds as $ruleId) {
+            $rule = Mage::getModel('salesrule/rule');
+            // phpcs:ignore Ecg.Performance.Loop.ModelLSD
+            $rule->load($ruleId);
+            if ($rule->getId()) {
+                $rule->setTimesUsed($rule->getTimesUsed() + 1);
                 // phpcs:ignore Ecg.Performance.Loop.ModelLSD
-                $rule->load($ruleId);
-                if ($rule->getId()) {
-                    $rule->setTimesUsed($rule->getTimesUsed() + 1);
-                    // phpcs:ignore Ecg.Performance.Loop.ModelLSD
-                    $rule->save();
+                $rule->save();
 
-                    if ($customerId) {
-                        $ruleCustomer = Mage::getModel('salesrule/rule_customer');
-                        $ruleCustomer->loadByCustomerRule($customerId, $ruleId);
+                if ($customerId) {
+                    $ruleCustomer = Mage::getModel('salesrule/rule_customer');
+                    $ruleCustomer->loadByCustomerRule($customerId, $ruleId);
 
-                        if ($ruleCustomer->getId()) {
-                            $ruleCustomer->setTimesUsed($ruleCustomer->getTimesUsed() + 1);
-                        } else {
-                            $ruleCustomer
-                            ->setCustomerId($customerId)
-                            ->setRuleId($ruleId)
-                            ->setTimesUsed(1);
-                        }
-
-                        // phpcs:ignore Ecg.Performance.Loop.ModelLSD
-                        $ruleCustomer->save();
+                    if ($ruleCustomer->getId()) {
+                        $ruleCustomer->setTimesUsed($ruleCustomer->getTimesUsed() + 1);
+                    } else {
+                        $ruleCustomer
+                        ->setCustomerId($customerId)
+                        ->setRuleId($ruleId)
+                        ->setTimesUsed(1);
                     }
+
+                    // phpcs:ignore Ecg.Performance.Loop.ModelLSD
+                    $ruleCustomer->save();
                 }
             }
+        }
 
+        $couponCode = (string) $order->getCouponCode();
+        if ($ruleIds && $couponCode !== '') {
             $coupon = Mage::getModel('salesrule/coupon');
-            $coupon->load($order->getCouponCode(), 'code');
+            $coupon->load($couponCode, 'code');
             if ($coupon->getId()) {
                 $coupon->setTimesUsed($coupon->getTimesUsed() + 1);
                 $coupon->save();


### PR DESCRIPTION
> ⚠️ **AI-generated PR (testing)**
>
> This PR was authored by Claude (Anthropic), running as @colinmollenhour's local Claude Code agent, to dogfood a new set of OpenMage-specific Skills. It addresses a bug from the issue tracker; the diff is small and targeted, but reviewers should treat it with the usual caution applied to AI work — it has had no human pre-review beyond the author noticing the change.
>
> **Skills loaded during this work:**
> - `mage-promotions` — Mage_SalesRule rule/coupon model context (already loaded earlier in the session, kept in scope).
> - `m1-events-observers` — Magento 1 event/observer wiring (`sales_order_place_after` → `Mage_SalesRule_Model_Observer::sales_order_afterPlace`), area scoping, observer method conventions.

## Summary

Fixes #4757.

`Mage_SalesRule_Model_Observer::sales_order_afterPlace` gated all rule/coupon usage tracking behind `\$order->getDiscountAmount() != 0`. A rule that only grants free shipping (no \$-discount) was therefore never counted, and a coupon that triggered such a rule never had its `times_used` incremented — defeating `uses_per_coupon` / `uses_per_customer` limits.

The fix:

- Drops the discount-amount gate.
- Always increments per-rule and per-customer-rule usage for every applied rule id on the order (a rule id is on `applied_rule_ids` only if it actually matched and was applied).
- Increments coupon usage whenever the order has both applied rules and a coupon code present. The previous code path also coupled coupon usage to discount amount, which has the same bug for free-shipping-only coupons.

Logic inside the loops is unchanged.

## Test plan
- [ ] Cart rule: condition matches all carts, action = *Free Shipping for matching items*, no \$-discount, coupon `FREESHIP` with \"Uses per Coupon = 1\".
- [ ] Place an order using \`FREESHIP\`; before the fix, \`salesrule_coupon.times_used\` stayed at 0 — after the fix, it becomes 1, and a second checkout with the same code is rejected.
- [ ] Sanity-check existing %-discount and fixed-discount rules: rule + customer + coupon counters still increment exactly once per placed order, no double-counting.
- [ ] Confirm orders with no applied rule (\`applied_rule_ids\` empty) and no coupon perform no model loads (the coupon block is gated on both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)