### PR TITLE
USE $_SERVER['SCRIPT_FILENAME'] instead of getenv()

### DIFF
--- a/.phpstan.dist.baselines/argument.type.php
+++ b/.phpstan.dist.baselines/argument.type.php
@@ -792,11 +792,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../app/code/core/Mage/Api/Helper/Data.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Parameter #1 $path of function basename expects string, string|false given.',
-    'count' => 1,
-    'path' => __DIR__ . '/../app/code/core/Mage/Api/Helper/Data.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Parameter #1 $node of method Varien_Simplexml_Config::setXml() expects Varien_Simplexml_Element, Varien_Simplexml_Element|false given.',
     'count' => 1,
     'path' => __DIR__ . '/../app/code/core/Mage/Api/Model/Config.php',
@@ -1090,11 +1085,6 @@ $ignoreErrors[] = [
     'rawMessage' => 'Parameter #2 ...$arrays of function array_merge expects array, array|false given.',
     'count' => 1,
     'path' => __DIR__ . '/../app/code/core/Mage/Api2/Model/Resource/Validator/Eav.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Parameter #1 $path of function basename expects string, string|false given.',
-    'count' => 1,
-    'path' => __DIR__ . '/../app/code/core/Mage/Api2/Model/Route/ApiType.php',
 ];
 $ignoreErrors[] = [
     'rawMessage' => 'Parameter #1 $adminId of method Mage_Api2_Adminhtml_Api2_RoleController::_addUserToRole() expects int, int|string given.',

--- a/app/code/core/Mage/Api/Helper/Data.php
+++ b/app/code/core/Mage/Api/Helper/Data.php
@@ -362,6 +362,7 @@ class Mage_Api_Helper_Data extends Mage_Core_Helper_Abstract
      * @param  bool               $htmlSpecialChars
      * @return string
      * @throws Zend_Uri_Exception
+     * @SuppressWarnings("PHPMD.Superglobals")
      */
     public function getServiceUrl($routePath = null, $routeParams = null, $htmlSpecialChars = false)
     {
@@ -379,7 +380,8 @@ class Mage_Api_Helper_Data extends Mage_Core_Helper_Abstract
         $uri = Zend_Uri_Http::fromString($url);
         $uri->setHost($request->getHttpHost());
         if (!$urlModel->getRouteFrontName()) {
-            $uri->setPath('/' . trim($request->getBasePath() . '/' . basename(getenv('SCRIPT_FILENAME')), '/'));
+            $scriptFilename = (string) ($_SERVER['SCRIPT_FILENAME'] ?? $_SERVER['SCRIPT_NAME'] ?? '');
+            $uri->setPath('/' . trim($request->getBasePath() . '/' . basename($scriptFilename), '/'));
         } else {
             $uri->setPath($request->getBaseUrl() . $request->getPathInfo());
         }

--- a/app/code/core/Mage/Api2/Model/Route/ApiType.php
+++ b/app/code/core/Mage/Api2/Model/Route/ApiType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @copyright  For copyright and license information, read the COPYING.txt file.
  * @link       /COPYING.txt
@@ -30,6 +32,7 @@ class Mage_Api2_Model_Route_ApiType extends Mage_Api2_Model_Route_Abstract imple
      * @param array               $reqs       Regular expression requirements for variables (keys as variable names)
      * @param null|Zend_Translate $translator Translator to use for this instance
      * @param mixed               $locale
+     * @SuppressWarnings("PHPMD.Superglobals")
      */
     public function __construct(
         $route,                             // @phpstan-ignore constructor.unusedParameter
@@ -38,7 +41,8 @@ class Mage_Api2_Model_Route_ApiType extends Mage_Api2_Model_Route_Abstract imple
         ?Zend_Translate $translator = null, // @phpstan-ignore constructor.unusedParameter
         $locale = null                      // @phpstan-ignore constructor.unusedParameter
     ) {
+        $scriptFilename = (string) ($_SERVER['SCRIPT_FILENAME'] ?? $_SERVER['SCRIPT_NAME'] ?? '');
         // phpcs:ignore Ecg.Security.ForbiddenFunction.Found
-        parent::__construct([Mage_Api2_Model_Route_Abstract::PARAM_ROUTE => str_replace('.php', '', basename(getenv('SCRIPT_FILENAME'))) . '/:api_type']);
+        parent::__construct([Mage_Api2_Model_Route_Abstract::PARAM_ROUTE => str_replace('.php', '', basename($scriptFilename)) . '/:api_type']);
     }
 }


### PR DESCRIPTION
### Description (*)

This change replaces `getenv('SCRIPT_FILENAME')` with `$_SERVER['SCRIPT_FILENAME']`.

Otherwise, if you try to access the REST API **using FrankenPHP as the web server**, you will receive error 400: 'API type "api" is not supported'.

```xml
<magento_api>
	<script/>
	<messages>
		<error>
			<data_item>
				<code>400</code>
				<message>API type "api" is not supported</message>
				<trace>#0 /xxx/app/code/core/Mage/Api2/Model/Server.php(190): Mage_Api2_Model_Config->getRoutes('api') #1 /var/www/xxx/app/code/core/Mage/Api2/Model/Server.php(96): Mage_Api2_Model_Server->_route(Object(Mage_Api2_Model_Request)) #2 /xxx/api.php(47): Mage_Api2_Model_Server->run() #3 /var/www/xxx/pub/default/api.php(7): require('/xxx...') #4 {main}</trace>
			</data_item>
		</error>
	</messages>
</magento_api>
```

In app/code/core/Mage/Api2/Model/Route/ApiType.php, OpenMage uses  `getenv('SCRIPT_FILENAME')` to read the script filename from an environment variable.

This works with "classic" webservers, such as Apache or nginx and the PHP-FPM runtime. These servers set variables such as SCRIPT_FILENAME as both environment variables and in the $_SERVER superglobal. More modern PHP runtimes, such as FrankenPHP only expose these variables in the $_SERVER superglobal and not as environment variables. As far as i understand, this is done for better isolation in FrankenPHP's worker mode. An environment variable would be visible to all PHP requests within the same worker process, whereas the `$_SERVER` superglobal is set individually set for each request.

Therefore, `getenv('SCRIPT_FILENAME')` can return incorrect or empty values on these modern runtimes. It's safer to use `$_SERVER['SCRIPT_FILENAME']`, which works on all runtimes (including Apache, nginx/FPM, Caddy/FPM, and FrankenPHP).

### Manual testing scenarios (*)
1. Run a store using FrankenPHP as the web server
2. Open /api/rest/orders in your browser (or any REST client, but a browser will suffice)
3. You will receive a 400 "API type "api" is not supported". It is expected to get a 401 `Unauthorized` or 403 `Access denied`, because you are not sending access tokens.

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
