### PR TITLE
fix: Disable global attribute field when editing on a store view scope

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/Element.php
@@ -95,6 +95,33 @@ class Mage_Adminhtml_Block_Catalog_Form_Renderer_Fieldset_Element extends Mage_A
     }
 
     /**
+     * Check whether the associated attribute is globally-scoped and this
+     * field is being rendered for a specific store view (not the
+     * default/all-store-views scope).
+     *
+     * Editing a global attribute from a store view scope writes a
+     * store-scoped row for it, corrupting attribute data since a global
+     * attribute should never carry a per-store value. This mirrors
+     * canDisplayUseDefault() (which already excludes global-scope
+     * attributes from the "use default" checkbox), covering the case that
+     * mechanism leaves open: the field itself was still editable and
+     * savable from a store view.
+     *
+     * @return bool
+     */
+    public function isGlobalAttributeOnStoreScope()
+    {
+        $attribute = $this->getAttribute();
+        if ($attribute === null || !$attribute->isScopeGlobal()) {
+            return false;
+        }
+
+        $dataObject = $this->getDataObject();
+
+        return $dataObject !== null && (bool) $dataObject->getStoreId();
+    }
+
+    /**
      * Disable field in default value using case
      *
      * @return $this
@@ -102,6 +129,10 @@ class Mage_Adminhtml_Block_Catalog_Form_Renderer_Fieldset_Element extends Mage_A
     public function checkFieldDisable()
     {
         if ($this->canDisplayUseDefault() && $this->usedDefault()) {
+            $this->getElement()->setDisabled(true);
+        }
+
+        if ($this->isGlobalAttributeOnStoreScope()) {
             $this->getElement()->setDisabled(true);
         }
 

--- a/tests/unit/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/ElementTest.php
+++ b/tests/unit/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/ElementTest.php
@@ -11,8 +11,9 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Adminhtml\Block\Catalog\Form\Renderer\Fieldset;
 
-// use Mage_Adminhtml_Block_Catalog_Form_Renderer_Fieldset_Element as Subject;
-use Override;
+use Mage_Adminhtml_Block_Catalog_Form_Renderer_Fieldset_Element as Subject;
+use Mage_Catalog_Model_Product;
+use Mage_Catalog_Model_Resource_Eav_Attribute;
 use OpenMage\Tests\Unit\OpenMageTest;
 use OpenMage\Tests\Unit\Traits\DataProvider\Mage\Adminhtml\Block\Catalog\Form\Renderer\Fieldset\ElementTrait;
 
@@ -20,13 +21,23 @@ final class ElementTest extends OpenMageTest
 {
     use ElementTrait;
 
-    // private static Subject $subject;
+    /**
+     * @covers Mage_Adminhtml_Block_Catalog_Form_Renderer_Fieldset_Element::isGlobalAttributeOnStoreScope()
+     * @dataProvider provideIsGlobalAttributeOnStoreScopeData
+     * @group Block
+     */
+    public function testIsGlobalAttributeOnStoreScope(
+        bool $expectedResult,
+        Mage_Catalog_Model_Resource_Eav_Attribute $attribute,
+        Mage_Catalog_Model_Product $dataObject,
+    ): void {
+        $methods = [
+            'getAttribute' => $attribute,
+            'getDataObject' => $dataObject,
+        ];
+        $mock = $this->getMockWithCalledMethods(Subject::class, $methods);
 
-    #[Override]
-    public static function setUpBeforeClass(): void
-    {
-        parent::setUpBeforeClass();
-        // self::$subject = new Subject();
-        self::markTestSkipped('');
+        self::assertInstanceOf(Subject::class, $mock);
+        self::assertSame($expectedResult, $mock->isGlobalAttributeOnStoreScope());
     }
 }

--- a/tests/unit/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/ElementTest.php
+++ b/tests/unit/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/ElementTest.php
@@ -30,7 +30,8 @@ final class ElementTest extends OpenMageTest
         bool $expectedResult,
         Mage_Catalog_Model_Resource_Eav_Attribute $attribute,
         Mage_Catalog_Model_Product $dataObject,
