### PR TITLE
Replace buttons added as widget_button with widget_container buttons in Catalog/Product/Edit

### DIFF
--- a/.phpstan.dist.baselines/booleanAnd.rightNotBoolean.php
+++ b/.phpstan.dist.baselines/booleanAnd.rightNotBoolean.php
@@ -64,11 +64,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'rawMessage' => 'Only booleans are allowed in &&, int|string|null given on the right side.',
     'count' => 1,
-    'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Only booleans are allowed in &&, int|string|null given on the right side.',
-    'count' => 1,
     'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Categories.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan.dist.baselines/booleanNot.exprNotBoolean.php
+++ b/.phpstan.dist.baselines/booleanNot.exprNotBoolean.php
@@ -122,11 +122,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Only booleans are allowed in a negated boolean, mixed given.',
-    'count' => 2,
-    'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Only booleans are allowed in a negated boolean, Varien_Data_Form_Element_Abstract|null given.',
     'count' => 1,
     'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes.php',

--- a/app/OpenMageVersionInterface.php
+++ b/app/OpenMageVersionInterface.php
@@ -94,4 +94,6 @@ interface OpenMageVersionInterface
     public const VERSION_20_17_0            = '20.17.0';
 
     public const VERSION_20_18_0            = '20.18.0';
+
+    public const VERSION_20_19_0            = '20.19.0';
 }

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php
@@ -12,13 +12,86 @@
  *
  * @package    Mage_Adminhtml
  */
