### PR TITLE
rector: add return type to `_isAllowed` acl check (#5351)

### DIFF
--- a/.rector.php
+++ b/.rector.php
@@ -87,6 +87,7 @@ try {
         ->withConfiguredRule(Renaming\MethodCall\RenameMethodRector::class, Migration\Zend\Acl::renameMethod())
         ->withConfiguredRule(Renaming\MethodCall\RenameMethodRector::class, Migration\Zend\Captcha::renameMethod())
         ->withConfiguredRule(ReplaceArgumentDefaultValueRector::class, Migration\Mage\Adminhtml::replaceArgumentDefaultValue())
+        ->withConfiguredRule(TypeDeclaration\ClassMethod\AddReturnTypeDeclarationRector::class, Migration\Mage\Adminhtml::addReturnTypeDeclaration())
         # skip: do not apply
         ->withSkip([
             # skip avoid renaming of methods in tests

--- a/dev/rector/Migration/Mage/Adminhtml.php
+++ b/dev/rector/Migration/Mage/Adminhtml.php
@@ -19,11 +19,23 @@ use Mage_Adminhtml_Block_Widget_Container;
 use Mage_Adminhtml_Block_Widget_Form;
 use Mage_Adminhtml_Block_Widget_Grid;
 use Mage_Adminhtml_Controller_Action;
+use PHPStan\Type\BooleanType;
 use Rector\Arguments\ValueObject\ReplaceArgumentDefaultValue;
 use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
 
 final class Adminhtml
 {
+    /**
+     * @return AddReturnTypeDeclaration[]
+     */
+    public static function addReturnTypeDeclaration(): array
+    {
+        return [
+            new AddReturnTypeDeclaration(Mage_Adminhtml_Controller_Action::class, '_isAllowed', new BooleanType()),
+        ];
+    }
+
     /**
      * @return MethodCallRename[]
      */


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Added rector rule to "fix" https://github.com/OpenMage/magento-lts/pull/5351#discussion_r3197633460

### Related Pull Requests
<!-- related pull request placeholder -->
- see OpenMage/magento-lts#5351

@Tomasz-Silpion 