### PR TITLE
update widget_grid event prefixes in adminhtml

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Grid.php
@@ -14,7 +14,7 @@
  */
 class Mage_Adminhtml_Block_Api_User_Grid extends Mage_Adminhtml_Block_Widget_Grid
 {
-    protected string $_eventPrefix = 'adminhtml_permissions_grid_user';
+    protected string $_eventPrefix = 'adminhtml_api_user_grid';
 
     public function __construct()
     {

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Grid.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 class Mage_Adminhtml_Block_Dashboard_Grid extends Mage_Adminhtml_Block_Widget_Grid
 {
+    protected string $_eventPrefix = 'adminhtml_dashboard_grid';
+
     /**
      * Setting default for every grid on dashboard
      */

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Viewed/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Viewed/Grid.php
@@ -14,6 +14,8 @@
  */
 class Mage_Adminhtml_Block_Report_Product_Viewed_Grid extends Mage_Adminhtml_Block_Report_Grid_Abstract
 {
+    protected string $_eventPrefix = 'adminhtml_report_product_viewed_grid';
+
     /**
      * Column for grid to be grouped by
      *

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Bestsellers/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Bestsellers/Grid.php
@@ -14,6 +14,8 @@
  */
 class Mage_Adminhtml_Block_Report_Sales_Bestsellers_Grid extends Mage_Adminhtml_Block_Report_Grid_Abstract
 {
+    protected string $_eventPrefix = 'adminhtml_report_sales_bestsellers_grid';
+
     protected $_columnGroupBy = 'period';
 
     public function __construct()

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons/Grid.php
@@ -14,6 +14,8 @@
  */
 class Mage_Adminhtml_Block_Report_Sales_Coupons_Grid extends Mage_Adminhtml_Block_Report_Grid_Abstract
 {
+    protected string $_eventPrefix = 'adminhtml_report_sales_coupons_grid';
+
     protected $_columnGroupBy = 'period';
 
     public function __construct()

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Invoiced/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Invoiced/Grid.php
@@ -14,6 +14,8 @@
  */
 class Mage_Adminhtml_Block_Report_Sales_Invoiced_Grid extends Mage_Adminhtml_Block_Report_Grid_Abstract
 {
+    protected string $_eventPrefix = 'adminhtml_report_sales_invoiced_grid';
+
     protected $_columnGroupBy = 'period';
 
     public function __construct()

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Refunded/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Refunded/Grid.php
@@ -14,6 +14,8 @@
  */
 class Mage_Adminhtml_Block_Report_Sales_Refunded_Grid extends Mage_Adminhtml_Block_Report_Grid_Abstract
 {
+    protected string $_eventPrefix = 'adminhtml_report_sales_refunded_grid';
+
     protected $_columnGroupBy = 'period';
 
     public function __construct()

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Sales/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Sales/Grid.php
@@ -14,6 +14,8 @@
  */
 class Mage_Adminhtml_Block_Report_Sales_Sales_Grid extends Mage_Adminhtml_Block_Report_Grid_Abstract
 {
+    protected string $_eventPrefix = 'adminhtml_report_sales_sales_grid';
+
     protected $_columnGroupBy = 'period';
 
     public function __construct()

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Shipping/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Shipping/Grid.php
@@ -14,6 +14,8 @@
  */
 class Mage_Adminhtml_Block_Report_Sales_Shipping_Grid extends Mage_Adminhtml_Block_Report_Grid_Abstract
 {
+    protected string $_eventPrefix = 'adminhtml_report_sales_shipping_grid';
+
     protected $_columnGroupBy = 'period';
 
     public function __construct()

--- a/app/code/core/Mage/Adminhtml/Block/Review/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Product/Grid.php
@@ -14,6 +14,8 @@
  */
 class Mage_Adminhtml_Block_Review_Product_Grid extends Mage_Adminhtml_Block_Catalog_Product_Grid
 {
+    protected string $_eventPrefix = 'adminhtml_review_product_grid';
+
     public function __construct()
     {
         parent::__construct();

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
@@ -14,6 +14,8 @@
  */
 class Mage_Adminhtml_Block_Sales_Order_Status_Grid extends Mage_Adminhtml_Block_Widget_Grid
 {
+    protected string $_eventPrefix = 'adminhtml_sales_order_status_grid';
+
     public function __construct()
     {
         parent::__construct();

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Product/Grid.php
@@ -14,6 +14,8 @@
  */
 class Mage_Adminhtml_Block_Urlrewrite_Product_Grid extends Mage_Adminhtml_Block_Catalog_Product_Grid
 {
+    protected string $_eventPrefix = 'adminhtml_urlrewrite_product_grid';
+
     /**
      * Disable massaction
      *

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
@@ -18,6 +18,8 @@
  */
 class Mage_Bundle_Block_Adminhtml_Catalog_Product_Edit_Tab_Bundle_Option_Search_Grid extends Mage_Adminhtml_Block_Widget_Grid
 {
+    protected string $_eventPrefix = 'bundle_adminhtml_catalog_product_edit_tab_bundle_option_search_grid';
+
     public function __construct()
     {
         parent::__construct();

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens/Grid.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens/Grid.php
@@ -14,7 +14,7 @@
  */
 class Mage_Oauth_Block_Adminhtml_Oauth_AuthorizedTokens_Grid extends Mage_Adminhtml_Block_Widget_Grid
 {
-    protected string $_eventPrefix = 'ouath_adminhtml_oauth_authorizedtokens_grid';
+    protected string $_eventPrefix = 'oauth_adminhtml_oauth_authorizedtokens_grid';
 
     public function __construct()
     {


### PR DESCRIPTION
### Description (*)
- Add missing eventPrefix declarations to classes which extend from `Mage_Adminhtml_Block_Widget_Grid` in their inheritance chain.
- Fix spelling error in oauth name
- rename the api grid

### Related Pull Requests
none

### Fixed Issues (if relevant)
none

### Manual testing scenarios (*)
use the now existing eventPrefix as observer.

### Questions or comments
none

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All automated tests passed successfully (all builds are green, SonarCloud checks are not required to merge)