-class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Widget
+class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Widget_Container
 {
     public function __construct()
     {
         parent::__construct();
         $this->setTemplate('catalog/product/edit.phtml');
         $this->setId('product_edit');
+
+        $isConfigured   = $this->getIsConfigured();
+        $isReadOnly     = $this->getProduct()->isReadonly();
+        $isPopup        = (bool)$this->getRequest()->getParam('popup');
+        $isProductId    = (bool)$this->getProductId();
+        $isProductSetId = (bool)$this->getProductSetId();
+
+        if ($isPopup) {
+            $this->_addButton(self::BUTTON_TYPE_CLOSE, [
+                'label'   => Mage::helper('catalog')->__('Close Window'),
+                'onclick' => 'window.close()',
+                'class'   => 'cancel',
+            ], -1);
+        }
+
+        if (!$isPopup) {
+            $this->_addButton(self::BUTTON_TYPE_BACK, [
+                'label'   => Mage::helper('catalog')->__('Back'),
+                'onclick' => Mage::helper('core/js')->getSetLocationJs($this->getUrl('*/*/', ['store' => $this->getRequest()->getParam('store', 0)])),
+                'class'   => 'back',
+            ], -1);
+        }
+
+        if (!$isReadOnly) {
+            $this->_addButton(self::BUTTON_TYPE_RESET, [
+                'label'   => Mage::helper('catalog')->__('Reset'),
+                'onclick' => Mage::helper('core/js')->getSetLocationJs($this->getUrl('*/*/*', ['_current' => true])),
+                'class'   => 'reset',
+            ], -1);
+        }
+
+        if (!$isPopup && $isProductId && $this->getProduct()->isDeleteable()) {
+            $this->_addButton(self::BUTTON_TYPE_DELETE, [
+                'label' => Mage::helper('catalog')->__('Delete'),
+                'onclick' => Mage::helper('core/js')->getConfirmSetLocationJs($this->getDeleteUrl()),
+                'class' => 'delete',
+            ]);
+        }
+
+        if (!$isPopup && $isProductId && $isConfigured && $this->getProduct()->isDuplicable()) {
+            if ($this->getProduct()->getMediaGalleryImages()->count() === 0) {
+                $onClickAction = Mage::helper('core/js')->getSetLocationJs($this->getDuplicateUrl(true));
+            } else {
+                $skipImgOnDuplicate = $this->helper('catalog/image')->skipProductImageOnDuplicate();
+                $onClickAction = "openDuplicateDialog('" . $this->getDuplicateUrl(false) . "','" . $this->getDuplicateUrl(true) . "'); return false;";
+
+                if ($skipImgOnDuplicate !== Mage_Catalog_Model_Product_Image::ON_DUPLICATE_ASK) {
+                    $onClickAction = Mage::helper('core/js')->getSetLocationJs($this->getDuplicateUrl((bool) $skipImgOnDuplicate));
+                }
+            }
+
+            $this->_addButton(self::BUTTON_TYPE_DUPLICATE, [
+                'label' => Mage::helper('catalog')->__('Duplicate'),
+                'onclick' => $onClickAction,
+                'class' => 'add duplicate',
+            ], 1);
+        }
+
+        if ($isProductSetId && $isConfigured && !$isReadOnly) {
+            $this->_addButton(self::BUTTON_TYPE_SAVE, [
+                'label'   => Mage::helper('catalog')->__('Save'),
+                'onclick' => 'productForm.submit()',
+                'class'   => 'save',
+            ], 1);
+
+            if (!$isPopup) {
+                $this->_addButton(self::BUTTON_TYPE_SAVE_EDIT, [
+                    'label' => Mage::helper('catalog')->__('Save and Continue Edit'),
+                    'onclick' => Mage::helper('core/js')->getSaveAndContinueEditJs($this->getSaveAndContinueUrl()),
+                    'class' => 'save continue',
+                ], 1);
+            }
+        }
     }
 
     /**
@@ -32,110 +105,9 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Wid
     }
 
     /**
-     * @inheritDoc
-     */
-    #[Override]
-    protected function _prepareLayout()
-    {
-        if (!$this->getRequest()->getParam('popup')) {
-            $this->setChild(
-                'back_button',
-                $this->getLayout()->createBlock('adminhtml/widget_button')
-                    ->setData([
-                        'label' => Mage::helper('catalog')->__('Back'),
-                        'onclick' => Mage::helper('core/js')->getSetLocationJs($this->getUrl('*/*/', ['store' => $this->getRequest()->getParam('store', 0)])),
-                        'class' => 'back',
-                    ]),
-            );
-        } else {
-            $this->setChild(
-                'back_button',
-                $this->getLayout()->createBlock('adminhtml/widget_button')
-                    ->setData([
-                        'label' => Mage::helper('catalog')->__('Close Window'),
-                        'onclick' => 'window.close()',
-                        'class' => 'cancel',
-                    ]),
-            );
-        }
-
-        if (!$this->getProduct()->isReadonly()) {
-            $this->setChild(
-                'reset_button',
-                $this->getLayout()->createBlock('adminhtml/widget_button')
-                    ->setData([
-                        'label' => Mage::helper('catalog')->__('Reset'),
-                        'onclick' => Mage::helper('core/js')->getSetLocationJs($this->getUrl('*/*/*', ['_current' => true])),
-                        'class' => 'reset',
-                    ]),
-            );
-
-            $this->setChild(
-                'save_button',
-                $this->getLayout()->createBlock('adminhtml/widget_button')
-                    ->setData([
-                        'label'   => Mage::helper('catalog')->__('Save'),
-                        'onclick' => 'productForm.submit()',
-                        'class'   => 'save',
-                    ]),
-            );
-        }
-
-        if (!$this->getRequest()->getParam('popup')) {
-            if (!$this->getProduct()->isReadonly()) {
-                $this->setChild(
-                    'save_and_edit_button',
-                    $this->getLayout()->createBlock('adminhtml/widget_button')
-                        ->setData([
-                            'label' => Mage::helper('catalog')->__('Save and Continue Edit'),
-                            'onclick' => Mage::helper('core/js')->getSaveAndContinueEditJs($this->getSaveAndContinueUrl()),
-                            'class' => 'save continue',
-                        ]),
-                );
-            }
-
-            if ($this->getProduct()->isDeleteable()) {
-                $this->setChild(
-                    'delete_button',
-                    $this->getLayout()->createBlock('adminhtml/widget_button')
-                        ->setData([
-                            'label' => Mage::helper('catalog')->__('Delete'),
-                            'onclick' => Mage::helper('core/js')->getConfirmSetLocationJs($this->getDeleteUrl()),
-                            'class' => 'delete',
-                        ]),
-                );
-            }
-
-            if ($this->getProduct()->isDuplicable() && $this->getProduct()->getId()) {
-                if ($this->getProduct()->getMediaGalleryImages()->count() === 0) {
-                    $onClickAction = Mage::helper('core/js')->getSetLocationJs($this->getDuplicateUrl(true));
-                } else {
-                    $skipImgOnDuplicate = $this->helper('catalog/image')->skipProductImageOnDuplicate();
-                    $onClickAction = "openDuplicateDialog('" . $this->getDuplicateUrl(false) . "','" . $this->getDuplicateUrl(true) . "'); return false;";
-
-                    if ($skipImgOnDuplicate !== Mage_Catalog_Model_Product_Image::ON_DUPLICATE_ASK) {
-                        $onClickAction = Mage::helper('core/js')->getSetLocationJs($this->getDuplicateUrl((bool) $skipImgOnDuplicate));
-                    }
-                }
-
-                $this->setChild(
-                    'duplicate_button',
-                    $this->getLayout()->createBlock('adminhtml/widget_button')
-                        ->setData([
-                            'label' => Mage::helper('catalog')->__('Duplicate'),
-                            'onclick' => $onClickAction,
-                            'class' => 'add duplicate',
-                        ]),
-                );
-            }
-        }
-
-        return parent::_prepareLayout();
-    }
-
-    /**
      * @return string
      */
+    #[Deprecated(message: 'Use $this->getButtonsHtml(\'header\')', since: OpenMageVersionInterface::VERSION_20_19_0)]
     public function getBackButtonHtml()
     {
         return $this->getChildHtml('back_button');
@@ -144,6 +116,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Wid
     /**
      * @return string
      */
+    #[Deprecated(message: 'Use $this->getButtonsHtml(\'header\')', since: OpenMageVersionInterface::VERSION_20_19_0)]
     public function getCancelButtonHtml()
     {
         return $this->getChildHtml('reset_button');
@@ -152,6 +125,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Wid
     /**
      * @return string
      */
+    #[Deprecated(message: 'Use $this->getButtonsHtml(\'header\')', since: OpenMageVersionInterface::VERSION_20_19_0)]
     public function getSaveButtonHtml()
     {
         return $this->getChildHtml('save_button');
@@ -160,6 +134,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Wid
     /**
      * @return string
      */
+    #[Deprecated(message: 'Use $this->getButtonsHtml(\'header\')', since: OpenMageVersionInterface::VERSION_20_19_0)]
     public function getSaveAndEditButtonHtml()
     {
         return $this->getChildHtml('save_and_edit_button');
@@ -168,6 +143,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Wid
     /**
      * @return string
      */
+    #[Deprecated(message: 'Use $this->getButtonsHtml(\'header\')', since: OpenMageVersionInterface::VERSION_20_19_0)]
     public function getDeleteButtonHtml()
     {
         return $this->getChildHtml('delete_button');
@@ -176,6 +152,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Wid
     /**
      * @return string
      */
+    #[Deprecated(message: 'Use $this->getButtonsHtml(\'header\')', since: OpenMageVersionInterface::VERSION_20_19_0)]
     public function getDuplicateButtonHtml()
     {
         return $this->getChildHtml('duplicate_button');

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php
@@ -22,9 +22,9 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit extends Mage_Adminhtml_Block_Wid
 
         $isConfigured   = $this->getIsConfigured();
         $isReadOnly     = $this->getProduct()->isReadonly();
-        $isPopup        = (bool)$this->getRequest()->getParam('popup');
-        $isProductId    = (bool)$this->getProductId();
-        $isProductSetId = (bool)$this->getProductSetId();
+        $isPopup        = (bool) $this->getRequest()->getParam('popup');
+        $isProductId    = (bool) $this->getProductId();
+        $isProductSetId = (bool) $this->getProductSetId();
 
         if ($isPopup) {
             $this->_addButton(self::BUTTON_TYPE_CLOSE, [

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Container.php
@@ -34,6 +34,8 @@ class Mage_Adminhtml_Block_Widget_Container extends Mage_Adminhtml_Block_Templat
 
     public const BUTTON_TYPE_VOID       = 'void';
 
+    public const BUTTON_TYPE_DUPLICATE  = 'duplicate';
+
     /**
      * So-called "container controller" to specify group of blocks participating in some action
      *

--- a/app/design/adminhtml/base/default/template/catalog/product/edit.phtml
+++ b/app/design/adminhtml/base/default/template/catalog/product/edit.phtml
@@ -14,19 +14,7 @@
 ?>
 <div class="content-header">
     <h3 class="icon-head head-products"><?php echo $this->getHeader() ?></h3>
-    <p class="content-buttons form-buttons"><?php echo $this->getBackButtonHtml() ?>
-    <?php echo $this->getCancelButtonHtml() ?>
-    <?php if($this->getProductId()): ?>
-        <?php echo $this->getDeleteButtonHtml() ?>
-        <?php if($this->getProductSetId() && $this->getIsConfigured()): ?>
-            <?php echo $this->getDuplicateButtonHtml() ?>
-        <?php endif ?>
-    <?php endif ?>
-    <?php if($this->getProductSetId() && $this->getIsConfigured()): ?>
-        <?php echo $this->getSaveButtonHtml() ?>
-        <?php echo $this->getSaveAndEditButtonHtml() ?>
-    <?php endif ?>
-    </p>
+    <p class="content-buttons form-buttons"><?php echo $this->getButtonsHtml('header') ?></p>
 </div>
 <form action="<?php echo $this->getSaveUrl() ?>" method="post" id="product_edit_form" enctype="multipart/form-data">
     <?php echo $this->getBlockHtml('formkey')?>


### PR DESCRIPTION
### Description (*)
It is currently not possible to add, remove or change buttons in the catalog/product/edit form without overriding/changing the edit.phtml, as all buttons are added as widget_button and then rendered by reference.

With the `Mage_Adminhtml_Block_Widget_Container->getButtonsHtml()` it is possible (but definitly needs some more events) to change the buttons without overriding the template itself, via an observer. (`controller_action_layout_render_before_adminhtml_catalog_product_edit`)

### Related Pull Requests
-

### Fixed Issues (if relevant)
-

### Manual testing scenarios (*)
Listen to the event and add a button to the product_edit.
(`Mage::app()->getLayout()->getBlock('product_edit');`)

### Questions or comments
I changed the internal layout id of the close button from "back_button" to "close_button" and the "save_and_edit_button" to "save-edit_button" as this are the constants provided by the widget_container class.
I didn't notice a problem, but I probably didn't check every possible configuration there is.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
