### PR TITLE
Fix custom admin URL: also apply to skin/js base URLs and cookie domain

### DIFF
--- a/.phpstan.dist.baselines/method.nonObject.php
+++ b/.phpstan.dist.baselines/method.nonObject.php
@@ -1263,7 +1263,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'rawMessage' => 'Cannot call method saveConfig() on Mage_Core_Model_Config|null.',
-    'count' => 2,
+    'count' => 7,
     'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custom.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan.dist.baselines/method.nonObject.php
+++ b/.phpstan.dist.baselines/method.nonObject.php
@@ -1267,11 +1267,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Observer.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Cannot call method deleteConfig() on Mage_Core_Model_Config|null.',
-    'count' => 2,
-    'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustom.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Cannot call method getNode() on Mage_Core_Model_Config|null.',
     'count' => 1,
     'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Search/Separator.php',

--- a/.phpstan.dist.baselines/method.nonObject.php
+++ b/.phpstan.dist.baselines/method.nonObject.php
@@ -1262,11 +1262,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Cannot call method saveConfig() on Mage_Core_Model_Config|null.',
-    'count' => 7,
-    'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custom.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Cannot call method getNode() on Mage_Core_Model_Config|null.',
     'count' => 3,
     'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Observer.php',

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custom.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custom.php
@@ -26,6 +26,16 @@ class Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom extends Mage_Core_
 
     public const XML_PATH_SECURE_BASE_LINK_URL     = 'web/secure/base_link_url';
 
+    public const XML_PATH_UNSECURE_BASE_SKIN_URL   = 'web/unsecure/base_skin_url';
+
+    public const XML_PATH_SECURE_BASE_SKIN_URL     = 'web/secure/base_skin_url';
+
+    public const XML_PATH_UNSECURE_BASE_JS_URL     = 'web/unsecure/base_js_url';
+
+    public const XML_PATH_SECURE_BASE_JS_URL       = 'web/secure/base_js_url';
+
+    public const XML_PATH_COOKIE_DOMAIN            = 'web/cookie/cookie_domain';
+
     /**
      * Validate custom admin URL before save
      *
@@ -97,7 +107,22 @@ class Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom extends Mage_Core_
     }
 
     /**
-     * Change secure/unsecure base_url after use_custom_url was modified
+     * Change secure/unsecure base_url, base_skin_url, base_js_url and cookie_domain
+     * (admin store scope only) after use_custom_url was modified.
+     *
+     * Static assets (skin/js) and the session cookie are not covered by
+     * base_url/base_link_url alone: Mage_Core_Model_Store::getBaseUrl() reads
+     * base_skin_url/base_js_url as their own, independent config paths (see
+     * app/code/core/Mage/Core/etc/config.xml), and Mage_Core_Model_Cookie::getDomain()
+     * uses cookie_domain verbatim if it's non-empty. Without this, a custom
+     * admin URL on a separate (sub)domain loads skin/js assets from the
+     * storefront's base_url/base_skin_url instead (typically blocked there by
+     * a hardened webserver config), and the session cookie's Domain attribute
+     * ends up scoped to the storefront domain instead of the admin one,
+     * breaking session/form-key continuity in the admin panel. cookie_domain
+     * is pinned to the custom admin URL's own host explicitly (not left
+     * empty) so the Domain attribute never depends on the current request's
+     * Host header.
      *
      * @return $this
      */
@@ -122,6 +147,45 @@ class Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom extends Mage_Core_
         Mage::getConfig()->saveConfig(
             self::XML_PATH_UNSECURE_BASE_URL,
             $value,
+            self::CONFIG_SCOPE,
+            self::CONFIG_SCOPE_ID,
+        );
+
+        // Static assets (skin/js) are separate config paths, not derived from base_url
+        Mage::getConfig()->saveConfig(
+            self::XML_PATH_SECURE_BASE_SKIN_URL,
+            $value . 'skin/',
+            self::CONFIG_SCOPE,
+            self::CONFIG_SCOPE_ID,
+        );
+        Mage::getConfig()->saveConfig(
+            self::XML_PATH_UNSECURE_BASE_SKIN_URL,
+            $value . 'skin/',
+            self::CONFIG_SCOPE,
+            self::CONFIG_SCOPE_ID,
+        );
+        Mage::getConfig()->saveConfig(
+            self::XML_PATH_SECURE_BASE_JS_URL,
+            $value . 'js/',
+            self::CONFIG_SCOPE,
+            self::CONFIG_SCOPE_ID,
+        );
+        Mage::getConfig()->saveConfig(
+            self::XML_PATH_UNSECURE_BASE_JS_URL,
+            $value . 'js/',
+            self::CONFIG_SCOPE,
+            self::CONFIG_SCOPE_ID,
+        );
+
+        // Pin the admin store's cookie domain explicitly to the custom admin
+        // URL's own host, rather than leaving it empty — an empty value
+        // would make Mage_Core_Model_Cookie::getDomain() derive the Domain
+        // attribute from the current request's Host header instead, which
+        // is client-supplied input and therefore a weaker choice than a
+        // known, fixed value.
+        Mage::getConfig()->saveConfig(
+            self::XML_PATH_COOKIE_DOMAIN,
+            (string) parse_url($value, PHP_URL_HOST),
             self::CONFIG_SCOPE,
             self::CONFIG_SCOPE_ID,
         );

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custom.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custom.php
@@ -138,13 +138,13 @@ class Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom extends Mage_Core_
         }
 
         // If use_custom is enabled AND value is not empty, update base URLs
