### PR TITLE
Api2: fixes adminhtml if Api1 is disabled

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
@@ -36,7 +36,7 @@ class Mage_Adminhtml_Api_RoleController extends Mage_Adminhtml_Controller_Action
     {
         $this->loadLayout();
         $this->_setActiveMenu('system/api/roles');
-        $this->_addBreadcrumb($this->__('Web services'), $this->__('Web services'));
+        $this->_addBreadcrumb($this->__('Web Services'), $this->__('Web Services'));
         $this->_addBreadcrumb($this->__('Permissions'), $this->__('Permissions'));
         $this->_addBreadcrumb($this->__('Roles'), $this->__('Roles'));
         return $this;

--- a/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/AttributeController.php
+++ b/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/AttributeController.php
@@ -44,7 +44,7 @@ class Mage_Api2_Adminhtml_Api2_AttributeController extends Mage_Adminhtml_Contro
 
         $this->loadLayout()->_setActiveMenu('system/api/rest_attributes');
 
-        $this->_addBreadcrumb($this->__('Web services'), $this->__('Web services'))
+        $this->_addBreadcrumb($this->__('Web Services'), $this->__('Web Services'))
             ->_addBreadcrumb($this->__('REST Attributes'), $this->__('REST Attributes'))
             ->_addBreadcrumb($this->__('Attributes'), $this->__('Attributes'));
 

--- a/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/RoleController.php
+++ b/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/RoleController.php
@@ -39,7 +39,7 @@ class Mage_Api2_Adminhtml_Api2_RoleController extends Mage_Adminhtml_Controller_
              ->_title($this->__('REST Roles'));
 
         $this->loadLayout()->_setActiveMenu('system/api/rest_roles');
-        $this->_addBreadcrumb($this->__('Web services'), $this->__('Web services'));
+        $this->_addBreadcrumb($this->__('Web Services'), $this->__('Web Services'));
         $this->_addBreadcrumb($this->__('REST Roles'), $this->__('REST Roles'));
         $this->_addBreadcrumb($this->__('Roles'), $this->__('Roles'));
 
@@ -83,7 +83,7 @@ class Mage_Api2_Adminhtml_Api2_RoleController extends Mage_Adminhtml_Controller_
              ->_title($this->__('Rest Roles'));
 
         $this->loadLayout()->_setActiveMenu('system/api/rest_roles');
-        $this->_addBreadcrumb($this->__('Web services'), $this->__('Web services'));
+        $this->_addBreadcrumb($this->__('Web Services'), $this->__('Web Services'));
         $this->_addBreadcrumb($this->__('REST Roles'), $this->__('REST Roles'));
         $this->_addBreadcrumb($this->__('Roles'), $this->__('Roles'));
 

--- a/app/code/core/Mage/Api2/etc/adminhtml.xml
+++ b/app/code/core/Mage/Api2/etc/adminhtml.xml
@@ -14,7 +14,9 @@
                 <children>
                     <system>
                         <children>
-                            <api>
+                            <api translate="title" module="api2">
+                                <title>Web Services</title>
+                                <sort_order>0</sort_order>
                                 <children>
                                     <rest_roles translate="title" module="api2">
                                         <title>REST - Roles</title>
@@ -55,7 +57,9 @@
     <menu>
         <system>
             <children>
-                <api>
+                <api translate="title" module="api2">
+                    <title>Web Services</title>
+                    <sort_order>25</sort_order>
                     <children>
                         <rest_roles translate="title" module="api2">
                             <title>REST - Roles</title>

--- a/app/locale/en_US/Mage_Adminhtml.csv
+++ b/app/locale/en_US/Mage_Adminhtml.csv
@@ -1249,7 +1249,6 @@
 "Watermark File for %s","Watermark File for %s"
 "We're in our typing table, coding away more features for Magento. Thank you for your patience.","We're in our typing table, coding away more features for Magento. Thank you for your patience."
 "Web Services","Web Services"
-"Web services","Web services"
 "Website","Website"
 "What is this?","What is this?"
 "Wishlist Report","Wishlist Report"

--- a/app/locale/en_US/Mage_Api2.csv
+++ b/app/locale/en_US/Mage_Api2.csv
@@ -233,6 +233,5 @@
 "User type ""%s"" no longer exists","User type ""%s"" no longer exists"
 "User type ""%s"" not found.","User type ""%s"" not found."
 "Web Services","Web Services"
-"Web services","Web services"
 "Write","Write"
 "ZIP/Postal Code","ZIP/Postal Code"


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
- Fixes rare case if Api2 is enabled, but Api1 is not, then the Menu doesn't work.
- also replace `Web services` for `Web Services`

### Related Pull Requests
<!-- related pull request placeholder -->
- see OpenMage/magento-lts#<issue_number>

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
- fixes OpenMage/magento-lts#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
