### PR TITLE
Fix missing method declaration for the model validation.

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
@@ -71,7 +71,7 @@ abstract class Mage_Catalog_Model_Resource_Abstract extends Mage_Eav_Model_Entit
     protected function _isCallableAttributeInstance($instance, $method, $args)
     {
         if ($instance instanceof Mage_Eav_Model_Entity_Attribute_Backend_Abstract
-            && ($method === 'beforeSave' || $method === 'afterSave')
+            && (in_array($method, ['beforeSave', 'afterSave', 'validate'], true))
         ) {
             $attributeCode = $instance->getAttribute()->getAttributeCode();
             if (isset($args[0]) && $args[0] instanceof Varien_Object && $args[0]->getData($attributeCode) === false) {


### PR DESCRIPTION
### Description (*)
The function `_isCallableAttributeInstance` is not just called for before/after save, but also while validating the model data.
In this process the $method value is 'validate'.

### Related Pull Requests
-

### Fixed Issues (if relevant)
- fixes OpenMage/magento-lts#5626

### Manual testing scenarios (*)
- follow the steps outlines in the issue (save a category while in a specific store view)

### Questions or comments
I tested adding/deleting and updating a category in default scope and specific store scope, didn't see any problems with the saving, product saving also seems unaffected.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