-        Mage::getConfig()->saveConfig(
+        Mage::getConfig()?->saveConfig(
             self::XML_PATH_SECURE_BASE_URL,
             $value,
             self::CONFIG_SCOPE,
             self::CONFIG_SCOPE_ID,
         );
-        Mage::getConfig()->saveConfig(
+        Mage::getConfig()?->saveConfig(
             self::XML_PATH_UNSECURE_BASE_URL,
             $value,
             self::CONFIG_SCOPE,
@@ -152,25 +152,25 @@ class Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom extends Mage_Core_
         );
 
         // Static assets (skin/js) are separate config paths, not derived from base_url
-        Mage::getConfig()->saveConfig(
+        Mage::getConfig()?->saveConfig(
             self::XML_PATH_SECURE_BASE_SKIN_URL,
             $value . 'skin/',
             self::CONFIG_SCOPE,
             self::CONFIG_SCOPE_ID,
         );
-        Mage::getConfig()->saveConfig(
+        Mage::getConfig()?->saveConfig(
             self::XML_PATH_UNSECURE_BASE_SKIN_URL,
             $value . 'skin/',
             self::CONFIG_SCOPE,
             self::CONFIG_SCOPE_ID,
         );
-        Mage::getConfig()->saveConfig(
+        Mage::getConfig()?->saveConfig(
             self::XML_PATH_SECURE_BASE_JS_URL,
             $value . 'js/',
             self::CONFIG_SCOPE,
             self::CONFIG_SCOPE_ID,
         );
-        Mage::getConfig()->saveConfig(
+        Mage::getConfig()?->saveConfig(
             self::XML_PATH_UNSECURE_BASE_JS_URL,
             $value . 'js/',
             self::CONFIG_SCOPE,
@@ -183,7 +183,7 @@ class Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom extends Mage_Core_
         // attribute from the current request's Host header instead, which
         // is client-supplied input and therefore a weaker choice than a
         // known, fixed value.
-        Mage::getConfig()->saveConfig(
+        Mage::getConfig()?->saveConfig(
             self::XML_PATH_COOKIE_DOMAIN,
             (string) parse_url($value, PHP_URL_HOST),
             self::CONFIG_SCOPE,

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustom.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustom.php
@@ -54,6 +54,31 @@ class Mage_Adminhtml_Model_System_Config_Backend_Admin_Usecustom extends Mage_Co
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE,
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE_ID,
             );
+            Mage::getConfig()->deleteConfig(
+                Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::XML_PATH_SECURE_BASE_SKIN_URL,
+                Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE,
+                Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE_ID,
+            );
+            Mage::getConfig()->deleteConfig(
+                Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::XML_PATH_UNSECURE_BASE_SKIN_URL,
+                Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE,
+                Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE_ID,
+            );
+            Mage::getConfig()->deleteConfig(
+                Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::XML_PATH_SECURE_BASE_JS_URL,
+                Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE,
+                Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE_ID,
+            );
+            Mage::getConfig()->deleteConfig(
+                Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::XML_PATH_UNSECURE_BASE_JS_URL,
+                Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE,
+                Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE_ID,
+            );
+            Mage::getConfig()->deleteConfig(
+                Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::XML_PATH_COOKIE_DOMAIN,
+                Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE,
+                Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE_ID,
+            );
         }
 
         // Set redirect flag if use custom admin URL changed

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustom.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustom.php
@@ -44,37 +44,37 @@ class Mage_Adminhtml_Model_System_Config_Backend_Admin_Usecustom extends Mage_Co
         $value = $this->getValue();
 
         if (!$value) {
-            Mage::getConfig()->deleteConfig(
+            Mage::getConfig()?->deleteConfig(
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::XML_PATH_SECURE_BASE_URL,
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE,
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE_ID,
             );
-            Mage::getConfig()->deleteConfig(
+            Mage::getConfig()?->deleteConfig(
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::XML_PATH_UNSECURE_BASE_URL,
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE,
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE_ID,
             );
-            Mage::getConfig()->deleteConfig(
+            Mage::getConfig()?->deleteConfig(
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::XML_PATH_SECURE_BASE_SKIN_URL,
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE,
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE_ID,
             );
-            Mage::getConfig()->deleteConfig(
+            Mage::getConfig()?->deleteConfig(
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::XML_PATH_UNSECURE_BASE_SKIN_URL,
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE,
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE_ID,
             );
-            Mage::getConfig()->deleteConfig(
+            Mage::getConfig()?->deleteConfig(
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::XML_PATH_SECURE_BASE_JS_URL,
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE,
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE_ID,
             );
-            Mage::getConfig()->deleteConfig(
+            Mage::getConfig()?->deleteConfig(
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::XML_PATH_UNSECURE_BASE_JS_URL,
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE,
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE_ID,
             );
-            Mage::getConfig()->deleteConfig(
+            Mage::getConfig()?->deleteConfig(
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::XML_PATH_COOKIE_DOMAIN,
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE,
                 Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::CONFIG_SCOPE_ID,


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
`Mage_Adminhtml_Model_System_Config_Backend_Admin_Custom::_afterSave()` (added in #4264) only updates `web/(un)secure/base_url` on the admin store scope when "Custom Admin URL" is saved. Two related config paths are left untouched, which breaks admin panels served from a separate (sub)domain:

- `base_skin_url`/`base_js_url` are independent config paths (see `Mage_Core_Model_Store::getBaseUrl()`), not derived from `base_url`. Without an override, admin skin/JS assets are requested against the storefront's `base_skin_url`/`base_js_url` instead — typically blocked there by a hardened webserver config (e.g. `deny` on `/skin/adminhtml/`), causing 403s on the admin login/dashboard.
- `web/cookie/cookie_domain` stays on its default-scope value (the storefront domain). `Mage_Core_Model_Cookie::getDomain()` uses it verbatim if non-empty, so the session cookie's `Domain` attribute never matches the admin domain, breaking session/form-key continuity after login.

`_afterSave()` now also saves `base_skin_url`/`base_js_url` (secure and unsecure) and pins `cookie_domain` explicitly to the custom admin URL's own host — a fixed, known value rather than one derived from the current request's `Host` header (which would be the case if left empty).

Also updated the phpstan baseline count for `Mage_Core_Model_Config|null::saveConfig()` in this file (2 → 7) to match the additional calls.

### Related Pull Requests
- follow-up to OpenMage/magento-lts#4264

### Fixed Issues (if relevant)
- none filed yet — found while running OpenMage with the admin panel on a dedicated subdomain

### Manual testing scenarios (*)
Setup: a store with the storefront on one domain (e.g. `shop.example.com`) and the admin panel reachable on a separate subdomain (e.g. `shop-admin.example.com`), both pointing at the same OpenMage installation.

1. In System Config > Advanced > Admin > Admin Base URL, enable "Use Custom Admin URL" and set "Custom Admin URL" to `https://shop-admin.example.com/`. Save.
2. Inspect `core_config_data` for `scope='stores' AND scope_id=0`: confirm `web/unsecure/base_url`, `web/secure/base_url`, `web/unsecure/base_skin_url`, `web/secure/base_skin_url`, `web/unsecure/base_js_url`, `web/secure/base_js_url` and `web/cookie/cookie_domain` are all set, with the skin/js URLs pointing at `https://shop-admin.example.com/skin/` and `/js/` respectively, and `cookie_domain` set to `shop-admin.example.com`.
3. Load `https://shop-admin.example.com/admin` in a browser — before this change, skin/JS assets (e.g. `login.css`) 404/403 because they're requested from the storefront domain instead; after this change they load correctly from the admin domain.
4. Log into the admin panel — before this change, the session cookie's `Domain` attribute stays pinned to the storefront domain, so the session/form key isn't reliably preserved across the login redirect; after this change, login and navigation work without form-key/session errors.
5. Re-run with "Use Custom Admin URL" disabled (or unchanged from a plain single-domain setup) to confirm existing single-domain behavior is unaffected.

### Questions or comments
No existing unit tests cover this class — happy to add coverage if the maintainers can point to the preferred pattern for testing `Mage_Core_Model_Config_Data` backend models (they need a Magento bootstrap/DB, unlike most pure unit tests in `tests/unit`).

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
