### PR TITLE
fix(security): deny ACL resources that have no explicit rule for a role

### DIFF
--- a/.phpstan.dist.baselines/argument.type.php
+++ b/.phpstan.dist.baselines/argument.type.php
@@ -47,16 +47,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../app/code/core/Mage/Admin/Model/Resource/Acl.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Parameter #2 $rolesArr of method Mage_Admin_Model_Resource_Acl::loadRoles() expects array, array|null given.',
-    'count' => 1,
-    'path' => __DIR__ . '/../app/code/core/Mage/Admin/Model/Resource/Acl.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Parameter #2 $rulesArr of method Mage_Admin_Model_Resource_Acl::loadRules() expects array, array|null given.',
-    'count' => 1,
-    'path' => __DIR__ . '/../app/code/core/Mage/Admin/Model/Resource/Acl.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Parameter #4 $assert of method Zend_Acl::allow() expects Zend_Acl_Assert_Interface|null, object|null given.',
     'count' => 2,
     'path' => __DIR__ . '/../app/code/core/Mage/Admin/Model/Resource/Acl.php',

--- a/.phpstan.dist.baselines/argument.type.php
+++ b/.phpstan.dist.baselines/argument.type.php
@@ -42,21 +42,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../app/Mage.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Parameter #2 $parent of method Mage_Admin_Model_Acl::addRoleParent() expects string|Zend_Acl_Role, string|null given.',
-    'count' => 1,
-    'path' => __DIR__ . '/../app/code/core/Mage/Admin/Model/Resource/Acl.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Parameter #4 $assert of method Zend_Acl::allow() expects Zend_Acl_Assert_Interface|null, object|null given.',
-    'count' => 2,
-    'path' => __DIR__ . '/../app/code/core/Mage/Admin/Model/Resource/Acl.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Parameter #4 $assert of method Zend_Acl::deny() expects Zend_Acl_Assert_Interface|null, object|null given.',
-    'count' => 1,
-    'path' => __DIR__ . '/../app/code/core/Mage/Admin/Model/Resource/Acl.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Parameter #1 $encodedValue of method Mage_Core_Helper_Data::jsonDecode() expects string, string|false given.',
     'count' => 1,
     'path' => __DIR__ . '/../app/code/core/Mage/Admin/Model/Resource/Block.php',

--- a/.phpstan.dist.baselines/missingType.iterableValue.php
+++ b/.phpstan.dist.baselines/missingType.iterableValue.php
@@ -127,16 +127,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../app/code/core/Mage/Admin/Model/Redirectpolicy.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Method Mage_Admin_Model_Resource_Acl::loadRoles() has parameter $rolesArr with no value type specified in iterable type array.',
-    'count' => 1,
-    'path' => __DIR__ . '/../app/code/core/Mage/Admin/Model/Resource/Acl.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method Mage_Admin_Model_Resource_Acl::loadRules() has parameter $rulesArr with no value type specified in iterable type array.',
-    'count' => 1,
-    'path' => __DIR__ . '/../app/code/core/Mage/Admin/Model/Resource/Acl.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Method Mage_Admin_Model_Resource_Block::getAllowedTypes() return type has no value type specified in iterable type array.',
     'count' => 1,
     'path' => __DIR__ . '/../app/code/core/Mage/Admin/Model/Resource/Block.php',

--- a/app/code/core/Mage/Admin/Model/Resource/Acl.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Acl.php
@@ -97,6 +97,7 @@ class Mage_Admin_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
             if (($rule['role_type'] ?? null) !== Mage_Admin_Model_Acl::ROLE_TYPE_GROUP) {
                 continue;
             }
+
             $roleId = $rule['role_type'] . $rule['role_id'];
             $resourceId = (string) $rule['resource_id'];
             $listed[$roleId][$resourceId] = true;
@@ -111,6 +112,7 @@ class Mage_Admin_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
             if (!str_starts_with($roleId, Mage_Admin_Model_Acl::ROLE_TYPE_GROUP) || isset($allowAll[$roleId])) {
                 continue;
             }
