### PR TITLE
Fix deprecated warnings related to using null as an array offset

### DIFF
--- a/.phpstan.dist.baselines/method.nonObject.php
+++ b/.phpstan.dist.baselines/method.nonObject.php
@@ -1087,11 +1087,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Block/Tax/Class/Edit.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Cannot call method setLegend() on Mage_Core_Block_Abstract|false.',
-    'count' => 1,
-    'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Block/Tax/Rate/Form.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Cannot call method toHtml() on Mage_Core_Block_Abstract|false.',
     'count' => 1,
     'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Block/Tax/Rate/Title/Fieldset.php',

--- a/.phpstan.dist.baselines/varTag.type.php
+++ b/.phpstan.dist.baselines/varTag.type.php
@@ -22,6 +22,11 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Block/System/Store/Edit/Form.php',
 ];
 $ignoreErrors[] = [
+    'rawMessage' => 'PHPDoc tag @var with type Mage_Adminhtml_Block_Tax_Rate_Title_Fieldset is not subtype of type Mage_Core_Block_Abstract|false.',
+    'count' => 1,
+    'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/Block/Tax/Rate/Form.php',
+];
+$ignoreErrors[] = [
     'rawMessage' => 'PHPDoc tag @var with type Mage_Admin_Model_Session is not subtype of type Mage_Adminhtml_Model_Session.',
     'count' => 1,
     'path' => __DIR__ . '/../app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php',

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Form.php
@@ -142,7 +142,12 @@ class Mage_Adminhtml_Block_Tax_Rate_Form extends Mage_Adminhtml_Block_Widget_For
         $form->setMethod('post');
 
         if (!Mage::app()->isSingleStoreMode()) {
-            $form->addElement(Mage::getBlockSingleton('adminhtml/tax_rate_title_fieldset')->setLegend(Mage::helper('tax')->__('Tax Titles')));
+            /** @var Mage_Adminhtml_Block_Tax_Rate_Title_Fieldset $taxRateTitleFieldset */
+            $taxRateTitleFieldset = Mage::getBlockSingleton('adminhtml/tax_rate_title_fieldset');
+            $taxRateTitleFieldset
+                ->setId('tax_rate_title_fieldset')
+                ->setLegend(Mage::helper('tax')->__('Tax Titles'));
+            $form->addElement($taxRateTitleFieldset);
         }
 
         $rateData = $rateObject->getData();

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Media.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Media.php
@@ -168,6 +168,8 @@ class Mage_Catalog_Model_Product_Attribute_Backend_Media extends Mage_Eav_Model_
         }
 
         foreach ($value['values'] as $mediaAttrCode => $attrData) {
+            $attrData ??= '';
+
             if (array_key_exists($attrData, $newImages)) {
                 $object->setData($mediaAttrCode, $newImages[$attrData]['new_file']);
                 $label = $newImages[$attrData]['label'] === null || !empty($newImages[$attrData]['label_use_default']) ? $newImages[$attrData]['label_default'] : $newImages[$attrData]['label'];

--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -199,7 +199,7 @@ abstract class Mage_Core_Controller_Varien_Action
     public function setFlag($action, $flag, $value)
     {
         if ($action === '') {
-            $action = $this->getRequest()->getActionName();
+            $action = $this->getRequest()->getActionName() ?? '';
         }
 
         $this->_flags[$action][$flag] = $value;

--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -487,6 +487,7 @@ class Mage_Eav_Model_Config
             return $code;
         }
 
+        $code ??= '';
         $storeId ??= $this->_storeId();
         $this->_initializeStore($storeId);
         $entityType = $this->getEntityType($entityType);

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Customer.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Customer.php
@@ -402,7 +402,7 @@ class Mage_ImportExport_Model_Export_Entity_Customer extends Mage_ImportExport_M
         // go through all valid attribute codes
         foreach ($validAttrCodes as $attrCode) {
             $attribute = $customer->getAttribute($attrCode);
-            $attrValue = $customer->getData($attrCode);
+            $attrValue = $customer->getData($attrCode) ?? '';
 
             if ($attribute && $attribute->getFrontendInput() == 'multiselect') {
                 $optionText = (array) $attribute->getSource()->getOptionText($attrValue);

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
@@ -525,7 +525,7 @@ class Mage_ImportExport_Model_Export_Entity_Product extends Mage_ImportExport_Mo
             return false;
         }
 
-        $categoryId = array_shift($rowCategories[$productId]);
+        $categoryId = array_shift($rowCategories[$productId]) ?? '';
         if (isset($this->_rootCategories[$categoryId])) {
             $dataRow[self::COL_ROOT_CATEGORY] = $this->_rootCategories[$categoryId];
         }
@@ -663,7 +663,7 @@ class Mage_ImportExport_Model_Export_Entity_Product extends Mage_ImportExport_Mo
                     $rowIsEmpty = true; // row is empty by default
 
                     foreach ($validAttrCodes as &$attrCode) { // go through all valid attribute codes
-                        $attrValue = $item->getData($attrCode);
+                        $attrValue = $item->getData($attrCode) ?? '';
 
                         if (!empty($this->_attributeValues[$attrCode])) {
                             if ($this->_attributeTypes[$attrCode] == 'multiselect') {


### PR DESCRIPTION
### Description (*)
PHP 8.5 deprecated the use of `null` as an array offset and as a key for the `array_key_exists` function

### Related Pull Requests
- see OpenMage/magento-lts#5708

### Fixed Issues (if relevant)
- fixes parts of OpenMage/magento-lts#5707

### Manual testing scenarios (*)
Use the markers below as a guide to replicate the warnings/errors(in dev mode)
- open install setup
- save product without image
- export product
- export customers
- save customer
- save internal product attribute
- open tax rate form

### Questions or comments
Mage_Core_Controller_Varien_Action::202 If no action is set, like in install setup
Mage_Catalog_Model_Product_Attribute_Backend_Media::171 If no image was added to the gallery `array ('image' => NULL,'small_image' => NULL,'thumbnail' => NULL)` while saving
Mage_ImportExport_Model_Export_Entity_Product::529 If a product is not assigned to any category while export
Mage_ImportExport_Model_Export_Entity_Product::666 If a product value is not set for any product while export
Mage_ImportExport_Model_Export_Entity_Customer::405 If a customer value is not set for any customer while saving
Mage_Eav_Model_Config::490 If an internal product attribute is saved (attribute code is disabled)
Mage_Adminhtml_Block_Tax_Rate_Form::146 Varien_Data_Form::125 throws, because no id was set for the tax_rate_title_fieldset

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
