### PR TITLE
Add execute method to CSP observers config

### DIFF
--- a/app/code/core/Mage/Csp/etc/config.xml
+++ b/app/code/core/Mage/Csp/etc/config.xml
@@ -76,6 +76,7 @@
                 <observers>
                     <csp_observer>
                         <class>csp/observer_addFrontendCspHeaders</class>
+                        <method>execute</method>
                     </csp_observer>
                 </observers>
             </http_response_send_before>
@@ -102,6 +103,7 @@
                 <observers>
                     <csp_observer>
                         <class>csp/observer_addAdminCspHeaders</class>
+                        <method>execute</method>
                     </csp_observer>
                 </observers>
             </http_response_send_before>


### PR DESCRIPTION
On Openmage 20.18.0 installation it doesn't find any observer method, thus throwing an error on my installation. This change fixes it.

<img width="929" height="877" alt="image" src="https://github.com/user-attachments/assets/51c1fb12-8245-4d9b-a74e-863b98736635" />


<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->




### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Just invoke the index or admin page

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->