### PR TITLE
Set correct getter for the review id in the rating collection filter

### DIFF
--- a/app/code/core/Mage/Review/Block/View.php
+++ b/app/code/core/Mage/Review/Block/View.php
@@ -14,7 +14,6 @@
  *
  * @method false|Mage_Rating_Model_Resource_Rating_Option_Vote_Collection getRatingCollection()
  * @method array                                                          getRatingSummaryCache()
- * @method int                                                            getReviewId()
  * @method int                                                            getTotalReviewsCache()
  * @method $this                                                          setRatingCollection(false|Mage_Rating_Model_Resource_Rating_Option_Vote_Collection $value)
  * @method setRatingSummaryCache(array $value)
@@ -68,7 +67,7 @@ class Mage_Review_Block_View extends Mage_Catalog_Block_Product_Abstract
         if (!$this->getRatingCollection()) {
             $ratingCollection = Mage::getModel('rating/rating_option_vote')
                 ->getResourceCollection()
-                ->setReviewFilter($this->getReviewId())
+                ->setReviewFilter((int)$this->getReviewData()->getId())
                 ->setStoreFilter(Mage::app()->getStore()->getId())
                 ->addRatingInfo(Mage::app()->getStore()->getId())
                 ->load();

--- a/app/code/core/Mage/Review/Block/View.php
+++ b/app/code/core/Mage/Review/Block/View.php
@@ -67,7 +67,7 @@ class Mage_Review_Block_View extends Mage_Catalog_Block_Product_Abstract
         if (!$this->getRatingCollection()) {
             $ratingCollection = Mage::getModel('rating/rating_option_vote')
                 ->getResourceCollection()
-                ->setReviewFilter((int)$this->getReviewData()->getId())
+                ->setReviewFilter((int) $this->getReviewData()->getId())
                 ->setStoreFilter(Mage::app()->getStore()->getId())
                 ->addRatingInfo(Mage::app()->getStore()->getId())
                 ->load();


### PR DESCRIPTION
### Description (*)
Then opening a review with a associated rating, the rating is not shown.
The block doesn't contain a `review_id` so the collection filter doesn't select anything, the only reference to the review is the registry entry, set in the controller.

### Related Pull Requests
-

### Fixed Issues (if relevant)
-

### Manual testing scenarios (*)
Add a review to a product, while at least one rating is active.
Approve the review and open it (click the review title while viewing the product) to get to the `review/product/view` page.

### Questions or comments
-

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
