### PR TITLE
Prevent override of existing buttons in getButtonsHtml

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Widget/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Container.php
@@ -232,8 +232,14 @@ class Mage_Adminhtml_Block_Widget_Container extends Mage_Adminhtml_Block_Templat
         foreach ($this->_buttons as $cachedButtons) {
             $buttons = [];
             foreach ($cachedButtons as $buttonId => $data) {
-                $buttons[$data['sort_order']]['buttonId'] = $buttonId;
-                $buttons[$data['sort_order']]['data'] = $data;
+                $sortOrder = $data['sort_order'];
+
+                while (isset($buttons[$sortOrder])) {
+                    $sortOrder++;
+                }
+
+                $buttons[$sortOrder]['buttonId'] = $buttonId;
+                $buttons[$sortOrder]['data'] = $data;
             }
 
             ksort($buttons);


### PR DESCRIPTION
### Description (*)
`Mage_Adminhtml_Block_Widget_Container` lets you add buttons with a custom `sort_order`.
This means it is possible for multiple buttons to get added with the same `sort_order` by different modules.

The `getButtonsHtml` function doesn't take this case into account and overrides a previously added button with another button, if it has the same `sort_order`.

### Related Pull Requests
-

### Fixed Issues (if relevant)
-

### Manual testing scenarios (*)
Add 2 buttons with the same custom `sort_order`, the later one will replace the first.

### Questions or comments
If the increment of a button exceeds an already defined button, it will be placed after it, instead of before.
example: 
`button_a` with sort_order `19`
`button_b` with sort_order `20`
`button_c` with sort_order `19` will be `21`, after `button_b`

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
