### PR TITLE
fix yesno select preselection, if 'no' is selected

### DIFF
--- a/app/code/core/Mage/Widget/Model/Widget.php
+++ b/app/code/core/Mage/Widget/Model/Widget.php
@@ -227,7 +227,7 @@ class Mage_Widget_Model_Widget extends Varien_Object
                 }
             }
 
-            if ($value) {
+            if ($value || $value === '0') {
                 $directive .= sprintf(' %s="%s"', $name, $value);
             }
         }


### PR DESCRIPTION
### Description (*)
After inserting a widget into a CMS-Page, it gets added as code created by the `getWidgetDeclaration` function.
If an element is a yes/no select with `1=yes` and `0=no` and "no" is selected then the code creation for this select gets skipped.
However after opening the widget again in the editor, the select will now have `yes` preselected.

Thats because the Varien_Data_Form_Element_Select uses the `in_array` function to check if the option should be selected.
While inserting the widget for the first time, the value it compares to is `null`, after opening it again it is an empty string `''`.
Checking an empty string against '0' (the value of the "no" option) is now different with newer php versions.

```
// $a is the value of the non existing `getWidgetDeclaration` code definition for the select
$a = [0 => ''];
// needle 0 is the value of the no option
var_dump(in_array(0, $a, false));
```
<img width="317" height="268" alt="image" src="https://github.com/user-attachments/assets/c12bd702-c481-4f23-867a-507fe6b4b91d" />

The PR adds code entries for `0` values, so it still matches.

### Related Pull Requests
-

### Fixed Issues (if relevant)
-

### Manual testing scenarios (*)
1. Edit a CMS-Page, add the "New Products List" widget and leave "Display Page Control" with "no" selected.
2. Open the inserted widget by double clicking on it. It now has "yes" selected for the "Display Page Control".

### Questions or comments
-

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