+
             $rules = $listed[$roleId] ?? [];
             foreach ($resources as $resourceId) {
                 if (!isset($rules[$resourceId])) {
@@ -140,7 +142,7 @@ class Mage_Admin_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
                     $roleId = $role['role_type'] . $role['user_id'];
                     if (!$acl->hasRole($roleId)) {
                         $acl->addRole(Mage::getModel('admin/acl_role_user', $roleId), $parent);
-                    } else {
+                    } elseif (!is_null($parent)) {
                         $acl->addRoleParent($roleId, $parent);
                     }
 
@@ -154,6 +156,7 @@ class Mage_Admin_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
     /**
      * Load rules
      *
+     * @param array<int, array<string, mixed>> $rulesArr
      * @return $this
      */
     public function loadRules(Mage_Admin_Model_Acl $acl, array $rulesArr)
@@ -164,6 +167,9 @@ class Mage_Admin_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
             $resource = $rule['resource_id'];
             $privileges = empty($rule['privileges']) ? null : explode(',', $rule['privileges']);
 
+            /**
+             * @var Zend_Acl_Assert_Interface|null $assert
+             */
             $assert = null;
             if ($rule['assert_id'] != 0) {
                 $assertClass = Mage::getSingleton('admin/config')->getAclAssert($rule['assert_type'])->getClassName();

--- a/app/code/core/Mage/Admin/Model/Resource/Acl.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Acl.php
@@ -61,8 +61,56 @@ class Mage_Admin_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
         $rulesArr = $adapter->fetchAll($select);
 
         $this->loadRules($acl, $rulesArr);
+        $this->denyUnlistedResources($acl, $rulesArr);
 
         return $acl;
+    }
+
+    /**
+     * Deny every registered resource that has no explicit rule for a group role.
+     *
+     * The role editor writes an explicit allow/deny row for every resource that exists
+     * when the role is saved. A resource added to code afterwards has no row, and
+     * Zend_Acl inherits the nearest ancestor's rule for it. A role allowed on a parent
+     * therefore gains every new child until the role is saved again. Denying the
+     * unlisted resources makes the runtime match what the role editor shows and saves.
+     *
+     * Roles with an "all" allow row keep full access. The role editor also writes an
+     * "all" deny row for every other role, so only the permission decides. User roles
+     * inherit from their group role through Zend_Acl role inheritance, so only group
+     * roles need rules.
+     *
+     * @param array<int, array<string, mixed>> $rulesArr
+     */
+    public function denyUnlistedResources(Mage_Admin_Model_Acl $acl, array $rulesArr): void
+    {
+        $listed = [];
+        $allowAll = [];
+        foreach ($rulesArr as $rule) {
+            if (($rule['role_type'] ?? null) !== Mage_Admin_Model_Acl::ROLE_TYPE_GROUP) {
+                continue;
+            }
+            $roleId = $rule['role_type'] . $rule['role_id'];
+            $resourceId = (string) $rule['resource_id'];
+            $listed[$roleId][$resourceId] = true;
+            if ($resourceId === self::ACL_ALL_RULES && $rule['permission'] === 'allow') {
+                $allowAll[$roleId] = true;
+            }
+        }
+
+        $resources = $acl->getResources();
+        foreach ($acl->getRoles() as $roleId) {
+            $roleId = (string) $roleId;
+            if (!str_starts_with($roleId, Mage_Admin_Model_Acl::ROLE_TYPE_GROUP) || isset($allowAll[$roleId])) {
+                continue;
+            }
+            $rules = $listed[$roleId] ?? [];
+            foreach ($resources as $resourceId) {
+                if (!isset($rules[$resourceId])) {
+                    $acl->deny($roleId, $resourceId);
+                }
+            }
+        }
     }
 
     /**

--- a/app/code/core/Mage/Admin/Model/Resource/Acl.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Acl.php
@@ -125,6 +125,7 @@ class Mage_Admin_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
     /**
      * Load roles
      *
+     * @param  array<int, array<string, mixed>> $rolesArr
      * @return $this
      * @throws Zend_Acl_Exception
      */
@@ -156,7 +157,7 @@ class Mage_Admin_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
     /**
      * Load rules
      *
-     * @param array<int, array<string, mixed>> $rulesArr
+     * @param  array<int, array<string, mixed>> $rulesArr
      * @return $this
      */
     public function loadRules(Mage_Admin_Model_Acl $acl, array $rulesArr)
@@ -168,10 +169,13 @@ class Mage_Admin_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
             $privileges = empty($rule['privileges']) ? null : explode(',', $rule['privileges']);
 
             /**
-             * @var Zend_Acl_Assert_Interface|null $assert
+             * @var null|Zend_Acl_Assert_Interface $assert
              */
             $assert = null;
             if ($rule['assert_id'] != 0) {
+                /**
+                 * @var interface-string<Zend_Acl_Assert_Interface> $assertClass
+                 */
                 $assertClass = Mage::getSingleton('admin/config')->getAclAssert($rule['assert_type'])->getClassName();
                 $assert = new $assertClass(unserialize($rule['assert_data'], ['allowed_classes' => false]));
             }

--- a/app/code/core/Mage/Admin/Model/Resource/Acl.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Acl.php
@@ -48,7 +48,9 @@ class Mage_Admin_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
 
         $rolesArr = $adapter->fetchAll($select);
 
-        $this->loadRoles($acl, $rolesArr);
+        if (is_array($rolesArr)) {
+            $this->loadRoles($acl, $rolesArr);
+        }
 
         $select = $adapter->select()
             ->from(['r' => $ruleTable])
@@ -58,10 +60,15 @@ class Mage_Admin_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
                 ['assert_type', 'assert_data'],
             );
 
+        /**
+         * @var array<int, array<string, mixed>> $rulesArr
+         */
         $rulesArr = $adapter->fetchAll($select);
 
-        $this->loadRules($acl, $rulesArr);
-        $this->denyUnlistedResources($acl, $rulesArr);
+        if (is_array($rulesArr)) {
+            $this->loadRules($acl, $rulesArr);
+            $this->denyUnlistedResources($acl, $rulesArr);
+        }
 
         return $acl;
     }

