### PR TITLE
Fix MariaDB 12.3 compatibility in cart

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Collection.php
@@ -146,8 +146,8 @@ class Mage_SalesRule_Model_Resource_Rule_Collection extends Mage_Rule_Model_Reso
                     ),
                     [],
                 )
-                ->where('from_date is null or from_date <= ?', $now)
-                ->where('to_date is null or to_date >= ?', $now);
+                ->where('`from_date` is null or `from_date` <= ?', $now)
+                ->where('`to_date` is null or `to_date` >= ?', $now);
 
             $this->addIsActiveFilter();
 


### PR DESCRIPTION
### Description (*)
MariaDB 12.3 adds `TO_DATE()` as a function. See [here](https://mariadb.com/docs/release-notes/community-server/12.3/mariadb-12.3-changes-and-improvements#compatibility-features), first line in "Compatibility Features"..

This collides with the unquoted column name `to_date` in app/code/core/Mage/SalesRule/Model/Resource/Rule/Collection.php.

### Related Pull Requests
none

### Fixed Issues (if relevant)
none

### Manual testing scenarios (*)
Add a product to cart. On MariaDB 12.3, opening the cart will result in:
> SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'is null or to_date >= '2026-07-27') AND (`is_active` = '1') AND (`main_table`...' at line 2, query was: SELECT `main_table`.* FROM `vn_salesrule` AS `main_table` INNER JOIN `vn_salesrule_customer_group` AS `customer_group_ids` ON main_table.rule_id = customer_group_ids.rule_id AND customer_group_ids.customer_group_id = 1 WHERE (EXISTS (SELECT 1 FROM `vn_salesrule_website` AS `website` WHERE (website.website_id IN (1)) AND (main_table.rule_id = website.rule_id))) AND (from_date is null or from_date <= '2026-07-27') AND (to_date is null or to_date >= '2026-07-27') AND (`is_active` = '1') AND (`main_table`.`coupon_type` = '1') ORDER BY sort_order ASC


### Questions or comments
I didn't check everything for MariaDB 12.3 compatibility. So far, I only noticed this issue with 12.3.


### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
