### PR TITLE
fix clockHelper instead null pointer during backend order creation

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
@@ -1702,7 +1702,7 @@ class Mage_Adminhtml_Model_Sales_Order_Create extends Varien_Object implements M
             $host = $this->getSession()
                 ->getStore()
                 ->getConfig(Mage_Customer_Model_Customer::XML_PATH_DEFAULT_EMAIL_DOMAIN);
-            $account = $customer->getIncrementId() ? $customer->getIncrementId() : $this->getClockHelper()->getTimestamp();
+            $account = $customer->getIncrementId() ? $customer->getIncrementId() : Mage::helper('core/clock')->getTimestamp();
             $email = $account . '@' . $host;
             $account = $this->getDataByKey('account');
             $account['email'] = $email;


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
When creating a guest order in backend, this Exception is thrown:

```
Fatal error: Uncaught Error: Call to a member function getTimestamp() on null in /app/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php:1705 Stack trace: #0 /app/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php(1492): Mage_Adminhtml_Model_Sales_Order_Create->_getNewCustomerEmail(Object(Mage_Customer_Model_Customer)) #1 /app/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php(1569): Mage_Adminhtml_Model_Sales_Order_Create->_prepareCustomer() #2 /app/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreateController.php(505): Mage_Adminhtml_Model_Sales_Order_Create->createOrder() #3 /app/app/code/core/Mage/Core/Controller/Varien/Action.php(430): Mage_Adminhtml_Sales_Order_CreateController->saveAction() #4 /app/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(253): Mage_Core_Controller_Varien_Action->dispatch('save') #5 /app/app/code/core/Mage/Core/Controller/Varien/Front.php(177): Mage_Core_Controller_Varien_Router_Standard->match(Object(Mage_Core_Controller_Request_Http)) #6 /app/app/code/core/Mage/Core/Model/App.php(352): Mage_Core_Controller_Varien_Front->dispatch() #7 /app/app/Mage.php(747): Mage_Core_Model_App->run(Array) #8 /app/index.php(78): Mage::run('', 'store') #9 {main} thrown in /app/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php on line 1705
```

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

Create back end guest order -> exception, `getClockHelper` seems to be unknown, now using explicit `Mage::getHelper`

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create back end guest order -> exception, `getClockHelper` seems to be unknown

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [ ] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