--- a/tests/unit/Mage/Admin/Model/Resource/AclTest.php
+++ b/tests/unit/Mage/Admin/Model/Resource/AclTest.php
@@ -11,8 +11,10 @@ declare(strict_types=1);
 
 namespace OpenMage\Tests\Unit\Mage\Admin\Model\Resource;
 
-// use Mage;
-// use Mage_Admin_Model_Resource_Acl as Subject;
+use Mage;
+use Mage_Admin_Model_Acl;
+use Mage_Admin_Model_Acl_Resource;
+use Mage_Admin_Model_Resource_Acl as Subject;
 use Override;
 use OpenMage\Tests\Unit\OpenMageTest;
 use OpenMage\Tests\Unit\Traits\DataProvider\Mage\Admin\Model\Resource\AclTrait;
@@ -21,13 +23,112 @@ final class AclTest extends OpenMageTest
 {
     use AclTrait;
 
-    // private static Subject $subject;
+    private const GROUP = 'G10';
+    private const USER = 'U20';
+
+    private static Subject $subject;
 
     #[Override]
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
-        // self::$subject = Mage::getModel('admin/resource_acl');
-        self::markTestSkipped('');
+        self::$subject = Mage::getResourceModel('admin/acl');
+    }
+
+    /**
+     * A child with no rule row must not inherit the parent's allow.
+     */
+    public function testUnlistedChildOfAllowedParentIsDenied(): void
+    {
+        $acl = $this->buildAcl([
+            $this->rule('admin/system', 'allow'),
+            $this->rule('admin/system/config', 'deny'),
+        ]);
+
+        self::assertTrue($acl->isAllowed(self::GROUP, 'admin/system'));
+        self::assertFalse($acl->isAllowed(self::GROUP, 'admin/system/config'));
+        self::assertFalse($acl->isAllowed(self::GROUP, 'admin/system/newthing'));
+    }
+
+    public function testExplicitRowsAreUnchanged(): void
+    {
+        $acl = $this->buildAcl([
+            $this->rule('admin/system', 'deny'),
+            $this->rule('admin/system/config', 'allow'),
+            $this->rule('admin/system/newthing', 'allow'),
+        ]);
+
+        self::assertFalse($acl->isAllowed(self::GROUP, 'admin/system'));
+        self::assertTrue($acl->isAllowed(self::GROUP, 'admin/system/config'));
+        self::assertTrue($acl->isAllowed(self::GROUP, 'admin/system/newthing'));
+    }
+
+    public function testAllRoleKeepsUnlistedResources(): void
+    {
+        $acl = $this->buildAcl([$this->rule('all', 'allow')]);
+
+        self::assertTrue($acl->isAllowed(self::GROUP, 'admin/system/newthing'));
+        self::assertTrue($acl->isAllowed(self::USER, 'admin/system/newthing'));
+    }
+
+    public function testUserRoleFollowsGroupDeny(): void
+    {
+        $acl = $this->buildAcl([$this->rule('admin/system', 'allow')]);
+
+        self::assertTrue($acl->isAllowed(self::USER, 'admin/system'));
+        self::assertFalse($acl->isAllowed(self::USER, 'admin/system/newthing'));
+    }
+
+    /**
+     * The role editor writes an "all" deny row for every non-admin role. That row
+     * must not count as full access.
+     */
+    public function testAllDenyRowDoesNotGrantUnlistedResources(): void
+    {
+        $acl = $this->buildAcl([
+            $this->rule('all', 'deny'),
+            $this->rule('admin/system', 'allow'),
+        ]);
+
+        self::assertTrue($acl->isAllowed(self::GROUP, 'admin/system'));
+        self::assertFalse($acl->isAllowed(self::GROUP, 'admin/system/newthing'));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rules
+     */
+    private function buildAcl(array $rules): Mage_Admin_Model_Acl
+    {
+        $acl = new Mage_Admin_Model_Acl();
+        // loadAclResources() registers "all" as a resource of its own.
+        $acl->add(new Mage_Admin_Model_Acl_Resource('all'));
+        $acl->add(new Mage_Admin_Model_Acl_Resource('admin'));
+        $acl->add(new Mage_Admin_Model_Acl_Resource('admin/system'), 'admin');
+        $acl->add(new Mage_Admin_Model_Acl_Resource('admin/system/config'), 'admin/system');
+        $acl->add(new Mage_Admin_Model_Acl_Resource('admin/system/newthing'), 'admin/system');
+
+        self::$subject->loadRoles($acl, [
+            ['role_id' => 10, 'parent_id' => 0, 'role_type' => 'G', 'user_id' => 0],
+            ['role_id' => 11, 'parent_id' => 10, 'role_type' => 'U', 'user_id' => 20],
+        ]);
+        self::$subject->loadRules($acl, $rules);
+        self::$subject->denyUnlistedResources($acl, $rules);
+
+        return $acl;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function rule(string $resource, string $permission): array
+    {
+        return [
+            'role_id' => 10,
+            'role_type' => 'G',
+            'resource_id' => $resource,
+            'privileges' => '',
+            'assert_id' => 0,
+            'permission' => $permission,
+        ];
     }
 }

--- a/tests/unit/Mage/Admin/Model/Resource/AclTest.php
+++ b/tests/unit/Mage/Admin/Model/Resource/AclTest.php
@@ -24,6 +24,7 @@ final class AclTest extends OpenMageTest
     use AclTrait;
 
     private const GROUP = 'G10';
+
     private const USER = 'U20';
 
     private static Subject $subject;

--- a/tests/unit/Mage/Admin/Model/Resource/AclTest.php
+++ b/tests/unit/Mage/Admin/Model/Resource/AclTest.php
@@ -101,11 +101,11 @@ final class AclTest extends OpenMageTest
     {
         $acl = new Mage_Admin_Model_Acl();
         // loadAclResources() registers "all" as a resource of its own.
-        $acl->add(new Mage_Admin_Model_Acl_Resource('all'));
-        $acl->add(new Mage_Admin_Model_Acl_Resource('admin'));
-        $acl->add(new Mage_Admin_Model_Acl_Resource('admin/system'), 'admin');
-        $acl->add(new Mage_Admin_Model_Acl_Resource('admin/system/config'), 'admin/system');
-        $acl->add(new Mage_Admin_Model_Acl_Resource('admin/system/newthing'), 'admin/system');
+        $acl->addResource(new Mage_Admin_Model_Acl_Resource('all'));
+        $acl->addResource(new Mage_Admin_Model_Acl_Resource('admin'));
+        $acl->addResource(new Mage_Admin_Model_Acl_Resource('admin/system'), 'admin');
+        $acl->addResource(new Mage_Admin_Model_Acl_Resource('admin/system/config'), 'admin/system');
+        $acl->addResource(new Mage_Admin_Model_Acl_Resource('admin/system/newthing'), 'admin/system');
 
         self::$subject->loadRoles($acl, [
             ['role_id' => 10, 'parent_id' => 0, 'role_type' => 'G', 'user_id' => 0],


### PR DESCRIPTION

## Problem

`Mage_Admin_Model_Resource_Rules::saveRel()` writes one explicit `allow`/`deny` row per ACL
resource when a role is saved. A resource added to `adminhtml.xml` after that save has no row.
`Mage_Admin_Model_Config::loadAclResources()` registers every resource with its parent, and
`Zend_Acl::isAllowed()` walks the resource parents, so the new resource inherits the nearest
ancestor's rule. A role with `allow` on `admin/system` silently gains every resource a later
module adds under `admin/system`.

Reproduction (no DB needed):

```php
$acl = new Mage_Admin_Model_Acl();
$acl->add(new Mage_Admin_Model_Acl_Resource('admin'));
$acl->add(new Mage_Admin_Model_Acl_Resource('admin/system'), 'admin');
$acl->add(new Mage_Admin_Model_Acl_Resource('admin/system/newthing'), 'admin/system');
$acl->addRole(new Mage_Admin_Model_Acl_Role_Group('G1'));
$acl->allow('G1', 'admin/system');
var_dump($acl->isAllowed('G1', 'admin/system/newthing')); // bool(true)
```

## Relation to #5254

#5254 (mine) removed the role editor's fallback that displayed inherited resources as checked.
Its description claimed the runtime "falls back to null/root, so users may not actually have
access". That claim was wrong: the runtime does inherit, and the fallback display was correct.
After #5254 the editor shows a new resource as unchecked while the role can use it.

This PR fixes the runtime instead of the display. With unlisted resources denied at load time,
the editor's unchecked box and the runtime agree, so #5254 does not need to be reverted.

## Change

`Mage_Admin_Model_Resource_Acl::loadAcl()` now calls `denyUnlistedResources()` after the
rules load. For every group role without an `all` **allow** row (`saveRel()` writes an `all` deny
row for every other role), every registered resource that has no explicit rule gets a `deny`. User roles inherit from their group through Zend_Acl role
inheritance, so only group roles need rules.

Cost: one `deny()` per (group role, unlisted resource) pair. Roles saved through the editor
have rows for almost every resource, so the count is small. The ACL is built at login and on
`reload_acl_flag`, not per request.

## Behavior change

A role that gained access to a resource only through inheritance loses it. That is the
intended effect; the role editor never showed or saved that access. Merchants who want it
open the role and tick the resource.

## Tests

`tests/unit/Mage/Admin/Model/Resource/AclTest.php` builds the ACL from in-memory role and
rule rows: unlisted child of an allowed parent is denied; explicit rows are unchanged; the
`all` allow row keeps everything; an `all` deny row does not; a user role follows its group's deny.