-    ): void {
+    ): void
+    {
         $methods = [
             'getAttribute' => $attribute,
             'getDataObject' => $dataObject,

--- a/tests/unit/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/ElementTest.php
+++ b/tests/unit/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/ElementTest.php
@@ -30,8 +30,7 @@ final class ElementTest extends OpenMageTest
         bool $expectedResult,
         Mage_Catalog_Model_Resource_Eav_Attribute $attribute,
         Mage_Catalog_Model_Product $dataObject,
-    ): void
-    {
+    ): void {
         $methods = [
             'getAttribute' => $attribute,
             'getDataObject' => $dataObject,

--- a/tests/unit/Traits/DataProvider/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/ElementTrait.php
+++ b/tests/unit/Traits/DataProvider/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/ElementTrait.php
@@ -11,4 +11,43 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Traits\DataProvider\Mage\Adminhtml\Block\Catalog\Form\Renderer\Fieldset;
 
-trait ElementTrait {}
+use Generator;
+use Mage_Catalog_Model_Product;
+use Mage_Catalog_Model_Resource_Eav_Attribute;
+
+trait ElementTrait
+{
+    /**
+     * @return Generator<string, list{bool, Mage_Catalog_Model_Resource_Eav_Attribute, Mage_Catalog_Model_Product}, void, void>
+     */
+    public static function provideIsGlobalAttributeOnStoreScopeData(): Generator
+    {
+        yield 'global attribute, store view scope' => [
+            true,
+            (new Mage_Catalog_Model_Resource_Eav_Attribute())
+                ->setIsGlobal(Mage_Catalog_Model_Resource_Eav_Attribute::SCOPE_GLOBAL),
+            (new Mage_Catalog_Model_Product())->setStoreId(1),
+        ];
+
+        yield 'global attribute, default values scope (store id 0)' => [
+            false,
+            (new Mage_Catalog_Model_Resource_Eav_Attribute())
+                ->setIsGlobal(Mage_Catalog_Model_Resource_Eav_Attribute::SCOPE_GLOBAL),
+            (new Mage_Catalog_Model_Product())->setStoreId(0),
+        ];
+
+        yield 'website-scope attribute, store view scope' => [
+            false,
+            (new Mage_Catalog_Model_Resource_Eav_Attribute())
+                ->setIsGlobal(Mage_Catalog_Model_Resource_Eav_Attribute::SCOPE_WEBSITE),
+            (new Mage_Catalog_Model_Product())->setStoreId(1),
+        ];
+
+        yield 'store-scope attribute, store view scope' => [
+            false,
+            (new Mage_Catalog_Model_Resource_Eav_Attribute())
+                ->setIsGlobal(Mage_Catalog_Model_Resource_Eav_Attribute::SCOPE_STORE),
+            (new Mage_Catalog_Model_Product())->setStoreId(1),
+        ];
+    }
+}


### PR DESCRIPTION
### Description (*)

`Mage_Adminhtml_Block_Catalog_Form_Renderer_Fieldset_Element::checkFieldDisable()` already disables the "use default" checkbox for global-scope attributes via `canDisplayUseDefault()`, but the field itself remains editable and savable when the fieldset is rendered for a specific store view (not the default/all-store-views scope). Saving from that state writes a store-scoped row for an attribute that should only ever have a global value, corrupting the attribute's data.

This adds `isGlobalAttributeOnStoreScope()` to detect that case (global-scope attribute + a data object with a non-default store id) and disable the field the same way `canDisplayUseDefault()`/`usedDefault()` already do, closing the gap that mechanism leaves open.

### Manual testing scenarios (*)

1. In admin, go to **Catalog > Attributes > Manage Attributes**, create (or pick an existing) attribute with **Scope = Global**.
2. Go to **Catalog > Manage Products**, open any product, switch to a specific store view (not "Default Values") using the store switcher.
3. Locate the global-scope attribute's field on the product edit form.
4. **Before this fix:** the field is editable; changing and saving it writes a store-scoped value row for that attribute.
5. **After this fix:** the field is disabled (same as attributes whose "Use Default Value" is checked), and no store-scoped row is written when saving.
6. Switch back to "Default Values" scope and confirm the field is still editable there, unaffected.

### Questions or comments

Added `isGlobalAttributeOnStoreScope()` and a PHPUnit test (`ElementTest`/`ElementTrait`) covering: global attribute on a store view (disabled), global attribute on default scope (editable), and website/store-scope attributes on a store view (unaffected, editable). Verified locally: PHPUnit, PHPStan, ECS and PHPMD all pass clean on the changed files.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)