### PR TITLE
Fix wrong DocBlock and getter in adminhtml grid classes

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -2038,7 +2038,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
      */
     public function getRowUrl($row)
     {
-        $res = parent::getRowUrl($row);
+        $res = $this->getData('row_url');
         return $res ?: '#';
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
@@ -251,7 +251,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column extends Mage_Adminhtml_Block_Widge
     }
 
     /**
-     * @param  string $renderer
+     * @param  Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract $renderer
      * @return $this
      */
     public function setRenderer($renderer)


### PR DESCRIPTION
### Description (*)
The base getRowUrl function tried to access a parent method, which doesn't exist, resulting in a getData magic call.
But because the $row (Model) is used as an index, it would result in an error in Varien_Object if you set the `row_url` as data in the grid.

The setRenderer function of the column should expect a renderer, not a string, as the getRenderer call is chained with function calls of the `Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract `. It is also the return type of the getter.

### Related Pull Requests
-

### Fixed Issues (if relevant)
-

### Manual testing scenarios (*)
Don't override the getRowUrl in a grid and set `$this->setData('row_url', 'url');`, it will result in an illegal offset error.

### Questions or comments
-

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
