### PR TITLE
Rewrite core and storefront JS from Prototype.js to vanilla JS (1/4)

### DIFF
--- a/app/design/frontend/base/default/layout/oauth.xml
+++ b/app/design/frontend/base/default/layout/oauth.xml
@@ -22,6 +22,7 @@
             <action method="removeItem"><type>js</type><name>scriptaculous/controls.js</name></action>
             <action method="removeItem"><type>js</type><name>scriptaculous/slider.js</name></action>
             <action method="removeItem"><type>js</type><name>varien/js.js</name></action>
+            <action method="removeItem"><type>js</type><name>varien/autocomplete.js</name></action>
             <action method="removeItem"><type>js</type><name>varien/menu.js</name></action>
         </reference>
         <remove name="top.links"/>

--- a/app/design/frontend/base/default/layout/page.xml
+++ b/app/design/frontend/base/default/layout/page.xml
@@ -26,6 +26,7 @@ Default layout, loads most of the pages
                 <action method="addJs"><script>scriptaculous/controls.js</script></action>
                 <action method="addJs"><script>scriptaculous/slider.js</script></action>
                 <action method="addJs"><script>varien/js.js</script></action>
+                <action method="addJs"><script>varien/autocomplete.js</script></action>
                 <action method="addJs"><script>varien/form.js</script></action>
                 <action method="addJs"><script>varien/menu.js</script></action>
                 <action method="addJs"><script>mage/translate.js</script></action>
@@ -104,6 +105,7 @@ Default layout, loads most of the pages
                 <action method="addJs"><script>lib/ccard.js</script></action>
                 <action method="addJs"><script>prototype/validation.js</script></action>
                 <action method="addJs"><script>varien/js.js</script></action>
+                <action method="addJs"><script>varien/autocomplete.js</script></action>
 
                 <action method="addCss"><stylesheet>css/styles.css</stylesheet></action>
                 <action method="addCss"><stylesheet>css/widgets.css</stylesheet></action>

--- a/app/design/frontend/rwd/default/layout/oauth.xml
+++ b/app/design/frontend/rwd/default/layout/oauth.xml
@@ -22,6 +22,7 @@
             <action method="removeItem"><type>js</type><name>scriptaculous/controls.js</name></action>
             <action method="removeItem"><type>js</type><name>scriptaculous/slider.js</name></action>
             <action method="removeItem"><type>js</type><name>varien/js.js</name></action>
+            <action method="removeItem"><type>js</type><name>varien/autocomplete.js</name></action>
             <action method="removeItem"><type>js</type><name>varien/menu.js</name></action>
         </reference>
         <remove name="top.links"/>

--- a/app/design/frontend/rwd/default/layout/page.xml
+++ b/app/design/frontend/rwd/default/layout/page.xml
@@ -31,6 +31,7 @@
                 <action method="addJs"><script>scriptaculous/controls.js</script></action>
                 <action method="addJs"><script>scriptaculous/slider.js</script></action>
                 <action method="addJs"><script>varien/js.js</script></action>
+                <action method="addJs"><script>varien/autocomplete.js</script></action>
                 <action method="addJs"><script>varien/form.js</script></action>
                 <action method="addJs"><script>mage/translate.js</script></action>
                 <action method="addJs"><script>mage/cookies.js</script></action>
@@ -147,6 +148,7 @@
                 <action method="addJs"><script>lib/ccard.js</script></action>
                 <action method="addJs"><script>prototype/validation.js</script></action>
                 <action method="addJs"><script>varien/js.js</script></action>
+                <action method="addJs"><script>varien/autocomplete.js</script></action>
 
                 <action method="addCss"><stylesheet>css/styles.css</stylesheet></action>
                 <action method="addCss"><stylesheet>css/widgets.css</stylesheet></action>

--- a/js/mage/captcha.js
+++ b/js/mage/captcha.js
@@ -11,61 +11,73 @@
  * @copyright   Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
-var Captcha = Class.create();
-Captcha.prototype = {
-    initialize: function(url, formId){
-        this.url = url;
-        this.formId = formId;
-    },
-    refresh: function(elem) {
-        formId = this.formId;
-        if (elem) Element.addClassName(elem, 'refreshing');
-        new Ajax.Request(this.url, {
-            onSuccess: function (response) {
-                if (response.responseText.isJSON()) {
-                    var json = response.responseText.evalJSON();
-                    if (!json.error && json.imgSrc) {
-                        $(formId).writeAttribute('src', json.imgSrc);
-                        if (elem) Element.removeClassName(elem, 'refreshing');
-                    } else {
-                        if (elem) Element.removeClassName(elem, 'refreshing');
-                    }
-                }
-            },
-            method: 'post',
-            parameters: {
-                'formId'   : this.formId
-            }
-        });
-    }
+function Captcha() {
+    this.initialize(...arguments);
+}
+
+Captcha.prototype.initialize = function(url, formId) {
+    this.url = url;
+    this.formId = formId;
 };
 
-document.observe('billing-request:completed', function(event) {
-    if (typeof window.checkout != 'undefined') {
-        if (window.checkout.method == 'guest' && $('guest_checkout')){
-            $('guest_checkout').captcha.refresh();
+Captcha.prototype.refresh = function(elem) {
+    const formId = this.formId;
+    if (elem) elem.classList.add('refreshing');
+    const params = new URLSearchParams();
+    params.append('formId', this.formId);
+    fetch(this.url, {
+        method: 'POST',
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        body: params
+    }).then(function(response) {
+        return response.text();
+    }).then(function(text) {
+        let json;
+        try {
+            json = JSON.parse(text);
+        } catch (e) {
+            if (elem) elem.classList.remove('refreshing');
+            return;
         }
-        if (window.checkout.method == 'register' && $('register_during_checkout')){
-            $('register_during_checkout').captcha.refresh();
+        if (!json.error && json.imgSrc) {
+            document.getElementById(formId).setAttribute('src', json.imgSrc);
+        }
+        if (elem) elem.classList.remove('refreshing');
+    }).catch(function() {
+        if (elem) elem.classList.remove('refreshing');
+    });
+};
+// The admin login templates load this file without varien/js.js, so inline
+// the Class.create hooks instead of calling Varien.classCompat.
+Captcha.superclass = null;
+Captcha.subclasses = [];
+if (typeof Class !== 'undefined' && Class.Methods) { Object.assign(Captcha, Class.Methods); }
+
+document.addEventListener('billing-request:completed', function(event) {
+    if (typeof window.checkout != 'undefined') {
+        if (window.checkout.method == 'guest' && document.getElementById('guest_checkout')){
+            document.getElementById('guest_checkout').captcha.refresh();
+        }
+        if (window.checkout.method == 'register' && document.getElementById('register_during_checkout')){
+            document.getElementById('register_during_checkout').captcha.refresh();
         }
     }
 });
 
-
-document.observe('login:setMethod', function(event) {
-    var switchCaptchaElement = function(shown, hidden) {
-        var inputPrefix = 'captcha-input-box-', imagePrefix = 'captcha-image-box-';
-        if ($(inputPrefix + hidden)) {
-            $(inputPrefix + hidden).hide();
-            $(imagePrefix + hidden).hide();
+document.addEventListener('login:setMethod', function(event) {
+    const switchCaptchaElement = function(shown, hidden) {
+        const inputPrefix = 'captcha-input-box-', imagePrefix = 'captcha-image-box-';
+        if (document.getElementById(inputPrefix + hidden)) {
+            document.getElementById(inputPrefix + hidden).style.display = 'none';
+            document.getElementById(imagePrefix + hidden).style.display = 'none';
         }
-        if ($(inputPrefix + shown)) {
-            $(inputPrefix + shown).show();
-            $(imagePrefix + shown).show();
+        if (document.getElementById(inputPrefix + shown)) {
+            document.getElementById(inputPrefix + shown).style.display = '';
+            document.getElementById(imagePrefix + shown).style.display = '';
         }
     };
 
-    switch (event.memo.method) {
+    switch (event.detail.method) {
         case 'guest':
             switchCaptchaElement('guest_checkout', 'register_during_checkout');
             break;

--- a/js/mage/centinel.js
+++ b/js/mage/centinel.js
@@ -11,91 +11,83 @@
  * @copyright   Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
-var CentinelAuthenticate = Class.create();
-CentinelAuthenticate.prototype = {
-    initialize : function(blockId, iframeId)
-    {
-        this._isAuthenticationStarted = false;
-        this._relatedBlocks = new Array();
-        this.centinelBlockId = blockId;
-        this.iframeId = iframeId;
-        if (this._isCentinelBlocksLoaded()) {
-            $(this.centinelBlockId).hide();
-        }
-    },
+function CentinelAuthenticate() {
+    this.initialize(...arguments);
+}
 
-    isAuthenticationStarted : function()
-    {
-        return this._isAuthenticationStarted;
-    },
-
-    addRelatedBlock : function(blockId)
-    {
-        this._relatedBlocks[this._relatedBlocks.size()] = blockId;
-    },
-
-    _hideRelatedBlocks : function()
-    {
-        for (var i = 0; i < this._relatedBlocks.size(); i++) {
-            $(this._relatedBlocks[i]).hide();
-        }
-    },
-
-    _showRelatedBlocks : function()
-    {
-        for (var i = 0; i < this._relatedBlocks.size(); i++) {
-            $(this._relatedBlocks[i]).show();
-        }
-    },
-
-    _isRelatedBlocksLoaded : function()
-    {
-        for (var i = 0; i < this._relatedBlocks.size(); i++) {
-            if(!$(this._relatedBlocks[i])) {
-                return false;
-            }
-        }
-        return true;
-    },
-
-    _isCentinelBlocksLoaded : function()
-    {
-        if(!$(this.centinelBlockId) || !$(this.iframeId)) {
-            return false;
-        }
-        return true;
-    },
-
-    start : function(authenticateUrl)
-    {
-        if (this._isRelatedBlocksLoaded() && this._isCentinelBlocksLoaded()) {
-            this._hideRelatedBlocks();
-            $(this.iframeId).src = authenticateUrl;
-            $(this.centinelBlockId).show();
-            this._isAuthenticationStarted = true;
-        }
-    },
-
-    success : function()
-    {
-        if (this._isRelatedBlocksLoaded() && this._isCentinelBlocksLoaded()) {
-            this._showRelatedBlocks();
-            $(this.centinelBlockId).hide();
-            this._isAuthenticationStarted = false;
-        }
-    },
-
-    cancel : function()
-    {
-        if (this._isAuthenticationStarted) {
-            if (this._isRelatedBlocksLoaded()) {
-                this._showRelatedBlocks();
-            }
-            if (this._isCentinelBlocksLoaded()) {
-                $(this.centinelBlockId).hide();
-                $(this.iframeId).src = '';
-            }
-            this._isAuthenticationStarted = false;
-        }
+CentinelAuthenticate.prototype.initialize = function(blockId, iframeId) {
+    this._isAuthenticationStarted = false;
+    this._relatedBlocks = [];
+    this.centinelBlockId = blockId;
+    this.iframeId = iframeId;
+    if (this._isCentinelBlocksLoaded()) {
+        document.getElementById(this.centinelBlockId).style.display = 'none';
     }
 };
+
+CentinelAuthenticate.prototype.isAuthenticationStarted = function() {
+    return this._isAuthenticationStarted;
+};
+
+CentinelAuthenticate.prototype.addRelatedBlock = function(blockId) {
+    this._relatedBlocks[this._relatedBlocks.length] = blockId;
+};
+
+CentinelAuthenticate.prototype._hideRelatedBlocks = function() {
+    for (let i = 0; i < this._relatedBlocks.length; i++) {
+        document.getElementById(this._relatedBlocks[i]).style.display = 'none';
+    }
+};
+
+CentinelAuthenticate.prototype._showRelatedBlocks = function() {
+    for (let i = 0; i < this._relatedBlocks.length; i++) {
+        document.getElementById(this._relatedBlocks[i]).style.display = '';
+    }
+};
+
+CentinelAuthenticate.prototype._isRelatedBlocksLoaded = function() {
+    for (let i = 0; i < this._relatedBlocks.length; i++) {
+        if (!document.getElementById(this._relatedBlocks[i])) {
+            return false;
+        }
+    }
+    return true;
+};
+
+CentinelAuthenticate.prototype._isCentinelBlocksLoaded = function() {
+    if (!document.getElementById(this.centinelBlockId) || !document.getElementById(this.iframeId)) {
+        return false;
+    }
+    return true;
+};
+
+CentinelAuthenticate.prototype.start = function(authenticateUrl) {
+    if (this._isRelatedBlocksLoaded() && this._isCentinelBlocksLoaded()) {
+        this._hideRelatedBlocks();
+        document.getElementById(this.iframeId).src = authenticateUrl;
+        document.getElementById(this.centinelBlockId).style.display = '';
+        this._isAuthenticationStarted = true;
+    }
+};
+
+CentinelAuthenticate.prototype.success = function() {
+    if (this._isRelatedBlocksLoaded() && this._isCentinelBlocksLoaded()) {
+        this._showRelatedBlocks();
+        document.getElementById(this.centinelBlockId).style.display = 'none';
+        this._isAuthenticationStarted = false;
+    }
+};
+
+CentinelAuthenticate.prototype.cancel = function() {
+    if (this._isAuthenticationStarted) {
+        if (this._isRelatedBlocksLoaded()) {
+            this._showRelatedBlocks();
+        }
+        if (this._isCentinelBlocksLoaded()) {
+            document.getElementById(this.centinelBlockId).style.display = 'none';
+            document.getElementById(this.iframeId).src = '';
+        }
+        this._isAuthenticationStarted = false;
+    }
+};
+Varien.classCompat(CentinelAuthenticate);

--- a/js/mage/translate.js
+++ b/js/mage/translate.js
@@ -12,28 +12,51 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-var Translate = Class.create();
+/**
+ * Rewritten to vanilla JS — no Prototype.js dependency.
+ *
+ * @constructor
+ * @param {Object} data - key/value translation map
+ */
+function Translate() {
+    this.initialize(...arguments);
+}
+
 Translate.prototype = {
-    initialize: function(data){
-        this.data = $H(data);
+    initialize: function(data) {
+        // Null-prototype map: translation keys like "hasOwnProperty" or "__proto__"
+        // stay plain data instead of touching Object.prototype.
+        this.data = Object.create(null);
+        if (data && typeof data === 'object') {
+            const keys = Object.keys(data);
+            for (let i = 0; i < keys.length; i++) {
+                this.data[keys[i]] = data[keys[i]];
+            }
+        }
     },
 
-    translate : function(){
-        var args = arguments;
-        var text = arguments[0];
-
-        if(this.data.get(text)){
-            return this.data.get(text);
+    translate: function () {
+        const text = arguments[0];
+        if (Object.prototype.hasOwnProperty.call(this.data, text) && this.data[text]) {
+            return this.data[text];
         }
         return text;
     },
-    add : function() {
+
+    add: function () {
         if (arguments.length > 1) {
-            this.data.set(arguments[0], arguments[1]);
-        } else if (typeof arguments[0] =='object') {
-            $H(arguments[0]).each(function (pair){
-                this.data.set(pair.key, pair.value);
-            }.bind(this));
+            this.data[arguments[0]] = arguments[1];
+        } else if (typeof arguments[0] === 'object') {
+            const obj = arguments[0];
+            const keys = Object.keys(obj);
+            for (let i = 0; i < keys.length; i++) {
+                this.data[keys[i]] = obj[keys[i]];
+            }
         }
     }
 };
+// The print layout loads this file before varien/js.js and the OAuth layouts
+// drop js.js, so inline the Class.create hooks instead of calling Varien.classCompat.
+Translate.superclass = null;
+Translate.subclasses = [];
+if (typeof Class !== 'undefined' && Class.Methods) { Object.assign(Translate, Class.Methods); }

--- a/js/mage/translate_inline.js
+++ b/js/mage/translate_inline.js
@@ -12,117 +12,141 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-var TranslateInline = Class.create();
-TranslateInline.prototype = {
-    initialize: function(trigEl, ajaxUrl, area) {
-        this.ajaxUrl = ajaxUrl;
-        this.area = area;
+function TranslateInline() {
+    this.initialize(...arguments);
+}
 
-        this.trigTimer = null;
-        this.trigContentEl = null;
-        this.trigEl = $(trigEl);
-        this.trigEl.observe('click', this.formShow.bind(this));
+TranslateInline.prototype.initialize = function(trigEl, ajaxUrl, area) {
+    this.ajaxUrl = ajaxUrl;
+    this.area = area;
 
-        Event.observe(document.body, 'mousemove', function(e) {
-            var target = Event.element(e);
-            if (!$(target).match('*[data-translate]')) {
-                target = target.up('*[data-translate]');
-            }
+    this.trigTimer = null;
+    this.trigContentEl = null;
+    this.trigEl = document.getElementById(trigEl);
+    this.trigEl.addEventListener('click', this.formShow.bind(this));
 
-            if (target && $(target).match('*[data-translate]')) {
-                this.trigShow(target, e);
+    document.body.addEventListener('mousemove', function(e) {
+        let target = e.target;
+        if (!target.matches('*[data-translate]')) {
+            target = target.closest('*[data-translate]');
+        }
+
+        if (target && target.matches('*[data-translate]')) {
+            this.trigShow(target, e);
+        } else {
+            if (e.target.matches('#' + trigEl)) {
+                this.trigHideClear();
             } else {
-                if (Event.element(e).match('#' + trigEl)) {
-                    this.trigHideClear();
-                } else {
-                    this.trigHideDelayed();
-                }
+                this.trigHideDelayed();
             }
-        }.bind(this));
-
-        this.helperDiv = document.createElement('div');
-    },
-
-    initializeElement: function(el) {
-        if (!el.initializedTranslate) {
-            el.addClassName('translate-inline');
-            el.initializedTranslate = true;
         }
-    },
+    }.bind(this));
 
-    reinitElements: function(el) {
-        $$('*[data-translate]').each(this.initializeElement.bind(this));
-    },
+};
 
-    trigShow: function(el, event) {
-        if (this.trigContentEl != el) {
-            this.trigHideClear();
-            this.trigContentEl = el;
-            var p = Element.cumulativeOffset(el);
+TranslateInline.prototype.initializeElement = function(el) {
+    if (!el.initializedTranslate) {
+        el.classList.add('translate-inline');
+        el.initializedTranslate = true;
+    }
+};
 
-            this.trigEl.style.left = p[0] + 'px';
-            this.trigEl.style.top = p[1] + 'px';
-            this.trigEl.style.display = 'block';
+TranslateInline.prototype.reinitElements = function(el) {
+    const self = this;
+    document.querySelectorAll('*[data-translate]').forEach(function(el) {
+        self.initializeElement(el);
+    });
+};
 
-            Event.stop(event);
-        };
-    },
-
-    trigHide: function() {
-        this.trigEl.style.display = 'none';
-        this.trigContentEl = null;
-    },
-
-    trigHideDelayed: function() {
-        if (this.trigTimer === null) {
-            this.trigTimer = window.setTimeout(this.trigHide.bind(this), 2000);
-        }
-    },
-
-    trigHideClear: function() {
-        clearInterval(this.trigTimer);
-        this.trigTimer = null;
-    },
-
-    formShow: function() {
-        if (this.formIsShown) {
-            return;
-        }
-        this.formIsShown = true;
-
-        var el = this.trigContentEl;
-        if (!el) {
-            return;
-        }
+TranslateInline.prototype.trigShow = function(el, event) {
+    if (this.trigContentEl != el) {
         this.trigHideClear();
-        eval('var data = ' + el.getAttribute('data-translate'));
-
-        var content = '<form id="translate-inline-form">';
-        var t = new Template(
-            '<div class="magento_table_container"><table cellspacing="0">' +
-                '<tr><th class="label">Location:</th><td class="value">#{location}</td></tr>' +
-                '<tr><th class="label">Scope:</th><td class="value">#{scope}</td></tr>' +
-                '<tr><th class="label">Shown:</th><td class="value">#{shown_escape}</td></tr>' +
-                '<tr><th class="label">Original:</th><td class="value">#{original_escape}</td></tr>' +
-                '<tr><th class="label">Translated:</th><td class="value">#{translated_escape}</td></tr>' +
-                '<tr><th class="label"><label for="perstore_#{i}">Store View Specific:</label></th><td class="value">' +
-                    '<input id="perstore_#{i}" name="translate[#{i}][perstore]" type="checkbox" value="1"/>' +
-                '</td></tr>' +
-                '<tr><th class="label"><label for="custom_#{i}">Custom:</label></th><td class="value">' +
-                    '<input name="translate[#{i}][original]" type="hidden" value="#{scope}::#{original_escape}"/>' +
-                    '<input id="custom_#{i}" name="translate[#{i}][custom]" class="input-text" value="#{translated_escape}" />' +
-                '</td></tr>' +
-            '</table></div>'
-        );
-        for (i = 0; i < data.length; i++) {
-            data[i]['i'] = i;
-            data[i]['shown_escape'] = this.escapeHTML(data[i]['shown']);
-            data[i]['translated_escape'] = this.escapeHTML(data[i]['translated']);
-            data[i]['original_escape'] = this.escapeHTML(data[i]['original']);
-            content += t.evaluate(data[i]);
+        this.trigContentEl = el;
+        let left = 0, top = 0, current = el;
+        while (current) {
+            left += current.offsetLeft;
+            top += current.offsetTop;
+            current = current.offsetParent;
         }
-        content += '</form><p class="a-center accent">Please refresh the page to see your changes after submitting this form.</p>';
 
+        this.trigEl.style.left = left + 'px';
+        this.trigEl.style.top = top + 'px';
+        this.trigEl.style.display = 'block';
+
+        event.preventDefault();
+        event.stopPropagation();
+    }
+};
+
+TranslateInline.prototype.trigHide = function() {
+    this.trigEl.style.display = 'none';
+    this.trigContentEl = null;
+};
+
+TranslateInline.prototype.trigHideDelayed = function() {
+    if (this.trigTimer === null) {
+        this.trigTimer = window.setTimeout(this.trigHide.bind(this), 2000);
+    }
+};
+
+TranslateInline.prototype.trigHideClear = function() {
+    clearTimeout(this.trigTimer);
+    this.trigTimer = null;
+};
+
+TranslateInline.prototype.formShow = function() {
+    if (this.formIsShown) {
+        return;
+    }
+    this.formIsShown = true;
+
+    const el = this.trigContentEl;
+    if (!el) {
+        return;
+    }
+    this.trigHideClear();
+    let data;
+    try {
+        data = JSON.parse(el.getAttribute('data-translate'));
+    } catch (e) {
+        this.formIsShown = false;
+        return;
+    }
+
+    let content = '<form id="translate-inline-form">';
+    const tpl =
+        '<div class="magento_table_container"><table cellspacing="0">' +
+            '<tr><th class="label">Location:</th><td class="value">#{location_escape}</td></tr>' +
+            '<tr><th class="label">Scope:</th><td class="value">#{scope_escape}</td></tr>' +
+            '<tr><th class="label">Shown:</th><td class="value">#{shown_escape}</td></tr>' +
+            '<tr><th class="label">Original:</th><td class="value">#{original_escape}</td></tr>' +
+            '<tr><th class="label">Translated:</th><td class="value">#{translated_escape}</td></tr>' +
+            '<tr><th class="label"><label for="perstore_#{i}">Store View Specific:</label></th><td class="value">' +
+                '<input id="perstore_#{i}" name="translate[#{i}][perstore]" type="checkbox" value="1"/>' +
+            '</td></tr>' +
+            '<tr><th class="label"><label for="custom_#{i}">Custom:</label></th><td class="value">' +
+                '<input name="translate[#{i}][original]" type="hidden" value="#{scope_escape}::#{original_escape}"/>' +
+                '<input id="custom_#{i}" name="translate[#{i}][custom]" class="input-text" value="#{translated_escape}" />' +
+            '</td></tr>' +
+        '</table></div>';
+    for (let i = 0; i < data.length; i++) {
+        // Only escaped values reach the markup: interpolate from this object,
+        // never from the parsed payload itself.
+        const row = {
+            i: i,
+            location_escape: this.escapeHTML(data[i]['location']),
+            scope_escape: this.escapeHTML(data[i]['scope']),
+            shown_escape: this.escapeHTML(data[i]['shown']),
+            translated_escape: this.escapeHTML(data[i]['translated']),
+            original_escape: this.escapeHTML(data[i]['original'])
+        };
+        content += tpl.replace(/#\{(\w+)\}/g, function(m, k) {
+            return Object.prototype.hasOwnProperty.call(row, k) ? row[k] : '';
+        });
+    }
+    content += '</form><p class="a-center accent">Please refresh the page to see your changes after submitting this form.</p>';
+
+    if (typeof Windows !== 'undefined' && typeof Dialog !== 'undefined') {
         this.overlayShowEffectOptions = Windows.overlayShowEffectOptions;
         this.overlayHideEffectOptions = Windows.overlayHideEffectOptions;
         Windows.overlayShowEffectOptions = {duration: 0};
@@ -138,8 +162,8 @@ TranslateInline.prototype = {
             height: 470,
             zIndex: 2100,
             recenterAuto: false,
-            hideEffect: Element.hide,
-            showEffect: Element.show,
+            hideEffect: function(el) { el.style.display = 'none'; },
+            showEffect: function(el) { el.style.display = ''; },
             id: "translate-inline",
             buttonClass: "form-button button",
             okLabel: "Submit",
@@ -147,54 +171,72 @@ TranslateInline.prototype = {
             cancel: this.formClose.bind(this),
             onClose: this.formClose.bind(this)
         });
-        this.trigHide();
-    },
+    }
+    this.trigHide();
+};
 
-    formOk: function(win) {
-        if (this.formIsSubmitted) {
-            return;
-        }
-        this.formIsSubmitted = true;
+TranslateInline.prototype.formOk = function(win) {
+    if (this.formIsSubmitted) {
+        return;
+    }
+    this.formIsSubmitted = true;
 
-        var inputs = $('translate-inline-form').getInputs(), parameters = {};
-        for (var i = 0; i < inputs.length; i++) {
-            if (inputs[i].type == 'checkbox') {
-                if (inputs[i].checked) {
-                    parameters[inputs[i].name] = inputs[i].value;
-                }
-            }
-            else {
+    const inputs = Array.from(document.getElementById('translate-inline-form').querySelectorAll('input')), parameters = {};
+    for (let i = 0; i < inputs.length; i++) {
+        if (inputs[i].type == 'checkbox') {
+            if (inputs[i].checked) {
                 parameters[inputs[i].name] = inputs[i].value;
             }
         }
-        parameters['area'] = this.area;
+        else {
+            parameters[inputs[i].name] = inputs[i].value;
+        }
+    }
+    parameters['area'] = this.area;
 
-        new Ajax.Request(this.ajaxUrl, {
-            method: 'post',
-            parameters: parameters,
-            onComplete: this.ajaxComplete.bind(this, win)
-        });
+    const body = new URLSearchParams();
+    for (const key in parameters) {
+        if (parameters.hasOwnProperty(key)) {
+            body.append(key, parameters[key]);
+        }
+    }
 
-        this.formIsSubmitted = false;
-    },
-
-    ajaxComplete: function(win, transport) {
+    const self = this;
+    fetch(this.ajaxUrl, {
+        method: 'POST',
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        body: body
+    }).then(function() {
         win.close();
-        this.formClose(win);
-    },
+        self.formClose(win);
+    });
 
-    formClose: function(win) {
+    this.formIsSubmitted = false;
+};
+
+TranslateInline.prototype.ajaxComplete = function(win, transport) {
+    win.close();
+    this.formClose(win);
+};
+
+TranslateInline.prototype.formClose = function(win) {
+    if (typeof Windows !== 'undefined') {
         Windows.overlayShowEffectOptions = this.overlayShowEffectOptions;
         Windows.overlayHideEffectOptions = this.overlayHideEffectOptions;
-        this.formIsShown = false;
-    },
-
-    escapeHTML: function(str) {
-        this.helperDiv.innerHTML = '';
-        var text = document.createTextNode(str);
-        this.helperDiv.appendChild(text);
-        var escaped = this.helperDiv.innerHTML;
-        escaped = escaped.replace(/"/g, '&quot;');
-        return escaped;
     }
+    this.formIsShown = false;
 };
+
+TranslateInline.prototype.escapeHTML = function(str) {
+    return String(str == null ? '' : str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+};
+// The OAuth layouts drop varien/js.js but keep this file, so inline the
+// Class.create hooks instead of calling Varien.classCompat.
+TranslateInline.superclass = null;
+TranslateInline.subclasses = [];
+if (typeof Class !== 'undefined' && Class.Methods) { Object.assign(TranslateInline, Class.Methods); }

--- a/js/prototype/validation.js
+++ b/js/prototype/validation.js
@@ -26,48 +26,147 @@
 * SOFTWARE.
 *
 */
-var Validator = Class.create();
 
-Validator.prototype = {
-    initialize : function(className, error, test, options) {
-        if(typeof test == 'function'){
-            this.options = $H(options);
-            this._test = test;
-        } else {
-            this.options = $H(test);
-            this._test = function(){return true};
+// ---- Internal helpers (not exposed globally) ----
+
+function _camelize(str) {
+    return str.replace(/-([a-z])/g, function(m, c) { return c.toUpperCase(); });
+}
+
+// Mirrors Prototype's $F(): unchecked checkbox/radio => null,
+// select[multiple] => array of selected values.
+function _getFieldValue(el) {
+    if (typeof el === 'string') { el = document.getElementById(el); }
+    if (!el) { return ''; }
+    const tag = el.tagName.toLowerCase();
+    if (tag === 'select') {
+        if (el.multiple) {
+            return Array.from(el.options)
+                .filter(function(o) { return o.selected; })
+                .map(function(o) { return o.value; });
         }
-        this.error = error || 'Validation failed.';
-        this.className = className;
-    },
-    test : function(v, elm) {
-        return (this._test(v,elm) && this.options.all(function(p){
-            return Validator.methods[p.key] ? Validator.methods[p.key](v,elm,p.value) : true;
-        }));
+        const idx = el.selectedIndex;
+        return (idx >= 0) ? el.options[idx].value : '';
     }
-}
-Validator.methods = {
-    pattern : function(v,elm,opt) {return Validation.get('IsEmpty').test(v) || opt.test(v)},
-    minLength : function(v,elm,opt) {return v.length >= opt},
-    maxLength : function(v,elm,opt) {return v.length <= opt},
-    min : function(v,elm,opt) {return v >= parseFloat(opt)},
-    max : function(v,elm,opt) {return v <= parseFloat(opt)},
-    notOneOf : function(v,elm,opt) {return $A(opt).all(function(value) {
-        return v != value;
-    })},
-    oneOf : function(v,elm,opt) {return $A(opt).any(function(value) {
-        return v == value;
-    })},
-    is : function(v,elm,opt) {return v == opt},
-    isNot : function(v,elm,opt) {return v != opt},
-    equalToField : function(v,elm,opt) {return v == $F(opt)},
-    notEqualToField : function(v,elm,opt) {return v != $F(opt)},
-    include : function(v,elm,opt) {return $A(opt).all(function(value) {
-        return Validation.get(value).test(v,elm);
-    })}
+    if (tag === 'input' && (el.type === 'checkbox' || el.type === 'radio')) {
+        return el.checked ? el.value : null;
+    }
+    return el.value || '';
 }
 
-var Validation = Class.create();
+function _isVisible(el) {
+    if (typeof el === 'string') { el = document.getElementById(el); }
+    if (!el) { return false; }
+    // Prototype's visible() checked the computed display only. Zero-size
+    // inputs (custom-styled checkboxes, file inputs) must still validate.
+    return window.getComputedStyle(el).display !== 'none';
+}
+
+function _splitClassName(cn) {
+    return (cn || '').split(/\s+/).filter(function(s) { return s.length > 0; });
+}
+
+// elm.advaiceContainer may be an id or an element, as $() accepted
+function _adviceContainer(elm) {
+    const c = elm.advaiceContainer;
+    return typeof c === 'string' ? document.getElementById(c) : c;
+}
+
+// ---- Validator ----
+
+function Validator() {
+    this.initialize(...arguments);
+}
+// Class.create metadata so Class.create(Validator, {...}) and Validator.addMethods()
+// keep working; js.js (Varien.classCompat) loads after this file, so it is inlined.
+Validator.superclass = null;
+Validator.subclasses = [];
+if (typeof Class !== 'undefined' && Class.Methods) { Object.assign(Validator, Class.Methods); }
+
+Validator.prototype.initialize = function(className, error, test, options) {
+    if (typeof test === 'function') {
+        this.options = Object.assign({}, options || {});
+        this._test = test;
+    } else {
+        this.options = Object.assign({}, test || {});
+        this._test = function() { return true; };
+    }
+    this.error = error || 'Validation failed.';
+    this.className = className;
+};
+
+Validator.prototype.test = function(v, elm) {
+    const self = this;
+    return this._test(v, elm) && Object.keys(this.options).every(function(key) {
+        return Validator.methods[key] ? Validator.methods[key](v, elm, self.options[key]) : true;
+    });
+};
+
+Validator.methods = {
+    pattern : function(v, elm, opt) { return Validation.get('IsEmpty').test(v) || opt.test(v); },
+    minLength : function(v, elm, opt) { return v.length >= opt; },
+    maxLength : function(v, elm, opt) { return v.length <= opt; },
+    min : function(v, elm, opt) { return v >= parseFloat(opt); },
+    max : function(v, elm, opt) { return v <= parseFloat(opt); },
+    notOneOf : function(v, elm, opt) {
+        return Array.from(opt).every(function(value) { return v != value; });
+    },
+    oneOf : function(v, elm, opt) {
+        return Array.from(opt).some(function(value) { return v == value; });
+    },
+    is : function(v, elm, opt) { return v == opt; },
+    isNot : function(v, elm, opt) { return v != opt; },
+    equalToField : function(v, elm, opt) { return v == _getFieldValue(opt); },
+    notEqualToField : function(v, elm, opt) { return v != _getFieldValue(opt); },
+    include : function(v, elm, opt) {
+        return Array.from(opt).every(function(value) {
+            return Validation.get(value).test(v, elm);
+        });
+    }
+};
+
+// ---- Validation ----
+
+function Validation() {
+    this.initialize(...arguments);
+}
+Validation.superclass = null;
+Validation.subclasses = [];
+if (typeof Class !== 'undefined' && Class.Methods) { Object.assign(Validation, Class.Methods); }
+
+Validation.prototype.initialize = function(form, options) {
+    if (typeof form === 'string') { form = document.getElementById(form); }
+    this.form = form;
+    if (!this.form) {
+        return;
+    }
+    this.options = Object.assign({
+        onSubmit : Validation.defaultOptions.onSubmit,
+        stopOnFirst : Validation.defaultOptions.stopOnFirst,
+        immediate : Validation.defaultOptions.immediate,
+        focusOnError : Validation.defaultOptions.focusOnError,
+        useTitles : Validation.defaultOptions.useTitles,
+        onFormValidate : Validation.defaultOptions.onFormValidate,
+        onElementValidate : Validation.defaultOptions.onElementValidate
+    }, options || {});
+    if (this.options.onSubmit) {
+        this.form.addEventListener('submit', this.onSubmit.bind(this), false);
+    }
+    if (this.options.immediate) {
+        const self = this;
+        Array.from(this.form.elements).forEach(function(input) {
+            if (input.tagName.toLowerCase() === 'select') {
+                input.addEventListener('blur', self.onChange.bind(self));
+            }
+            if (input.type.toLowerCase() === 'radio' || input.type.toLowerCase() === 'checkbox') {
+                input.addEventListener('click', self.onChange.bind(self));
+            } else {
+                input.addEventListener('change', self.onChange.bind(self));
+            }
+        });
+    }
+};
+
 Validation.defaultOptions = {
     onSubmit : true,
     stopOnFirst : false,
@@ -80,225 +179,197 @@ Validation.defaultOptions = {
     onElementValidate : function(result, elm) {}
 };
 
-Validation.prototype = {
-    initialize : function(form, options){
-        this.form = $(form);
-        if (!this.form) {
-            return;
-        }
-        this.options = Object.extend({
-            onSubmit : Validation.defaultOptions.onSubmit,
-            stopOnFirst : Validation.defaultOptions.stopOnFirst,
-            immediate : Validation.defaultOptions.immediate,
-            focusOnError : Validation.defaultOptions.focusOnError,
-            useTitles : Validation.defaultOptions.useTitles,
-            onFormValidate : Validation.defaultOptions.onFormValidate,
-            onElementValidate : Validation.defaultOptions.onElementValidate
-        }, options || {});
-        if(this.options.onSubmit) Event.observe(this.form,'submit',this.onSubmit.bind(this),false);
-        if(this.options.immediate) {
-            Form.getElements(this.form).each(function(input) { // Thanks Mike!
-                if (input.tagName.toLowerCase() == 'select') {
-                    Event.observe(input, 'blur', this.onChange.bindAsEventListener(this));
-                }
-                if (input.type.toLowerCase() == 'radio' || input.type.toLowerCase() == 'checkbox') {
-                    Event.observe(input, 'click', this.onChange.bindAsEventListener(this));
-                } else {
-                    Event.observe(input, 'change', this.onChange.bindAsEventListener(this));
-                }
-            }, this);
-        }
-    },
-    onChange : function (ev) {
-        Validation.isOnChange = true;
-        Validation.validate(Event.element(ev),{
-                useTitle : this.options.useTitles,
-                onElementValidate : this.options.onElementValidate
-        });
-        Validation.isOnChange = false;
-    },
-    onSubmit :  function(ev){
-        if(!this.validate()) Event.stop(ev);
-    },
-    validate : function() {
-        var result = false;
-        var useTitles = this.options.useTitles;
-        var callback = this.options.onElementValidate;
-        try {
-            if(this.options.stopOnFirst) {
-                result = Form.getElements(this.form).all(function(elm) {
-                    if (elm.hasClassName('local-validation') && !this.isElementInForm(elm, this.form)) {
-                        return true;
-                    }
-                    return Validation.validate(elm,{useTitle : useTitles, onElementValidate : callback});
-                }, this);
-            } else {
-                result = Form.getElements(this.form).collect(function(elm) {
-                    if (elm.hasClassName('local-validation') && !this.isElementInForm(elm, this.form)) {
-                        return true;
-                    }
-                    return Validation.validate(elm,{useTitle : useTitles, onElementValidate : callback});
-                }, this).all();
-            }
-        } catch (e) {
-        }
-        if(!result && this.options.focusOnError) {
-            try{
-                Form.getElements(this.form).findAll(function(elm){return $(elm).hasClassName('validation-failed')}).first().focus()
-            }
-            catch(e){
-            }
-        }
-        this.options.onFormValidate(result, this.form);
-        return result;
-    },
-    reset : function() {
-        Form.getElements(this.form).each(Validation.reset);
-    },
-    isElementInForm : function(elm, form) {
-        var domForm = elm.up('form');
-        if (domForm == form) {
-            return true;
-        }
-        return false;
+Validation.prototype.onChange = function(ev) {
+    Validation.isOnChange = true;
+    Validation.validate(ev.target, {
+        useTitle : this.options.useTitles,
+        onElementValidate : this.options.onElementValidate
+    });
+    Validation.isOnChange = false;
+};
+
+Validation.prototype.onSubmit = function(ev) {
+    if (!this.validate()) {
+        ev.preventDefault();
+        ev.stopPropagation();
     }
-}
+};
 
-Object.extend(Validation, {
-    validate : function(elm, options){
-        options = Object.extend({
-            useTitle : false,
-            onElementValidate : function(result, elm) {}
-        }, options || {});
-        elm = $(elm);
-
-        var cn = $w(elm.className);
-        return result = cn.all(function(value) {
-            var test = Validation.test(value,elm,options.useTitle);
-            options.onElementValidate(test, elm);
-            return test;
-        });
-    },
-    insertAdvice : function(elm, advice){
-        var container = $(elm).up('.field-row');
-        if(container){
-            Element.insert(container, {after: advice});
-        } else if (elm.up('td.value')) {
-            elm.up('td.value').insert({bottom: advice});
-        } else if (elm.advaiceContainer && $(elm.advaiceContainer)) {
-            $(elm.advaiceContainer).update(advice);
-        }
-        else {
-            switch (elm.type.toLowerCase()) {
-                case 'checkbox':
-                case 'radio':
-                    var p = elm.parentNode;
-                    if(p) {
-                        Element.insert(p, {'bottom': advice});
-                    } else {
-                        Element.insert(elm, {'after': advice});
-                    }
-                    break;
-                default:
-                    Element.insert(elm, {'after': advice});
-            }
-        }
-    },
-    showAdvice : function(elm, advice, adviceName){
-        if(!elm.advices){
-            elm.advices = new Hash();
-        }
-        else{
-            elm.advices.each(function(pair){
-                if (!advice || pair.value.id != advice.id) {
-                    // hide non-current advice after delay
-                    this.hideAdvice(elm, pair.value);
+Validation.prototype.validate = function() {
+    let result = false;
+    const useTitles = this.options.useTitles;
+    const callback = this.options.onElementValidate;
+    const self = this;
+    try {
+        const elements = Array.from(this.form.elements);
+        if (this.options.stopOnFirst) {
+            result = elements.every(function(elm) {
+                if (elm.classList.contains('local-validation') && !self.isElementInForm(elm, self.form)) {
+                    return true;
                 }
-            }.bind(this));
-        }
-        elm.advices.set(adviceName, advice);
-        if(typeof Effect == 'undefined') {
-            advice.style.display = 'block';
+                return Validation.validate(elm, {useTitle : useTitles, onElementValidate : callback});
+            });
         } else {
-            if(!advice._adviceAbsolutize) {
-                new Effect.Appear(advice, {duration : 1 });
-            } else {
-                Position.absolutize(advice);
-                advice.show();
-                advice.setStyle({
-                    'top':advice._adviceTop,
-                    'left': advice._adviceLeft,
-                    'width': advice._adviceWidth,
-                    'z-index': 1000
-                });
-                advice.addClassName('advice-absolute');
-            }
-        }
-    },
-    hideAdvice : function(elm, advice){
-        if (advice != null) {
-            if(typeof Effect == 'undefined') {
-                advice.hide();
-            } else {
-                new Effect.Fade(advice, {duration : 1, afterFinishInternal : function() {advice.hide();}});
-            }
-        }
-    },
-    updateCallback : function(elm, status) {
-        if (typeof elm.callbackFunction != 'undefined') {
-            eval(elm.callbackFunction+'(\''+elm.id+'\',\''+status+'\')');
-        }
-    },
-    ajaxError : function(elm, errorMsg) {
-        var name = 'validate-ajax';
-        var advice = Validation.getAdvice(name, elm);
-        if (advice == null) {
-            advice = this.createAdvice(name, elm, false, errorMsg);
-        }
-        this.showAdvice(elm, advice, 'validate-ajax');
-        this.updateCallback(elm, 'failed');
-
-        elm.addClassName('validation-failed');
-        elm.addClassName('validate-ajax');
-        if (Validation.defaultOptions.addClassNameToContainer && Validation.defaultOptions.containerClassName != '') {
-            var container = elm.up(Validation.defaultOptions.containerClassName);
-            if (container && this.allowContainerClassName(elm)) {
-                container.removeClassName('validation-passed');
-                container.addClassName('validation-error');
-            }
-        }
-    },
-    allowContainerClassName: function (elm) {
-        if (elm.type == 'radio' || elm.type == 'checkbox') {
-            return elm.hasClassName('change-container-classname');
-        }
-
-        return true;
-    },
-    test : function(name, elm, useTitle) {
-        var v = Validation.get(name);
-        var prop = '__advice'+name.camelize();
-        try {
-        if(Validation.isVisible(elm) && !v.test($F(elm), elm)) {
-            //if(!elm[prop]) {
-                var advice = Validation.getAdvice(name, elm);
-                if (advice == null) {
-                    advice = this.createAdvice(name, elm, useTitle);
+            result = elements.map(function(elm) {
+                if (elm.classList.contains('local-validation') && !self.isElementInForm(elm, self.form)) {
+                    return true;
                 }
-                this.showAdvice(elm, advice, name);
-                this.updateCallback(elm, 'failed');
-            //}
+                return Validation.validate(elm, {useTitle : useTitles, onElementValidate : callback});
+            }).every(function(v) { return v; });
+        }
+    } catch (e) {
+    }
+    if (!result && this.options.focusOnError) {
+        try {
+            const failed = Array.from(this.form.elements).filter(function(elm) {
+                return elm.classList.contains('validation-failed');
+            });
+            if (failed.length) { failed[0].focus(); }
+        } catch(e) {
+        }
+    }
+    this.options.onFormValidate(result, this.form);
+    return result;
+};
+
+Validation.prototype.reset = function() {
+    Array.from(this.form.elements).forEach(Validation.reset);
+};
+
+Validation.prototype.isElementInForm = function(elm, form) {
+    const domForm = elm.closest('form');
+    return domForm === form;
+};
+
+// ---- Validation static methods ----
+
+Validation.validate = function(elm, options) {
+    options = Object.assign({
+        useTitle : false,
+        onElementValidate : function(result, elm) {}
+    }, options || {});
+    if (typeof elm === 'string') { elm = document.getElementById(elm); }
+
+    const cn = _splitClassName(elm.className);
+    return cn.every(function(value) {
+        const test = Validation.test(value, elm, options.useTitle);
+        options.onElementValidate(test, elm);
+        return test;
+    });
+};
+
+Validation.insertAdvice = function(elm, advice) {
+    if (typeof elm === 'string') { elm = document.getElementById(elm); }
+    const container = elm.closest('.field-row');
+    if (container) {
+        container.insertAdjacentHTML('afterend', advice);
+    } else if (elm.closest('td.value')) {
+        elm.closest('td.value').insertAdjacentHTML('beforeend', advice);
+    } else if (elm.advaiceContainer && _adviceContainer(elm)) {
+        _adviceContainer(elm).innerHTML = advice;
+    } else {
+        switch (elm.type.toLowerCase()) {
+            case 'checkbox':
+            case 'radio':
+                const p = elm.parentNode;
+                if (p) {
+                    p.insertAdjacentHTML('beforeend', advice);
+                } else {
+                    elm.insertAdjacentHTML('afterend', advice);
+                }
+                break;
+            default:
+                elm.insertAdjacentHTML('afterend', advice);
+        }
+    }
+};
+
+Validation.showAdvice = function(elm, advice, adviceName) {
+    if (!elm.advices) {
+        elm.advices = {};
+    } else {
+        const self = this;
+        Object.keys(elm.advices).forEach(function(key) {
+            const pair = elm.advices[key];
+            if (!advice || pair.id != advice.id) {
+                self.hideAdvice(elm, pair);
+            }
+        });
+    }
+    elm.advices[adviceName] = advice;
+    if (advice._adviceAbsolutize) {
+        // Position.absolutize + setStyle from the original; used by absolute-advice fields
+        advice.style.position = 'absolute';
+        advice.style.top = advice._adviceTop;
+        advice.style.left = advice._adviceLeft;
+        advice.style.width = advice._adviceWidth;
+        advice.style.zIndex = 1000;
+        advice.classList.add('advice-absolute');
+    }
+    advice.style.display = 'block';
+};
+
+Validation.hideAdvice = function(elm, advice) {
+    if (advice != null) {
+        advice.style.display = 'none';
+    }
+};
+
+Validation.updateCallback = function(elm, status) {
+    if (typeof elm.callbackFunction != 'undefined') {
+        eval(elm.callbackFunction+'(\''+elm.id+'\',\''+status+'\')');
+    }
+};
+
+Validation.ajaxError = function(elm, errorMsg) {
+    const name = 'validate-ajax';
+    let advice = Validation.getAdvice(name, elm);
+    if (advice == null) {
+        advice = this.createAdvice(name, elm, false, errorMsg);
+    }
+    this.showAdvice(elm, advice, 'validate-ajax');
+    this.updateCallback(elm, 'failed');
+
+    elm.classList.add('validation-failed');
+    elm.classList.add('validate-ajax');
+    if (Validation.defaultOptions.addClassNameToContainer && Validation.defaultOptions.containerClassName != '') {
+        const container = elm.closest(Validation.defaultOptions.containerClassName);
+        if (container && this.allowContainerClassName(elm)) {
+            container.classList.remove('validation-passed');
+            container.classList.add('validation-error');
+        }
+    }
+};
+
+Validation.allowContainerClassName = function(elm) {
+    if (elm.type == 'radio' || elm.type == 'checkbox') {
+        return elm.classList.contains('change-container-classname');
+    }
+    return true;
+};
+
+Validation.test = function(name, elm, useTitle) {
+    const v = Validation.get(name);
+    const prop = '__advice' + _camelize(name);
+    try {
+        if (Validation.isVisible(elm) && !v.test(_getFieldValue(elm), elm)) {
+            var advice = Validation.getAdvice(name, elm);
+            if (advice == null) {
+                advice = this.createAdvice(name, elm, useTitle);
+            }
+            this.showAdvice(elm, advice, name);
+            this.updateCallback(elm, 'failed');
             elm[prop] = 1;
             if (!elm.advaiceContainer) {
-                elm.removeClassName('validation-passed');
-                elm.addClassName('validation-failed');
+                elm.classList.remove('validation-passed');
+                elm.classList.add('validation-failed');
             }
 
-           if (Validation.defaultOptions.addClassNameToContainer && Validation.defaultOptions.containerClassName != '') {
-                var container = elm.up(Validation.defaultOptions.containerClassName);
+            if (Validation.defaultOptions.addClassNameToContainer && Validation.defaultOptions.containerClassName != '') {
+                var container = elm.closest(Validation.defaultOptions.containerClassName);
                 if (container && this.allowContainerClassName(elm)) {
-                    container.removeClassName('validation-passed');
-                    container.addClassName('validation-error');
+                    container.classList.remove('validation-passed');
+                    container.classList.add('validation-error');
                 }
             }
             return false;
@@ -307,112 +378,120 @@ Object.extend(Validation, {
             this.hideAdvice(elm, advice);
             this.updateCallback(elm, 'passed');
             elm[prop] = '';
-            elm.removeClassName('validation-failed');
-            elm.addClassName('validation-passed');
+            elm.classList.remove('validation-failed');
+            elm.classList.add('validation-passed');
             if (Validation.defaultOptions.addClassNameToContainer && Validation.defaultOptions.containerClassName != '') {
-                var container = elm.up(Validation.defaultOptions.containerClassName);
-                if (container && !container.down('.validation-failed') && this.allowContainerClassName(elm)) {
+                var container = elm.closest(Validation.defaultOptions.containerClassName);
+                if (container && !container.querySelector('.validation-failed') && this.allowContainerClassName(elm)) {
                     if (!Validation.get('IsEmpty').test(elm.value) || !this.isVisible(elm)) {
-                        container.addClassName('validation-passed');
+                        container.classList.add('validation-passed');
                     } else {
-                        container.removeClassName('validation-passed');
+                        container.classList.remove('validation-passed');
                     }
-                    container.removeClassName('validation-error');
+                    container.classList.remove('validation-error');
                 }
             }
             return true;
         }
-        } catch(e) {
-            throw(e)
-        }
-    },
-    isVisible : function(elm) {
-        while(elm.tagName != 'BODY') {
-            if(!$(elm).visible()) return false;
-            elm = elm.parentNode;
-        }
-        return true;
-    },
-    getAdvice : function(name, elm) {
-        return $('advice-' + name + '-' + Validation.getElmID(elm)) || $('advice-' + Validation.getElmID(elm));
-    },
-    createAdvice : function(name, elm, useTitle, customError) {
-        var v = Validation.get(name);
-        var errorMsg = useTitle ? ((elm && elm.title) ? elm.title : v.error) : v.error;
-        if (customError) {
-            errorMsg = customError;
-        }
-        try {
-            if (Translator){
-                errorMsg = Translator.translate(errorMsg);
-            }
-        }
-        catch(e){}
-
-        advice = '<div class="validation-advice" id="advice-' + name + '-' + Validation.getElmID(elm) +'" style="display:none">' + errorMsg + '</div>'
-
-
-        Validation.insertAdvice(elm, advice);
-        advice = Validation.getAdvice(name, elm);
-        if($(elm).hasClassName('absolute-advice')) {
-            var dimensions = $(elm).getDimensions();
-            var originalPosition = Position.cumulativeOffset(elm);
-
-            advice._adviceTop = (originalPosition[1] + dimensions.height) + 'px';
-            advice._adviceLeft = (originalPosition[0])  + 'px';
-            advice._adviceWidth = (dimensions.width)  + 'px';
-            advice._adviceAbsolutize = true;
-        }
-        return advice;
-    },
-    getElmID : function(elm) {
-        return elm.id ? elm.id : elm.name;
-    },
-    reset : function(elm) {
-        elm = $(elm);
-        var cn = $w(elm.className);
-        cn.each(function(value) {
-            var prop = '__advice'+value.camelize();
-            if(elm[prop]) {
-                var advice = Validation.getAdvice(value, elm);
-                if (advice) {
-                    advice.hide();
-                }
-                elm[prop] = '';
-            }
-            elm.removeClassName('validation-failed');
-            elm.removeClassName('validation-passed');
-            if (Validation.defaultOptions.addClassNameToContainer && Validation.defaultOptions.containerClassName != '') {
-                var container = elm.up(Validation.defaultOptions.containerClassName);
-                if (container) {
-                    container.removeClassName('validation-passed');
-                    container.removeClassName('validation-error');
-                }
-            }
-        });
-    },
-    add : function(className, error, test, options) {
-        var nv = {};
-        nv[className] = new Validator(className, error, test, options);
-        Object.extend(Validation.methods, nv);
-    },
-    addAllThese : function(validators) {
-        var nv = {};
-        $A(validators).each(function(value) {
-                nv[value[0]] = new Validator(value[0], value[1], value[2], (value.length > 3 ? value[3] : {}));
-            });
-        Object.extend(Validation.methods, nv);
-    },
-    get : function(name) {
-        return  Validation.methods[name] ? Validation.methods[name] : Validation.methods['_LikeNoIDIEverSaw_'];
-    },
-    methods : {
-        '_LikeNoIDIEverSaw_' : new Validator('_LikeNoIDIEverSaw_','',{})
+    } catch(e) {
+        throw(e);
     }
-});
+};
+
+Validation.isVisible = function(elm) {
+    while (elm.tagName != 'BODY') {
+        if (!_isVisible(elm)) return false;
+        elm = elm.parentNode;
+    }
+    return true;
+};
+
+Validation.getAdvice = function(name, elm) {
+    return document.getElementById('advice-' + name + '-' + Validation.getElmID(elm))
+        || document.getElementById('advice-' + Validation.getElmID(elm));
+};
+
+Validation.createAdvice = function(name, elm, useTitle, customError) {
+    const v = Validation.get(name);
+    let errorMsg = useTitle ? ((elm && elm.title) ? elm.title : v.error) : v.error;
+    if (customError) {
+        errorMsg = customError;
+    }
+    try {
+        if (Translator) {
+            errorMsg = Translator.translate(errorMsg);
+        }
+    } catch(e) {}
+
+    let advice = '<div class="validation-advice" id="advice-' + name + '-' + Validation.getElmID(elm) + '" style="display:none">' + errorMsg + '</div>';
+
+    Validation.insertAdvice(elm, advice);
+    advice = Validation.getAdvice(name, elm);
+    if (elm.classList.contains('absolute-advice')) {
+        const rect = elm.getBoundingClientRect();
+        const scrollLeft = window.pageXOffset || document.documentElement.scrollLeft;
+        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+        advice._adviceTop = (rect.top + scrollTop + rect.height) + 'px';
+        advice._adviceLeft = (rect.left + scrollLeft) + 'px';
+        advice._adviceWidth = rect.width + 'px';
+        advice._adviceAbsolutize = true;
+    }
+    return advice;
+};
+
+Validation.getElmID = function(elm) {
+    return elm.id ? elm.id : elm.name;
+};
+
+Validation.reset = function(elm) {
+    if (typeof elm === 'string') { elm = document.getElementById(elm); }
+    const cn = _splitClassName(elm.className);
+    cn.forEach(function(value) {
+        const prop = '__advice' + _camelize(value);
+        if (elm[prop]) {
+            const advice = Validation.getAdvice(value, elm);
+            if (advice) {
+                advice.style.display = 'none';
+            }
+            elm[prop] = '';
+        }
+        elm.classList.remove('validation-failed');
+        elm.classList.remove('validation-passed');
+        if (Validation.defaultOptions.addClassNameToContainer && Validation.defaultOptions.containerClassName != '') {
+            const container = elm.closest(Validation.defaultOptions.containerClassName);
+            if (container) {
+                container.classList.remove('validation-passed');
+                container.classList.remove('validation-error');
+            }
+        }
+    });
+};
+
+Validation.add = function(className, error, test, options) {
+    const nv = {};
+    nv[className] = new Validator(className, error, test, options);
+    Object.assign(Validation.methods, nv);
+};
+
+Validation.addAllThese = function(validators) {
+    const nv = {};
+    validators.forEach(function(value) {
+        nv[value[0]] = new Validator(value[0], value[1], value[2], (value.length > 3 ? value[3] : {}));
+    });
+    Object.assign(Validation.methods, nv);
+};
+
+Validation.get = function(name) {
+    return Validation.methods[name] ? Validation.methods[name] : Validation.methods['_LikeNoIDIEverSaw_'];
+};
+
+Validation.methods = {
+    '_LikeNoIDIEverSaw_' : new Validator('_LikeNoIDIEverSaw_', '', {})
+};
 
 Validation.add('IsEmpty', '', function(v) {
-    return  (v == '' || (v == null) || (v.length == 0) || /^\s+$/.test(v));
+    return (v == '' || (v == null) || (v.length == 0) || /^\s+$/.test(v));
 });
 
 Validation.addAllThese([
@@ -430,56 +509,56 @@ Validation.addAllThese([
                     || (!isNaN(parseNumber(v)) && /^\s*-?\d*(\.\d*)?\s*$/.test(v));
             }],
     ['validate-number-range', 'The value is not within the specified range.', function(v, elm) {
-                if (Validation.get('IsEmpty').test(v)) {
-                    return true;
-                }
+        if (Validation.get('IsEmpty').test(v)) {
+            return true;
+        }
 
-                var numValue = parseNumber(v);
-                if (isNaN(numValue)) {
-                    return false;
-                }
+        const numValue = parseNumber(v);
+        if (isNaN(numValue)) {
+            return false;
+        }
 
-                var reRange = /^number-range-(-?[\d.,]+)?-(-?[\d.,]+)?$/,
-                    result = true;
+        const reRange = /^number-range-(-?[\d.,]+)?-(-?[\d.,]+)?$/;
+        let result = true;
 
-                $w(elm.className).each(function(name) {
-                    var m = reRange.exec(name);
-                    if (m) {
-                        result = result
-                            && (m[1] == null || m[1] == '' || numValue >= parseNumber(m[1]))
-                            && (m[2] == null || m[2] == '' || numValue <= parseNumber(m[2]));
-                    }
-                });
+        _splitClassName(elm.className).forEach(function(name) {
+            const m = reRange.exec(name);
+            if (m) {
+                result = result
+                    && (m[1] == null || m[1] == '' || numValue >= parseNumber(m[1]))
+                    && (m[2] == null || m[2] == '' || numValue <= parseNumber(m[2]));
+            }
+        });
 
-                return result;
-            }],
+        return result;
+    }],
     ['validate-digits', 'Please use numbers only in this field. Please avoid spaces or other characters such as dots or commas.', function(v) {
                 return Validation.get('IsEmpty').test(v) ||  !/[^\d]/.test(v);
             }],
     ['validate-digits-range', 'The value is not within the specified range.', function(v, elm) {
-                if (Validation.get('IsEmpty').test(v)) {
-                    return true;
-                }
+        if (Validation.get('IsEmpty').test(v)) {
+            return true;
+        }
 
-                var numValue = parseNumber(v);
-                if (isNaN(numValue)) {
-                    return false;
-                }
+        const numValue = parseNumber(v);
+        if (isNaN(numValue)) {
+            return false;
+        }
 
-                var reRange = /^digits-range-(-?\d+)?-(-?\d+)?$/,
-                    result = true;
+        const reRange = /^digits-range-(-?\d+)?-(-?\d+)?$/;
+        let result = true;
 
-                $w(elm.className).each(function(name) {
-                    var m = reRange.exec(name);
-                    if (m) {
-                        result = result
-                            && (m[1] == null || m[1] == '' || numValue >= parseNumber(m[1]))
-                            && (m[2] == null || m[2] == '' || numValue <= parseNumber(m[2]));
-                    }
-                });
+        _splitClassName(elm.className).forEach(function(name) {
+            const m = reRange.exec(name);
+            if (m) {
+                result = result
+                    && (m[1] == null || m[1] == '' || numValue >= parseNumber(m[1]))
+                    && (m[2] == null || m[2] == '' || numValue <= parseNumber(m[2]));
+            }
+        });
 
-                return result;
-            }],
+        return result;
+    }],
     ['validate-hex-color', 'Please enter a valid hexadecimal color. For example ff0000.', function (v) {
                 return Validation.get('IsEmpty').test(v) ||  /^[a-f0-9]{6}$/i.test(v)
             }],
@@ -514,17 +593,17 @@ Validation.addAllThese([
                 return Validation.get('IsEmpty').test(v) || /^(\()?\d{3}(\))?(-|\s)?\d{3}(-|\s)\d{4}$/.test(v);
             }],
     ['validate-date', 'Please enter a valid date.', function(v) {
-                var test = new Date(v);
+                const test = new Date(v);
                 return Validation.get('IsEmpty').test(v) || !isNaN(test);
             }],
     ['validate-date-range', 'The From Date value should be less than or equal to the To Date value.', function(v, elm) {
-            var m = /\bdate-range-(\w+)-(\w+)\b/.exec(elm.className);
+            const m = /\bdate-range-(\w+)-(\w+)\b/.exec(elm.className);
             if (!m || m[2] == 'to' || Validation.get('IsEmpty').test(v)) {
                 return true;
             }
 
-            var currentYear = new Date().getFullYear() + '';
-            var normalizedTime = function(v) {
+            const currentYear = new Date().getFullYear() + '';
+            const normalizedTime = function(v) {
                 v = v.split(/[.\/]/);
                 if (v[2] && v[2].length < 4) {
                     v[2] = currentYear.substr(0, v[2].length) + v[2];
@@ -532,7 +611,7 @@ Validation.addAllThese([
                 return new Date(v.join('/')).getTime();
             };
 
-            var dependentElements = Element.select(elm.form, '.validate-date-range.date-range-' + m[1] + '-to');
+            const dependentElements = elm.form.querySelectorAll('.validate-date-range.date-range-' + m[1] + '-to');
             return !dependentElements.length || Validation.get('IsEmpty').test(dependentElements[0].value)
                 || normalizedTime(v) <= normalizedTime(dependentElements[0].value);
         }],
@@ -545,10 +624,10 @@ Validation.addAllThese([
                 return Validation.get('IsEmpty').test(v) ||  /^[\S ]+$/.test(v)
                     }],
     ['validate-password', 'Please enter more characters or clean leading or trailing spaces.', function(v, elm) {
-                var pass=v.strip(); /*strip leading and trailing spaces*/
-                var reMin = new RegExp(/^min-pass-length-[0-9]+$/);
-                var minLength = 7;
-                $w(elm.className).each(function(name, index) {
+                const pass=v.trim(); /*strip leading and trailing spaces*/
+                const reMin = new RegExp(/^min-pass-length-[0-9]+$/);
+                let minLength = 7;
+                _splitClassName(elm.className).forEach(function(name, index) {
                     if (name.match(reMin)) {
                         minLength = name.split('-')[3];
                     }
@@ -556,16 +635,16 @@ Validation.addAllThese([
                 return (!(v.length > 0 && v.length < minLength) && v.length == pass.length);
             }],
     ['validate-admin-password', 'Please enter more characters. Password should contain both numeric and alphabetic characters.', function(v, elm) {
-                var pass=v.strip();
+                const pass=v.trim();
                 if (0 == pass.length) {
                     return true;
                 }
                 if (!(/[a-z]/i.test(v)) || !(/[0-9]/.test(v))) {
                     return false;
                 }
-                var reMin = new RegExp(/^min-admin-pass-length-[0-9]+$/);
-                var minLength = 7;
-                $w(elm.className).each(function(name, index) {
+                const reMin = new RegExp(/^min-admin-pass-length-[0-9]+$/);
+                let minLength = 7;
+                _splitClassName(elm.className).forEach(function(name, index) {
                     if (name.match(reMin)) {
                         minLength = name.split('-')[4];
                     }
@@ -573,28 +652,27 @@ Validation.addAllThese([
                 return !(pass.length < minLength);
             }],
     ['validate-cpassword', 'Please make sure your passwords match.', function(v) {
-                var conf = $('confirmation') ? $('confirmation') : $$('.validate-cpassword')[0];
-                var pass = false;
-                if ($('password')) {
-                    pass = $('password');
+                const conf = document.getElementById('confirmation') ? document.getElementById('confirmation') : document.querySelector('.validate-cpassword');
+                let pass = false;
+                if (document.getElementById('password')) {
+                    pass = document.getElementById('password');
                 }
-                var passwordElements = $$('.validate-password');
-                for (var i = 0; i < passwordElements.size(); i++) {
-                    var passwordElement = passwordElements[i];
-                    if (passwordElement.up('form').id == conf.up('form').id) {
+                const passwordElements = document.querySelectorAll('.validate-password');
+                for (let i = 0; i < passwordElements.length; i++) {
+                    const passwordElement = passwordElements[i];
+                    if (passwordElement.closest('form').id == conf.closest('form').id) {
                         pass = passwordElement;
                     }
                 }
-                if ($$('.validate-admin-password').size()) {
-                    pass = $$('.validate-admin-password')[0];
+                if (document.querySelectorAll('.validate-admin-password').length) {
+                    pass = document.querySelectorAll('.validate-admin-password')[0];
                 }
                 return (pass.value == conf.value);
             }],
     ['validate-both-passwords', 'Please make sure your passwords match.', function(v, input) {
-                var dependentInput = $(input.form[input.name == 'password' ? 'confirmation' : 'password']),
-                    isEqualValues  = input.value == dependentInput.value;
+                const dependentInput = input.form[input.name == 'password' ? 'confirmation' : 'password'], isEqualValues  = input.value == dependentInput.value;
 
-                if (isEqualValues && dependentInput.hasClassName('validation-failed')) {
+                if (isEqualValues && dependentInput.classList.contains('validation-failed')) {
                     Validation.test(this.className, dependentInput);
                 }
 
@@ -625,9 +703,9 @@ Validation.addAllThese([
             }],
     ['validate-date-au', 'Please use this date format: dd/mm/yyyy. For example 17/03/2006 for the 17th of March, 2006.', function(v) {
                 if(Validation.get('IsEmpty').test(v)) return true;
-                var regex = /^(\d{2})\/(\d{2})\/(\d{4})$/;
+                const regex = /^(\d{2})\/(\d{2})\/(\d{4})$/;
                 if(!regex.test(v)) return false;
-                var d = new Date(v.replace(regex, '$2/$1/$3'));
+                const d = new Date(v.replace(regex, '$2/$1/$3'));
                 return ( parseInt(RegExp.$2, 10) == (1+d.getMonth()) ) &&
                             (parseInt(RegExp.$1, 10) == d.getDate()) &&
                             (parseInt(RegExp.$3, 10) == d.getFullYear() );
@@ -640,17 +718,17 @@ Validation.addAllThese([
                 return Validation.get('IsEmpty').test(v) ||  /^\$?\-?([1-9]{1}[0-9]{0,2}(\,[0-9]{3})*(\.[0-9]{0,2})?|[1-9]{1}\d*(\.[0-9]{0,2})?|0(\.[0-9]{0,2})?|(\.[0-9]{1,2})?)$/.test(v)
             }],
     ['validate-one-required', 'Please select one of the above options.', function (v,elm) {
-                var p = elm.parentNode;
-                var options = p.getElementsByTagName('INPUT');
-                return $A(options).any(function(elm) {
-                    return $F(elm);
+                const p = elm.parentNode;
+                const options = p.getElementsByTagName('INPUT');
+                return Array.from(options).some(function(el) {
+                    return _getFieldValue(el);
                 });
             }],
     ['validate-one-required-by-name', 'Please select one of the options.', function (v,elm) {
-                var inputs = $$('input[name="' + elm.name.replace(/([\\"])/g, '\\$1') + '"]');
+                const inputs = document.querySelectorAll('input[name="' + elm.name.replace(/([\\"])/g, '\\$1') + '"]');
 
-                var error = 1;
-                for(var i=0;i<inputs.length;i++) {
+                let error = 1;
+                for(let i=0;i<inputs.length;i++) {
                     if((inputs[i].type == 'checkbox' || inputs[i].type == 'radio') && inputs[i].checked == true) {
                         error = 0;
                     }
@@ -685,14 +763,14 @@ Validation.addAllThese([
         }],
 
     ['validate-special-price', 'The Special Price is active only when lower than the Actual Price.', function(v) {
-        var priceInput = $('price');
-        var priceType = $('price_type');
-        var priceValue = parseFloat(v);
+        const priceInput = document.getElementById('price');
+        const priceType = document.getElementById('price_type');
+        const priceValue = parseFloat(v);
 
         // Passed on non-related validators conditions (to not change order of validation)
         if(
             !priceInput
-            || !$F(priceInput)
+            || !_getFieldValue(priceInput)
             || Validation.get('IsEmpty').test(v)
             || !Validation.get('validate-number').test(v)
         ) {
@@ -701,7 +779,7 @@ Validation.addAllThese([
         if(priceType) {
             return (priceType && priceValue <= 99.99);
         }
-        return priceValue < parseFloat($F(priceInput));
+        return priceValue < parseFloat(_getFieldValue(priceInput));
     }],
     ['validate-state', 'Please select State/Province.', function(v) {
                 return (v!=0 || v == '');
@@ -713,9 +791,9 @@ Validation.addAllThese([
             }],
     ['validate-cc-number', 'Please enter a valid credit card number.', function(v, elm) {
                 // remove non-numerics
-                var ccTypeContainer = $(elm.id.substr(0,elm.id.indexOf('_cc_number')) + '_cc_type');
-                if (ccTypeContainer && typeof Validation.creditCartTypes.get(ccTypeContainer.value) != 'undefined'
-                        && Validation.creditCartTypes.get(ccTypeContainer.value)[2] == false) {
+                const ccTypeContainer = document.getElementById(elm.id.substr(0,elm.id.indexOf('_cc_number')) + '_cc_type');
+                if (ccTypeContainer && typeof Validation.creditCartTypes[ccTypeContainer.value] != 'undefined'
+                        && Validation.creditCartTypes[ccTypeContainer.value][2] == false) {
                     if (!Validation.get('IsEmpty').test(v) && Validation.get('validate-digits').test(v)) {
                         return true;
                     } else {
@@ -729,43 +807,45 @@ Validation.addAllThese([
                 elm.value = removeDelimiters(elm.value);
                 v         = removeDelimiters(v);
 
-                var ccTypeContainer = $(elm.id.substr(0,elm.id.indexOf('_cc_number')) + '_cc_type');
+                const ccTypeContainer = document.getElementById(elm.id.substr(0,elm.id.indexOf('_cc_number')) + '_cc_type');
                 if (!ccTypeContainer) {
                     return true;
                 }
-                var ccType = ccTypeContainer.value;
+                const ccType = ccTypeContainer.value;
 
-                if (typeof Validation.creditCartTypes.get(ccType) == 'undefined') {
+                if (typeof Validation.creditCartTypes[ccType] == 'undefined') {
                     return false;
                 }
 
                 // Other card type or switch or solo card
-                if (Validation.creditCartTypes.get(ccType)[0]==false) {
+                if (Validation.creditCartTypes[ccType][0]==false) {
                     return true;
                 }
 
-                var validationFailure = false;
-                Validation.creditCartTypes.each(function (pair) {
-                    if (pair.key == ccType) {
-                        if (pair.value[0] && !v.match(pair.value[0])) {
+                let validationFailure = false;
+                const keys = Object.keys(Validation.creditCartTypes);
+                for (let i = 0; i < keys.length; i++) {
+                    const key = keys[i];
+                    if (key == ccType) {
+                        if (Validation.creditCartTypes[key][0] && !v.match(Validation.creditCartTypes[key][0])) {
                             validationFailure = true;
                         }
-                        throw $break;
+                        break;
                     }
-                });
+                }
 
                 if (validationFailure) {
                     return false;
                 }
 
-                if (ccTypeContainer.hasClassName('validation-failed') && Validation.isOnChange) {
+                if (ccTypeContainer.classList.contains('validation-failed') && Validation.isOnChange) {
                     Validation.validate(ccTypeContainer);
                 }
 
                 return true;
             }],
      ['validate-cc-type-select', 'Card type does not match credit card number.', function(v, elm) {
-                var ccNumberContainer = $(elm.id.substr(0,elm.id.indexOf('_cc_type')) + '_cc_number');
+                const ccNumberContainer = document.getElementById(elm.id.substr(0,elm.id.indexOf('_cc_type')) + '_cc_number');
                 if (Validation.isOnChange && Validation.get('IsEmpty').test(ccNumberContainer.value)) {
                     return true;
                 }
@@ -775,28 +855,28 @@ Validation.addAllThese([
                 return Validation.get('validate-cc-type').test(ccNumberContainer.value, ccNumberContainer);
             }],
      ['validate-cc-exp', 'Incorrect credit card expiration date.', function(v, elm) {
-                var ccExpMonth   = v;
-                var ccExpYear    = $(elm.id.substr(0,elm.id.indexOf('_expiration')) + '_expiration_yr').value;
-                var currentTime  = new Date();
-                var currentMonth = currentTime.getMonth() + 1;
-                var currentYear  = currentTime.getFullYear();
+                const ccExpMonth   = v;
+                const ccExpYear    = document.getElementById(elm.id.substr(0,elm.id.indexOf('_expiration')) + '_expiration_yr').value;
+                const currentTime  = new Date();
+                const currentMonth = currentTime.getMonth() + 1;
+                const currentYear  = currentTime.getFullYear();
                 if (ccExpMonth < currentMonth && ccExpYear == currentYear) {
                     return false;
                 }
                 return true;
             }],
      ['validate-cc-cvn', 'Please enter a valid credit card verification number.', function(v, elm) {
-                var ccTypeContainer = $(elm.id.substr(0,elm.id.indexOf('_cc_cid')) + '_cc_type');
+                const ccTypeContainer = document.getElementById(elm.id.substr(0,elm.id.indexOf('_cc_cid')) + '_cc_type');
                 if (!ccTypeContainer) {
                     return true;
                 }
-                var ccType = ccTypeContainer.value;
+                const ccType = ccTypeContainer.value;
 
-                if (typeof Validation.creditCartTypes.get(ccType) == 'undefined') {
+                if (typeof Validation.creditCartTypes[ccType] == 'undefined') {
                     return false;
                 }
 
-                var re = Validation.creditCartTypes.get(ccType)[1];
+                const re = Validation.creditCartTypes[ccType][1];
 
                 if (v.match(re)) {
                     return true;
@@ -818,10 +898,10 @@ Validation.addAllThese([
                 return true;
             }],
      ['validate-length', 'Text length does not satisfy specified text range.', function (v, elm) {
-                var reMax = new RegExp(/^maximum-length-[0-9]+$/);
-                var reMin = new RegExp(/^minimum-length-[0-9]+$/);
-                var result = true;
-                $w(elm.className).each(function(name, index) {
+                const reMax = new RegExp(/^maximum-length-[0-9]+$/);
+                const reMin = new RegExp(/^minimum-length-[0-9]+$/);
+                let result = true;
+                _splitClassName(elm.className).forEach(function(name, index) {
                     if (name.match(reMax) && result) {
                        var length = name.split('-')[2];
                        result = (v.length <= length);
@@ -835,17 +915,17 @@ Validation.addAllThese([
             }],
      ['validate-percents', 'Please enter a number lower than 100.', {max:100}],
      ['required-file', 'Please select a file', function(v, elm) {
-         var result = !Validation.get('IsEmpty').test(v);
+         let result = !Validation.get('IsEmpty').test(v);
          if (result === false) {
-             ovId = elm.id + '_value';
-             if ($(ovId)) {
-                 result = !Validation.get('IsEmpty').test($(ovId).value);
+             const ovId = elm.id + '_value';
+             if (document.getElementById(ovId)) {
+                 result = !Validation.get('IsEmpty').test(document.getElementById(ovId).value);
              }
          }
          return result;
      }],
      ['validate-cc-ukss', 'Please enter issue number or start date for switch/solo card type.', function(v,elm) {
-         var endposition;
+         let endposition;
 
          if (elm.id.match(/(.)+_cc_issue$/)) {
              endposition = elm.id.indexOf('_cc_issue');
@@ -855,29 +935,39 @@ Validation.addAllThese([
              endposition = elm.id.indexOf('_start_year');
          }
 
-         var prefix = elm.id.substr(0,endposition);
+         const prefix = elm.id.substr(0,endposition);
 
-         var ccTypeContainer = $(prefix + '_cc_type');
+         const ccTypeContainer = document.getElementById(prefix + '_cc_type');
 
          if (!ccTypeContainer) {
                return true;
          }
-         var ccType = ccTypeContainer.value;
+         const ccType = ccTypeContainer.value;
 
          if(['SS','SM','SO'].indexOf(ccType) == -1){
              return true;
          }
 
-         $(prefix + '_cc_issue').advaiceContainer
-           = $(prefix + '_start_month').advaiceContainer
-           = $(prefix + '_start_year').advaiceContainer
-           = $(prefix + '_cc_type_ss_div').down('ul li.adv-container');
+         const issueEl = document.getElementById(prefix + '_cc_issue');
+         const startMonthEl = document.getElementById(prefix + '_start_month');
+         const startYearEl = document.getElementById(prefix + '_start_year');
+         const advContainer = document.getElementById(prefix + '_cc_type_ss_div');
 
-         var ccIssue   =  $(prefix + '_cc_issue').value;
-         var ccSMonth  =  $(prefix + '_start_month').value;
-         var ccSYear   =  $(prefix + '_start_year').value;
+         if (issueEl) {
+             issueEl.advaiceContainer = advContainer ? advContainer.querySelector('ul li.adv-container') : null;
+         }
+         if (startMonthEl) {
+             startMonthEl.advaiceContainer = advContainer ? advContainer.querySelector('ul li.adv-container') : null;
+         }
+         if (startYearEl) {
+             startYearEl.advaiceContainer = advContainer ? advContainer.querySelector('ul li.adv-container') : null;
+         }
 
-         var ccStartDatePresent = (ccSMonth && ccSYear) ? true : false;
+         const ccIssue   = issueEl ? issueEl.value : '';
+         const ccSMonth  = startMonthEl ? startMonthEl.value : '';
+         const ccSYear   = startYearEl ? startYearEl.value : '';
+
+         const ccStartDatePresent = (ccSMonth && ccSYear) ? true : false;
 
          if (!ccStartDatePresent && !ccIssue){
              return false;
@@ -898,8 +988,8 @@ function parseNumber(v)
         return parseFloat(v);
     }
 
-    var isDot  = v.indexOf('.');
-    var isComa = v.indexOf(',');
+    const isDot  = v.indexOf('.');
+    const isComa = v.indexOf(',');
 
     if (isDot != -1 && isComa != -1) {
         if (isComa > isDot) {
@@ -923,7 +1013,7 @@ function parseNumber(v)
  * 2 - check or not credit card number trough Luhn algorithm by
  *     function validateCreditCard which you can find above in this file
  */
-Validation.creditCartTypes = $H({
+Validation.creditCartTypes = {
 //    'SS': [new RegExp('^((6759[0-9]{12})|(5018|5020|5038|6304|6759|6761|6763[0-9]{12,19})|(49[013][1356][0-9]{12})|(6333[0-9]{12})|(6334[0-4]\d{11})|(633110[0-9]{10})|(564182[0-9]{10}))([0-9]{2,3})?$'), new RegExp('^([0-9]{3}|[0-9]{4})?$'), true],
     'SO': [new RegExp('^(6334[5-9]([0-9]{11}|[0-9]{13,14}))|(6767([0-9]{12}|[0-9]{14,15}))$'), new RegExp('^([0-9]{3}|[0-9]{4})?$'), true],
     'VI': [new RegExp('^4[0-9]{12}([0-9]{3})?$'), new RegExp('^[0-9]{3}$'), true],
@@ -934,4 +1024,13 @@ Validation.creditCartTypes = $H({
     'DICL': [new RegExp('^(30[0-5][0-9]{13}|3095[0-9]{12}|35(2[8-9][0-9]{12}|[3-8][0-9]{13})|36[0-9]{12}|3[8-9][0-9]{14}|6011(0[0-9]{11}|[2-4][0-9]{11}|74[0-9]{10}|7[7-9][0-9]{10}|8[6-9][0-9]{10}|9[0-9]{11})|62(2(12[6-9][0-9]{10}|1[3-9][0-9]{11}|[2-8][0-9]{12}|9[0-1][0-9]{11}|92[0-5][0-9]{10})|[4-6][0-9]{13}|8[2-8][0-9]{12})|6(4[4-9][0-9]{13}|5[0-9]{14}))$'), new RegExp('^[0-9]{3}$'), true],
     'SM': [new RegExp('(^(5[0678])[0-9]{11,18}$)|(^(6[^05])[0-9]{11,18}$)|(^(601)[^1][0-9]{9,16}$)|(^(6011)[0-9]{9,11}$)|(^(6011)[0-9]{13,16}$)|(^(65)[0-9]{11,13}$)|(^(65)[0-9]{15,18}$)|(^(49030)[2-9]([0-9]{10}$|[0-9]{12,13}$))|(^(49033)[5-9]([0-9]{10}$|[0-9]{12,13}$))|(^(49110)[1-2]([0-9]{10}$|[0-9]{12,13}$))|(^(49117)[4-9]([0-9]{10}$|[0-9]{12,13}$))|(^(49118)[0-2]([0-9]{10}$|[0-9]{12,13}$))|(^(4936)([0-9]{12}$|[0-9]{14,15}$))'), new RegExp('^([0-9]{3}|[0-9]{4})?$'), true],
     'OT': [false, new RegExp('^([0-9]{3}|[0-9]{4})?$'), false]
-});
+};
+
+// Backward-compatible .get() method on creditCartTypes for code that used $H().get()
+Validation.creditCartTypes.get = function(key) {
+    return this[key];
+};
+// Payment modules register card types with creditCartTypes.set('XX', [...])
+Validation.creditCartTypes.set = function(key, value) {
+    this[key] = value;
+};

--- a/js/varien/accordion.js
+++ b/js/varien/accordion.js
@@ -11,48 +11,74 @@
  * @copyright   Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
-Accordion = Class.create();
+
+/**
+ * Rewritten to vanilla JS — no Prototype.js dependency.
+ *
+ * @constructor
+ * @param {string} elem - container element ID
+ * @param {string} clickableEntity - CSS selector for clickable headers within sections
+ * @param {boolean} [checkAllow=false]
+ */
+function Accordion() {
+    this.initialize(...arguments);
+}
+
 Accordion.prototype = {
     initialize: function(elem, clickableEntity, checkAllow) {
-        this.container = $(elem);
+        this.container = document.getElementById(elem);
         this.checkAllow = checkAllow || false;
         this.disallowAccessToNextSections = false;
-        this.sections = $$('#' + elem + ' .section');
+        this.sections = Array.prototype.slice.call(document.querySelectorAll('#' + elem + ' .section'));
         this.currentSection = false;
-        var headers = $$('#' + elem + ' .section ' + clickableEntity);
-        headers.each(function(header) {
-            Event.observe(header,'click',this.sectionClicked.bindAsEventListener(this));
-        }.bind(this));
+
+        const headers = document.querySelectorAll('#' + elem + ' .section ' + clickableEntity);
+        const self = this;
+        headers.forEach(function (header) {
+            header.addEventListener('click', function (event) {
+                self.sectionClicked(event);
+            });
+        });
     },
 
-    sectionClicked: function(event) {
-        this.openSection($(Event.element(event)).up('.section'));
-        Event.stop(event);
+    sectionClicked: function (event) {
+        const target = event.target;
+        const section = target.closest('.section');
+        if (section) {
+            this.openSection(section);
+        }
+        event.preventDefault();
+        event.stopPropagation();
     },
 
-    openSection: function(section) {
-        var section = $(section);
-
-        // Check allow
-        if (this.checkAllow && !Element.hasClassName(section, 'allow')){
+    openSection: function (section) {
+        if (typeof section === 'string') {
+            section = document.getElementById(section);
+        }
+        if (!section) {
             return;
         }
 
-        if(section.id != this.currentSection) {
+        if (this.checkAllow && !section.classList.contains('allow')) {
+            return;
+        }
+
+        if (section.id !== this.currentSection) {
             this.closeExistingSection();
             this.currentSection = section.id;
-            $(this.currentSection).addClassName('active');
-            var contents = Element.select(section, '.a-item');
-            contents[0].show();
-            //Effect.SlideDown(contents[0], {duration:.2});
+            document.getElementById(this.currentSection).classList.add('active');
+            const contents = section.querySelectorAll('.a-item');
+            if (contents[0]) {
+                contents[0].style.display = '';
+            }
 
             if (this.disallowAccessToNextSections) {
-                var pastCurrentSection = false;
-                for (var i=0; i<this.sections.length; i++) {
+                let pastCurrentSection = false;
+                for (let i = 0; i < this.sections.length; i++) {
                     if (pastCurrentSection) {
-                        Element.removeClassName(this.sections[i], 'allow');
+                        this.sections[i].classList.remove('allow');
                     }
-                    if (this.sections[i].id==section.id) {
+                    if (this.sections[i].id === section.id) {
                         pastCurrentSection = true;
                     }
                 }
@@ -60,19 +86,26 @@ Accordion.prototype = {
         }
     },
 
-    closeSection: function(section) {
-        $(section).removeClassName('active');
-        var contents = Element.select(section, '.a-item');
-        contents[0].hide();
-        //Effect.SlideUp(contents[0]);
+    closeSection: function (section) {
+        if (typeof section === 'string') {
+            section = document.getElementById(section);
+        }
+        if (!section) {
+            return;
+        }
+        section.classList.remove('active');
+        const contents = section.querySelectorAll('.a-item');
+        if (contents[0]) {
+            contents[0].style.display = 'none';
+        }
     },
 
-    openNextSection: function(setAllow){
-        for (section in this.sections) {
-            var nextIndex = parseInt(section)+1;
-            if (this.sections[section].id == this.currentSection && this.sections[nextIndex]){
+    openNextSection: function (setAllow) {
+        for (let i = 0; i < this.sections.length; i++) {
+            const nextIndex = i + 1;
+            if (this.sections[i].id === this.currentSection && this.sections[nextIndex]) {
                 if (setAllow) {
-                    Element.addClassName(this.sections[nextIndex], 'allow');
+                    this.sections[nextIndex].classList.add('allow');
                 }
                 this.openSection(this.sections[nextIndex]);
                 return;
@@ -80,12 +113,12 @@ Accordion.prototype = {
         }
     },
 
-    openPrevSection: function(setAllow){
-        for (section in this.sections) {
-            var prevIndex = parseInt(section)-1;
-            if (this.sections[section].id == this.currentSection && this.sections[prevIndex]){
+    openPrevSection: function (setAllow) {
+        for (let i = 0; i < this.sections.length; i++) {
+            const prevIndex = i - 1;
+            if (this.sections[i].id === this.currentSection && this.sections[prevIndex]) {
                 if (setAllow) {
-                    Element.addClassName(this.sections[prevIndex], 'allow');
+                    this.sections[prevIndex].classList.add('allow');
                 }
                 this.openSection(this.sections[prevIndex]);
                 return;
@@ -93,9 +126,10 @@ Accordion.prototype = {
         }
     },
 
-    closeExistingSection: function() {
-        if(this.currentSection) {
+    closeExistingSection: function () {
+        if (this.currentSection) {
             this.closeSection(this.currentSection);
         }
     }
 };
+Varien.classCompat(Accordion);

--- a/js/varien/autocomplete.js
+++ b/js/varien/autocomplete.js
@@ -1,0 +1,276 @@
+/**
+ * OpenMage
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE_AFL.txt.
+ * It is also available at https://opensource.org/license/afl-3-0-php
+ *
+ * @category    Varien
+ * @package     js
+ * @copyright   Copyright (c) 2020-2024 The OpenMage Contributors (https://www.openmage.org)
+ * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+/**
+ * Lightweight vanilla autocomplete (replaces Scriptaculous Ajax.Autocompleter).
+ * Works in all prototype_mode values (full/shim/none) — uses fetch, no Prototype.
+ * The server is expected to return an HTML <ul> with <li> entries.
+ *
+ * Self-contained: load this file wherever a search/autocomplete field exists.
+ * Detach it (and swap in another implementation) by removing it from layout —
+ * the only consumers are Varien.searchForm.initAutocomplete (storefront search)
+ * and the admin global search (page/header.phtml).
+ */
+if (!window.Varien) {
+    window.Varien = {};
+}
+
+/**
+ * @constructor
+ * @param {string|HTMLElement} element - the input field (id or node)
+ * @param {string|HTMLElement} update  - the results container (id or node)
+ * @param {string} url
+ * @param {object} options - paramName, minChars, method, frequency, indicator,
+ *                           updateElement, afterUpdateElement, onShow, onHide, parameters
+ */
+Varien.Autocomplete = function(element, update, url, options) {
+    this.element = typeof element === 'string' ? document.getElementById(element) : element;
+    this.update  = typeof update  === 'string' ? document.getElementById(update)  : update;
+    this.url = url;
+    this.options = Object.assign({
+        paramName: 'query',
+        minChars: 1,
+        method: 'get',
+        frequency: 0.4,
+        indicator: null,
+        updateElement: null,
+        afterUpdateElement: null,
+        onShow: null,
+        onHide: null,
+        parameters: {}
+    }, options || {});
+
+    this.active = false;
+    this.hasFocus = false;
+    this.index = -1;
+    this.entryCount = 0;
+    this.observer = null;
+
+    if (!this.element || !this.update) {
+        return;
+    }
+
+    this.oldValue = this.element.value;
+    this.update.style.display = 'none';
+    this.element.setAttribute('autocomplete', 'off');
+
+    const self = this;
+    this.element.addEventListener('keydown', function(e) { self.onKeyDown(e); });
+    this.element.addEventListener('focus', function() { self.onFocus(); });
+    this.element.addEventListener('blur', function() { self.onBlur(); });
+};
+
+Varien.Autocomplete.prototype = {
+    onKeyDown: function(evt) {
+        switch (evt.keyCode) {
+            case 38: // up
+                evt.preventDefault();
+                this.markPrevious();
+                return;
+            case 40: // down
+                evt.preventDefault();
+                this.markNext();
+                return;
+            case 13: // return
+                if (this.active && this.index >= 0) {
+                    evt.preventDefault();
+                    this.selectEntry();
+                }
+                return;
+            case 27: // esc
+                this.hide();
+                this.active = false;
+                return;
+            case 9: // tab
+                if (this.active && this.index >= 0) {
+                    this.selectEntry();
+                }
+                return;
+        }
+    },
+
+    onFocus: function() {
+        this.hasFocus = true;
+        this.startObserving();
+    },
+
+    onBlur: function() {
+        const self = this;
+        this.hasFocus = false;
+        // Delay so a click on a dropdown entry can register first
+        setTimeout(function() {
+            if (!self.hasFocus) {
+                self.hide();
+                self.stopObserving();
+            }
+        }, 250);
+    },
+
+    startObserving: function() {
+        if (this.observer) {
+            return;
+        }
+        const self = this;
+        this.observer = setInterval(function() { self.onObserverEvent(); }, this.options.frequency * 1000);
+    },
+
+    stopObserving: function() {
+        if (this.observer) {
+            clearInterval(this.observer);
+            this.observer = null;
+        }
+    },
+
+    onObserverEvent: function() {
+        const val = this.element.value;
+        if (val === this.oldValue) {
+            return;
+        }
+        this.oldValue = val;
+        if (val.length >= this.options.minChars) {
+            this.getUpdatedChoices();
+        } else {
+            this.hide();
+            this.active = false;
+        }
+    },
+
+    getUpdatedChoices: function() {
+        const params = {};
+        params[this.options.paramName] = this.element.value;
+        const extra = this.options.parameters || {};
+        Object.keys(extra).forEach(function(k) { params[k] = extra[k]; });
+
+        const indicator = this.options.indicator
+            ? (typeof this.options.indicator === 'string' ? document.getElementById(this.options.indicator) : this.options.indicator)
+            : null;
+        if (indicator) indicator.style.display = '';
+
+        const self = this;
+        const method = (this.options.method || 'get').toUpperCase();
+        let fetchUrl = this.url;
+        const fetchOpts = { method: method, headers: { 'X-Requested-With': 'XMLHttpRequest' } };
+        const qs = new URLSearchParams(params).toString();
+        if (method === 'GET') {
+            fetchUrl += (fetchUrl.indexOf('?') === -1 ? '?' : '&') + qs;
+        } else {
+            fetchOpts.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+            fetchOpts.body = qs;
+        }
+
+        fetch(fetchUrl, fetchOpts)
+            .then(function(resp) { return resp.text(); })
+            .then(function(text) {
+                if (indicator) indicator.style.display = 'none';
+                self.updateChoices(text);
+            })
+            .catch(function() {
+                if (indicator) indicator.style.display = 'none';
+            });
+    },
+
+    updateChoices: function(html) {
+        this.update.innerHTML = html;
+        const entries = this.update.querySelectorAll('li');
+        this.entryCount = entries.length;
+        this.index = -1;
+
+        const self = this;
+        for (let i = 0; i < entries.length; i++) {
+            (function(idx) {
+                entries[idx].addEventListener('click', function(e) {
+                    e.preventDefault();
+                    self.index = idx;
+                    self.selectEntry();
+                });
+                entries[idx].addEventListener('mouseover', function() { self.setActive(idx); });
+            })(i);
+        }
+
+        if (this.entryCount > 0) {
+            this.show();
+            this.active = true;
+        } else {
+            this.hide();
+            this.active = false;
+        }
+    },
+
+    show: function() {
+        if (typeof this.options.onShow === 'function') {
+            this.options.onShow(this.element, this.update);
+        } else {
+            this.update.style.display = '';
+        }
+    },
+
+    hide: function() {
+        // Note: do not stop the polling observer here — it must keep running while
+        // the field has focus so that typing past minChars is detected. The observer
+        // is stopped on blur (see onBlur).
+        if (typeof this.options.onHide === 'function') {
+            this.options.onHide(this.element, this.update);
+        } else {
+            this.update.style.display = 'none';
+        }
+    },
+
+    setActive: function(idx) {
+        const entries = this.update.querySelectorAll('li');
+        for (let i = 0; i < entries.length; i++) {
+            entries[i].classList.toggle('selected', i === idx);
+        }
+        this.index = idx;
+    },
+
+    markPrevious: function() {
+        if (this.index > 0) {
+            this.setActive(this.index - 1);
+        } else {
+            this.setActive(this.entryCount - 1);
+        }
+    },
+
+    markNext: function() {
+        if (this.index < this.entryCount - 1) {
+            this.setActive(this.index + 1);
+        } else {
+            this.setActive(0);
+        }
+    },
+
+    selectEntry: function() {
+        this.active = false;
+        const entries = this.update.querySelectorAll('li');
+        const selected = entries[this.index];
+        if (!selected) {
+            return;
+        }
+        this.updateElement(selected);
+        this.hide();
+    },
+
+    updateElement: function(selected) {
+        if (typeof this.options.updateElement === 'function') {
+            this.options.updateElement(selected);
+        } else {
+            const value = (selected.textContent || '').replace(/^\s+|\s+$/g, '');
+            this.element.value = value;
+            this.oldValue = value;
+            this.element.focus();
+        }
+        if (typeof this.options.afterUpdateElement === 'function') {
+            this.options.afterUpdateElement(this.element, selected);
+        }
+    }
+};

--- a/js/varien/configurable.js
+++ b/js/varien/configurable.js
@@ -11,35 +11,56 @@
  * @copyright   Copyright (c) 2017-2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/**
+ * Rewritten to vanilla JS — no Prototype.js dependency.
+ */
+
 if (typeof Product == 'undefined') {
     var Product = {};
 }
 
 /**************************** CONFIGURABLE PRODUCT **************************/
-Product.Config = Class.create();
+Product.Config = function () {
+    this.initialize(...arguments);
+};
+
 Product.Config.prototype = {
-    initialize: function(config){
-        this.config     = config;
-        this.taxConfig  = this.config.taxConfig;
+    initialize: function (config) {
+        this.config = config;
+        this.taxConfig = this.config.taxConfig;
         if (config.containerId) {
-            this.settings   = $$('#' + config.containerId + ' ' + '.super-attribute-select');
+            this.settings = Array.from(document.querySelectorAll('#' + config.containerId + ' .super-attribute-select'));
         } else {
-            this.settings   = $$('.super-attribute-select');
+            this.settings = Array.from(document.querySelectorAll('.super-attribute-select'));
         }
-        this.state      = new Hash();
-        this.priceTemplate = new Template(this.config.template);
-        this.prices     = config.prices;
+        this.state = {};
+        this.prices = config.prices;
+
+        // Simple template: replace #{key} with obj[key]
+        const tpl = this.config.template;
+        this.priceTemplate = {
+            evaluate: function (obj) {
+                return tpl.replace(/#\{(\w+)\}/g, function (m, key) {
+                    return obj[key] !== undefined ? obj[key] : '';
+                });
+            }
+        };
 
         // Set default values from config
         if (config.defaultValues) {
             this.values = config.defaultValues;
         }
 
-        // Overwrite defaults by url
-        var separatorIndex = window.location.href.indexOf('#');
+        // Overwrite defaults by url hash
+        const separatorIndex = window.location.href.indexOf('#');
         if (separatorIndex != -1) {
-            var paramsStr = window.location.href.substr(separatorIndex+1);
-            var urlValues = paramsStr.toQueryParams();
+            const paramsStr = window.location.href.substr(separatorIndex + 1);
+            const urlValues = {};
+            paramsStr.split('&').forEach(function (pair) {
+                const parts = pair.split('=');
+                if (parts[0]) urlValues[decodeURIComponent(parts[0])] = decodeURIComponent(parts[1] || '');
+            });
             if (!this.values) {
                 this.values = {};
             }
@@ -51,136 +72,141 @@ Product.Config.prototype = {
         // Overwrite defaults by inputs values if needed
         if (config.inputsInitialized) {
             this.values = {};
-            this.settings.each(function(element) {
+            var self = this;
+            this.settings.forEach(function (element) {
                 if (element.value) {
-                    var attributeId = element.id.replace(/[a-z]*/, '');
-                    this.values[attributeId] = element.value;
+                    const attributeId = element.id.replace(/[a-z]*/, '');
+                    self.values[attributeId] = element.value;
                 }
-            }.bind(this));
+            });
         }
 
         // Put events to check select reloads
-        this.settings.each(function(element){
-            Event.observe(element, 'change', this.configure.bind(this));
-        }.bind(this));
+        var self = this;
+        this.settings.forEach(function (element) {
+            element.addEventListener('change', self.configure.bind(self));
+        });
 
         // fill state
-        this.settings.each(function(element){
-            var attributeId = element.id.replace(/[a-z]*/, '');
-            if(attributeId && this.config.attributes[attributeId]) {
-                element.config = this.config.attributes[attributeId];
+        this.settings.forEach(function (element) {
+            const attributeId = element.id.replace(/[a-z]*/, '');
+            if (attributeId && self.config.attributes[attributeId]) {
+                element.config = self.config.attributes[attributeId];
                 element.attributeId = attributeId;
-                this.state[attributeId] = false;
+                self.state[attributeId] = false;
             }
-        }.bind(this));
+        });
 
         // Init settings dropdown
-        var childSettings = [];
-        for(var i=this.settings.length-1;i>=0;i--){
-            var prevSetting = this.settings[i-1] ? this.settings[i-1] : false;
-            var nextSetting = this.settings[i+1] ? this.settings[i+1] : false;
-            if (i == 0){
+        const childSettings = [];
+        for (var i = this.settings.length - 1; i >= 0; i--) {
+            const prevSetting = this.settings[i - 1] ? this.settings[i - 1] : false;
+            const nextSetting = this.settings[i + 1] ? this.settings[i + 1] : false;
+            if (i == 0) {
                 this.fillSelect(this.settings[i]);
             } else {
                 this.settings[i].disabled = true;
             }
-            $(this.settings[i]).childSettings = childSettings.clone();
-            $(this.settings[i]).prevSetting   = prevSetting;
-            $(this.settings[i]).nextSetting   = nextSetting;
+            this.settings[i].childSettings = childSettings.slice();
+            this.settings[i].prevSetting = prevSetting;
+            this.settings[i].nextSetting = nextSetting;
             childSettings.push(this.settings[i]);
         }
 
         // Set values to inputs
         this.configureForValues();
-        document.observe("dom:loaded", this.configureForValues.bind(this));
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', this.configureForValues.bind(this));
+        } else {
+            this.configureForValues();
+        }
     },
 
     configureForValues: function () {
         if (this.values) {
-            this.settings.each(function(element){
-                var attributeId = element.attributeId;
-                element.value = (typeof(this.values[attributeId]) == 'undefined')? '' : this.values[attributeId];
-                this.configureElement(element);
-            }.bind(this));
+            const self = this;
+            this.settings.forEach(function (element) {
+                const attributeId = element.attributeId;
+                element.value = (typeof(self.values[attributeId]) == 'undefined') ? '' : self.values[attributeId];
+                self.configureElement(element);
+            });
         }
     },
 
-    configure: function(event){
-        var element = Event.element(event);
+    configure: function (event) {
+        const element = event.target;
         this.configureElement(element);
     },
 
-    configureElement : function(element) {
+    configureElement: function (element) {
         this.reloadOptionLabels(element);
-        if(element.value){
+        if (element.value) {
             this.state[element.config.id] = element.value;
-            if(element.nextSetting){
+            if (element.nextSetting) {
                 element.nextSetting.disabled = false;
                 this.fillSelect(element.nextSetting);
                 this.resetChildren(element.nextSetting);
             }
-        }
-        else {
+        } else {
             this.resetChildren(element);
         }
         this.reloadPrice();
     },
 
-    reloadOptionLabels: function(element){
-        var selectedPrice;
-        if(element.options[element.selectedIndex].config && !this.config.stablePrices){
+    reloadOptionLabels: function (element) {
+        let selectedPrice;
+        if (element.options[element.selectedIndex].config && !this.config.stablePrices) {
             selectedPrice = parseFloat(element.options[element.selectedIndex].config.price);
-        }
-        else{
+        } else {
             selectedPrice = 0;
         }
-        for(var i=0;i<element.options.length;i++){
-            if(element.options[i].config){
-                element.options[i].text = this.getOptionLabel(element.options[i].config, element.options[i].config.price-selectedPrice);
+        for (let i = 0; i < element.options.length; i++) {
+            if (element.options[i].config) {
+                element.options[i].text = this.getOptionLabel(element.options[i].config, element.options[i].config.price - selectedPrice);
             }
         }
     },
 
-    resetChildren : function(element){
-        if(element.childSettings) {
-            for(var i=0;i<element.childSettings.length;i++){
+    resetChildren: function (element) {
+        if (element.childSettings) {
+            for (let i = 0; i < element.childSettings.length; i++) {
                 element.childSettings[i].selectedIndex = 0;
                 element.childSettings[i].disabled = true;
-                if(element.config){
+                if (element.config) {
                     this.state[element.config.id] = false;
                 }
             }
         }
     },
 
-    fillSelect: function(element){
-        var attributeId = element.id.replace(/[a-z]*/, '');
-        var options = this.getAttributeOptions(attributeId);
+    fillSelect: function (element) {
+        const attributeId = element.id.replace(/[a-z]*/, '');
+        const options = this.getAttributeOptions(attributeId);
         this.clearSelect(element);
         element.options[0] = new Option('', '');
         element.options[0].innerHTML = this.config.chooseText;
 
-        var prevConfig = false;
-        if(element.prevSetting){
+        let prevConfig = false;
+        if (element.prevSetting) {
             prevConfig = element.prevSetting.options[element.prevSetting.selectedIndex];
         }
 
-        if(options) {
-            var index = 1;
-            for(var i=0;i<options.length;i++){
-                var allowedProducts = [];
-                if(prevConfig) {
-                    for(var j=0;j<options[i].products.length;j++){
-                        if(prevConfig.config.allowedProducts
-                            && prevConfig.config.allowedProducts.indexOf(options[i].products[j])>-1){
+        if (options) {
+            let index = 1;
+            for (let i = 0; i < options.length; i++) {
+                let allowedProducts = [];
+                if (prevConfig) {
+                    for (let j = 0; j < options[i].products.length; j++) {
+                        if (prevConfig.config && prevConfig.config.allowedProducts
+                            && prevConfig.config.allowedProducts.indexOf(options[i].products[j]) > -1) {
                             allowedProducts.push(options[i].products[j]);
                         }
                     }
                 } else {
-                    allowedProducts = options[i].products.clone();
+                    allowedProducts = options[i].products.slice();
                 }
 
-                if(allowedProducts.size()>0){
+                if (allowedProducts.length > 0) {
                     options[i].allowedProducts = allowedProducts;
                     element.options[index] = new Option(this.getOptionLabel(options[i], options[i].price), options[i].id);
                     if (typeof options[i].price != 'undefined') {
@@ -193,12 +219,12 @@ Product.Config.prototype = {
         }
     },
 
-    getOptionLabel: function(option, price){
+    getOptionLabel: function (option, price) {
         var price = parseFloat(price);
         if (this.taxConfig.includeTax) {
             var tax = price / (100 + this.taxConfig.defaultTax) * this.taxConfig.defaultTax;
             var excl = price - tax;
-            var incl = excl*(1+(this.taxConfig.currentTax/100));
+            var incl = excl * (1 + (this.taxConfig.currentTax / 100));
         } else {
             var tax = price * (this.taxConfig.currentTax / 100);
             var excl = price;
@@ -211,63 +237,61 @@ Product.Config.prototype = {
             price = excl;
         }
 
-        var str = option.label;
-        if(price){
+        let str = option.label;
+        if (price) {
             if (this.taxConfig.showBothPrices) {
-                str+= ' ' + this.formatPrice(excl, true) + ' (' + this.formatPrice(price, true) + ' ' + this.taxConfig.inclTaxTitle + ')';
+                str += ' ' + this.formatPrice(excl, true) + ' (' + this.formatPrice(price, true) + ' ' + this.taxConfig.inclTaxTitle + ')';
             } else {
-                str+= ' ' + this.formatPrice(price, true);
+                str += ' ' + this.formatPrice(price, true);
             }
         }
         return str;
     },
 
-    formatPrice: function(price, showSign){
-        var str = '';
+    formatPrice: function (price, showSign) {
+        let str = '';
         price = parseFloat(price);
-        if(showSign){
-            if(price<0){
-                str+= '-';
+        if (showSign) {
+            if (price < 0) {
+                str += '-';
                 price = -price;
-            }
-            else{
-                str+= '+';
+            } else {
+                str += '+';
             }
         }
 
-        var roundedPrice = (Math.round(price*100)/100).toString();
+        const roundedPrice = (Math.round(price * 100) / 100).toString();
 
         if (this.prices && this.prices[roundedPrice]) {
-            str+= this.prices[roundedPrice];
-        }
-        else {
-            str+= this.priceTemplate.evaluate({price:price.toFixed(2)});
+            str += this.prices[roundedPrice];
+        } else {
+            str += this.priceTemplate.evaluate({price: price.toFixed(2)});
         }
         return str;
     },
 
-    clearSelect: function(element){
-        for(var i=element.options.length-1;i>=0;i--){
+    clearSelect: function (element) {
+        for (let i = element.options.length - 1; i >= 0; i--) {
             element.remove(i);
         }
     },
 
-    getAttributeOptions: function(attributeId){
-        if(this.config.attributes[attributeId]){
+    getAttributeOptions: function (attributeId) {
+        if (this.config.attributes[attributeId]) {
             return this.config.attributes[attributeId].options;
         }
     },
 
-    reloadPrice: function(){
+    reloadPrice: function () {
         if (this.config.disablePriceReload) {
             return;
         }
-        var price    = 0;
-        var oldPrice = 0;
-        for(var i=this.settings.length-1;i>=0;i--){
-            var selected = this.settings[i].options[this.settings[i].selectedIndex];
-            if(selected.config){
-                price    += parseFloat(selected.config.price);
+        let price = 0;
+        let oldPrice = 0;
+        for (let i = this.settings.length - 1; i >= 0; i--) {
+            const selected = this.settings[i].options[this.settings[i].selectedIndex];
+            if (selected.config) {
+                price += parseFloat(selected.config.price);
                 oldPrice += parseFloat(selected.config.oldPrice);
             }
         }
@@ -278,27 +302,25 @@ Product.Config.prototype = {
         return price;
     },
 
-    reloadOldPrice: function(){
+    reloadOldPrice: function () {
         if (this.config.disablePriceReload) {
             return;
         }
-        if ($('old-price-'+this.config.productId)) {
-
-            var price = parseFloat(this.config.oldPrice);
-            for(var i=this.settings.length-1;i>=0;i--){
-                var selected = this.settings[i].options[this.settings[i].selectedIndex];
-                if(selected.config){
-                    price+= parseFloat(selected.config.price);
+        const oldPriceEl = document.getElementById('old-price-' + this.config.productId);
+        if (oldPriceEl) {
+            let price = parseFloat(this.config.oldPrice);
+            for (let i = this.settings.length - 1; i >= 0; i--) {
+                const selected = this.settings[i].options[this.settings[i].selectedIndex];
+                if (selected.config) {
+                    price += parseFloat(selected.config.oldPrice);
                 }
             }
             if (price < 0)
                 price = 0;
             price = this.formatPrice(price);
 
-            if($('old-price-'+this.config.productId)){
-                $('old-price-'+this.config.productId).innerHTML = price;
-            }
-
+            oldPriceEl.innerHTML = price;
         }
     }
 };
+Varien.classCompat(Product.Config);

--- a/js/varien/form.js
+++ b/js/varien/form.js
@@ -12,233 +12,286 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-VarienForm = Class.create();
+/**
+ * Rewritten to vanilla JS — no Prototype.js dependency.
+ */
+
+function VarienForm() {
+    this.initialize(...arguments);
+}
+
 VarienForm.prototype = {
-    initialize: function(formId, firstFieldFocus){
-        this.form       = $(formId);
+    initialize: function (formId, firstFieldFocus) {
+        this.form = document.getElementById(formId);
         if (!this.form) {
             return;
         }
-        this.cache      = $A();
+        this.cache = [];
         this.currLoader = false;
         this.currDataIndex = false;
         if (typeof Validation === 'function') {
-            this.validator  = new Validation(this.form);
+            this.validator = new Validation(this.form);
         }
-        this.elementFocus   = this.elementOnFocus.bindAsEventListener(this);
-        this.elementBlur    = this.elementOnBlur.bindAsEventListener(this);
-        this.childLoader    = this.onChangeChildLoad.bindAsEventListener(this);
+        this.elementFocus = this.elementOnFocus.bind(this);
+        this.elementBlur = this.elementOnBlur.bind(this);
+        this.childLoader = this.onChangeChildLoad.bind(this);
         this.highlightClass = 'highlight';
         this.extraChildParams = '';
-        this.firstFieldFocus= firstFieldFocus || false;
+        this.firstFieldFocus = firstFieldFocus || false;
         this.bindElements();
-        if(this.firstFieldFocus){
-            try{
-                Form.Element.focus(Form.findFirstElement(this.form));
-            }
-            catch(e){}
+        if (this.firstFieldFocus) {
+            try {
+                const elements = this.form.elements;
+                for (let i = 0; i < elements.length; i++) {
+                    const el = elements[i];
+                    // Form.findFirstElement only considered input, select and textarea
+                    if (/^(input|select|textarea)$/i.test(el.tagName)
+                        && !el.disabled && el.type !== 'hidden' && el.offsetParent !== null
+                    ) {
+                        el.focus();
+                        break;
+                    }
+                }
+            } catch (e) {}
         }
     },
 
-    submit : function(url){
-        if(this.validator && this.validator.validate()){
-             this.form.submit();
+    submit: function (url) {
+        if (this.validator && this.validator.validate()) {
+            this.form.submit();
         }
         return false;
     },
 
-    bindElements:function (){
-        var elements = Form.getElements(this.form);
-        for (var row in elements) {
-            if (elements[row].id) {
-                Event.observe(elements[row],'focus',this.elementFocus);
-                Event.observe(elements[row],'blur',this.elementBlur);
+    bindElements: function () {
+        const elements = Array.prototype.slice.call(this.form.elements);
+        for (let i = 0; i < elements.length; i++) {
+            if (elements[i].id) {
+                elements[i].addEventListener('focus', this.elementFocus);
+                elements[i].addEventListener('blur', this.elementBlur);
             }
         }
     },
 
-    elementOnFocus: function(event){
-        var element = Event.findElement(event, 'fieldset');
-        if(element){
-            Element.addClassName(element, this.highlightClass);
+    elementOnFocus: function (event) {
+        const element = event.target.closest('fieldset');
+        if (element) {
+            element.classList.add(this.highlightClass);
         }
     },
 
-    elementOnBlur: function(event){
-        var element = Event.findElement(event, 'fieldset');
-        if(element){
-            Element.removeClassName(element, this.highlightClass);
+    elementOnBlur: function (event) {
+        const element = event.target.closest('fieldset');
+        if (element) {
+            element.classList.remove(this.highlightClass);
         }
     },
 
-    setElementsRelation: function(parent, child, dataUrl, first){
-        if (parent=$(parent)) {
-            // TODO: array of relation and caching
-            if (!this.cache[parent.id]){
-                this.cache[parent.id] = $A();
-                this.cache[parent.id]['child']     = child;
-                this.cache[parent.id]['dataUrl']   = dataUrl;
-                this.cache[parent.id]['data']      = $A();
-                this.cache[parent.id]['first']      = first || false;
+    setElementsRelation: function (parent, child, dataUrl, first) {
+        if (typeof parent === 'string') {
+            parent = document.getElementById(parent);
+        }
+        if (parent) {
+            if (!this.cache[parent.id]) {
+                this.cache[parent.id] = [];
+                this.cache[parent.id]['child'] = child;
+                this.cache[parent.id]['dataUrl'] = dataUrl;
+                this.cache[parent.id]['data'] = [];
+                this.cache[parent.id]['first'] = first || false;
             }
-            Event.observe(parent,'change',this.childLoader);
+            parent.addEventListener('change', this.childLoader);
         }
     },
 
-    onChangeChildLoad: function(event){
-        element = Event.element(event);
+    onChangeChildLoad: function (event) {
+        const element = event.target;
         this.elementChildLoad(element);
     },
 
-    elementChildLoad: function(element, callback){
+    elementChildLoad: function (element, callback) {
         this.callback = callback || false;
         if (element.value) {
             this.currLoader = element.id;
             this.currDataIndex = element.value;
             if (this.cache[element.id]['data'][element.value]) {
                 this.setDataToChild(this.cache[element.id]['data'][element.value]);
-            }
-            else{
-                new Ajax.Request(this.cache[this.currLoader]['dataUrl'],{
-                        method: 'post',
-                        parameters: {"parent":element.value},
-                        onComplete: this.reloadChildren.bind(this)
-                });
+            } else {
+                const self = this;
+                const formData = new FormData();
+                formData.append('parent', element.value);
+                fetch(this.cache[this.currLoader]['dataUrl'], {
+                    method: 'POST',
+                    body: formData,
+                    headers: { 'X-Requested-With': 'XMLHttpRequest' }
+                })
+                // Ajax.Request used onComplete: run on any status, and fall back
+                // to an empty result if the body is not JSON.
+                .then(function (resp) { return resp.text(); })
+                .then(function (text) { self.reloadChildren({ responseText: text }); })
+                .catch(function () { self.reloadChildren({ responseText: '' }); });
             }
         }
     },
 
-    reloadChildren: function(transport){
-        var data = transport.responseJSON || transport.responseText.evalJSON(true) || {};
+    reloadChildren: function (transport) {
+        let data;
+        try {
+            data = typeof transport.responseJSON !== 'undefined' ? transport.responseJSON : JSON.parse(transport.responseText);
+        } catch (e) {
+            data = {};
+        }
         this.cache[this.currLoader]['data'][this.currDataIndex] = data;
         this.setDataToChild(data);
     },
 
-    setDataToChild: function(data){
+    setDataToChild: function (data) {
+        const child = document.getElementById(this.cache[this.currLoader]['child']);
+        if (!child) {
+            return;
+        }
+        let el;
         if (data.length) {
-            var child = $(this.cache[this.currLoader]['child']);
-            if (child){
-                var html = '<select name="'+child.name+'" id="'+child.id+'" class="'+child.className+'" title="'+child.title+'" '+this.extraChildParams+'>';
-                if(this.cache[this.currLoader]['first']){
-                    html+= '<option value="">'+this.cache[this.currLoader]['first']+'</option>';
-                }
-                for (var i in data){
-                    if(data[i].value) {
-                        html+= '<option value="'+data[i].value+'"';
-                        if(child.value && (child.value == data[i].value || child.value == data[i].label)){
-                            html+= ' selected';
-                        }
-                        html+='>'+data[i].label+'</option>';
+            el = document.createElement('select');
+            if (this.cache[this.currLoader]['first']) {
+                const first = document.createElement('option');
+                first.value = '';
+                first.text = this.cache[this.currLoader]['first'];
+                el.appendChild(first);
+            }
+            for (const i in data) {
+                if (data[i].value) {
+                    const option = document.createElement('option');
+                    option.value = data[i].value;
+                    option.text = data[i].label;
+                    if (child.value && (child.value == data[i].value || child.value == data[i].label)) {
+                        option.selected = true;
                     }
+                    el.appendChild(option);
                 }
-                html+= '</select>';
-                Element.insert(child, {before: html});
-                Element.remove(child);
             }
+        } else {
+            el = document.createElement('input');
+            el.type = 'text';
         }
-        else{
-            var child = $(this.cache[this.currLoader]['child']);
-            if (child){
-                var html = '<input type="text" name="'+child.name+'" id="'+child.id+'" class="'+child.className+'" title="'+child.title+'" '+this.extraChildParams+'>';
-                Element.insert(child, {before: html});
-                Element.remove(child);
-            }
-        }
+        el.name = child.name;
+        el.id = child.id;
+        el.className = child.className;
+        el.title = child.title;
+        this._applyExtraChildParams(el);
+        child.parentNode.replaceChild(el, child);
 
         this.bindElements();
         if (this.callback) {
             this.callback();
         }
+    },
+
+    /**
+     * extraChildParams is a template-supplied raw attribute string
+     * (e.g. ' onchange="shipping.setSameAsBilling(false);"'). Parse it on an
+     * inert template element and copy the attributes over, so the replacement
+     * child keeps supporting it without string-built HTML.
+     */
+    _applyExtraChildParams: function (el) {
+        if (!this.extraChildParams) {
+            return;
+        }
+        const tpl = document.createElement('template');
+        tpl.innerHTML = '<div ' + this.extraChildParams + '></div>';
+        const probe = tpl.content.firstElementChild;
+        if (!probe) {
+            return;
+        }
+        Array.prototype.forEach.call(probe.attributes, function (attr) {
+            el.setAttribute(attr.name, attr.value);
+        });
     }
 };
+// The OAuth layouts load this file without varien/js.js, so inline the
+// Class.create hooks instead of calling Varien.classCompat.
+VarienForm.superclass = null;
+VarienForm.subclasses = [];
+if (typeof Class !== 'undefined' && Class.Methods) { Object.assign(VarienForm, Class.Methods); }
 
-RegionUpdater = Class.create();
+function RegionUpdater() {
+    this.initialize(...arguments);
+}
+
 RegionUpdater.prototype = {
-    initialize: function (countryEl, regionTextEl, regionSelectEl, regions, disableAction, zipEl){
-        this.countryEl = $(countryEl);
-        this.regionTextEl = $(regionTextEl);
-        this.regionSelectEl = $(regionSelectEl);
-        this.zipEl = $(zipEl);
+    initialize: function (countryEl, regionTextEl, regionSelectEl, regions, disableAction, zipEl) {
+        this.countryEl = document.getElementById(countryEl);
+        this.regionTextEl = document.getElementById(regionTextEl);
+        this.regionSelectEl = document.getElementById(regionSelectEl);
+        this.zipEl = document.getElementById(zipEl);
         this.config = regions['config'];
         delete regions.config;
         this.regions = regions;
 
-        this.disableAction = (typeof disableAction=='undefined') ? 'hide' : disableAction;
-        this.zipOptions = (typeof zipOptions=='undefined') ? false : zipOptions;
+        this.disableAction = (typeof disableAction == 'undefined') ? 'hide' : disableAction;
+        this.zipOptions = (typeof zipOptions == 'undefined') ? false : zipOptions;
 
-        if (this.regionSelectEl.options.length<=1) {
+        if (this.regionSelectEl.options.length <= 1) {
             this.update();
         }
 
-        Event.observe(this.countryEl, 'change', this.update.bind(this));
+        this.countryEl.addEventListener('change', this.update.bind(this));
     },
 
-    _checkRegionRequired: function(){
-        var label, wildCard;
-        var elements = [this.regionTextEl, this.regionSelectEl];
-        var that = this;
+    _checkRegionRequired: function () {
+        const that = this;
+        const elements = [this.regionTextEl, this.regionSelectEl];
         if (typeof this.config == 'undefined') {
             return;
         }
-        var regionRequired = this.config.regions_required.indexOf(this.countryEl.value) >= 0;
+        const regionRequired = this.config.regions_required.indexOf(this.countryEl.value) >= 0;
 
-        elements.each(function(currentElement) {
+        elements.forEach(function (currentElement) {
             if (typeof Validation !== 'undefined') {
                 Validation.reset(currentElement);
             }
-            label = $$('label[for="' + currentElement.id + '"]')[0];
+            const label = document.querySelector('label[for="' + currentElement.id + '"]');
             if (label) {
-                wildCard = label.down('em') || label.down('span.required');
+                let wildCard = label.querySelector('em') || label.querySelector('span.required');
                 if (!wildCard) {
-                    label.insert(' <span class="required">*</span>');
-                    wildCard = label.down('span.required');
+                    label.insertAdjacentHTML('beforeend', ' <span class="required">*</span>');
+                    wildCard = label.querySelector('span.required');
                 }
                 if (!that.config.show_all_regions) {
                     if (regionRequired) {
-                        label.up().show();
+                        label.parentNode.style.display = '';
                     } else {
-                        label.up().hide();
+                        label.parentNode.style.display = 'none';
                     }
                 }
-            }
 
-            if (label && wildCard) {
-                if (!regionRequired) {
-                    wildCard.hide();
-                    if (label.hasClassName('required')) {
-                        label.removeClassName('required');
-                    }
-                } else if (regionRequired) {
-                    wildCard.show();
-                    if (!label.hasClassName('required')) {
-                        label.addClassName('required');
+                if (wildCard) {
+                    if (!regionRequired) {
+                        wildCard.style.display = 'none';
+                        label.classList.remove('required');
+                    } else {
+                        wildCard.style.display = '';
+                        label.classList.add('required');
                     }
                 }
             }
 
             if (!regionRequired) {
-                if (currentElement.hasClassName('required-entry')) {
-                    currentElement.removeClassName('required-entry');
-                }
-                if ('select' == currentElement.tagName.toLowerCase() &&
-                    currentElement.hasClassName('validate-select')) {
-                    currentElement.removeClassName('validate-select');
+                currentElement.classList.remove('required-entry');
+                if ('select' == currentElement.tagName.toLowerCase()) {
+                    currentElement.classList.remove('validate-select');
                 }
             } else {
-                if (!currentElement.hasClassName('required-entry')) {
-                    currentElement.addClassName('required-entry');
-                }
-                if ('select' == currentElement.tagName.toLowerCase() &&
-                    !currentElement.hasClassName('validate-select')) {
-                    currentElement.addClassName('validate-select');
+                currentElement.classList.add('required-entry');
+                if ('select' == currentElement.tagName.toLowerCase()) {
+                    currentElement.classList.add('validate-select');
                 }
             }
         });
     },
 
-    update: function(){
+    update: function () {
         if (this.regions[this.countryEl.value]) {
-            var i, option, region, def;
+            let i, option, region, def;
 
             def = this.regionSelectEl.getAttribute('defaultValue');
             if (this.regionTextEl) {
@@ -249,12 +302,17 @@ RegionUpdater.prototype = {
             }
 
             this.regionSelectEl.options.length = 1;
-            for (regionId in this.regions[this.countryEl.value]) {
+            for (const regionId in this.regions[this.countryEl.value]) {
                 region = this.regions[this.countryEl.value][regionId];
 
                 option = document.createElement('OPTION');
                 option.value = regionId;
-                option.text = region.name.stripTags();
+                // String#stripTags: inline translation wraps region names in
+                // data-translate spans, which option.text would show verbatim.
+                // An inert template parses the markup without a regex.
+                const nameTpl = document.createElement('template');
+                nameTpl.innerHTML = region.name;
+                option.text = nameTpl.content.textContent;
                 option.title = region.name;
 
                 if (this.regionSelectEl.options.add) {
@@ -274,7 +332,6 @@ RegionUpdater.prototype = {
                 if (this.regionTextEl) {
                     this.regionTextEl.style.display = 'none';
                 }
-
                 this.regionSelectEl.style.display = '';
             } else if (this.disableAction == 'disable') {
                 if (this.regionTextEl) {
@@ -309,114 +366,121 @@ RegionUpdater.prototype = {
         }
 
         this._checkRegionRequired();
-        // Make Zip and its label required/optional
-        var zipUpdater = new ZipUpdater(this.countryEl.value, this.zipEl);
+        const zipUpdater = new ZipUpdater(this.countryEl.value, this.zipEl);
         zipUpdater.update();
     },
 
-    setMarkDisplay: function(elem, display){
-        elem = $(elem);
-        var labelElement = elem.up(0).down('label > span.required') ||
-                           elem.up(1).down('label > span.required') ||
-                           elem.up(0).down('label.required > em') ||
-                           elem.up(1).down('label.required > em');
-        if(labelElement) {
-            inputElement = labelElement.up().next('input');
+    setMarkDisplay: function (elem, display) {
+        if (typeof elem === 'string') {
+            elem = document.getElementById(elem);
+        }
+        if (!elem) return;
+        const parent0 = elem.parentNode;
+        const parent1 = parent0 ? parent0.parentNode : null;
+        const labelElement = (parent0 ? parent0.querySelector('label > span.required') : null) ||
+                           (parent1 ? parent1.querySelector('label > span.required') : null) ||
+                           (parent0 ? parent0.querySelector('label.required > em') : null) ||
+                           (parent1 ? parent1.querySelector('label.required > em') : null);
+        if (labelElement) {
+            const labelParent = labelElement.parentNode;
+            let inputElement = labelParent ? labelParent.nextElementSibling : null;
+            if (inputElement && inputElement.tagName !== 'INPUT') inputElement = null;
             if (display) {
-                labelElement.show();
+                labelElement.style.display = '';
                 if (inputElement) {
-                    inputElement.addClassName('required-entry');
+                    inputElement.classList.add('required-entry');
                 }
             } else {
-                labelElement.hide();
+                labelElement.style.display = 'none';
                 if (inputElement) {
-                    inputElement.removeClassName('required-entry');
+                    inputElement.classList.remove('required-entry');
                 }
             }
         }
     },
 
     sortSelect: function () {
-        var elem = this.regionSelectEl;
-        var tmpArray = new Array();
-        var currentVal = $(elem).value;
-        for (var i = 0; i < $(elem).options.length; i++) {
-            if (i == 0) {
-                continue;
-            }
-            tmpArray[i-1] = new Array();
-            tmpArray[i-1][0] = $(elem).options[i].text;
-            tmpArray[i-1][1] = $(elem).options[i].value;
+        const elem = this.regionSelectEl;
+        const tmpArray = [];
+        const currentVal = elem.value;
+        for (var i = 1; i < elem.options.length; i++) {
+            tmpArray.push([elem.options[i].text, elem.options[i].value]);
         }
-        tmpArray.sort();
-        for (var i = 1; i <= tmpArray.length; i++) {
-            var op = new Option(tmpArray[i-1][0], tmpArray[i-1][1]);
-            $(elem).options[i] = op;
+        tmpArray.sort(function (a, b) {
+            return a[0].localeCompare(b[0]);
+        });
+        for (var i = 0; i < tmpArray.length; i++) {
+            elem.options[i + 1] = new Option(tmpArray[i][0], tmpArray[i][1]);
         }
-        $(elem).value = currentVal;
-        return;
+        elem.value = currentVal;
     }
 };
+RegionUpdater.superclass = null;
+RegionUpdater.subclasses = [];
+if (typeof Class !== 'undefined' && Class.Methods) { Object.assign(RegionUpdater, Class.Methods); }
 
-ZipUpdater = Class.create();
+function ZipUpdater() {
+    this.initialize(...arguments);
+}
+
 ZipUpdater.prototype = {
-    initialize: function(country, zipElement){
+    initialize: function (country, zipElement) {
         this.country = country;
-        this.zipElement = $(zipElement);
+        this.zipElement = typeof zipElement === 'string' ? document.getElementById(zipElement) : zipElement;
     },
 
-    update: function(){
-        // Country ISO 2-letter codes must be pre-defined
+    update: function () {
         if (typeof optionalZipCountries == 'undefined') {
             return false;
         }
 
-        // Ajax-request and normal content load compatibility
         if (this.zipElement != undefined) {
             if (typeof Validation !== 'undefined') {
                 Validation.reset(this.zipElement);
             }
             this._setPostcodeOptional();
         } else {
-            Event.observe(window, "load", this._setPostcodeOptional.bind(this));
+            window.addEventListener('load', this._setPostcodeOptional.bind(this));
         }
     },
 
-    _setPostcodeOptional: function(){
-        this.zipElement = $(this.zipElement);
-        if (this.zipElement === undefined) {
+    _setPostcodeOptional: function () {
+        if (typeof this.zipElement === 'string') {
+            this.zipElement = document.getElementById(this.zipElement);
+        }
+        if (this.zipElement === undefined || this.zipElement === null) {
             return false;
         }
 
-        // find label
-        var label = $$('label[for="' + this.zipElement.id + '"]')[0];
-        if (label !== undefined) {
-            var wildCard = label.down('em') || label.down('span.required');
+        const label = document.querySelector('label[for="' + this.zipElement.id + '"]');
+        let wildCard;
+        if (label !== undefined && label !== null) {
+            wildCard = label.querySelector('em') || label.querySelector('span.required');
             if (!wildCard) {
-                label.insert(' <span class="required">*</span>');
-                wildCard = label.down('span.required');
+                label.insertAdjacentHTML('beforeend', ' <span class="required">*</span>');
+                wildCard = label.querySelector('span.required');
             }
         }
 
-        // Make Zip and its label required/optional
         if (optionalZipCountries.indexOf(this.country) != -1) {
-            if (label !== undefined && label.hasClassName('required')) {
-                label.removeClassName('required');
+            if (label) {
+                label.classList.remove('required');
             }
-            while (this.zipElement.hasClassName('required-entry')) {
-                this.zipElement.removeClassName('required-entry');
-            }
-            if (wildCard !== undefined) {
-                wildCard.hide();
+            this.zipElement.classList.remove('required-entry');
+            if (wildCard) {
+                wildCard.style.display = 'none';
             }
         } else {
-            if (label !== undefined && !label.hasClassName('required')) {
-                label.addClassName('required');
+            if (label) {
+                label.classList.add('required');
             }
-            this.zipElement.addClassName('required-entry');
-            if (wildCard !== undefined) {
-                wildCard.show();
+            this.zipElement.classList.add('required-entry');
+            if (wildCard) {
+                wildCard.style.display = '';
             }
         }
     }
 };
+ZipUpdater.superclass = null;
+ZipUpdater.subclasses = [];
+if (typeof Class !== 'undefined' && Class.Methods) { Object.assign(ZipUpdater, Class.Methods); }

--- a/js/varien/js.js
+++ b/js/varien/js.js
@@ -11,6 +11,11 @@
  * @copyright   Copyright (c) 2020-2024 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/**
+ * Rewritten to vanilla JS — no Prototype.js dependency.
+ */
+
 function popWin(url,win,para) {
     var win = window.open(url,win,para);
     win.focus();
@@ -37,12 +42,11 @@ function setPLocation(url, setFocus){
  */
 function decorateGeneric(elements, decorateParams)
 {
-    var allSupportedParams = ['odd', 'even', 'first', 'last'];
-    var _decorateParams = {};
-    var total = elements.length;
+    const allSupportedParams = ['odd', 'even', 'first', 'last'];
+    const _decorateParams = {};
+    const total = elements.length;
 
     if (total) {
-        // determine params called
         if (typeof(decorateParams) == 'undefined') {
             decorateParams = allSupportedParams;
         }
@@ -56,23 +60,21 @@ function decorateGeneric(elements, decorateParams)
             _decorateParams[decorateParams[k]] = true;
         }
 
-        // decorate elements
-        // elements[0].addClassName('first'); // will cause bug in IE (#5587)
         if (_decorateParams.first) {
-            Element.addClassName(elements[0], 'first');
+            elements[0].classList.add('first');
         }
         if (_decorateParams.last) {
-            Element.addClassName(elements[total-1], 'last');
+            elements[total-1].classList.add('last');
         }
-        for (var i = 0; i < total; i++) {
+        for (let i = 0; i < total; i++) {
             if ((i + 1) % 2 == 0) {
                 if (_decorateParams.even) {
-                    Element.addClassName(elements[i], 'even');
+                    elements[i].classList.add('even');
                 }
             }
             else {
                 if (_decorateParams.odd) {
-                    Element.addClassName(elements[i], 'odd');
+                    elements[i].classList.add('odd');
                 }
             }
         }
@@ -85,39 +87,38 @@ function decorateGeneric(elements, decorateParams)
  * @deprecated
  */
 function decorateTable(table, options) {
-    var table = $(table);
+    if (typeof table === 'string') {
+        table = document.getElementById(table);
+    }
     if (table) {
-        // set default options
-        var _options = {
+        const _options = {
             'tbody'    : false,
             'tbody tr' : ['odd', 'even', 'first', 'last'],
             'thead tr' : ['first', 'last'],
             'tfoot tr' : ['first', 'last'],
             'tr td'    : ['last']
         };
-        // overload options
         if (typeof(options) != 'undefined') {
-            for (var k in options) {
+            for (const k in options) {
                 _options[k] = options[k];
             }
         }
-        // decorate
         if (_options['tbody']) {
-            decorateGeneric(table.select('tbody'), _options['tbody']);
+            decorateGeneric(table.querySelectorAll('tbody'), _options['tbody']);
         }
         if (_options['tbody tr']) {
-            decorateGeneric(table.select('tbody tr'), _options['tbody tr']);
+            decorateGeneric(table.querySelectorAll('tbody tr'), _options['tbody tr']);
         }
         if (_options['thead tr']) {
-            decorateGeneric(table.select('thead tr'), _options['thead tr']);
+            decorateGeneric(table.querySelectorAll('thead tr'), _options['thead tr']);
         }
         if (_options['tfoot tr']) {
-            decorateGeneric(table.select('tfoot tr'), _options['tfoot tr']);
+            decorateGeneric(table.querySelectorAll('tfoot tr'), _options['tfoot tr']);
         }
         if (_options['tr td']) {
-            var allRows = table.select('tr');
+            const allRows = table.querySelectorAll('tr');
             if (allRows.length) {
-                for (var i = 0; i < allRows.length; i++) {
+                for (let i = 0; i < allRows.length; i++) {
                     decorateGeneric(allRows[i].getElementsByTagName('TD'), _options['tr td']);
                 }
             }
@@ -131,12 +132,15 @@ function decorateTable(table, options) {
  * @deprecated
  */
 function decorateList(list, nonRecursive) {
-    if ($(list)) {
+    if (typeof list === 'string') {
+        list = document.getElementById(list);
+    }
+    if (list) {
+        let items;
         if (typeof(nonRecursive) == 'undefined') {
-            var items = $(list).select('li');
-        }
-        else {
-            var items = $(list).childElements();
+            items = list.querySelectorAll('li');
+        } else {
+            items = Array.prototype.slice.call(list.children);
         }
         decorateGeneric(items, ['odd', 'even', 'last']);
     }
@@ -148,10 +152,12 @@ function decorateList(list, nonRecursive) {
  * @deprecated
  */
 function decorateDataList(list) {
-    list = $(list);
+    if (typeof list === 'string') {
+        list = document.getElementById(list);
+    }
     if (list) {
-        decorateGeneric(list.select('dt'), ['odd', 'even', 'last']);
-        decorateGeneric(list.select('dd'), ['odd', 'even', 'last']);
+        decorateGeneric(list.querySelectorAll('dt'), ['odd', 'even', 'last']);
+        decorateGeneric(list.querySelectorAll('dd'), ['odd', 'even', 'last']);
     }
 }
 
@@ -159,13 +165,13 @@ function decorateDataList(list) {
  * Parse SID and produces the correct URL
  */
 function parseSidUrl(baseUrl, urlExt) {
-    var sidPos = baseUrl.indexOf('/?SID=');
-    var sid = '';
+    const sidPos = baseUrl.indexOf('?');
+    let sid = '';
     urlExt = (urlExt != undefined) ? urlExt : '';
 
-    if(sidPos > -1) {
-        sid = '?' + baseUrl.substring(sidPos + 2);
-        baseUrl = baseUrl.substring(0, sidPos + 1);
+    if (sidPos > -1) {
+        sid = baseUrl.substring(sidPos);
+        baseUrl = baseUrl.substring(0, sidPos);
     }
 
     return baseUrl+urlExt+sid;
@@ -180,20 +186,20 @@ function parseSidUrl(baseUrl, urlExt) {
  */
 
 function formatCurrency(price, format, showPlus){
-    var precision = isNaN(format.precision = Math.abs(format.precision)) ? 2 : format.precision;
-    var requiredPrecision = isNaN(format.requiredPrecision = Math.abs(format.requiredPrecision)) ? 2 : format.requiredPrecision;
+    let precision = isNaN(format.precision = Math.abs(format.precision)) ? 2 : format.precision;
+    const requiredPrecision = isNaN(format.requiredPrecision = Math.abs(format.requiredPrecision)) ? 2 : format.requiredPrecision;
 
     //precision = (precision > requiredPrecision) ? precision : requiredPrecision;
     //for now we don't need this difference so precision is requiredPrecision
     precision = requiredPrecision;
 
-    var integerRequired = isNaN(format.integerRequired = Math.abs(format.integerRequired)) ? 1 : format.integerRequired;
+    const integerRequired = isNaN(format.integerRequired = Math.abs(format.integerRequired)) ? 1 : format.integerRequired;
 
-    var decimalSymbol = format.decimalSymbol == undefined ? "," : format.decimalSymbol;
-    var groupSymbol = format.groupSymbol == undefined ? "." : format.groupSymbol;
-    var groupLength = format.groupLength == undefined ? 3 : format.groupLength;
+    const decimalSymbol = format.decimalSymbol == undefined ? "," : format.decimalSymbol;
+    const groupSymbol = format.groupSymbol == undefined ? "." : format.groupSymbol;
+    const groupLength = format.groupLength == undefined ? 3 : format.groupLength;
 
-    var s = '';
+    let s = '';
 
     if (showPlus == undefined || showPlus == true) {
         s = price < 0 ? "-" : ( showPlus ? "+" : "");
@@ -201,19 +207,19 @@ function formatCurrency(price, format, showPlus){
         s = '';
     }
 
-    var i = parseInt(price = Math.abs(+price || 0).toFixed(precision)) + "";
-    var pad = (i.length < integerRequired) ? (integerRequired - i.length) : 0;
+    let i = parseInt(price = Math.abs(+price || 0).toFixed(precision)) + "";
+    let pad = (i.length < integerRequired) ? (integerRequired - i.length) : 0;
     while (pad) { i = '0' + i; pad--; }
-    j = (j = i.length) > groupLength ? j % groupLength : 0;
-    re = new RegExp("(\\d{" + groupLength + "})(?=\\d)", "g");
+    const j = i.length > groupLength ? i.length % groupLength : 0;
+    const re = new RegExp("(\\d{" + groupLength + "})(?=\\d)", "g");
 
     /**
      * replace(/-/, 0) is only for fixing Safari bug which appears
      * when Math.abs(0).toFixed() executed on "0" number.
      * Result is "0.-0" :(
      */
-    var r = (j ? i.substr(0, j) + groupSymbol : "") + i.substr(j).replace(re, "$1" + groupSymbol) + (precision ? decimalSymbol + Math.abs(price - i).toFixed(precision).replace(/-/, 0).slice(2) : "");
-    var pattern = '';
+    const r = (j ? i.substr(0, j) + groupSymbol : "") + i.substr(j).replace(re, "$1" + groupSymbol) + (precision ? decimalSymbol + Math.abs(price - i).toFixed(precision).replace(/-/, 0).slice(2) : "");
+    let pattern = '';
     if (format.pattern.indexOf('{sign}') == -1) {
         pattern = s + format.pattern;
     } else {
@@ -221,20 +227,23 @@ function formatCurrency(price, format, showPlus){
     }
 
     return pattern.replace('%s', r).replace(/^\s\s*/, '').replace(/\s\s*$/, '');
-};
+}
 
 function expandDetails(el, childClass) {
-    if (Element.hasClassName(el,'show-details')) {
-        $$(childClass).each(function(item){
-            item.hide();
+    if (typeof el === 'string') {
+        el = document.getElementById(el);
+    }
+    if (el.classList.contains('show-details')) {
+        document.querySelectorAll(childClass).forEach(function(item){
+            item.style.display = 'none';
         });
-        Element.removeClassName(el,'show-details');
+        el.classList.remove('show-details');
     }
     else {
-        $$(childClass).each(function(item){
-            item.show();
+        document.querySelectorAll(childClass).forEach(function(item){
+            item.style.display = '';
         });
-        Element.addClassName(el,'show-details');
+        el.classList.add('show-details');
     }
 }
 
@@ -242,15 +251,15 @@ function expandDetails(el, childClass) {
 var isIE = false;
 
 if (!window.Varien)
-    var Varien = new Object();
+    var Varien = {};
 
 Varien.showLoading = function(){
-    var loader = $('loading-process');
-    loader && loader.show();
+    const loader = document.getElementById('loading-process');
+    if (loader) loader.style.display = '';
 };
 Varien.hideLoading = function(){
-    var loader = $('loading-process');
-    loader && loader.hide();
+    const loader = document.getElementById('loading-process');
+    if (loader) loader.style.display = 'none';
 };
 Varien.GlobalHandlers = {
     onCreate: function() {
@@ -258,53 +267,97 @@ Varien.GlobalHandlers = {
     },
 
     onComplete: function() {
-        if(Ajax.activeRequestCount == 0) {
+        if(typeof Ajax !== 'undefined' && Ajax.activeRequestCount == 0) {
             Varien.hideLoading();
         }
     }
 };
 
-Ajax.Responders.register(Varien.GlobalHandlers);
+if (typeof Ajax !== 'undefined' && typeof Ajax.Responders !== 'undefined') {
+    Ajax.Responders.register(Varien.GlobalHandlers);
+}
+
+/**
+ * Run the <script> elements inside a container, as Element.update() did with
+ * evalScripts. innerHTML inserts scripts inert; re-creating them executes them.
+ */
+Varien.evalScripts = function(container) {
+    if (!container) return;
+    Array.from(container.querySelectorAll('script')).forEach(function(old) {
+        const s = document.createElement('script');
+        Array.from(old.attributes).forEach(function(attr) {
+            s.setAttribute(attr.name, attr.value);
+        });
+        s.textContent = old.textContent;
+        old.parentNode.replaceChild(s, old);
+    });
+};
+
+/**
+ * Give a plain constructor the metadata Prototype's Class.create attached, so
+ * extensions can still call Class.create(Ctor, {...}) or Ctor.addMethods({...})
+ * while Prototype loads. Each class keeps its constructor body in
+ * prototype.initialize, so prototype.initialize wrappers keep working too.
+ */
+Varien.classCompat = function(ctor, parent) {
+    ctor.superclass = parent || null;
+    ctor.subclasses = [];
+    if (parent && parent.subclasses) {
+        parent.subclasses.push(ctor);
+    }
+    if (typeof Class !== 'undefined' && Class.Methods) {
+        Object.assign(ctor, Class.Methods);
+    }
+};
 
 /**
  * Quick Search form client model
+ * @constructor
  */
-Varien.searchForm = Class.create();
+Varien.searchForm = function() {
+    this.initialize(...arguments);
+};
+
 Varien.searchForm.prototype = {
-    initialize : function(form, field, emptyText){
-        this.form   = $(form);
-        this.field  = $(field);
+    initialize: function(form, field, emptyText) {
+        this.form = typeof form === 'string' ? document.getElementById(form) : form;
+        this.field = typeof field === 'string' ? document.getElementById(field) : field;
         this.emptyText = emptyText;
 
-        Event.observe(this.form,  'submit', this.submit.bind(this));
-        Event.observe(this.field, 'focus', this.focus.bind(this));
-        Event.observe(this.field, 'blur', this.blur.bind(this));
+        this.form.addEventListener('submit', this.submit.bind(this));
+        this.field.addEventListener('focus', this.focus.bind(this));
+        this.field.addEventListener('blur', this.blur.bind(this));
         this.blur();
     },
 
-    submit : function(event){
+    submit: function(event){
         if (this.field.value == this.emptyText || this.field.value == ''){
-            Event.stop(event);
+            event.preventDefault();
+            event.stopPropagation();
             return false;
         }
         return true;
     },
 
-    focus : function(event){
+    focus: function(event){
         if(this.field.value==this.emptyText){
             this.field.value='';
         }
-
     },
 
-    blur : function(event){
+    blur: function(event){
         if(this.field.value==''){
             this.field.value=this.emptyText;
         }
     },
 
-    initAutocomplete : function(url, destinationElement){
-        new Ajax.Autocompleter(
+    initAutocomplete: function(url, destinationElement){
+        // Themes that ship their own page.xml may not load varien/autocomplete.js
+        if (Varien.Autocomplete === undefined) {
+            if (window.console) console.warn('Varien.Autocomplete is not loaded; add varien/autocomplete.js to the layout');
+            return;
+        }
+        this.autocomplete = new Varien.Autocomplete(
             this.field,
             destinationElement,
             url,
@@ -313,71 +366,85 @@ Varien.searchForm.prototype = {
                 method: 'get',
                 minChars: 2,
                 updateElement: this._selectAutocompleteItem.bind(this),
-                onShow : function(element, update) {
-                    if(!update.style.position || update.style.position=='absolute') {
-                        update.style.position = 'absolute';
-                        Position.clone(element, update, {
-                            setHeight: false,
-                            offsetTop: element.offsetHeight
-                        });
-                    }
-                    Effect.Appear(update,{duration:0});
+                onShow: function(element, update) {
+                    update.style.position = 'absolute';
+                    const rect = element.getBoundingClientRect();
+                    update.style.left = (window.scrollX + rect.left) + 'px';
+                    update.style.top = (window.scrollY + rect.top + element.offsetHeight) + 'px';
+                    update.style.display = '';
                 }
-
             }
         );
     },
 
-    _selectAutocompleteItem : function(element){
+    _selectAutocompleteItem: function(element){
         if(element.title){
             this.field.value = element.title;
         }
         this.form.submit();
     }
 };
+Varien.classCompat(Varien.searchForm);
 
-Varien.Tabs = Class.create();
-Varien.Tabs.prototype = {
-  initialize: function(selector) {
-    var self=this;
-    $$(selector+' a').each(this.initTab.bind(this));
-  },
-
-  initTab: function(el) {
-      el.href = 'javascript:void(0)';
-      if ($(el.parentNode).hasClassName('active')) {
-        this.showContent(el);
-      }
-      el.observe('click', this.showContent.bind(this, el));
-  },
-
-  showContent: function(a) {
-    var li = $(a.parentNode), ul = $(li.parentNode);
-    ul.getElementsBySelector('li', 'ol').each(function(el){
-      var contents = $(el.id+'_contents');
-      if (el==li) {
-        el.addClassName('active');
-        contents.show();
-      } else {
-        el.removeClassName('active');
-        contents.hide();
-      }
-    });
-  }
+/**
+ * Tabs widget
+ * @constructor
+ */
+Varien.Tabs = function() {
+    this.initialize(...arguments);
 };
 
-Varien.DateElement = Class.create();
+Varien.Tabs.prototype = {
+    initialize: function(selector) {
+        const links = document.querySelectorAll(selector + ' a');
+        const self = this;
+        links.forEach(function(el) { self.initTab(el); });
+    },
+
+    initTab: function(el) {
+        el.href = 'javascript:void(0)';
+        if (el.parentNode.classList.contains('active')) {
+            this.showContent(el);
+        }
+        const self = this;
+        el.addEventListener('click', function() { self.showContent(el); });
+    },
+
+    showContent: function(a) {
+        const li = a.parentNode;
+        const ul = li.parentNode;
+        const items = ul.querySelectorAll('li, ol');
+        items.forEach(function(el){
+            const contents = document.getElementById(el.id + '_contents');
+            if (el === li) {
+                el.classList.add('active');
+                if (contents) contents.style.display = '';
+            } else {
+                el.classList.remove('active');
+                if (contents) contents.style.display = 'none';
+            }
+        });
+    }
+};
+Varien.classCompat(Varien.Tabs);
+
+/**
+ * Date element with validation
+ * @constructor
+ */
+Varien.DateElement = function() {
+    this.initialize(...arguments);
+};
+
 Varien.DateElement.prototype = {
     initialize: function(type, content, required, format) {
         if (type == 'id') {
-            // id prefix
-            this.day    = $(content + 'day');
-            this.month  = $(content + 'month');
-            this.year   = $(content + 'year');
-            this.full   = $(content + 'full');
-            this.advice = $(content + 'date-advice');
+            this.day    = document.getElementById(content + 'day');
+            this.month  = document.getElementById(content + 'month');
+            this.year   = document.getElementById(content + 'year');
+            this.full   = document.getElementById(content + 'full');
+            this.advice = document.getElementById(content + 'date-advice');
         } else if (type == 'container') {
-            // content must be container with data
             this.day    = content.day;
             this.month  = content.month;
             this.year   = content.year;
@@ -390,29 +457,30 @@ Varien.DateElement.prototype = {
         this.required = required;
         this.format   = format;
 
-        this.day.addClassName('validate-custom');
+        this.day.classList.add('validate-custom');
         this.day.validate = this.validate.bind(this);
-        this.month.addClassName('validate-custom');
+        this.month.classList.add('validate-custom');
         this.month.validate = this.validate.bind(this);
-        this.year.addClassName('validate-custom');
+        this.year.classList.add('validate-custom');
         this.year.validate = this.validate.bind(this);
 
         this.setDateRange(false, false);
         this.year.setAttribute('autocomplete','off');
 
-        this.advice.hide();
+        this.advice.style.display = 'none';
 
-        var date = new Date;
+        const date = new Date;
         this.curyear = date.getFullYear();
     },
+
     validate: function() {
-        var error = false,
-            day   = parseInt(this.day.value, 10)   || 0,
-            month = parseInt(this.month.value, 10) || 0,
-            year  = parseInt(this.year.value, 10)  || 0;
-        if (this.day.value.strip().empty()
-            && this.month.value.strip().empty()
-            && this.year.value.strip().empty()
+        let error = false;
+        const day   = parseInt(this.day.value, 10)   || 0;
+        const month = parseInt(this.month.value, 10) || 0;
+        const year  = parseInt(this.year.value, 10)  || 0;
+        if (this.day.value.trim().length === 0
+            && this.month.value.trim().length === 0
+            && this.year.value.trim().length === 0
         ) {
             if (this.required) {
                 error = 'This date is a required value.';
@@ -422,7 +490,9 @@ Varien.DateElement.prototype = {
         } else if (!day || !month || !year) {
             error = 'Please enter a valid full date';
         } else {
-            var date = new Date, countDaysInMonth = 0, errorType = null;
+            const date = new Date;
+            var countDaysInMonth = 0;
+            let errorType = null;
             date.setYear(year);date.setMonth(month-1);date.setDate(32);
             countDaysInMonth = 32 - date.getDate();
             if(!countDaysInMonth || countDaysInMonth>31) countDaysInMonth = 31;
@@ -438,8 +508,8 @@ Varien.DateElement.prototype = {
                 if(day % 10 == day) this.day.value = '0'+day;
                 if(month % 10 == month) this.month.value = '0'+month;
                 this.full.value = this.format.replace(/%[mb]/i, this.month.value).replace(/%[de]/i, this.day.value).replace(/%y/i, this.year.value);
-                var testFull = this.month.value + '/' + this.day.value + '/'+ this.year.value;
-                var test = new Date(testFull);
+                const testFull = this.month.value + '/' + this.day.value + '/'+ this.year.value;
+                const test = new Date(testFull);
                 if (isNaN(test)) {
                     error = 'Please enter a valid date.';
                 } else {
@@ -447,9 +517,9 @@ Varien.DateElement.prototype = {
                 }
             }
             var valueError = false;
-            if (!error && !this.validateData()){//(year<1900 || year>curyear) {
-                errorType = this.validateDataErrorType;//'year';
-                valueError = this.validateDataErrorText;//'Please enter a valid year (1900-%d).';
+            if (!error && !this.validateData()){
+                errorType = this.validateDataErrorType;
+                valueError = this.validateDataErrorText;
                 error = valueError;
             }
         }
@@ -464,20 +534,19 @@ Varien.DateElement.prototype = {
             } else {
                 this.advice.innerHTML = this.errorTextModifier(error);
             }
-            this.advice.show();
+            this.advice.style.display = '';
             return false;
         }
 
-        // fixing elements class
-        this.day.removeClassName('validation-failed');
-        this.month.removeClassName('validation-failed');
-        this.year.removeClassName('validation-failed');
+        this.day.classList.remove('validation-failed');
+        this.month.classList.remove('validation-failed');
+        this.year.classList.remove('validation-failed');
 
-        this.advice.hide();
+        this.advice.style.display = 'none';
         return true;
     },
     validateData: function() {
-        var year = this.fullDate.getFullYear();
+        const year = this.fullDate.getFullYear();
         return (year>=1900 && year<=this.curyear);
     },
     validateDataErrorType: 'year',
@@ -494,26 +563,41 @@ Varien.DateElement.prototype = {
         this.fullDate = date;
     }
 };
+Varien.classCompat(Varien.DateElement);
 
-Varien.DOB = Class.create();
+/**
+ * DOB (Date of Birth) widget
+ * @constructor
+ */
+Varien.DOB = function() {
+    this.initialize(...arguments);
+};
+
 Varien.DOB.prototype = {
     initialize: function(selector, required, format) {
-        var el = $$(selector)[0];
-        var container       = {};
-        container.day       = Element.select(el, '.dob-day input')[0];
-        container.month     = Element.select(el, '.dob-month input')[0];
-        container.year      = Element.select(el, '.dob-year input')[0];
-        container.full      = Element.select(el, '.dob-full input')[0];
-        container.advice    = Element.select(el, '.validation-advice')[0];
+        const el = document.querySelector(selector);
+        const container       = {};
+        container.day       = el.querySelector('.dob-day input');
+        container.month     = el.querySelector('.dob-month input');
+        container.year      = el.querySelector('.dob-year input');
+        container.full      = el.querySelector('.dob-full input');
+        container.advice    = el.querySelector('.validation-advice');
 
         new Varien.DateElement('container', container, required, format);
     }
 };
+Varien.classCompat(Varien.DOB);
 
-Varien.dateRangeDate = Class.create();
-Varien.dateRangeDate.prototype = Object.extend(new Varien.DateElement(), {
+/**
+ * Date range validator
+ * @constructor
+ */
+Varien.dateRangeDate = function() {
+    this.initialize(...arguments);
+};
+Varien.dateRangeDate.prototype = Object.assign(Object.create(Varien.DateElement.prototype), {
     validateData: function() {
-        var validate = true;
+        let validate = true;
         if (this.minDate || this.maxValue) {
             if (this.minDate) {
                 this.minDate = new Date(this.minDate);
@@ -546,10 +630,10 @@ Varien.dateRangeDate.prototype = Object.extend(new Varien.DateElement(), {
     validateDataErrorText: 'Date should be between %s and %s',
     errorTextModifier: function(text) {
         if (this.minDate) {
-            text = text.sub('%s', this.dateFormat(this.minDate));
+            text = text.replace('%s', this.dateFormat(this.minDate));
         }
         if (this.maxDate) {
-            text = text.sub('%s', this.dateFormat(this.maxDate));
+            text = text.replace('%s', this.dateFormat(this.maxDate));
         }
         return text;
     },
@@ -557,19 +641,29 @@ Varien.dateRangeDate.prototype = Object.extend(new Varien.DateElement(), {
         return (date.getMonth() + 1) + '/' + date.getDate() + '/' + date.getFullYear();
     }
 });
+Varien.classCompat(Varien.dateRangeDate, Varien.DateElement);
 
-Varien.FileElement = Class.create();
+/**
+ * File upload element
+ * @constructor
+ */
+Varien.FileElement = function() {
+    this.initialize(...arguments);
+};
+
 Varien.FileElement.prototype = {
-    initialize: function (id) {
-        this.fileElement = $(id);
-        this.hiddenElement = $(id + '_value');
+    initialize: function(id) {
+        this.fileElement = document.getElementById(id);
+        this.hiddenElement = document.getElementById(id + '_value');
 
-        this.fileElement.observe('change', this.selectFile.bind(this));
+        this.fileElement.addEventListener('change', this.selectFile.bind(this));
     },
+
     selectFile: function(event) {
-        this.hiddenElement.value = this.fileElement.getValue();
+        this.hiddenElement.value = this.fileElement.value;
     }
 };
+Varien.classCompat(Varien.FileElement);
 
 if (typeof Validation !== 'undefined') {
     Validation.addAllThese([
@@ -580,34 +674,41 @@ if (typeof Validation !== 'undefined') {
 }
 
 function truncateOptions() {
-    $$('.truncated').each(function(element){
-        Event.observe(element, 'mouseover', function(){
-            if (element.down('div.truncated_full_value')) {
-                element.down('div.truncated_full_value').addClassName('show');
+    document.querySelectorAll('.truncated').forEach(function(element){
+        element.addEventListener('mouseover', function(){
+            const fullValue = element.querySelector('div.truncated_full_value');
+            if (fullValue) {
+                fullValue.classList.add('show');
             }
         });
-        Event.observe(element, 'mouseout', function(){
-            if (element.down('div.truncated_full_value')) {
-                element.down('div.truncated_full_value').removeClassName('show');
+        element.addEventListener('mouseout', function(){
+            const fullValue = element.querySelector('div.truncated_full_value');
+            if (fullValue) {
+                fullValue.classList.remove('show');
             }
         });
-
     });
 }
-Event.observe(window, 'load', function(){
+window.addEventListener('load', function(){
    truncateOptions();
 });
 
-Element.addMethods({
-    getInnerText: function(element)
-    {
-        element = $(element);
-        if(element.innerText && !Prototype.Browser.Opera) {
-            return element.innerText;
+/**
+ * getInnerText — added to HTMLElement.prototype for backward compat
+ */
+if (typeof HTMLElement !== 'undefined' && !HTMLElement.prototype.getInnerText) {
+    HTMLElement.prototype.getInnerText = function() {
+        if (this.innerText) {
+            return this.innerText;
         }
-        return element.innerHTML.stripScripts().unescapeHTML().replace(/[\n\r\s]+/g, ' ').strip();
-    }
-});
+        // Clone the node, drop non-text elements, normalize whitespace
+        const tmp = this.cloneNode(true);
+        Array.prototype.forEach.call(tmp.querySelectorAll('script, style, noscript'), function(el) {
+            el.parentNode.removeChild(el);
+        });
+        return (tmp.textContent || '').replace(/[\n\r\s]+/g, ' ').trim();
+    };
+}
 
 /**
  * Executes event handler on the element. Works with event handlers attached by Prototype,
@@ -618,8 +719,8 @@ Element.addMethods({
  * @example fireEvent($('my-input', 'click'));
  */
 function fireEvent(element, event) {
-    var evt = document.createEvent("HTMLEvents");
-    evt.initEvent(event, true, true ); // event type, bubbling, cancelable
+    const evt = document.createEvent("HTMLEvents");
+    evt.initEvent(event, true, true );
     return element.dispatchEvent(evt);
 }
 
@@ -634,8 +735,8 @@ function fireEvent(element, event) {
  */
 function modulo(dividend, divisor)
 {
-    var epsilon = divisor / 10000;
-    var remainder = dividend % divisor;
+    const epsilon = divisor / 10000;
+    let remainder = dividend % divisor;
 
     if (Math.abs(remainder - divisor) < epsilon || Math.abs(remainder) < epsilon) {
         remainder = 0;
@@ -646,14 +747,14 @@ function modulo(dividend, divisor)
 
 /**
  * Create form element. Set parameters into it and send
- *
- * @param url
- * @param parametersArray
- * @param method
+ * @constructor
  */
-Varien.formCreator = Class.create();
+Varien.formCreator = function() {
+    this.initialize(...arguments);
+};
+
 Varien.formCreator.prototype = {
-    initialize : function(url, parametersArray, method) {
+    initialize: function(url, parametersArray, method) {
         this.url = url;
         this.parametersArray = JSON.parse(parametersArray);
         this.method = method;
@@ -662,43 +763,72 @@ Varien.formCreator.prototype = {
         this.createForm();
         this.setFormData();
     },
-    createForm : function() {
-        this.form = new Element('form', { 'method': this.method, action: this.url });
+
+    createForm: function() {
+        this.form = document.createElement('form');
+        this.form.method = this.method;
+        this.form.action = this.url;
     },
-    setFormData : function () {
-        for (var key in this.parametersArray) {
-            Element.insert(
-                this.form,
-                new Element('input', { name: key, value: this.parametersArray[key], type: 'hidden' })
-            );
+    setFormData: function() {
+        for (const key in this.parametersArray) {
+            if (this.parametersArray.hasOwnProperty(key)) {
+                const input = document.createElement('input');
+                input.type = 'hidden';
+                input.name = key;
+                input.value = this.parametersArray[key];
+                this.form.appendChild(input);
+            }
         }
     }
 };
+Varien.classCompat(Varien.formCreator);
 
 function customFormSubmit(url, parametersArray, method) {
-    var createdForm = new Varien.formCreator(url, parametersArray, method);
-    Element.insert($$('body')[0], createdForm.form);
+    const createdForm = new Varien.formCreator(url, parametersArray, method);
+    document.body.appendChild(createdForm.form);
     createdForm.form.submit();
 }
 
 function customFormSubmitToParent(url, parametersArray, method) {
-    new Ajax.Request(url, {
+    const params = JSON.parse(parametersArray);
+    const formData = new FormData();
+    Object.keys(params).forEach(function(key) {
+        formData.append(key, params[key]);
+    });
+
+    fetch(url, {
         method: method,
-        parameters: JSON.parse(parametersArray),
-        onSuccess: function (response) {
-            var node = document.createElement('div');
-            node.innerHTML = response.responseText;
-            var responseMessage = node.getElementsByClassName('messages')[0];
-            var pageTitle = window.document.body.getElementsByClassName('page-title')[0];
-            pageTitle.insertAdjacentHTML('afterend', responseMessage.outerHTML);
-            window.opener.focus();
-            window.opener.location.href = response.transport.responseURL;
+        body: formData,
+        headers: { 'X-Requested-With': 'XMLHttpRequest' }
+    })
+    .then(function(response) {
+        // Ajax.Request only ran onSuccess on a 2xx status
+        if (!response.ok) {
+            throw new Error('Request failed with status ' + response.status);
         }
+        return response.text().then(function(text) {
+            return { text: text, url: response.url };
+        });
+    })
+    .then(function(result) {
+        const node = document.createElement('div');
+        node.innerHTML = result.text;
+        const responseMessage = node.getElementsByClassName('messages')[0];
+        const pageTitle = window.document.body.getElementsByClassName('page-title')[0];
+        if (pageTitle && responseMessage) {
+            pageTitle.insertAdjacentHTML('afterend', responseMessage.outerHTML);
+        }
+        window.opener.focus();
+        // Follow redirects the same way Ajax.Request's transport.responseURL did
+        window.opener.location.href = result.url || url;
+    })
+    .catch(function(e) {
+        if (window.console) console.error(e);
     });
 }
 
 function buttonDisabler() {
-    var buttons = document.querySelectorAll('button.save');
+    const buttons = document.querySelectorAll('button.save');
     buttons.forEach(function(button) {
         button.disabled = true;
     });

--- a/js/varien/menu.js
+++ b/js/varien/menu.js
@@ -13,92 +13,94 @@
  */
 
 /**
+ * Rewritten to vanilla JS — no Prototype.js dependency.
+ */
+
+/**
  * @classDescription simple Navigation with replacing old handlers
  * @param {String} id id of ul element with navigation lists
  * @param {Object} settings object with settings
  */
 var mainNav = function() {
 
-    var main = {
-        obj_nav :   $(arguments[0]) || $("nav"),
+    const main = {
+        // $() accepted an element or an id
+        obj_nav: (typeof arguments[0] === 'string' ? document.getElementById(arguments[0]) : arguments[0])
+            || document.getElementById('nav'),
 
-        settings :  {
-            show_delay      :   0,
-            hide_delay      :   0,
+        settings: {
+            show_delay: 0,
+            hide_delay: 0,
         },
 
-        init :  function(obj, level) {
-            obj.lists = obj.childElements();
-            obj.lists.each(function(el,ind){
+        init: function(obj, level) {
+            obj.lists = Array.from(obj.children);
+            obj.lists.forEach(function(el) {
                 main.handlNavElement(el);
             });
         },
 
-        handlNavElement :   function(list) {
-            if(list !== undefined){
-                list.onmouseover = function(){
-                    main.fireNavEvent(this,true);
+        handlNavElement: function(list) {
+            if (list !== undefined) {
+                list.onmouseover = function() {
+                    main.fireNavEvent(this, true);
                 };
-                list.onmouseout = function(){
-                    main.fireNavEvent(this,false);
+                list.onmouseout = function() {
+                    main.fireNavEvent(this, false);
                 };
-                if(list.down("ul")){
-                    main.init(list.down("ul"), true);
+                const subList = list.querySelector('ul');
+                if (subList) {
+                    main.init(subList, true);
                 }
             }
         },
 
-        fireNavEvent :  function(elm,ev) {
-            if(ev){
-                elm.addClassName("over");
-                elm.down("a").addClassName("over");
-                if (elm.childElements()[1]) {
-                    main.show(elm.childElements()[1]);
+        fireNavEvent: function(elm, ev) {
+            const children = Array.from(elm.children);
+            if (ev) {
+                elm.classList.add('over');
+                var a = elm.querySelector('a');
+                if (a) a.classList.add('over');
+                if (children[1]) {
+                    main.show(children[1]);
                 }
             } else {
-                elm.removeClassName("over");
-                elm.down("a").removeClassName("over");
-                if (elm.childElements()[1]) {
-                    main.hide(elm.childElements()[1]);
+                elm.classList.remove('over');
+                var a = elm.querySelector('a');
+                if (a) a.classList.remove('over');
+                if (children[1]) {
+                    main.hide(children[1]);
                 }
             }
         },
 
-        show : function (sub_elm) {
+        show: function(sub_elm) {
             if (sub_elm.hide_time_id) {
                 clearTimeout(sub_elm.hide_time_id);
             }
             sub_elm.show_time_id = setTimeout(function() {
-                if (!sub_elm.hasClassName("shown-sub")) {
-                    sub_elm.addClassName("shown-sub");
-                }
+                sub_elm.classList.add('shown-sub');
             }, main.settings.show_delay);
         },
 
-        hide : function (sub_elm) {
+        hide: function(sub_elm) {
             if (sub_elm.show_time_id) {
                 clearTimeout(sub_elm.show_time_id);
             }
-            sub_elm.hide_time_id = setTimeout(function(){
-                if (sub_elm.hasClassName("shown-sub")) {
-                    sub_elm.removeClassName("shown-sub");
-                }
+            sub_elm.hide_time_id = setTimeout(function() {
+                sub_elm.classList.remove('shown-sub');
             }, main.settings.hide_delay);
         }
-
     };
+
     if (arguments[1]) {
-        main.settings = Object.extend(main.settings, arguments[1]);
+        Object.assign(main.settings, arguments[1]);
     }
     if (main.obj_nav) {
         main.init(main.obj_nav, false);
     }
 };
 
-document.observe("dom:loaded", function() {
-    //run navigation without delays and with default id="#nav"
-    //mainNav();
-
-    //run navigation with delays
-    mainNav("nav", {"show_delay":"100","hide_delay":"100"});
+document.addEventListener('DOMContentLoaded', function() {
+    mainNav('nav', {'show_delay': '100', 'hide_delay': '100'});
 });

--- a/js/varien/payment.js
+++ b/js/varien/payment.js
@@ -11,47 +11,62 @@
  * @copyright   Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
-var paymentForm = Class.create();
-paymentForm.prototype = {
-    initialize: function(formId){
-        this.formId = formId;
-        this.validator = new Validation(this.formId);
-        var elements = Form.getElements(formId);
 
-        var method = null;
-        for (var i=0; i<elements.length; i++) {
-            if (elements[i].name=='payment[method]' || elements[i].name=='form_key') {
+/**
+ * Rewritten to vanilla JS — no Prototype.js dependency.
+ */
+
+function paymentForm() {
+    this.initialize(...arguments);
+}
+
+paymentForm.prototype = {
+    initialize: function(formId) {
+        this.formId = formId;
+        this.currentMethod = null;
+        this.validator = new Validation(this.formId);
+
+        const form = document.getElementById(formId);
+        // Form.getElements returned input, select, textarea and button only.
+        // form.elements also lists fieldsets; a disabled fieldset disables its children.
+        const elements = form ? Array.from(form.elements).filter(function(el) {
+            return /^(input|select|textarea|button)$/i.test(el.tagName);
+        }) : [];
+        let method = null;
+
+        for (let i = 0; i < elements.length; i++) {
+            if (elements[i].name === 'payment[method]' || elements[i].name === 'form_key') {
                 if (elements[i].checked) {
                     method = elements[i].value;
                 }
             } else {
-                if((elements[i].type) && ('submit' != elements[i].type.toLowerCase())) {
+                if (elements[i].type && elements[i].type.toLowerCase() !== 'submit') {
                     elements[i].disabled = true;
                 }
             }
-            elements[i].setAttribute('autocomplete','off');
+            elements[i].setAttribute('autocomplete', 'off');
         }
+
         if (method) this.switchMethod(method);
     },
 
-    switchMethod: function(method){
-        if (this.currentMethod && $('payment_form_'+this.currentMethod)) {
-            var form = $('payment_form_'+this.currentMethod);
-            form.style.display = 'none';
-            var elements = form.getElementsByTagName('input');
-            for (var i=0; i<elements.length; i++) elements[i].disabled = true;
-            var elements = form.getElementsByTagName('select');
-            for (var i=0; i<elements.length; i++) elements[i].disabled = true;
-
+    switchMethod: function(method) {
+        if (this.currentMethod) {
+            const oldForm = document.getElementById('payment_form_' + this.currentMethod);
+            if (oldForm) {
+                oldForm.style.display = 'none';
+                Array.from(oldForm.getElementsByTagName('input')).forEach(function(el) { el.disabled = true; });
+                Array.from(oldForm.getElementsByTagName('select')).forEach(function(el) { el.disabled = true; });
+            }
         }
-        if ($('payment_form_'+method)){
-            var form = $('payment_form_'+method);
-            form.style.display = '';
-            var elements = form.getElementsByTagName('input');
-            for (var i=0; i<elements.length; i++) elements[i].disabled = false;
-            var elements = form.getElementsByTagName('select');
-            for (var i=0; i<elements.length; i++) elements[i].disabled = false;
+
+        const newForm = document.getElementById('payment_form_' + method);
+        if (newForm) {
+            newForm.style.display = '';
+            Array.from(newForm.getElementsByTagName('input')).forEach(function(el) { el.disabled = false; });
+            Array.from(newForm.getElementsByTagName('select')).forEach(function(el) { el.disabled = false; });
             this.currentMethod = method;
         }
     }
 };
+Varien.classCompat(paymentForm);

--- a/js/varien/product.js
+++ b/js/varien/product.js
@@ -17,17 +17,19 @@ if(typeof Product=='undefined') {
 
 /********************* IMAGE ZOOMER ***********************/
 
-Product.Zoom = Class.create();
+Product.Zoom = function(imageEl, trackEl, handleEl, zoomInEl, zoomOutEl, hintEl) {
+    this.initialize(imageEl, trackEl, handleEl, zoomInEl, zoomOutEl, hintEl);
+};
 Product.Zoom.prototype = {
     initialize: function(imageEl, trackEl, handleEl, zoomInEl, zoomOutEl, hintEl){
-        this.containerEl = $(imageEl).parentNode;
-        this.imageEl = $(imageEl);
-        this.handleEl = $(handleEl);
-        this.trackEl = $(trackEl);
-        this.hintEl = $(hintEl);
+        this.containerEl = document.getElementById(imageEl).parentNode;
+        this.imageEl = document.getElementById(imageEl);
+        this.handleEl = document.getElementById(handleEl);
+        this.trackEl = document.getElementById(trackEl);
+        this.hintEl = document.getElementById(hintEl);
 
-        this.containerDim = Element.getDimensions(this.containerEl);
-        this.imageDim = Element.getDimensions(this.imageEl);
+        this.containerDim = {width: this.containerEl.offsetWidth, height: this.containerEl.offsetHeight};
+        this.imageDim = {width: this.imageEl.offsetWidth, height: this.imageEl.offsetHeight};
 
         this.imageDim.ratio = this.imageDim.width/this.imageDim.height;
 
@@ -41,9 +43,9 @@ Product.Zoom.prototype = {
 
         if (this.imageDim.width <= this.containerDim.width
             && this.imageDim.height <= this.containerDim.height) {
-            this.trackEl.up().hide();
-            this.hintEl.hide();
-            this.containerEl.removeClassName('product-image-zoom');
+            this.trackEl.parentNode.style.display = 'none';
+            this.hintEl.style.display = 'none';
+            this.containerEl.classList.remove('product-image-zoom');
             return;
         }
 
@@ -59,41 +61,51 @@ Product.Zoom.prototype = {
 
         this.selects = document.getElementsByTagName('select');
 
-        this.draggable = new Draggable(imageEl, {
-            starteffect:false,
-            reverteffect:false,
-            endeffect:false,
-            snap:this.contain.bind(this)
-        });
+        if (typeof Draggable !== 'undefined') {
+            this.draggable = new Draggable(imageEl, {
+                starteffect:false,
+                reverteffect:false,
+                endeffect:false,
+                snap:this.contain.bind(this)
+            });
+        } else {
+            this.draggable = { element: this.imageEl };
+        }
 
-        this.slider = new Control.Slider(handleEl, trackEl, {
-            axis:'horizontal',
-            minimum:0,
-            maximum:Element.getDimensions(this.trackEl).width,
-            alignX:0,
-            increment:1,
-            sliderValue:0,
-            onSlide:this.scale.bind(this),
-            onChange:this.scale.bind(this)
-        });
+        if (typeof Control !== 'undefined' && typeof Control.Slider !== 'undefined') {
+            this.slider = new Control.Slider(handleEl, trackEl, {
+                axis:'horizontal',
+                minimum:0,
+                maximum:this.trackEl.offsetWidth,
+                alignX:0,
+                increment:1,
+                sliderValue:0,
+                onSlide:this.scale.bind(this),
+                onChange:this.scale.bind(this)
+            });
+        } else {
+            this.slider = { value: 0, disabled: false, setValue: function(v) { this.value = v; }, setDisabled: function() { this.disabled = true; } };
+        }
 
         this.scale(0);
 
-        Event.observe(this.imageEl, 'dblclick', this.toggleFull.bind(this));
+        this.imageEl.addEventListener('dblclick', this.toggleFull.bind(this));
 
-        Event.observe($(zoomInEl), 'mousedown', this.startZoomIn.bind(this));
-        Event.observe($(zoomInEl), 'mouseup', this.stopZooming.bind(this));
-        Event.observe($(zoomInEl), 'mouseout', this.stopZooming.bind(this));
+        const zoomInElNode = document.getElementById(zoomInEl);
+        zoomInElNode.addEventListener('mousedown', this.startZoomIn.bind(this));
+        zoomInElNode.addEventListener('mouseup', this.stopZooming.bind(this));
+        zoomInElNode.addEventListener('mouseout', this.stopZooming.bind(this));
 
-        Event.observe($(zoomOutEl), 'mousedown', this.startZoomOut.bind(this));
-        Event.observe($(zoomOutEl), 'mouseup', this.stopZooming.bind(this));
-        Event.observe($(zoomOutEl), 'mouseout', this.stopZooming.bind(this));
+        const zoomOutElNode = document.getElementById(zoomOutEl);
+        zoomOutElNode.addEventListener('mousedown', this.startZoomOut.bind(this));
+        zoomOutElNode.addEventListener('mouseup', this.stopZooming.bind(this));
+        zoomOutElNode.addEventListener('mouseout', this.stopZooming.bind(this));
     },
 
     toggleFull: function () {
         this.showFull = !this.showFull;
 
-        val_scale = !this.showFull ? this.slider.value : 1;
+        const val_scale = !this.showFull ? this.slider.value : 1;
         this.scale(val_scale);
 
         this.trackEl.style.visibility = this.showFull ? 'hidden' : 'visible';
@@ -104,9 +116,9 @@ Product.Zoom.prototype = {
     },
 
     scale: function (v) {
-        var centerX  = (this.containerDim.width*(1-this.imageZoom)/2-this.imageX)/this.imageZoom;
-        var centerY  = (this.containerDim.height*(1-this.imageZoom)/2-this.imageY)/this.imageZoom;
-        var overSize = (this.imageDim.width > this.containerDim.width || this.imageDim.height > this.containerDim.height);
+        const centerX  = (this.containerDim.width*(1-this.imageZoom)/2-this.imageX)/this.imageZoom;
+        const centerY  = (this.containerDim.height*(1-this.imageZoom)/2-this.imageY)/this.imageZoom;
+        const overSize = (this.imageDim.width > this.containerDim.width || this.imageDim.height > this.containerDim.height);
 
         this.imageZoom = this.floorZoom+(v*(this.ceilingZoom-this.floorZoom));
 
@@ -141,7 +153,7 @@ Product.Zoom.prototype = {
             this.zoomBtnPressed = true;
             this.sliderAccel = .002;
             this.periodicalZoom();
-            this.zoomer = new PeriodicalExecuter(this.periodicalZoom.bind(this), .05);
+            this.zoomer = setInterval(this.periodicalZoom.bind(this), 50);
         }
         return this;
     },
@@ -152,7 +164,7 @@ Product.Zoom.prototype = {
             this.zoomBtnPressed = true;
             this.sliderAccel = -.002;
             this.periodicalZoom();
-            this.zoomer = new PeriodicalExecuter(this.periodicalZoom.bind(this), .05);
+            this.zoomer = setInterval(this.periodicalZoom.bind(this), 50);
         }
         return this;
     },
@@ -178,7 +190,7 @@ Product.Zoom.prototype = {
             this.sliderSpeed /= 1.5;
             if (Math.abs(this.sliderSpeed)<.001) {
                 this.sliderSpeed = 0;
-                this.zoomer.stop();
+                clearInterval(this.zoomer);
                 this.zoomer = null;
             }
         }
@@ -192,10 +204,10 @@ Product.Zoom.prototype = {
 
     contain: function (x,y,draggable) {
 
-        var dim = Element.getDimensions(draggable.element);
+        const dim = {width: draggable.element.offsetWidth, height: draggable.element.offsetHeight};
 
-        var xMin = 0, xMax = this.containerDim.width-dim.width;
-        var yMin = 0, yMax = this.containerDim.height-dim.height;
+        const xMin = 0, xMax = this.containerDim.width-dim.width;
+        const yMin = 0, yMax = this.containerDim.height-dim.height;
 
         x = x>xMin ? xMin : x;
         x = x<xMax ? xMax : x;
@@ -219,25 +231,36 @@ Product.Zoom.prototype = {
         return [x,y];
     }
 };
+Varien.classCompat(Product.Zoom);
 
 /**************************** CONFIGURABLE PRODUCT **************************/
-Product.Config = Class.create();
+Product.Config = function(config) {
+    this.initialize(config);
+};
 Product.Config.prototype = {
     initialize: function(config){
         this.config     = config;
         this.taxConfig  = this.config.taxConfig;
-        this.settings   = $$('.super-attribute-select');
-        this.state      = new Hash();
-        this.priceTemplate = new Template(this.config.template);
+        this.settings   = Array.from(document.querySelectorAll('.super-attribute-select'));
+        this.state      = {};
+        // Simple template: replace #{key} with obj[key]
+        const tpl = this.config.template;
+        this.priceTemplate = {
+            evaluate: function (obj) {
+                return tpl.replace(/#\{(\w+)\}/g, function (m, key) {
+                    return obj[key] !== undefined ? obj[key] : '';
+                });
+            }
+        };
         this.prices     = config.prices;
 
-        this.settings.each(function(element){
-            Event.observe(element, 'change', this.configure.bind(this));
+        this.settings.forEach(function(element){
+            element.addEventListener('change', this.configure.bind(this));
         }.bind(this));
 
         // fill state
-        this.settings.each(function(element){
-            var attributeId = element.id.replace(/[a-z]*/, '');
+        this.settings.forEach(function(element){
+            const attributeId = element.id.replace(/[a-z]*/, '');
             if(attributeId && this.config.attributes[attributeId]) {
                 element.config = this.config.attributes[attributeId];
                 element.attributeId = attributeId;
@@ -246,19 +269,19 @@ Product.Config.prototype = {
         }.bind(this));
 
         // Init settings dropdown
-        var childSettings = [];
+        const childSettings = [];
         for(var i=this.settings.length-1;i>=0;i--){
-            var prevSetting = this.settings[i-1] ? this.settings[i-1] : false;
-            var nextSetting = this.settings[i+1] ? this.settings[i+1] : false;
+            const prevSetting = this.settings[i-1] ? this.settings[i-1] : false;
+            const nextSetting = this.settings[i+1] ? this.settings[i+1] : false;
             if(i==0){
                 this.fillSelect(this.settings[i]);
             }
             else {
                 this.settings[i].disabled=true;
             }
-            $(this.settings[i]).childSettings = childSettings.clone();
-            $(this.settings[i]).prevSetting   = prevSetting;
-            $(this.settings[i]).nextSetting   = nextSetting;
+            this.settings[i].childSettings = childSettings.slice();
+            this.settings[i].prevSetting   = prevSetting;
+            this.settings[i].nextSetting   = nextSetting;
             childSettings.push(this.settings[i]);
         }
 
@@ -267,10 +290,14 @@ Product.Config.prototype = {
             this.values = config.defaultValues;
         }
 
-        var separatorIndex = window.location.href.indexOf('#');
+        const separatorIndex = window.location.href.indexOf('#');
         if (separatorIndex != -1) {
-            var paramsStr = window.location.href.substr(separatorIndex+1);
-            var urlValues = paramsStr.toQueryParams();
+            const paramsStr = window.location.href.substr(separatorIndex+1);
+            const urlValues = {};
+            const searchParams = new URLSearchParams(paramsStr);
+            searchParams.forEach(function(value, key) {
+                urlValues[key] = value;
+            });
             if (!this.values) {
                 this.values = {};
             }
@@ -280,13 +307,13 @@ Product.Config.prototype = {
         }
 
         this.configureForValues();
-        document.observe("dom:loaded", this.configureForValues.bind(this));
+        document.addEventListener('DOMContentLoaded', this.configureForValues.bind(this));
     },
 
     configureForValues: function () {
         if (this.values) {
-            this.settings.each(function(element){
-                var attributeId = element.attributeId;
+            this.settings.forEach(function(element){
+                const attributeId = element.attributeId;
                 element.value = (typeof(this.values[attributeId]) == 'undefined')? '' : this.values[attributeId];
                 this.configureElement(element);
             }.bind(this));
@@ -294,7 +321,7 @@ Product.Config.prototype = {
     },
 
     configure: function(event){
-        var element = Event.element(event);
+        const element = event.target;
         this.configureElement(element);
     },
 
@@ -316,14 +343,14 @@ Product.Config.prototype = {
     },
 
     reloadOptionLabels: function(element){
-        var selectedPrice;
+        let selectedPrice;
         if(element.options[element.selectedIndex].config){
             selectedPrice = parseFloat(element.options[element.selectedIndex].config.price);
         }
         else{
             selectedPrice = 0;
         }
-        for(var i=0;i<element.options.length;i++){
+        for(let i=0;i<element.options.length;i++){
             if(element.options[i].config){
                 element.options[i].text = this.getOptionLabel(element.options[i].config, element.options[i].config.price-selectedPrice);
             }
@@ -332,7 +359,7 @@ Product.Config.prototype = {
 
     resetChildren : function(element){
         if(element.childSettings) {
-            for(var i=0;i<element.childSettings.length;i++){
+            for(let i=0;i<element.childSettings.length;i++){
                 element.childSettings[i].selectedIndex = 0;
                 element.childSettings[i].disabled = true;
                 if(element.config){
@@ -343,33 +370,33 @@ Product.Config.prototype = {
     },
 
     fillSelect: function(element){
-        var attributeId = element.id.replace(/[a-z]*/, '');
-        var options = this.getAttributeOptions(attributeId);
+        const attributeId = element.id.replace(/[a-z]*/, '');
+        const options = this.getAttributeOptions(attributeId);
         this.clearSelect(element);
         element.options[0] = new Option('', '');
         element.options[0].innerHTML = this.config.chooseText;
 
-        var prevConfig = false;
+        let prevConfig = false;
         if(element.prevSetting){
             prevConfig = element.prevSetting.options[element.prevSetting.selectedIndex];
         }
 
         if(options) {
-            var index = 1;
-            for(var i=0;i<options.length;i++){
-                var allowedProducts = [];
+            let index = 1;
+            for(let i=0;i<options.length;i++){
+                let allowedProducts = [];
                 if(prevConfig) {
-                    for(var j=0;j<options[i].products.length;j++){
+                    for(let j=0;j<options[i].products.length;j++){
                         if(prevConfig.config.allowedProducts
                             && prevConfig.config.allowedProducts.indexOf(options[i].products[j])>-1){
                             allowedProducts.push(options[i].products[j]);
                         }
                     }
                 } else {
-                    allowedProducts = options[i].products.clone();
+                    allowedProducts = options[i].products.slice();
                 }
 
-                if(allowedProducts.size()>0){
+                if(allowedProducts.length>0){
                     options[i].allowedProducts = allowedProducts;
                     element.options[index] = new Option(this.getOptionLabel(options[i], options[i].price), options[i].id);
                     element.options[index].config = options[i];
@@ -397,7 +424,7 @@ Product.Config.prototype = {
             price = excl;
         }
 
-        var str = option.label;
+        let str = option.label;
         if(price){
             if (this.taxConfig.showBothPrices) {
                 str+= ' ' + this.formatPrice(excl, true) + ' (' + this.formatPrice(price, true) + ' ' + this.taxConfig.inclTaxTitle + ')';
@@ -409,7 +436,7 @@ Product.Config.prototype = {
     },
 
     formatPrice: function(price, showSign){
-        var str = '';
+        let str = '';
         price = parseFloat(price);
         if(showSign){
             if(price<0){
@@ -421,19 +448,19 @@ Product.Config.prototype = {
             }
         }
 
-        var roundedPrice = (Math.round(price*100)/100).toString();
+        const roundedPrice = (Math.round(price*100)/100).toString();
 
         if (this.prices && this.prices[roundedPrice]) {
             str+= this.prices[roundedPrice];
         }
         else {
-            str+= this.priceTemplate.evaluate({price:price.toFixed(2)});
+            str+= this.priceTemplate.evaluate({price: price.toFixed(2)});
         }
         return str;
     },
 
     clearSelect: function(element){
-        for(var i=element.options.length-1;i>=0;i--){
+        for(let i=element.options.length-1;i>=0;i--){
             element.remove(i);
         }
     },
@@ -445,10 +472,10 @@ Product.Config.prototype = {
     },
 
     reloadPrice: function(){
-        var price    = 0;
-        var oldPrice = 0;
-        for(var i=this.settings.length-1;i>=0;i--){
-            var selected = this.settings[i].options[this.settings[i].selectedIndex];
+        let price    = 0;
+        let oldPrice = 0;
+        for(let i=this.settings.length-1;i>=0;i--){
+            const selected = this.settings[i].options[this.settings[i].selectedIndex];
             if(selected.config){
                 price    += parseFloat(selected.config.price);
                 oldPrice += parseFloat(selected.config.oldPrice);
@@ -462,13 +489,13 @@ Product.Config.prototype = {
     },
 
     reloadOldPrice: function(){
-        if ($('old-price-'+this.config.productId)) {
+        if (document.getElementById('old-price-'+this.config.productId)) {
 
-            var price = parseFloat(this.config.oldPrice);
-            for(var i=this.settings.length-1;i>=0;i--){
-                var selected = this.settings[i].options[this.settings[i].selectedIndex];
+            let price = parseFloat(this.config.oldPrice);
+            for(let i=this.settings.length-1;i>=0;i--){
+                const selected = this.settings[i].options[this.settings[i].selectedIndex];
                 if(selected.config){
-                    var parsedOldPrice = parseFloat(selected.config.oldPrice);
+                    const parsedOldPrice = parseFloat(selected.config.oldPrice);
                     price += isNaN(parsedOldPrice) ? 0 : parsedOldPrice;
                 }
             }
@@ -476,23 +503,26 @@ Product.Config.prototype = {
                 price = 0;
             price = this.formatPrice(price);
 
-            if($('old-price-'+this.config.productId)){
-                $('old-price-'+this.config.productId).innerHTML = price;
+            if(document.getElementById('old-price-'+this.config.productId)){
+                document.getElementById('old-price-'+this.config.productId).innerHTML = price;
             }
 
         }
     }
 };
+Varien.classCompat(Product.Config);
 
 
 /**************************** SUPER PRODUCTS ********************************/
 
 Product.Super = {};
-Product.Super.Configurable = Class.create();
+Product.Super.Configurable = function(container, observeCss, updateUrl, updatePriceUrl, priceContainerId) {
+    this.initialize(container, observeCss, updateUrl, updatePriceUrl, priceContainerId);
+};
 
 Product.Super.Configurable.prototype = {
     initialize: function(container, observeCss, updateUrl, updatePriceUrl, priceContainerId) {
-        this.container = $(container);
+        this.container = document.getElementById(container);
         this.observeCss = observeCss;
         this.updateUrl = updateUrl;
         this.updatePriceUrl = updatePriceUrl;
@@ -500,25 +530,59 @@ Product.Super.Configurable.prototype = {
         this.registerObservers();
     },
     registerObservers: function() {
-        var elements = this.container.getElementsByClassName(this.observeCss);
-        elements.each(function(element){
-            Event.observe(element, 'change', this.update.bindAsEventListener(this));
+        const elements = this.container.getElementsByClassName(this.observeCss);
+        Array.from(elements).forEach(function(element){
+            element.addEventListener('change', this.update.bind(this));
         }.bind(this));
         return this;
     },
     update: function(event) {
-        var elements = this.container.getElementsByClassName(this.observeCss);
-        var parameters = Form.serializeElements(elements, true);
-
-        new Ajax.Updater(this.container, this.updateUrl + '?ajax=1', {
-                parameters:parameters,
-                onComplete:this.registerObservers.bind(this)
+        const elements = this.container.getElementsByClassName(this.observeCss);
+        // Form.serializeElements skipped disabled fields and unchecked boxes,
+        // and sent every selected option of a multi-select
+        const params = new URLSearchParams();
+        Array.from(elements).forEach(function(element) {
+            if (!element.name || element.disabled) return;
+            if ((element.type === 'checkbox' || element.type === 'radio') && !element.checked) return;
+            if (element.type === 'select-multiple') {
+                Array.from(element.options).forEach(function(opt) {
+                    if (opt.selected) params.append(element.name, opt.value);
+                });
+                return;
+            }
+            params.append(element.name, element.value);
         });
-        var priceContainer = $(this.priceContainerId);
+        const paramString = params.toString();
+
+        const self = this;
+        fetch(this.updateUrl + '?ajax=1', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-Requested-With': 'XMLHttpRequest'},
+            body: paramString
+        }).then(function(response) {
+            // Ajax.Updater only replaced the container on a 2xx status
+            return response.ok ? response.text() : null;
+        }).then(function(html) {
+            if (html !== null) {
+                self.container.innerHTML = html;
+            }
+            self.registerObservers();
+        });
+
+        const priceContainer = document.getElementById(this.priceContainerId);
         if(priceContainer) {
-            new Ajax.Updater(priceContainer, this.updatePriceUrl + '?ajax=1', {
-                parameters:parameters
+            fetch(this.updatePriceUrl + '?ajax=1', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-Requested-With': 'XMLHttpRequest'},
+                body: paramString
+            }).then(function(response) {
+                return response.ok ? response.text() : null;
+            }).then(function(html) {
+                if (html !== null) {
+                    priceContainer.innerHTML = html;
+                }
             });
         }
     }
 };
+Varien.classCompat(Product.Super.Configurable);

--- a/js/varien/product_options.js
+++ b/js/varien/product_options.js
@@ -12,12 +12,19 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
+/**
+ * Rewritten to vanilla JS — no Prototype.js dependency.
+ */
+
 var Product = Product || {};
 
 /**************************** PRICE RELOADER ********************************/
-Product.OptionsPrice = Class.create();
+Product.OptionsPrice = function () {
+    this.initialize(...arguments);
+};
+
 Product.OptionsPrice.prototype = {
-    initialize: function(config) {
+    initialize: function (config) {
         this.productId          = config.productId;
         this.priceFormat        = config.priceFormat;
         this.includeTax         = config.includeTax;
@@ -35,9 +42,9 @@ Product.OptionsPrice.prototype = {
         this.tierPrices         = config.tierPrices;
         this.tierPricesInclTax  = config.tierPricesInclTax;
 
-        this.oldPlusDisposition = config.oldPlusDisposition;
-        this.plusDisposition    = config.plusDisposition;
-        this.plusDispositionTax = config.plusDispositionTax;
+        this.oldPlusDisposition  = config.oldPlusDisposition;
+        this.plusDisposition     = config.plusDisposition;
+        this.plusDispositionTax  = config.plusDispositionTax;
 
         this.oldMinusDisposition = config.oldMinusDisposition;
         this.minusDisposition    = config.minusDisposition;
@@ -48,16 +55,16 @@ Product.OptionsPrice.prototype = {
         this.customPrices   = {};
         this.containers     = {};
 
-        this.displayZeroPrice   = true;
+        this.displayZeroPrice = true;
 
         this.initPrices();
     },
 
-    setDuplicateIdSuffix: function(idSuffix) {
+    setDuplicateIdSuffix: function (idSuffix) {
         this.duplicateIdSuffix = idSuffix;
     },
 
-    initPrices: function() {
+    initPrices: function () {
         this.containers[0] = 'product-price-' + this.productId;
         this.containers[1] = 'bundle-price-' + this.productId;
         this.containers[2] = 'price-including-tax-' + this.productId;
@@ -65,97 +72,106 @@ Product.OptionsPrice.prototype = {
         this.containers[4] = 'old-price-' + this.productId;
     },
 
-    changePrice: function(key, price) {
+    changePrice: function (key, price) {
         this.optionPrices[key] = price;
     },
 
-    addCustomPrices: function(key, price) {
+    addCustomPrices: function (key, price) {
         this.customPrices[key] = price;
     },
-    getOptionPrices: function() {
-        var price = 0;
-        var nonTaxable = 0;
-        var oldPrice = 0;
-        var priceInclTax = 0;
-        var currentTax = this.currentTax;
-        $H(this.optionPrices).each(function(pair) {
-            if ('undefined' != typeof(pair.value.price) && 'undefined' != typeof(pair.value.oldPrice)) {
-                price += parseFloat(pair.value.price);
-                oldPrice += parseFloat(pair.value.oldPrice);
-            } else if (pair.key == 'nontaxable') {
-                nonTaxable = pair.value;
-            } else if (pair.key == 'priceInclTax') {
-                priceInclTax += pair.value;
-            } else if (pair.key == 'optionsPriceInclTax') {
-                priceInclTax += pair.value * (100 + currentTax) / 100;
+
+    getOptionPrices: function () {
+        let price = 0;
+        let nonTaxable = 0;
+        let oldPrice = 0;
+        let priceInclTax = 0;
+        const currentTax = this.currentTax;
+        const optionPrices = this.optionPrices;
+
+        Object.keys(optionPrices).forEach(function (key) {
+            const value = optionPrices[key];
+            if ('undefined' != typeof(value.price) && 'undefined' != typeof(value.oldPrice)) {
+                price += parseFloat(value.price);
+                oldPrice += parseFloat(value.oldPrice);
+            } else if (key == 'nontaxable') {
+                nonTaxable = value;
+            } else if (key == 'priceInclTax') {
+                priceInclTax += value;
+            } else if (key == 'optionsPriceInclTax') {
+                priceInclTax += value * (100 + currentTax) / 100;
             } else {
-                price += parseFloat(pair.value);
-                oldPrice += parseFloat(pair.value);
+                price += parseFloat(value);
+                oldPrice += parseFloat(value);
             }
         });
+
         return [price, nonTaxable, oldPrice, priceInclTax];
     },
 
-    reload: function() {
-        var price;
-        var formattedPrice;
-        var optionPrices = this.getOptionPrices();
-        var nonTaxable = optionPrices[1];
-        var optionOldPrice = optionPrices[2];
-        var priceInclTax = optionPrices[3];
+    reload: function () {
+        const self = this;
+        let price;
+        let formattedPrice;
+        let optionPrices = this.getOptionPrices();
+        const nonTaxable = optionPrices[1];
+        const optionOldPrice = optionPrices[2];
+        const priceInclTax = optionPrices[3];
         optionPrices = optionPrices[0];
 
-        $H(this.containers).each(function(pair) {
-            var _productPrice;
-            var _plusDisposition;
-            var _minusDisposition;
-            var _priceInclTax;
-            var excl;
-            var incl;
-            var tax;
+        Object.keys(this.containers).forEach(function (key) {
+            let containerId = self.containers[key];
+            let _productPrice;
+            let _plusDisposition;
+            let _minusDisposition;
+            let _priceInclTax;
+            let excl;
+            let incl;
+            let tax;
 
-            if ($(pair.value) == null) {
-                pair.value = "product-price-weee-" + this.productId;
+            if (!document.getElementById(containerId)) {
+                containerId = 'product-price-weee-' + self.productId;
             }
-            if ($(pair.value)) {
-                if (pair.value == 'old-price-'+this.productId && this.productOldPrice != this.productPrice) {
-                    _productPrice = this.productOldPrice;
-                    _plusDisposition = this.oldPlusDisposition;
-                    _minusDisposition = this.oldMinusDisposition;
+
+            const el = document.getElementById(containerId);
+            if (el) {
+                if (containerId == 'old-price-' + self.productId && self.productOldPrice != self.productPrice) {
+                    _productPrice = self.productOldPrice;
+                    _plusDisposition = self.oldPlusDisposition;
+                    _minusDisposition = self.oldMinusDisposition;
                 } else {
-                    _productPrice = this.productPrice;
-                    _plusDisposition = this.plusDisposition;
-                    _minusDisposition = this.minusDisposition;
+                    _productPrice = self.productPrice;
+                    _plusDisposition = self.plusDisposition;
+                    _minusDisposition = self.minusDisposition;
                 }
                 _priceInclTax = priceInclTax;
 
-                if (pair.value == 'old-price-'+this.productId && optionOldPrice !== undefined) {
-                    price = optionOldPrice+parseFloat(_productPrice);
-                } else if (this.specialTaxPrice == 'true' && this.priceInclTax !== undefined && this.priceExclTax !== undefined) {
-                    price = optionPrices+parseFloat(this.priceExclTax);
-                    _priceInclTax += this.priceInclTax;
+                if (containerId == 'old-price-' + self.productId && optionOldPrice !== undefined) {
+                    price = optionOldPrice + parseFloat(_productPrice);
+                } else if (self.specialTaxPrice == 'true' && self.priceInclTax !== undefined && self.priceExclTax !== undefined) {
+                    price = optionPrices + parseFloat(self.priceExclTax);
+                    _priceInclTax += self.priceInclTax;
                 } else {
-                    price = optionPrices+parseFloat(_productPrice);
-                    _priceInclTax += parseFloat(_productPrice) * (100 + this.currentTax) / 100;
+                    price = optionPrices + parseFloat(_productPrice);
+                    _priceInclTax += parseFloat(_productPrice) * (100 + self.currentTax) / 100;
                 }
 
-                if (this.specialTaxPrice == 'true') {
+                if (self.specialTaxPrice == 'true') {
                     excl = price;
                     incl = _priceInclTax;
-                } else if (this.includeTax == 'true') {
-                    // tax = tax included into product price by admin
-                    tax = price / (100 + this.defaultTax) * this.defaultTax;
+                } else if (self.includeTax == 'true') {
+                    // tax included into product price by admin
+                    tax = price / (100 + self.defaultTax) * self.defaultTax;
                     excl = price - tax;
-                    incl = excl*(1+(this.currentTax/100));
+                    incl = excl * (1 + (self.currentTax / 100));
                 } else {
-                    tax = price * (this.currentTax / 100);
+                    tax = price * (self.currentTax / 100);
                     excl = price;
                     incl = excl + tax;
                 }
 
-                var subPrice = 0;
-                var subPriceincludeTax = 0;
-                Object.values(this.customPrices).each(function(el){
+                let subPrice = 0;
+                let subPriceincludeTax = 0;
+                Object.values(self.customPrices).forEach(function (el) {
                     if (el.excludeTax && el.includeTax) {
                         subPrice += parseFloat(el.excludeTax);
                         subPriceincludeTax += parseFloat(el.includeTax);
@@ -167,114 +183,102 @@ Product.OptionsPrice.prototype = {
                 excl += subPrice;
                 incl += subPriceincludeTax;
 
-                if (typeof this.exclDisposition == 'undefined') {
+                if (typeof self.exclDisposition == 'undefined') {
                     excl += parseFloat(_plusDisposition);
                 }
 
-                incl += parseFloat(_plusDisposition) + parseFloat(this.plusDispositionTax);
+                incl += parseFloat(_plusDisposition) + parseFloat(self.plusDispositionTax);
                 excl -= parseFloat(_minusDisposition);
                 incl -= parseFloat(_minusDisposition);
 
-                //adding nontaxlable part of options
+                // adding nontaxable part of options
                 excl += parseFloat(nonTaxable);
                 incl += parseFloat(nonTaxable);
 
-                if (pair.value == 'price-including-tax-'+this.productId) {
+                if (containerId == 'price-including-tax-' + self.productId) {
                     price = incl;
-                } else if (pair.value == 'price-excluding-tax-'+this.productId) {
+                } else if (containerId == 'price-excluding-tax-' + self.productId) {
                     price = excl;
-                } else if (pair.value == 'old-price-'+this.productId) {
-                    if (this.showIncludeTax || this.showBothPrices) {
-                        price = incl;
-                    } else {
-                        price = excl;
-                    }
+                } else if (containerId == 'old-price-' + self.productId) {
+                    price = (self.showIncludeTax || self.showBothPrices) ? incl : excl;
                 } else {
-                    if (this.showIncludeTax) {
-                        price = incl;
-                    } else {
-                        price = excl;
-                    }
+                    price = self.showIncludeTax ? incl : excl;
                 }
 
                 if (price < 0) price = 0;
 
-                if (price > 0 || this.displayZeroPrice) {
-                    formattedPrice = this.formatPrice(price);
-                } else {
-                    formattedPrice = '';
-                }
+                formattedPrice = (price > 0 || self.displayZeroPrice) ? self.formatPrice(price) : '';
 
-                if ($(pair.value).select('.price')[0]) {
-                    $(pair.value).select('.price')[0].innerHTML = formattedPrice;
-                    if ($(pair.value+this.duplicateIdSuffix) && $(pair.value+this.duplicateIdSuffix).select('.price')[0]) {
-                        $(pair.value+this.duplicateIdSuffix).select('.price')[0].innerHTML = formattedPrice;
+                const priceEl = el.querySelector('.price');
+                if (priceEl) {
+                    priceEl.innerHTML = formattedPrice;
+                    var dupEl = document.getElementById(containerId + self.duplicateIdSuffix);
+                    if (dupEl) {
+                        const dupPriceEl = dupEl.querySelector('.price');
+                        if (dupPriceEl) dupPriceEl.innerHTML = formattedPrice;
                     }
                 } else {
-                    $(pair.value).innerHTML = formattedPrice;
-                    if ($(pair.value+this.duplicateIdSuffix)) {
-                        $(pair.value+this.duplicateIdSuffix).innerHTML = formattedPrice;
-                    }
+                    el.innerHTML = formattedPrice;
+                    var dupEl = document.getElementById(containerId + self.duplicateIdSuffix);
+                    if (dupEl) dupEl.innerHTML = formattedPrice;
                 }
-            };
-        }.bind(this));
+            }
+        });
 
-        if (typeof(skipTierPricePercentUpdate) === "undefined" && typeof(this.tierPrices) !== "undefined") {
-            for (var i = 0; i < this.tierPrices.length; i++) {
-                $$('.benefit').each(function(el) {
-                    var parsePrice = function(html) {
-                        var format = this.priceFormat;
-                        var decimalSymbol = format.decimalSymbol === undefined ? "," : format.decimalSymbol;
-                        var regexStr = '[^0-9-' + decimalSymbol + ']';
-                        //remove all characters except number and decimal symbol
+        if (typeof(skipTierPricePercentUpdate) === 'undefined' && typeof(this.tierPrices) !== 'undefined') {
+            for (let i = 0; i < this.tierPrices.length; i++) {
+                document.querySelectorAll('.benefit').forEach(function (benefitEl) {
+                    const parsePrice = function (html) {
+                        const format = self.priceFormat;
+                        const decimalSymbol = format.decimalSymbol === undefined ? ',' : format.decimalSymbol;
+                        const regexStr = '[^0-9-' + decimalSymbol + ']';
                         html = html.replace(new RegExp(regexStr, 'g'), '');
                         html = html.replace(decimalSymbol, '.');
                         return parseFloat(html);
-                    }.bind(this);
+                    };
 
-                    var updateTierPriceInfo = function(priceEl, tierPriceDiff, tierPriceEl, benefitEl) {
-                        if (typeof(tierPriceEl) === "undefined") {
-                            //tierPrice is not shown, e.g., MAP, no need to update the tier price info
+                    const updateTierPriceInfo = function (priceEl, tierPriceDiff, tierPriceEl, el) {
+                        if (typeof(tierPriceEl) === 'undefined') {
                             return;
                         }
-                        var price = parsePrice(priceEl.innerHTML);
-                        var tierPrice = price + tierPriceDiff;
+                        const price = parsePrice(priceEl.innerHTML);
+                        const tierPrice = price + tierPriceDiff;
 
-                        tierPriceEl.innerHTML = this.formatPrice(tierPrice);
+                        tierPriceEl.innerHTML = self.formatPrice(tierPrice);
 
-                        var $percent = Selector.findChildElements(benefitEl, ['.percent.tier-' + i]);
-                        $percent.each(function(el) {
-                            el.innerHTML = Math.ceil(100 - ((100 / price) * tierPrice));
+                        el.querySelectorAll('.percent.tier-' + i).forEach(function (percentEl) {
+                            percentEl.innerHTML = Math.ceil(100 - ((100 / price) * tierPrice));
                         });
-                    }.bind(this);
+                    };
 
-                    var tierPriceElArray = $$('.tier-price.tier-' + i + ' .price');
-                    if (this.showBothPrices) {
-                        var containerExclTax = $(this.containers[3]);
-                        var tierPriceExclTaxDiff = this.tierPrices[i];
+                    const tierPriceElArray = document.querySelectorAll('.tier-price.tier-' + i + ' .price');
+                    if (self.showBothPrices) {
+                        const containerExclTax = document.getElementById(self.containers[3]);
+                        var tierPriceExclTaxDiff = self.tierPrices[i];
                         var tierPriceExclTaxEl = tierPriceElArray[0];
-                        updateTierPriceInfo(containerExclTax, tierPriceExclTaxDiff, tierPriceExclTaxEl, el);
-                        var containerInclTax = $(this.containers[2]);
-                        var tierPriceInclTaxDiff = this.tierPricesInclTax[i];
+                        updateTierPriceInfo(containerExclTax, tierPriceExclTaxDiff, tierPriceExclTaxEl, benefitEl);
+                        const containerInclTax = document.getElementById(self.containers[2]);
+                        var tierPriceInclTaxDiff = self.tierPricesInclTax[i];
                         var tierPriceInclTaxEl = tierPriceElArray[1];
-                        updateTierPriceInfo(containerInclTax, tierPriceInclTaxDiff, tierPriceInclTaxEl, el);
-                    } else if (this.showIncludeTax) {
-                        var container = $(this.containers[0]);
-                        var tierPriceInclTaxDiff = this.tierPricesInclTax[i];
+                        updateTierPriceInfo(containerInclTax, tierPriceInclTaxDiff, tierPriceInclTaxEl, benefitEl);
+                    } else if (self.showIncludeTax) {
+                        var container = document.getElementById(self.containers[0]);
+                        var tierPriceInclTaxDiff = self.tierPricesInclTax[i];
                         var tierPriceInclTaxEl = tierPriceElArray[0];
-                        updateTierPriceInfo(container, tierPriceInclTaxDiff, tierPriceInclTaxEl, el);
+                        updateTierPriceInfo(container, tierPriceInclTaxDiff, tierPriceInclTaxEl, benefitEl);
                     } else {
-                        var container = $(this.containers[0]);
-                        var tierPriceExclTaxDiff = this.tierPrices[i];
+                        var container = document.getElementById(self.containers[0]);
+                        var tierPriceExclTaxDiff = self.tierPrices[i];
                         var tierPriceExclTaxEl = tierPriceElArray[0];
-                        updateTierPriceInfo(container, tierPriceExclTaxDiff, tierPriceExclTaxEl, el);
+                        updateTierPriceInfo(container, tierPriceExclTaxDiff, tierPriceExclTaxEl, benefitEl);
                     }
-                }, this);
+                });
             }
         }
-
     },
-    formatPrice: function(price) {
+
+    formatPrice: function (price) {
         return formatCurrency(price, this.priceFormat);
     }
 };
+Varien.classCompat(Product.OptionsPrice);

--- a/js/varien/telephone.js
+++ b/js/varien/telephone.js
@@ -11,110 +11,82 @@
  * @copyright   Copyright (c) 2022 The OpenMage Contributors (https://www.openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
-var telephoneElem = Class.create();
+
+/**
+ * Rewritten to vanilla JS — no Prototype.js dependency.
+ */
+
+function telephoneElem() {
+    this.initialize(...arguments);
+}
 
 telephoneElem.prototype = {
-    initialize : function(fval,f1,f2,f3,f4){
-        this.valField = fval;
-        this.f1 = f1;
-        this.f2 = f2;
-        this.f3 = f3;
-        this.f4 = f4;
-        this.last = f3;
+    initialize: function(fval, f1, f2, f3, f4) {
+        this.valField = document.getElementById(fval);
+        this.f1 = document.getElementById(f1);
+        this.f2 = document.getElementById(f2);
+        this.f3 = document.getElementById(f3);
+        this.f4 = f4 ? document.getElementById(f4) : null;
+        this.last = this.f4 || this.f3;
 
-        this.eventKeyPress = this.keyPress.bindAsEventListener(this);
-        this.eventKeyUp = this.keyUp.bindAsEventListener(this);
+        this.eventKeyUp = this.keyUp.bind(this);
 
-        Event.observe(this.f1, "keyup", this.eventKeyUp);
-        Event.observe(this.f2, "keyup", this.eventKeyUp);
-        Event.observe(this.f3, "keyup", this.eventKeyUp);
+        this.f1.addEventListener('keyup', this.eventKeyUp);
+        this.f2.addEventListener('keyup', this.eventKeyUp);
+        this.f3.addEventListener('keyup', this.eventKeyUp);
 
-        Event.observe(this.f1, "keypress", this.eventKeyPress);
-        Event.observe(this.f2, "keypress", this.eventKeyPress);
-        Event.observe(this.f3, "keypress", this.eventKeyPress);
-
-        if (this.f4)
-        {
-            Event.observe(this.f4, "keyup", this.eventKeyUp);
-            Event.observe(this.f4, "keypress", this.eventKeyPress);
-            this.last = f4;
+        if (this.f4) {
+            this.f4.addEventListener('keyup', this.eventKeyUp);
         }
+
         this.loadValues();
     },
 
-    keyPress: function(event){
-        var code = event.keyCode;
-/*		if ((event.keyCode < 48 || event.keyCode > 57) && event.keyCode != Event.KEY_BACKSPACE && event.keyCode != Event.KEY_DELETE && event.keyCode != Event.KEY_LEFT && event.keyCode != Event.KEY_RIGHT)
-        {
-            Event.stop(event);
-        }*/
-    },
-
-    keyUp: function(event){
-        var element = Event.element(event);
-        var code = event.keyCode;
-        if (element.id != this.last && code != Event.KEY_TAB && code != 16 && code != Event.KEY_BACKSPACE && code != Event.KEY_DELETE && code != Event.KEY_LEFT && code != Event.KEY_RIGHT)
-        {
-            var size = element.size;
-            if (element.value.length == size)
-            {
-                if (nextElem = this.getNextElement(element.id))
-                {
-                    Field.activate(nextElem);
-                }
+    keyUp: function(event) {
+        const element = event.target;
+        const code = event.keyCode;
+        const skipKeys = [9, 16, 8, 46, 37, 39]; // Tab, Shift, Backspace, Delete, Left, Right
+        if (element !== this.last && skipKeys.indexOf(code) === -1) {
+            const size = parseInt(element.getAttribute('size'), 10) || element.size;
+            if (element.value.length === size) {
+                const next = this.getNextElement(element);
+                if (next) next.focus();
             }
         }
         this.setValField();
     },
 
-    getNextElement: function(curent_id){
-        if (curent_id == this.last)
-        {
-            return false;
-        }
-
-        if (curent_id == this.f1)
-        {
-            return this.f2;
-        }
-        if (curent_id == this.f2)
-        {
-            return this.f3;
-        }
-        if (curent_id == this.f3)
-        {
-            return this.f4;
-        }
-
-        return false;
+    getNextElement: function(element) {
+        if (element === this.last) return null;
+        if (element === this.f1) return this.f2;
+        if (element === this.f2) return this.f3;
+        if (element === this.f3) return this.f4;
+        return null;
     },
 
-    setValField: function(){
-        cur_value = '';
-        if($F(this.f1)) cur_value += '(' + $F(this.f1) + ') ';
-        if($F(this.f2)) cur_value += $F(this.f2);
-        if($F(this.f3)) cur_value += '-' + $F(this.f3);
-        if (this.f4) cur_value += $F(this.f4) ? '-' + $F(this.f4) : '';
-
-        $(this.valField).value = cur_value;
+    setValField: function() {
+        let val = '';
+        if (this.f1.value) val += '(' + this.f1.value + ') ';
+        if (this.f2.value) val += this.f2.value;
+        if (this.f3.value) val += '-' + this.f3.value;
+        if (this.f4) val += this.f4.value ? '-' + this.f4.value : '';
+        this.valField.value = val;
     },
 
-    loadValues: function(){
-        var val = $F(this.valField);
-        if (val && val.length)
-        {
-            re = /^[\(]?(\d{3})[\)]?[-|\s]?(\d{3})[-|\s](\d{4})[-|\s]?(\d{0,4})?$/;
-            if (re.test(val))
-            {
-                arrVal = re.exec(val);
-                $(this.f1).value = arrVal[1];
-                $(this.f2).value = arrVal[2];
-                $(this.f3).value = arrVal[3];
-                if (this.f4 && arrVal[4])
-                {
-                    $(this.f4).value = arrVal[4];
+    loadValues: function() {
+        const val = this.valField.value;
+        if (val && val.length) {
+            const re = /^[\(]?(\d{3})[\)]?[-|\s]?(\d{3})[-|\s](\d{4})[-|\s]?(\d{1,4})?$/;
+            if (re.test(val)) {
+                const arrVal = re.exec(val);
+                this.f1.value = arrVal[1];
+                this.f2.value = arrVal[2];
+                this.f3.value = arrVal[3];
+                if (this.f4 && arrVal[4]) {
+                    this.f4.value = arrVal[4];
                 }
             }
         }
     }
 };
+Varien.classCompat(telephoneElem);

--- a/js/varien/weee.js
+++ b/js/varien/weee.js
@@ -12,14 +12,24 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
+/**
+ * Rewritten to vanilla JS — no Prototype.js dependency.
+ */
+
 /**************************** WEEE STUFF ********************************/
-function taxToggle(details, switcher, expandedClassName)
-{
-    if ($(details).style.display == 'none') {
-        $(details).show();
-        $(switcher).addClassName(expandedClassName);
+function taxToggle(details, switcher, expandedClassName) {
+    // Templates pass either an id or an element (e.g. `this`), like $() accepted
+    const detailsEl  = typeof details === 'string' ? document.getElementById(details) : details;
+    const switcherEl = typeof switcher === 'string' ? document.getElementById(switcher) : switcher;
+    if (!detailsEl || !switcherEl) {
+        return;
+    }
+
+    if (detailsEl.style.display === 'none') {
+        detailsEl.style.display  = '';
+        switcherEl.classList.add(expandedClassName);
     } else {
-        $(details).hide();
-        $(switcher).removeClassName(expandedClassName);
+        detailsEl.style.display  = 'none';
+        switcherEl.classList.remove(expandedClassName);
     }
 }

--- a/skin/frontend/base/default/js/bundle.js
+++ b/skin/frontend/base/default/js/bundle.js
@@ -4,36 +4,46 @@
  * @license    Academic Free License (AFL 3.0)
  * @package     base_default
  */
+
+/**
+ * Rewritten to vanilla JS — no Prototype.js dependency.
+ */
+
 if(typeof Product=='undefined') {
     var Product = {};
 }
+
 /**************************** BUNDLE PRODUCT **************************/
-Product.Bundle = Class.create();
+Product.Bundle = function () {
+    this.initialize(...arguments);
+};
+
 Product.Bundle.prototype = {
-    initialize: function(config){
+    initialize: function (config) {
         this.config = config;
 
         // Set preconfigured values for correct price base calculation
         if (config.defaultValues) {
-            for (var option in config.defaultValues) {
+            for (const option in config.defaultValues) {
                 if (this.config['options'][option].isMulti) {
-                    var selected = new Array();
-                    for (var i = 0; i < config.defaultValues[option].length; i++) {
+                    const selected = [];
+                    for (let i = 0; i < config.defaultValues[option].length; i++) {
                         selected.push(config.defaultValues[option][i]);
                     }
                     this.config.selected[option] = selected;
                 } else {
-                    this.config.selected[option] = new Array(config.defaultValues[option] + "");
+                    this.config.selected[option] = [config.defaultValues[option] + ""];
                 }
             }
         }
 
         this.reloadPrice();
     },
-    changeSelection: function(selection){
-        var parts = selection.id.split('-');
+
+    changeSelection: function (selection) {
+        const parts = selection.id.split('-');
         if (this.config['options'][parts[2]].isMulti) {
-            selected = new Array();
+            const selected = [];
             if (selection.tagName == 'SELECT') {
                 for (var i = 0; i < selection.options.length; i++) {
                     if (selection.options[i].selected && selection.options[i].value != '') {
@@ -41,8 +51,8 @@ Product.Bundle.prototype = {
                     }
                 }
             } else if (selection.tagName == 'INPUT') {
-                selector = parts[0]+'-'+parts[1]+'-'+parts[2];
-                selections = $$('.'+selector);
+                const selector = parts[0] + '-' + parts[1] + '-' + parts[2];
+                const selections = document.querySelectorAll('.' + selector);
                 for (var i = 0; i < selections.length; i++) {
                     if (selections[i].checked && selections[i].value != '') {
                         selected.push(selections[i].value);
@@ -52,30 +62,32 @@ Product.Bundle.prototype = {
             this.config.selected[parts[2]] = selected;
         } else {
             if (selection.value != '') {
-                this.config.selected[parts[2]] = new Array(selection.value);
+                this.config.selected[parts[2]] = [selection.value];
             } else {
-                this.config.selected[parts[2]] = new Array();
+                this.config.selected[parts[2]] = [];
             }
             this.populateQty(parts[2], selection.value);
-            var tierPriceElement = $('bundle-option-' + parts[2] + '-tier-prices'),
-                tierPriceHtml = '';
+            const tierPriceElement = document.getElementById('bundle-option-' + parts[2] + '-tier-prices');
+            let tierPriceHtml = '';
             if (selection.value != '' && this.config.options[parts[2]].selections[selection.value].customQty == 1) {
                 tierPriceHtml = this.config.options[parts[2]].selections[selection.value].tierPriceHtml;
             }
-            tierPriceElement.update(tierPriceHtml);
+            tierPriceElement.innerHTML = tierPriceHtml;
+            // option_tierprices.phtml ships inline scripts (MSRP help links); update() ran them
+            Varien.evalScripts(tierPriceElement);
         }
         this.reloadPrice();
     },
 
-    reloadPrice: function() {
-        var calculatedPrice = 0;
-        var dispositionPrice = 0;
-        var includeTaxPrice = 0;
+    reloadPrice: function () {
+        let calculatedPrice = 0;
+        let dispositionPrice = 0;
+        let includeTaxPrice = 0;
 
-        for (var option in this.config.selected) {
+        for (const option in this.config.selected) {
             if (this.config.options[option]) {
-                for (var i=0; i < this.config.selected[option].length; i++) {
-                    var prices = this.selectionPrice(option, this.config.selected[option][i]);
+                for (let i = 0; i < this.config.selected[option].length; i++) {
+                    const prices = this.selectionPrice(option, this.config.selected[option][i]);
                     calculatedPrice += Number(prices[0]);
                     dispositionPrice += Number(prices[1]);
                     includeTaxPrice += Number(prices[2]);
@@ -83,34 +95,39 @@ Product.Bundle.prototype = {
             }
         }
 
-        //Tax is calculated in a different way for the the TOTAL BASED method
-        //We round the taxes at the end. Hence we do the same for consistency
-        //This variable is set in the bundle.phtml
         if (taxCalcMethod == CACL_TOTAL_BASE) {
-            var calculatedPriceFormatted = calculatedPrice.toFixed(10);
-            var includeTaxPriceFormatted = includeTaxPrice.toFixed(10);
-            var tax = includeTaxPriceFormatted - calculatedPriceFormatted;
+            const calculatedPriceFormatted = calculatedPrice.toFixed(10);
+            const includeTaxPriceFormatted = includeTaxPrice.toFixed(10);
+            const tax = includeTaxPriceFormatted - calculatedPriceFormatted;
             calculatedPrice = includeTaxPrice - Math.round(tax * 100) / 100;
         }
 
-        //make sure that the prices are all rounded to two digits
-        //this is needed when tax calculation is based on total for dynamic
-        //price bundle product. For fixed price bundle product, the rounding
-        //needs to be done after option price is added to base price
         if (this.config.priceType == '0') {
-            calculatedPrice = Math.round(calculatedPrice*100)/100;
-            dispositionPrice = Math.round(dispositionPrice*100)/100;
-            includeTaxPrice = Math.round(includeTaxPrice*100)/100;
-
+            calculatedPrice = Math.round(calculatedPrice * 100) / 100;
+            dispositionPrice = Math.round(dispositionPrice * 100) / 100;
+            includeTaxPrice = Math.round(includeTaxPrice * 100) / 100;
         }
 
-        var event = $(document).fire('bundle:reload-price', {
+        const eventDetail = {
             price: calculatedPrice,
             priceInclTax: includeTaxPrice,
             dispositionPrice: dispositionPrice,
-            bundle: this
-        });
-        if (!event.noReloadPrice) {
+            bundle: this,
+            noReloadPrice: false
+        };
+        const event = new CustomEvent('bundle:reload-price', {bubbles: true, cancelable: true, detail: eventDetail});
+        // document.fire() exposed the payload as event.memo; keep that alias for existing observers
+        event.memo = eventDetail;
+        document.dispatchEvent(event);
+        // Observers may set the flag on the event (as with document.fire()) or on the payload
+        let noReloadPrice = eventDetail.noReloadPrice || event.noReloadPrice;
+        // Prototype registers custom-event observers on dataavailable, which a native
+        // CustomEvent never reaches. Fire through Prototype too while it loads.
+        if (window.Event && typeof Event.fire === 'function') {
+            noReloadPrice = noReloadPrice || Event.fire(document, 'bundle:reload-price', eventDetail).noReloadPrice;
+        }
+
+        if (!noReloadPrice) {
             optionsPrice.specialTaxPrice = 'true';
             optionsPrice.changePrice('bundle', calculatedPrice);
             optionsPrice.changePrice('nontaxable', dispositionPrice);
@@ -121,26 +138,28 @@ Product.Bundle.prototype = {
         return calculatedPrice;
     },
 
-    selectionPrice: function(optionId, selectionId) {
+    selectionPrice: function (optionId, selectionId) {
         if (selectionId == '' || selectionId == 'none' || typeof(this.config.options[optionId].selections[selectionId]) == 'undefined') {
             return 0;
         }
-        var qty = null;
-        var tierPriceInclTax, tierPriceExclTax;
+        let qty = null;
+        let tierPriceInclTax, tierPriceExclTax;
         if (this.config.options[optionId].selections[selectionId].customQty == 1 && !this.config['options'][optionId].isMulti) {
-            if ($('bundle-option-' + optionId + '-qty-input')) {
-                qty = $('bundle-option-' + optionId + '-qty-input').value;
+            const qtyInput = document.getElementById('bundle-option-' + optionId + '-qty-input');
+            if (qtyInput) {
+                qty = qtyInput.value;
             } else {
                 qty = 1;
             }
         } else {
             qty = this.config.options[optionId].selections[selectionId].qty;
         }
+        let price, tierPrice;
         if (this.config.priceType == '0') {
             price = this.config.options[optionId].selections[selectionId].price;
             tierPrice = this.config.options[optionId].selections[selectionId].tierPrice;
 
-            for (var i=0; i < tierPrice.length; i++) {
+            for (let i = 0; i < tierPrice.length; i++) {
                 if (Number(tierPrice[i].price_qty) <= qty && Number(tierPrice[i].price) <= price) {
                     price = tierPrice[i].price;
                     tierPriceInclTax = tierPrice[i].priceInclTax;
@@ -148,25 +167,24 @@ Product.Bundle.prototype = {
                 }
             }
         } else {
-            selection = this.config.options[optionId].selections[selectionId];
+            var selection = this.config.options[optionId].selections[selectionId];
             if (selection.priceType == '0') {
                 price = selection.priceValue;
             } else {
-                price = (this.config.basePrice*selection.priceValue)/100;
+                price = (this.config.basePrice * selection.priceValue) / 100;
             }
         }
-        //price += this.config.options[optionId].selections[selectionId].plusDisposition;
-        //price -= this.config.options[optionId].selections[selectionId].minusDisposition;
-        //return price*qty;
-        var disposition = this.config.options[optionId].selections[selectionId].plusDisposition +
+
+        let disposition = this.config.options[optionId].selections[selectionId].plusDisposition +
             this.config.options[optionId].selections[selectionId].minusDisposition;
 
         if (this.config.specialPrice) {
-            newPrice = (price*this.config.specialPrice)/100;
+            const newPrice = (price * this.config.specialPrice) / 100;
             price = Math.min(newPrice, price);
         }
 
-        selection = this.config.options[optionId].selections[selectionId];
+        var selection = this.config.options[optionId].selections[selectionId];
+        let priceInclTax;
         if (tierPriceInclTax !== undefined && tierPriceExclTax !== undefined) {
             priceInclTax = tierPriceInclTax;
             price = tierPriceExclTax;
@@ -178,25 +196,21 @@ Product.Bundle.prototype = {
         }
 
         if (this.config.priceType == '1' || taxCalcMethod == CACL_TOTAL_BASE) {
-            var result = new Array(price*qty, disposition*qty, priceInclTax*qty);
-            return result;
-        }
-        else if (taxCalcMethod == CACL_UNIT_BASE) {
-            price = (Math.round(price*100)/100).toString();
-            disposition = (Math.round(disposition*100)/100).toString();
-            priceInclTax = (Math.round(priceInclTax*100)/100).toString();
-            var result = new Array(price*qty, disposition*qty, priceInclTax*qty);
-            return result;
-        } else { //taxCalcMethod == CACL_ROW_BASE)
-            price = (Math.round(price*qty*100)/100).toString();
-            disposition = (Math.round(disposition*qty*100)/100).toString();
-            priceInclTax = (Math.round(priceInclTax*qty*100)/100).toString();
-            var result = new Array(price, disposition, priceInclTax);
-            return result;
+            return [price * qty, disposition * qty, priceInclTax * qty];
+        } else if (taxCalcMethod == CACL_UNIT_BASE) {
+            price = (Math.round(price * 100) / 100).toString();
+            disposition = (Math.round(disposition * 100) / 100).toString();
+            priceInclTax = (Math.round(priceInclTax * 100) / 100).toString();
+            return [price * qty, disposition * qty, priceInclTax * qty];
+        } else {
+            price = (Math.round(price * qty * 100) / 100).toString();
+            disposition = (Math.round(disposition * qty * 100) / 100).toString();
+            priceInclTax = (Math.round(priceInclTax * qty * 100) / 100).toString();
+            return [price, disposition, priceInclTax];
         }
     },
 
-    populateQty: function(optionId, selectionId){
+    populateQty: function (optionId, selectionId) {
         if (selectionId == '' || selectionId == 'none') {
             this.showQtyInput(optionId, '0', false);
             return;
@@ -208,19 +222,19 @@ Product.Bundle.prototype = {
         }
     },
 
-    showQtyInput: function(optionId, value, canEdit) {
-        elem = $('bundle-option-' + optionId + '-qty-input');
+    showQtyInput: function (optionId, value, canEdit) {
+        const elem = document.getElementById('bundle-option-' + optionId + '-qty-input');
         elem.value = value;
         elem.disabled = !canEdit;
         if (canEdit) {
-            elem.removeClassName('qty-disabled');
+            elem.classList.remove('qty-disabled');
         } else {
-            elem.addClassName('qty-disabled');
+            elem.classList.add('qty-disabled');
         }
     },
 
     changeOptionQty: function (element, event) {
-        var checkQty = true;
+        let checkQty = true;
         if (typeof(event) != 'undefined') {
             if (event.keyCode == 8 || event.keyCode == 46) {
                 checkQty = false;
@@ -229,28 +243,30 @@ Product.Bundle.prototype = {
         if (checkQty && (Number(element.value) == 0 || isNaN(Number(element.value)))) {
             element.value = 1;
         }
-        parts = element.id.split('-');
-        optionId = parts[2];
+        const parts = element.id.split('-');
+        const optionId = parts[2];
         if (!this.config['options'][optionId].isMulti) {
-            selectionId = this.config.selected[optionId][0];
-            this.config.options[optionId].selections[selectionId].qty = element.value*1;
+            const selectionId = this.config.selected[optionId][0];
+            this.config.options[optionId].selections[selectionId].qty = element.value * 1;
             this.reloadPrice();
         }
     },
 
-    validationCallback: function (elmId, result){
-        if (elmId == undefined || $(elmId) == undefined) {
+    validationCallback: function (elmId, result) {
+        const el = typeof elmId === 'string' ? document.getElementById(elmId) : elmId;
+        if (!el) {
             return;
         }
-        var container = $(elmId).up('ul.options-list');
-        if (typeof container != 'undefined') {
+        const container = el.closest('ul.options-list');
+        if (container) {
             if (result == 'failed') {
-                container.removeClassName('validation-passed');
-                container.addClassName('validation-failed');
+                container.classList.remove('validation-passed');
+                container.classList.add('validation-failed');
             } else {
-                container.removeClassName('validation-failed');
-                container.addClassName('validation-passed');
+                container.classList.remove('validation-failed');
+                container.classList.add('validation-passed');
             }
         }
     }
 };
+Varien.classCompat(Product.Bundle);

--- a/skin/frontend/base/default/js/checkout/review.js
+++ b/skin/frontend/base/default/js/checkout/review.js
@@ -1,15 +1,169 @@
 /**
- * @copyright  For copyright and license information, read the COPYING.txt file.
- * @link       /COPYING.txt
+ * @copyright  For copyright and license information, read the README.md file.
+ * @link       /README.md
  * @license    Academic Free License (AFL 3.0)
  * @package     base_default
  */
 
 /**
+ * Helper: enable an array/NodeList of form elements (replaces .invoke('enable')).
+ */
+function _reviewEnableElements(elements) {
+    Array.from(elements).forEach(function(el) { el.disabled = false; });
+}
+
+/**
+ * Helper: disable an array/NodeList of form elements (replaces .invoke('disable')).
+ */
+function _reviewDisableElements(elements) {
+    Array.from(elements).forEach(function(el) { el.disabled = true; });
+}
+
+/**
+ * Helper: fetch HTML and put it into a container, optionally evaluating scripts.
+ */
+function _reviewAjaxUpdater(container, url, options) {
+    const el = typeof container === 'string' ? document.getElementById(container) : container;
+    if (!el) return;
+    // Ajax.Updater defaulted to POST with a form-encoded body
+    let body = '';
+    if (options.parameters) {
+        if (typeof options.parameters === 'string') {
+            body = options.parameters;
+        } else {
+            // Repeat keys for array values (billing[street][], multi-selects) —
+            // URLSearchParams(object) would flatten them to "a,b"
+            const usp = new URLSearchParams();
+            Object.keys(options.parameters).forEach(function(key) {
+                const value = options.parameters[key];
+                if (Array.isArray(value)) {
+                    value.forEach(function(item) { usp.append(key, item); });
+                } else {
+                    usp.append(key, value);
+                }
+            });
+            body = usp.toString();
+        }
+    }
+    fetch(url, {
+        method: 'POST',
+        body: body,
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'X-Requested-With': 'XMLHttpRequest'
+        }
+    }).then(function(resp) {
+        return resp.text().then(function(text) {
+            return { ok: resp.ok, status: resp.status, text: text };
+        });
+    }).then(function(result) {
+        const response = { responseText: result.text, status: result.status };
+        // Only treat 2xx as success: inserting an error page into the review
+        // area and reporting success would let the order proceed on a failed save
+        if (result.ok) {
+            el.innerHTML = result.text;
+            if (options.evalScripts !== false) {
+                Varien.evalScripts(el);
+            }
+            if (options.onSuccess) options.onSuccess(response);
+        } else if (options.onFailure) {
+            options.onFailure(response);
+        }
+        if (options.onComplete) options.onComplete(response);
+    }).catch(function() {
+        if (options.onFailure) options.onFailure({ responseText: '', status: 0 });
+        if (options.onComplete) options.onComplete({ responseText: '', status: 0 });
+    });
+}
+
+/**
+ * Helper: serialize form to a plain object (replaces Form.serialize(true)).
+ */
+function _reviewSerializeForm(form) {
+    const data = {};
+    // Accumulate repeated names (billing[street][]) into arrays instead of
+    // letting later fields overwrite earlier ones
+    function append(name, value) {
+        if (Object.prototype.hasOwnProperty.call(data, name)) {
+            if (!Array.isArray(data[name])) data[name] = [data[name]];
+            data[name].push(value);
+        } else {
+            data[name] = value;
+        }
+    }
+    Array.from(form.elements).forEach(function(el) {
+        if (!el.name || el.disabled || el.type === 'file') return;
+        if (el.type === 'checkbox' || el.type === 'radio') {
+            // Form.serialize() omitted unchecked boxes and repeated checked names
+            // accumulated, e.g. agreement[1], agreement[2]
+            if (el.checked) append(el.name, el.value);
+        } else if (el.type === 'select-multiple') {
+            // .value on a multi-select only yields the first selected option
+            Array.from(el.options).forEach(function(opt) {
+                if (opt.selected) append(el.name, opt.value);
+            });
+        } else if (el.type !== 'submit' && el.type !== 'button') {
+            append(el.name, el.value);
+        }
+    });
+    return data;
+}
+
+/**
  * Controller of order review form that may select shipping method
  */
-OrderReviewController = Class.create();
+function OrderReviewController() { this.initialize(...arguments); }
+
 OrderReviewController.prototype = {
+    initialize: function(orderForm, orderFormSubmit, shippingSelect, shippingSubmitForm, shippingResultId, shippingSubmit) {
+        if (!orderForm) {
+            return;
+        }
+        this.form = orderForm;
+        if (orderFormSubmit) {
+            this.formSubmit = orderFormSubmit;
+            orderFormSubmit.addEventListener('click', this._submitOrder.bind(this));
+        }
+
+        if (shippingSubmitForm) {
+            this.reloadByShippingSelect = true;
+            if (shippingSubmitForm && shippingSelect) {
+                this.shippingSelect = shippingSelect;
+                shippingSelect.addEventListener('change', this._submitShipping.bind(this, shippingSubmitForm.action, shippingResultId));
+                this._updateOrderSubmit(false);
+            } else {
+                this._canSubmitOrder = true;
+            }
+        } else {
+            Array.from(this.form.elements).forEach(this._bindElementChange.bind(this));
+
+            const shippingSelectEl = typeof shippingSelect === 'string'
+                ? document.getElementById(shippingSelect) : shippingSelect;
+            if (shippingSelectEl) {
+                this.shippingSelect = shippingSelectEl.id;
+                this.shippingMethodsContainer = shippingSelectEl.parentElement;
+            } else {
+                this.shippingSelect = shippingSelect;
+            }
+            this._updateOrderSubmit(false);
+        }
+    },
+    /**
+     * shippingSelect is an element when a shipping submit form is used, or an id otherwise
+     */
+    _getShippingSelect : function () {
+        if (!this.shippingSelect) {
+            return null;
+        }
+        return typeof this.shippingSelect === 'string'
+            ? document.getElementById(this.shippingSelect) : this.shippingSelect;
+    },
+
+    _getShippingSelectId : function () {
+        const el = this._getShippingSelect();
+        return el ? el.id : this.shippingSelect;
+    },
+
     _canSubmitOrder : false,
     _pleaseWait : false,
     shippingSelect : false,
@@ -23,55 +177,6 @@ OrderReviewController.prototype = {
     _submitUpdateOrderUrl : false,
     _itemsGrid : false,
 
-    /**
-     * Add listeners to provided objects, if any
-     * @param orderForm - form of the order submission
-     * @param orderFormSubmit - element for the order form submission (optional)
-     * @param shippingSelect - dropdown with available shipping methods (optional)
-     * @param shippingSubmitForm - form of shipping method submission (optional, requires shippingSelect)
-     * @param shippingResultId - element where to update results of shipping ajax submission (optional, requires shippingSubmitForm)
-     */
-    initialize : function(orderForm, orderFormSubmit, shippingSelect, shippingSubmitForm, shippingResultId, shippingSubmit)
-    {
-        if (!orderForm) {
-            return;
-        }
-        this.form = orderForm;
-        if (orderFormSubmit) {
-            this.formSubmit = orderFormSubmit;
-            Event.observe(orderFormSubmit, 'click', this._submitOrder.bind(this));
-        }
-
-        if (shippingSubmitForm) {
-            this.reloadByShippingSelect = true;
-            if (shippingSubmitForm && shippingSelect) {
-                this.shippingSelect = shippingSelect;
-                Event.observe(
-                    shippingSelect,
-                    'change',
-                    this._submitShipping.bindAsEventListener(this, shippingSubmitForm.action, shippingResultId)
-                );
-                this._updateOrderSubmit(false);
-            } else {
-                this._canSubmitOrder = true;
-            }
-        } else {
-            Form.getElements(this.form).each(this._bindElementChange, this);
-
-            if (shippingSelect && $(shippingSelect)) {
-                this.shippingSelect = $(shippingSelect).id;
-                this.shippingMethodsContainer = $(this.shippingSelect).up();
-            } else {
-                this.shippingSelect = shippingSelect;
-            }
-            this._updateOrderSubmit(false);
-        }
-    },
-
-    /**
-     * Register element that should show up when ajax request is in progress
-     * @param element
-     */
     addPleaseWait : function(element)
     {
         if (element) {
@@ -79,47 +184,38 @@ OrderReviewController.prototype = {
         }
     },
 
-    /**
-     * Dispatch an ajax request of shipping method submission
-     * @param event
-     * @param url - url where to submit shipping method
-     * @param resultId - id of element to be updated
-     */
-    _submitShipping : function(event, url, resultId)
+    _submitShipping : function(url, resultId, event)
     {
         if (this.shippingSelect && url && resultId) {
             this._updateOrderSubmit(true);
             if (this._pleaseWait) {
-                this._pleaseWait.show();
+                this._pleaseWait.style.display = '';
             }
             if ('' != this.shippingSelect.value) {
-                new Ajax.Updater(resultId, url, {
+                const self = this;
+                _reviewAjaxUpdater(resultId, url, {
                     parameters: {isAjax:true, shipping_method:this.shippingSelect.value},
+                    evalScripts: true,
                     onComplete: function() {
-                        if (this._pleaseWait) {
-                            this._pleaseWait.hide();
+                        if (self._pleaseWait) {
+                            self._pleaseWait.style.display = 'none';
                         }
-                    }.bind(this),
-                    onSuccess: this._onSubmitShippingSuccess.bind(this),
-                    evalScripts: true
+                    },
+                    onSuccess: function() {
+                        self._onSubmitShippingSuccess();
+                    }
                 });
             }
         }
     },
 
-    /**
-     * Set event observer to Update Order button
-     * @param element
-     * @param url - url to submit on Update button
-     * @param resultId - id of element to be updated
-     */
     setUpdateButton : function(element, url, resultId)
     {
         if (element) {
             this._ubpdateOrderButton = element;
             this._submitUpdateOrderUrl = url;
             this._itemsGrid = resultId;
-            Event.observe(element, 'click', this._submitUpdateOrder.bindAsEventListener(this, url, resultId));
+            element.addEventListener('click', this._submitUpdateOrder.bind(this, url, resultId));
             if(this.shippingSelect) {
                 this._updateShipping();
             }
@@ -129,40 +225,30 @@ OrderReviewController.prototype = {
         }
     },
 
-    /**
-     * Set event observer to copy data from shipping address to billing
-     * @param element
-     */
     setCopyElement : function(element)
     {
         if (element) {
             this._copyElement = element;
-            Event.observe(element, 'click', this._copyShippingToBilling.bind(this));
+            element.addEventListener('click', this._copyShippingToBilling.bind(this));
             this._copyShippingToBilling();
         }
     },
 
-    /**
-     * Set observers to Shipping Address elements
-     * @param element Container of Shipping Address elements
-     */
     setShippingAddressContainer: function(element)
     {
         if (element) {
-            Form.getElements(element).each(function(input) {
+            const inputs = element.querySelectorAll('input, select, textarea');
+            const self = this;
+            Array.from(inputs).forEach(function(input) {
                 if (input.type.toLowerCase() == 'radio' || input.type.toLowerCase() == 'checkbox') {
-                    Event.observe(input, 'click', this._onShippingChange.bindAsEventListener(this));
+                    input.addEventListener('click', self._onShippingChange.bind(self));
                 } else {
-                    Event.observe(input, 'change', this._onShippingChange.bindAsEventListener(this));
+                    input.addEventListener('change', self._onShippingChange.bind(self));
                 }
-            }, this);
+            });
         }
     },
 
-    /**
-     * Sets Container element of Shipping Method
-     * @param element Container element of Shipping Method
-     */
     setShippingMethodContainer: function(element)
     {
         if (element) {
@@ -170,52 +256,41 @@ OrderReviewController.prototype = {
         }
     },
 
-    /**
-     * Copy element value from shipping to billing address
-     * @param el
-     */
     _copyElementValue: function(el)
     {
-        var newId = el.id.replace('shipping:','billing:');
-        if (newId && $(newId) && $(newId).type != 'hidden') {
-            $(newId).value = el.value;
-            $(newId).setAttribute('readOnly', 'readonly');
-            $(newId).addClassName('local-validation');
-            $(newId).setStyle({opacity:.5});
-            $(newId).disable();
+        const newId = el.id.replace('shipping:','billing:');
+        const newEl = document.getElementById(newId);
+        if (newId && newEl && newEl.type != 'hidden') {
+            newEl.value = el.value;
+            newEl.setAttribute('readOnly', 'readonly');
+            newEl.classList.add('local-validation');
+            newEl.style.opacity = .5;
+            newEl.disabled = true;
         }
     },
 
-    /**
-     * Copy data from shipping address to billing
-     */
     _copyShippingToBilling : function (event)
     {
         if (!this._copyElement) {
             return;
         }
         if (this._copyElement.checked) {
-            this._copyElementValue($('shipping:country_id'));
+            this._copyElementValue(document.getElementById('shipping:country_id'));
             billingRegionUpdater.update();
-            $$('[id^="shipping:"]').each(this._copyElementValue);
+            document.querySelectorAll('[id^="shipping:"]').forEach(this._copyElementValue.bind(this));
             this._clearValidation('billing');
         } else {
-            $$('[id^="billing:"]').invoke('enable');
-            $$('[id^="billing:"]').each(function(el){el.removeAttribute("readOnly");});
-            $$('[id^="billing:"]').invoke('removeClassName', 'local-validation');
-            $$('[id^="billing:"]').invoke('setStyle', {opacity:1});
+            _reviewEnableElements(document.querySelectorAll('[id^="billing:"]'));
+            document.querySelectorAll('[id^="billing:"]').forEach(function(el){el.removeAttribute("readOnly");});
+            document.querySelectorAll('[id^="billing:"]').forEach(function(el){el.classList.remove('local-validation');});
+            document.querySelectorAll('[id^="billing:"]').forEach(function(el){el.style.opacity = 1;});
         }
         if (event) {
             this._updateOrderSubmit(true);
         }
     },
 
-    /**
-     * Dispatch an ajax request of Update Order submission
-     * @param url - url where to submit shipping method
-     * @param resultId - id of element to be updated
-     */
-    _submitUpdateOrder : function(event, url, resultId)
+    _submitUpdateOrder : function(url, resultId, event)
     {
         this._copyShippingToBilling();
         if (url && resultId && this._validateForm()) {
@@ -224,27 +299,36 @@ OrderReviewController.prototype = {
             }
             this._updateOrderSubmit(true);
             if (this._pleaseWait) {
-                this._pleaseWait.show();
+                this._pleaseWait.style.display = '';
             }
             this._toggleButton(this._ubpdateOrderButton, true);
 
-            arr = $$('[id^="billing:"]').invoke('enable');
-            var formData = this.form.serialize(true);
-            if (this._copyElement.checked) {
-                $$('[id^="billing:"]').invoke('disable');
-                this._copyElement.enable();
+            _reviewEnableElements(document.querySelectorAll('[id^="billing:"]'));
+            const formData = _reviewSerializeForm(this.form);
+            if (this._copyElement && this._copyElement.checked) {
+                _reviewDisableElements(document.querySelectorAll('[id^="billing:"]'));
+                this._copyElement.disabled = false;
             }
             formData.isAjax = true;
-            new Ajax.Updater(resultId, url, {
+            const self = this;
+            _reviewAjaxUpdater(resultId, url, {
                 parameters: formData,
+                evalScripts: true,
                 onComplete: function() {
-                    if (this._pleaseWait && !this._updateShippingMethods) {
-                        this._pleaseWait.hide();
+                    if (self._pleaseWait && !self._updateShippingMethods) {
+                        self._pleaseWait.style.display = 'none';
                     }
-                    this._toggleButton(this._ubpdateOrderButton, false);
-                }.bind(this),
-                onSuccess: this._updateShippingMethodsElement.bind(this),
-                evalScripts: true
+                    self._toggleButton(self._ubpdateOrderButton, false);
+                },
+                onSuccess: function() {
+                    self._updateShippingMethodsElement();
+                },
+                onFailure: function() {
+                    // don't leave the please-wait spinner up when the save failed
+                    if (self._pleaseWait) {
+                        self._pleaseWait.style.display = 'none';
+                    }
+                }
             });
         } else {
             if (this._copyElement && this._copyElement.checked) {
@@ -253,48 +337,63 @@ OrderReviewController.prototype = {
         }
     },
 
-    /**
-     * Update Shipping Methods Element from server
-     */
     _updateShippingMethodsElement : function (){
-        if (this._updateShippingMethods ) {
-            new Ajax.Updater($(this.shippingMethodsContainer).up(), this.shippingMethodsUpdateUrl, {
-                onComplete: this._updateShipping.bind(this),
-                onSuccess: this._onSubmitShippingSuccess.bind(this),
-                evalScripts: false
-            });
+        const self = this;
+        if (this._updateShippingMethods) {
+            const containerEl = typeof this.shippingMethodsContainer === 'string'
+                ? document.getElementById(this.shippingMethodsContainer)
+                : this.shippingMethodsContainer;
+            if (containerEl && containerEl.parentElement) {
+                _reviewAjaxUpdater(containerEl.parentElement, this.shippingMethodsUpdateUrl, {
+                    evalScripts: false,
+                    onComplete: function() {
+                        self._updateShipping();
+                    },
+                    // Only a successful refresh may re-enable order submission
+                    onSuccess: function() {
+                        self._onSubmitShippingSuccess();
+                    }
+                });
+            }
         } else {
             this._onSubmitShippingSuccess();
         }
     },
 
-    /**
-     * Update Shipping Method select element and bind events
-     */
     _updateShipping : function () {
-        if ($(this.shippingSelect)) {
-            $(this.shippingSelect).enable();
-            Event.stopObserving($(this.shippingSelect), 'change');
+        const shipSelect = this._getShippingSelect();
+        if (shipSelect) {
+            shipSelect.disabled = false;
 
-            this._bindElementChange($(this.shippingSelect));
-            Event.observe(
-                $(this.shippingSelect),
-                'change',
-                this._submitUpdateOrder.bindAsEventListener(this, this._submitUpdateOrderUrl, this._itemsGrid)
-            );
+            // Event.stopObserving(select, 'change') dropped Prototype observers only.
+            // Remove just the handlers this controller added and keep the node, so
+            // listeners other scripts attached survive.
+            const self = this;
+            if (this._shippingChangeHandlers) {
+                this._shippingChangeHandlers.forEach(function(handler) {
+                    shipSelect.removeEventListener('change', handler);
+                });
+            }
+            this._shippingChangeHandlers = [
+                this._onElementChange.bind(this),
+                function(e) {
+                    self._submitUpdateOrder(self._submitUpdateOrderUrl, self._itemsGrid, e);
+                }
+            ];
+            this._shippingChangeHandlers.forEach(function(handler) {
+                shipSelect.addEventListener('change', handler);
+            });
 
-            $(this.shippingSelect + '_update').hide();
-            $(this.shippingSelect).show();
+            const updateEl = document.getElementById(this._getShippingSelectId() + '_update');
+            if (updateEl) updateEl.style.display = 'none';
+            shipSelect.style.display = '';
         }
         this._updateShippingMethods = false;
         if (this._pleaseWait) {
-            this._pleaseWait.hide();
+            this._pleaseWait.style.display = 'none';
         }
     },
 
-    /**
-     * Validate Order form
-     */
     _validateForm : function()
     {
         if (!this.form) {
@@ -307,92 +406,79 @@ OrderReviewController.prototype = {
         return this.formValidator.validate();
     },
 
-    /**
-     * Actions on change Shipping Address data
-     * @param event
-     */
     _onShippingChange : function(event){
-        var element = Event.element(event);
-        if (element != $(this.shippingSelect) && !($(this.shippingSelect) && $(this.shippingSelect).disabled)) {
-            if ($(this.shippingSelect)) {
-                $(this.shippingSelect).disable();
-                $(this.shippingSelect).hide();
-                if ($('advice-required-entry-' + this.shippingSelect)) {
-                    $('advice-required-entry-' + this.shippingSelect).hide();
+        const element = event.target;
+        const shipSelect = this._getShippingSelect();
+        if (element != shipSelect && !(shipSelect && shipSelect.disabled)) {
+            if (shipSelect) {
+                shipSelect.disabled = true;
+                shipSelect.style.display = 'none';
+                const adviceEl = document.getElementById('advice-required-entry-' + this._getShippingSelectId());
+                if (adviceEl) {
+                    adviceEl.style.display = 'none';
                 }
             }
-            if (this.shippingMethodsContainer && $(this.shippingMethodsContainer)) {
-                $(this.shippingMethodsContainer).hide();
+            if (this.shippingMethodsContainer) {
+                const containerEl = typeof this.shippingMethodsContainer === 'string'
+                    ? document.getElementById(this.shippingMethodsContainer)
+                    : this.shippingMethodsContainer;
+                if (containerEl) containerEl.style.display = 'none';
             }
 
-            if (this.shippingSelect && $(this.shippingSelect + '_update')) {
-                $(this.shippingSelect + '_update').show();
+            if (this.shippingSelect) {
+                const updateEl = document.getElementById(this._getShippingSelectId() + '_update');
+                if (updateEl) updateEl.style.display = '';
             }
             this._updateShippingMethods = true;
         }
     },
 
-    /**
-     * Bind onChange event listener to elements for update Submit Order button state
-     * @param input
-     */
     _bindElementChange : function(input){
-        Event.observe(input, 'change', this._onElementChange.bindAsEventListener(this));
+        input.addEventListener('change', this._onElementChange.bind(this));
     },
 
-    /**
-     * Disable Submit Order button
-     */
     _onElementChange : function(){
         this._updateOrderSubmit(true);
     },
 
-    /**
-     * Clear validation result for all form elements or for elements with id prefix
-     * @param idprefix
-     */
     _clearValidation : function(idprefix)
     {
-        var prefix = '';
+        let prefix = '';
         if (idprefix) {
             prefix = '[id*="' + idprefix + ':"]';
-            $$(prefix).each(function(el){
-                el.up().removeClassName('validation-failed')
-                    .removeClassName('validation-passed')
-                    .removeClassName('validation-error');
+            document.querySelectorAll(prefix).forEach(function(el){
+                // el.up() with no selector is the direct parent
+                const up = el.parentElement;
+                if (up) {
+                    up.classList.remove('validation-failed', 'validation-passed', 'validation-error');
+                }
             });
         } else {
             this.formValidator.reset();
         }
-        $$('.validation-advice' + prefix).invoke('remove');
-        $$('.validation-failed' + prefix).invoke('removeClassName', 'validation-failed');
-        $$('.validation-passed' + prefix).invoke('removeClassName', 'validation-passed');
-        $$('.validation-error' + prefix).invoke('removeClassName', 'validation-error');
+        document.querySelectorAll('.validation-advice' + prefix).forEach(function(el){ el.remove(); });
+        document.querySelectorAll('.validation-failed' + prefix).forEach(function(el){ el.classList.remove('validation-failed'); });
+        document.querySelectorAll('.validation-passed' + prefix).forEach(function(el){ el.classList.remove('validation-passed'); });
+        document.querySelectorAll('.validation-error' + prefix).forEach(function(el){ el.classList.remove('validation-error'); });
     },
 
-    /**
-     * Attempt to submit order
-     */
     _submitOrder : function()
     {
         if (this._canSubmitOrder && (this.reloadByShippingSelect || this._validateForm())) {
             this.form.submit();
             this._updateOrderSubmit(true);
             if (this._ubpdateOrderButton) {
-                this._ubpdateOrderButton.addClassName('no-checkout');
-                this._ubpdateOrderButton.setStyle({opacity:.5});
+                this._ubpdateOrderButton.classList.add('no-checkout');
+                this._ubpdateOrderButton.style.opacity = .5;
             }
             if (this._pleaseWait) {
-                this._pleaseWait.show();
+                this._pleaseWait.style.display = '';
             }
             return;
         }
         this._updateOrderSubmit(true);
     },
 
-    /**
-     * Explicitly enable order submission
-     */
     _onSubmitShippingSuccess : function()
     {
         this._updateOrderSubmit(false);
@@ -401,14 +487,9 @@ OrderReviewController.prototype = {
         }
     },
 
-    /**
-     * Check/Set whether order can be submitted
-     * Also disables form submission element, if any
-     * @param shouldDisable - whether should prevent order submission explicitly
-     */
     _updateOrderSubmit : function(shouldDisable)
     {
-        var isDisabled = shouldDisable || (
+        const isDisabled = shouldDisable || (
             this.reloadByShippingSelect && (!this.shippingSelect || '' == this.shippingSelect.value)
         );
         this._canSubmitOrder = !isDisabled;
@@ -417,20 +498,15 @@ OrderReviewController.prototype = {
         }
     },
 
-    /**
-     * Enable/Disable button
-     *
-     * @param button
-     * @param disable
-     */
     _toggleButton : function(button, disable)
     {
         button.disabled = disable;
-        button.removeClassName('no-checkout');
-        button.setStyle({opacity:1});
+        button.classList.remove('no-checkout');
+        button.style.opacity = 1;
         if (disable) {
-            button.addClassName('no-checkout');
-            button.setStyle({opacity:.5});
+            button.classList.add('no-checkout');
+            button.style.opacity = .5;
         }
     }
 };
+Varien.classCompat(OrderReviewController);

--- a/skin/frontend/base/default/js/giftmessage.js
+++ b/skin/frontend/base/default/js/giftmessage.js
@@ -1,38 +1,55 @@
 /**
- * @copyright  For copyright and license information, read the COPYING.txt file.
- * @link       /COPYING.txt
+ * @copyright  For copyright and license information, read the README.md file.
+ * @link       /README.md
  * @license    Academic Free License (AFL 3.0)
  * @package     base_default
  */
-var GiftMessage = Class.create();
+
+function GiftMessage() { this.initialize(...arguments); }
 
 GiftMessage.prototype = {
-    uniqueId: 0,
-    initialize: function (buttonId) {
+    initialize: function(buttonId) {
         GiftMessageStack.addObject(this);
         this.buttonId = buttonId;
         this.initListeners();
     },
+    uniqueId: 0,
     editGiftMessage: function (evt) {
-        var popUpUrl = this.url + '?uniqueId=' + this.uniqueId;
+        const popUpUrl = this.url + '?uniqueId=' + this.uniqueId;
         this.popUp = window.open(popUpUrl, 'giftMessage', 'width=350,height=400,resizable=yes,scrollbars=yes');
         this.popUp.focus();
-        Event.stop(evt);
+        evt.preventDefault();
+        evt.stopPropagation();
     },
     initListeners: function () {
-        var items = $(this.buttonId).getElementsByClassName('listen-for-click');
-        items.each(function(item) {
-           Event.observe(item, 'click', this.editGiftMessage.bindAsEventListener(this));
-           item.controller = this;
-        }.bind(this));
+        const items = document.getElementById(this.buttonId).querySelectorAll('.listen-for-click');
+        const self = this;
+        items.forEach(function(item) {
+           item.addEventListener('click', self.editGiftMessage.bind(self));
+           item.controller = self;
+        });
     },
     reloadContainer: function (url) {
-        new Ajax.Updater(this.buttonId, url, {onComplete:this.initListeners.bind(this)});
+        const self = this;
+        // Ajax.Updater defaulted to POST with the XHR header and ran onComplete on any outcome
+        fetch(url, {
+            method: 'POST',
+            headers: { 'X-Requested-With': 'XMLHttpRequest' }
+        }).then(function(resp) { return resp.text(); }).then(function(html) {
+            const container = document.getElementById(self.buttonId);
+            if (container) {
+                container.innerHTML = html;
+            }
+            self.initListeners();
+        }).catch(function() {
+            self.initListeners();
+        });
     },
     initWindow: function (windowObject) {
         this.windowObj = windowObject;
     }
 };
+Varien.classCompat(GiftMessage);
 
 var GiftMessageStack = {
     _stack: [],
@@ -46,8 +63,8 @@ var GiftMessageStack = {
         return 'objectStack' + (this._nextUniqueId++);
     },
     getObjectById: function(id) {
-        var giftMessageObject = false;
-        this._stack.each(function(item){
+        let giftMessageObject = false;
+        this._stack.forEach(function(item){
            if(item.uniqueId == id) {
                giftMessageObject = item;
            }
@@ -56,7 +73,8 @@ var GiftMessageStack = {
     }
 };
 
-var GiftMessageWindow = Class.create();
+function GiftMessageWindow() { this.initialize(...arguments); }
+
 GiftMessageWindow.prototype = {
     initialize: function(uniqueId, formId, removeUrl) {
         this.uniqueId = uniqueId;
@@ -67,23 +85,25 @@ GiftMessageWindow.prototype = {
         }
         if(formId) {
             this.form = new VarienForm(formId, true);
-            this.formElement = $(formId);
+            this.formElement = document.getElementById(formId);
             this.initListeners();
         }
     },
     initListeners: function() {
-        removeButtons = this.formElement.getElementsByClassName('listen-remove');
-        removeButtons.each(function(item){
-            Event.observe(item, 'click', this.remove.bindAsEventListener(this));
-        }.bind(this));
+        const self = this;
+        const removeButtons = this.formElement.querySelectorAll('.listen-remove');
+        removeButtons.forEach(function(item){
+            item.addEventListener('click', self.remove.bind(self));
+        });
 
-        cancelButtons = this.formElement.getElementsByClassName('listen-cancel');
-        cancelButtons.each(function(item){
-            Event.observe(item, 'click', this.cancel.bindAsEventListener(this));
-        }.bind(this));
+        const cancelButtons = this.formElement.querySelectorAll('.listen-cancel');
+        cancelButtons.forEach(function(item){
+            item.addEventListener('click', self.cancel.bind(self));
+        });
     },
     cancel: function(evt)  {
-        Event.stop(evt);
+        evt.preventDefault();
+        evt.stopPropagation();
         window.opener.focus();
         window.close();
     },
@@ -92,7 +112,8 @@ GiftMessageWindow.prototype = {
         window.close();
     },
     remove: function(evt)  {
-        Event.stop(evt);
+        evt.preventDefault();
+        evt.stopPropagation();
         if(this.confirmMessage && !window.confirm(this.confirmMessage)) {
             return;
         }
@@ -109,3 +130,4 @@ GiftMessageWindow.prototype = {
         }, 3000);
     }
 };
+Varien.classCompat(GiftMessageWindow);

--- a/skin/frontend/base/default/js/msrp.js
+++ b/skin/frontend/base/default/js/msrp.js
@@ -16,18 +16,18 @@ Catalog.Map = {
 
     addHelpLink: function(linkElement, title, actualPrice, msrpPrice, addToCartLink) {
         if (typeof linkElement == 'string') {
-            linkElement = $$(linkElement)[0];
+            linkElement = document.querySelectorAll(linkElement)[0];
         }
 
         if (!linkElement) {
             return;
         }
 
-        var helpLink = {
+        const helpLink = {
             'link': linkElement
         };
 
-        var showPopup = false;
+        let showPopup = false;
 
         if (typeof title == 'string' && title) {
             helpLink.title = title;
@@ -59,57 +59,73 @@ Catalog.Map = {
         if (!showPopup) {
             this.setGotoView(linkElement, addToCartLink);
         } else {
-            var helpLinkIndex = this.helpLinks.push(helpLink) - 1;
-            Event.observe(linkElement, 'click', this.showHelp.bind(this.helpLinks[helpLinkIndex]));
+            const helpLinkIndex = this.helpLinks.push(helpLink) - 1;
+            linkElement.addEventListener('click', this.showHelp.bind(this.helpLinks[helpLinkIndex]));
         }
         return helpLink;
     },
 
+    /**
+     * Replace the click handler this module installed on an element.
+     * Mirrors stopObserving('click') without cloning the node, so callers
+     * keep a live reference and unrelated listeners survive.
+     */
+    _setClickHandler: function(element, handler) {
+        if (element._mapClickHandler) {
+            element.removeEventListener('click', element._mapClickHandler);
+        }
+        element._mapClickHandler = handler;
+        element.addEventListener('click', handler);
+        return element;
+    },
+
     setGotoView: function(element, viewPageUrl) {
-        $(element).stopObserving('click');
         element.href = viewPageUrl;
         if(window.opener) {
-            Event.observe(element, 'click', function(event) {
+            this._setClickHandler(element, function(event) {
                 setPLocation(this.href,true);
                 Catalog.Map.hideHelp();
-                event.stop();
+                event.preventDefault();
+                event.stopPropagation();
             });
         } else {
-            Event.observe(element, 'click', function(event) {
+            this._setClickHandler(element, function(event) {
                 setLocation(this.href);
                 Catalog.Map.hideHelp();
-                event.stop();
+                event.preventDefault();
+                event.stopPropagation();
             });
         }
+        return element;
     },
 
     showSelects: function() {
-        var elements = document.getElementsByTagName("select");
-        for (i=0;i< elements.length;i++) {
+        const elements = document.getElementsByTagName("select");
+        for (let i = 0; i < elements.length; i++) {
             elements[i].style.visibility='visible';
         }
     },
 
     hideSelects: function() {
-        var elements = document.getElementsByTagName("select");
-        for (i=0;i< elements.length;i++) {
+        const elements = document.getElementsByTagName("select");
+        for (let i = 0; i < elements.length; i++) {
             elements[i].style.visibility='hidden';
         }
     },
 
     showHelp: function(event) {
-        var helpBox = $('map-popup');
+        const helpBox = document.getElementById('map-popup');
         if (!helpBox) {
             return;
         }
 
         //Move help box to be right in body tag
-        var bodyNode = $$('body')[0];
+        const bodyNode = document.querySelector('body');
         if (helpBox.parentNode != bodyNode) {
             helpBox.remove();
-            bodyNode.insert(helpBox);
+            bodyNode.insertAdjacentElement('beforeend', helpBox);
             // Fix for FF4-FF5 bug with missing alt text after DOM manipulations
-            var paypalImg = helpBox.select('.paypal-logo > a > img')[0];
+            const paypalImg = helpBox.querySelectorAll('.paypal-logo > a > img')[0];
             if (paypalImg) paypalImg.src = paypalImg.src;
         }
 
@@ -119,110 +135,109 @@ Catalog.Map = {
                 helpBox.offsetPosition = {left:0, top: 0};
             }
 
-            helpBox.removeClassName('map-popup-right');
-            helpBox.removeClassName('map-popup-left');
-            if (Element.getWidth(bodyNode) < event.pageX + Element.getWidth(helpBox)) {
-                helpBox.addClassName('map-popup-left');
-            } else if (event.pageX - Element.getWidth(helpBox) < 0) {
-                helpBox.addClassName('map-popup-right');
+            helpBox.classList.remove('map-popup-right');
+            helpBox.classList.remove('map-popup-left');
+            if (bodyNode.offsetWidth < event.pageX + helpBox.offsetWidth) {
+                helpBox.classList.add('map-popup-left');
+            } else if (event.pageX - helpBox.offsetWidth < 0) {
+                helpBox.classList.add('map-popup-right');
             }
 
-            helpBox.style.left = event.pageX - (Element.getWidth(helpBox) / 2) + 'px';
+            helpBox.style.left = event.pageX - (helpBox.offsetWidth / 2) + 'px';
             helpBox.style.top = event.pageY + 10 + 'px';
 
             //Title
-            var mapTitle = $('map-popup-heading');
+            const mapTitle = document.getElementById('map-popup-heading');
             if (typeof this.title != 'undefined') {
-                Element.update(mapTitle, this.title);
-                $(mapTitle).show();
+                mapTitle.innerHTML = this.title;
+                mapTitle.style.display = '';
             } else {
-                $(mapTitle).hide();
+                mapTitle.style.display = 'none';
             }
 
             //MSRP price
-            var mapMsrp = $('map-popup-msrp-box');
+            const mapMsrp = document.getElementById('map-popup-msrp-box');
             if (typeof this.msrp != 'undefined') {
-                Element.update($('map-popup-msrp'), this.msrp);
-                $(mapMsrp).show();
+                document.getElementById('map-popup-msrp').innerHTML = this.msrp;
+                mapMsrp.style.display = '';
             } else {
-                $(mapMsrp).hide();
+                mapMsrp.style.display = 'none';
             }
 
             //Actual price
-            var mapPrice = $('map-popup-price-box');
+            const mapPrice = document.getElementById('map-popup-price-box');
             if (typeof this.price != 'undefined') {
-                var price = typeof this.price == 'object' ? this.price.innerHTML : this.price;
-                Element.update($('map-popup-price'), price);
-                $(mapPrice).show();
+                const price = typeof this.price == 'object' ? this.price.innerHTML : this.price;
+                document.getElementById('map-popup-price').innerHTML = price;
+                mapPrice.style.display = '';
             } else {
-                $(mapPrice).hide();
+                mapPrice.style.display = 'none';
             }
 
             //`Add to cart` button
-            var cartButton = $('map-popup-button');
+            const cartButton = document.getElementById('map-popup-button');
             if (typeof this.cartLink != 'undefined') {
                 if (typeof productAddToCartForm == 'undefined' || this.notUseForm) {
                     Catalog.Map.setGotoView(cartButton, this.cartLink);
-                    productAddToCartForm = $('product_addtocart_form_from_popup');
+                    window.productAddToCartForm = document.getElementById('product_addtocart_form_from_popup');
                 } else {
                     if (this.qty) {
                         productAddToCartForm.qty = this.qty;
                     }
-                    cartButton.stopObserving('click');
                     cartButton.href = this.cartLink;
-                    Event.observe(cartButton, 'click', function () {
+                    Catalog.Map._setClickHandler(cartButton, function () {
                         productAddToCartForm.action = this.href;
                         productAddToCartForm.submit(this);
                     });
                 }
                 productAddToCartForm.action = this.cartLink;
-                var productField = $('map-popup-product-id');
+                const productField = document.getElementById('map-popup-product-id');
                 productField.value = this.product_id;
-                $(cartButton).show();
-                $$('.additional-addtocart-box').invoke('show');
+                cartButton.style.display = '';
+                document.querySelectorAll('.additional-addtocart-box').forEach(function(el) { el.style.display = ''; });
             } else {
-                $(cartButton).hide();
-                $$('.additional-addtocart-box').invoke('hide');
+                cartButton.style.display = 'none';
+                document.querySelectorAll('.additional-addtocart-box').forEach(function(el) { el.style.display = 'none'; });
             }
 
             //Horizontal line
-            var mapText = $('map-popup-text'),
-                mapTextWhatThis = $('map-popup-text-what-this'),
-                mapContent = $('map-popup-content');
-            if (!mapMsrp.visible() && !mapPrice.visible() && !cartButton.visible()) {
+            const mapText = document.getElementById('map-popup-text'), mapTextWhatThis = document.getElementById('map-popup-text-what-this'), mapContent = document.getElementById('map-popup-content');
+            if (mapMsrp.style.display === 'none' && mapPrice.style.display === 'none' && cartButton.style.display === 'none') {
                 //If just `What's this?` link
-                $(mapText).hide();
-                $(mapTextWhatThis).show();
-                $(mapTextWhatThis).removeClassName('map-popup-only-text');
-                $(mapContent).hide().setStyle({visibility: 'hidden'});
-                $('product_addtocart_form_from_popup').hide();
+                mapText.style.display = 'none';
+                mapTextWhatThis.style.display = '';
+                mapTextWhatThis.classList.remove('map-popup-only-text');
+                mapContent.style.display = 'none';
+                mapContent.style.visibility = 'hidden';
+                document.getElementById('product_addtocart_form_from_popup').style.display = 'none';
             } else {
-                $(mapTextWhatThis).hide();
-                $(mapText).show();
-                $(mapText).addClassName('map-popup-only-text');
-                $(mapContent).show().setStyle({visibility: 'visible'});
-                $('product_addtocart_form_from_popup').show();
+                mapTextWhatThis.style.display = 'none';
+                mapText.style.display = '';
+                mapText.classList.add('map-popup-only-text');
+                mapContent.style.display = '';
+                mapContent.style.visibility = 'visible';
+                document.getElementById('product_addtocart_form_from_popup').style.display = '';
             }
 
-            $(helpBox).show();
-            var closeButton = $('map-popup-close');
+            helpBox.style.display = '';
+            const closeButton = document.getElementById('map-popup-close');
             if (closeButton) {
-                $(closeButton).stopObserving('click');
-                Event.observe(closeButton, 'click', Catalog.Map.showHelp.bind(this));
+                Catalog.Map._setClickHandler(closeButton, Catalog.Map.showHelp.bind(this));
                 Catalog.Map.active = this.link;
             }
         } else {
-            $(helpBox).hide();
+            helpBox.style.display = 'none';
             Catalog.Map.active = false;
         }
 
-        Event.stop(event);
+        event.preventDefault();
+        event.stopPropagation();
     },
 
     hideHelp: function(){
-        var helpBox = $('map-popup');
+        const helpBox = document.getElementById('map-popup');
         if (helpBox) {
-            $(helpBox).hide();
+            helpBox.style.display = 'none';
             Catalog.Map.active = false;
         }
     },
@@ -230,12 +245,12 @@ Catalog.Map = {
     bindProductForm: function(){
         if (('undefined' != typeof productAddToCartForm) && productAddToCartForm) {
             productAddToCartFormOld = productAddToCartForm;
-            productAddToCartForm = new VarienForm('product_addtocart_form_from_popup');
+            window.productAddToCartForm = new VarienForm('product_addtocart_form_from_popup');
             productAddToCartForm.submitLight = productAddToCartFormOld.submitLight;
-        } else if(!$('product_addtocart_form_from_popup')) {
+        } else if(!document.getElementById('product_addtocart_form_from_popup')) {
             return false;
         } else if ('undefined' == typeof productAddToCartForm) {
-            productAddToCartForm = new VarienForm('product_addtocart_form_from_popup');
+            window.productAddToCartForm = new VarienForm('product_addtocart_form_from_popup');
         }
 
         productAddToCartForm.submit = function(button, url) {
@@ -243,29 +258,33 @@ Catalog.Map = {
                 if (Catalog.Map.active) {
                     Catalog.Map.hideHelp();
                 }
-                if (productAddToCartForm.qty && $('qty')) {
-                    $('qty').value = productAddToCartForm.qty;
+                if (productAddToCartForm.qty && document.getElementById('qty')) {
+                    document.getElementById('qty').value = productAddToCartForm.qty;
                 }
-                parentResult = productAddToCartFormOld.submit();
+                productAddToCartFormOld.submit();
                 return false;
             }
             if(window.opener) {
-                var parentButton = button;
-                new Ajax.Request(this.form.action, {
-                    parameters: {isAjax: 1, method: 'GET'},
-                    onSuccess: function () {
-                        window.opener.focus();
-                        if (parentButton && parentButton.href) {
-                            setPLocation(parentButton.href, true);
-                            Catalog.Map.hideHelp();
-                        }
+                const parentButton = button;
+                fetch(this.form.action, {
+                    method: 'POST',
+                    body: new URLSearchParams({isAjax: 1, method: 'GET'}),
+                    headers: { 'X-Requested-With': 'XMLHttpRequest' }
+                }).then(function(response) {
+                    if (!response.ok) {
+                        return;
+                    }
+                    window.opener.focus();
+                    if (parentButton && parentButton.href) {
+                        setPLocation(parentButton.href, true);
+                        Catalog.Map.hideHelp();
                     }
                 });
                 return;
             }
             if (this.validator.validate()) {
-                var form = this.form;
-                var oldUrl = form.action;
+                const form = this.form;
+                const oldUrl = form.action;
 
                 if (url) {
                    form.action = url;
@@ -289,22 +308,22 @@ Catalog.Map = {
     }
 };
 
-Event.observe(window, 'resize', function(event) {
+window.addEventListener('resize', function(event) {
     if (Catalog.Map.active) {
         Catalog.Map.showHelp(event);
     }
 });
 
-$(document).observe('bundle:reload-price', function (event) { //reload price
-    var data = event.memo, bundle = data.bundle;
+document.addEventListener('bundle:reload-price', function (event) { //reload price
+    const data = event.detail, bundle = data.bundle;
     if (!Number(bundle.config.isMAPAppliedDirectly) && !Number(bundle.config.isFixedPrice)) {
-        var canApplyMAP = false;
+        let canApplyMAP = false;
         try {
-            for (var option in bundle.config.selected) {
+            for (const option in bundle.config.selected) {
                 if (bundle.config.options[option] && bundle.config.options[option].selections) {
-                    var selections = bundle.config.options[option].selections;
-                    for (var i = 0, l = bundle.config.selected[option].length; i < l; i++) {
-                        var selectionId = bundle.config.selected[option][i];
+                    const selections = bundle.config.options[option].selections;
+                    for (let i = 0, l = bundle.config.selected[option].length; i < l; i++) {
+                        const selectionId = bundle.config.selected[option][i];
                         if (Number(selections[selectionId].canApplyMAP)) {
                             canApplyMAP = true;
                             break;
@@ -319,19 +338,19 @@ $(document).observe('bundle:reload-price', function (event) { //reload price
             canApplyMAP = true;
         }
         if (canApplyMAP) {
-            $$('.full-product-price').each(function(e){
-                $(e).hide();
+            document.querySelectorAll('.full-product-price').forEach(function(e){
+                e.style.display = 'none';
             });
-            $$('.map-info').each(function(e){
-                $(e).show();
+            document.querySelectorAll('.map-info').forEach(function(e){
+                e.style.display = '';
             });
-            event.noReloadPrice = true;
+            event.detail.noReloadPrice = true;
         } else {
-            $$('.full-product-price').each(function(e){
-                $(e).show();
+            document.querySelectorAll('.full-product-price').forEach(function(e){
+                e.style.display = '';
             });
-            $$('.map-info').each(function(e){
-                $(e).hide();
+            document.querySelectorAll('.map-info').forEach(function(e){
+                e.style.display = 'none';
             });
         }
     }

--- a/skin/frontend/base/default/js/opcheckout.js
+++ b/skin/frontend/base/default/js/opcheckout.js
@@ -4,9 +4,161 @@
  * @license    Academic Free License (AFL 3.0)
  * @package     base_default
  */
-var Checkout = Class.create();
+
+/**
+ * Helper: fetch wrapper mimicking Ajax.Request / Ajax.Updater callback style.
+ * Callbacks receive a transport-like object with responseText and responseJSON.
+ */
+var _opcAjax = function(url, opts) {
+    const method = (opts.method || 'get').toUpperCase();
+    // Ajax.Request always sent X-Requested-With; the controllers read isAjax()
+    const fetchOpts = { method: method, headers: { 'X-Requested-With': 'XMLHttpRequest' } };
+
+    if (opts.parameters && method === 'POST') {
+        if (typeof opts.parameters === 'string') {
+            fetchOpts.body = opts.parameters;
+            fetchOpts.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+        } else if (opts.parameters instanceof FormData) {
+            fetchOpts.body = opts.parameters;
+        } else {
+            fetchOpts.body = new URLSearchParams(opts.parameters).toString();
+            fetchOpts.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+        }
+    } else if (opts.parameters && method === 'GET') {
+        const sep = url.indexOf('?') === -1 ? '?' : '&';
+        if (typeof opts.parameters === 'string') {
+            url += sep + opts.parameters;
+        } else {
+            url += sep + new URLSearchParams(opts.parameters).toString();
+        }
+    }
+
+    fetch(url, fetchOpts).then(function(resp) {
+        return resp.text().then(function(text) {
+            const transport = { responseText: text, responseJSON: null, status: resp.status };
+            try { transport.responseJSON = JSON.parse(text); } catch(e) {}
+            return { ok: resp.ok, transport: transport };
+        });
+    }).then(function(result) {
+        // Callbacks run outside the fetch chain. Ajax.Request caught an exception
+        // in onSuccess and still ran onComplete; it never treated it as a failed
+        // request, so a callback bug must not trigger ajaxFailure's redirect.
+        try {
+            if (!result.ok) {
+                if (opts.onFailure) opts.onFailure(result.transport);
+            } else {
+                if (opts.onSuccess) opts.onSuccess(result.transport);
+            }
+        } catch (e) {
+            if (window.console) console.error(e);
+        }
+        if (opts.onComplete) opts.onComplete(result.transport);
+    }, function() {
+        const transport = { responseText: '', responseJSON: null, status: 0 };
+        if (opts.onFailure) opts.onFailure(transport);
+        if (opts.onComplete) opts.onComplete(transport);
+    });
+};
+
+/**
+ * Helper: fetch HTML and put it into a container element (replaces Ajax.Updater).
+ */
+var _opcAjaxUpdate = function(containerId, url, opts) {
+    const wrappedSuccess = opts.onSuccess;
+    const wrappedComplete = opts.onComplete;
+
+    _opcAjax(url, Object.assign({}, opts, {
+        onSuccess: function(transport) {
+            const el = document.getElementById(containerId);
+            if (el) {
+                el.innerHTML = transport.responseText;
+                // Ajax.Updater defaulted to evalScripts: false
+                if (opts.evalScripts) {
+                    Varien.evalScripts(el);
+                }
+            }
+            if (wrappedSuccess) wrappedSuccess(transport);
+        },
+        onComplete: function(transport) {
+            if (wrappedComplete) wrappedComplete(transport);
+        }
+    }));
+};
+
+/**
+ * Helper: parse JSON from a transport-like object.
+ */
+var _opcParseResponse = function(transport) {
+    if (transport.responseJSON) return transport.responseJSON;
+    if (transport.responseText) {
+        try { return JSON.parse(transport.responseText); } catch(e) {}
+    }
+    return {};
+};
+
+/**
+ * Helper: get all form elements (replaces Form.getElements).
+ */
+var _opcFormElements = function(formId) {
+    const form = typeof formId === 'string' ? document.getElementById(formId) : formId;
+    if (!form) return [];
+    return Array.from(form.elements);
+};
+
+/**
+ * Helper: serialize a form (replaces Form.serialize).
+ */
+var _opcSerializeForm = function(formId) {
+    const form = typeof formId === 'string' ? document.getElementById(formId) : formId;
+    if (!form) return '';
+    return new URLSearchParams(new FormData(form)).toString();
+};
+
+/**
+ * Helper: strip HTML tags from a string.
+ */
+var _opcStripTags = function(str) {
+    if (typeof str !== 'string') return String(str || '');
+    const tpl = document.createElement('template');
+    tpl.innerHTML = str;
+    return tpl.content.textContent || '';
+};
+
+/**
+ * Helper: iterate over object entries (replaces Hash.each).
+ */
+var _opcEachEntry = function(obj, fn) {
+    const keys = Object.keys(obj);
+    for (let i = 0; i < keys.length; i++) {
+        fn({ key: keys[i], value: obj[keys[i]] });
+    }
+};
+
+/**
+ * Helper: dispatch a custom event on an element.
+ */
+var _opcFireEvent = function(el, eventName, data) {
+    if (!el) return;
+    const evt = new CustomEvent(eventName, { detail: data, bubbles: true });
+    // Prototype-era observers read event.memo — keep both properties populated
+    evt.memo = data || {};
+    el.dispatchEvent(evt);
+    // Prototype registers custom-event observers on dataavailable, which a native
+    // CustomEvent never reaches. Fire through Prototype too while it loads.
+    if (window.Event && typeof Event.fire === 'function') {
+        Event.fire(el, eventName, data || {});
+    }
+};
+
+// =====================================================================
+// Checkout
+// =====================================================================
+
+var Checkout = function(accordion, urls) {
+    this.initialize(accordion, urls);
+};
 Checkout.prototype = {
-    initialize: function(accordion, urls){
+    initialize: function(accordion, urls) {
         this.accordion = accordion;
         this.progressUrl = urls.progress;
         this.reviewUrl = urls.review;
@@ -22,9 +174,16 @@ Checkout.prototype = {
         //We use billing as beginning step since progress bar tracks from billing
         this.currentStep = 'billing';
 
-        this.accordion.sections.each(function(section) {
-            Event.observe($(section).down('.step-title'), 'click', this._onSectionClick.bindAsEventListener(this));
-        }.bind(this));
+        const self = this;
+        this.accordion.sections.forEach(function(section) {
+            const sectionEl = typeof section === 'string' ? document.getElementById(section) : section;
+            if (sectionEl) {
+                const title = sectionEl.querySelector('.step-title');
+                if (title) {
+                    title.addEventListener('click', self._onSectionClick.bind(self));
+                }
+            }
+        });
 
         this.accordion.disallowAccessToNextSections = true;
     },
@@ -35,15 +194,16 @@ Checkout.prototype = {
      * @param event
      */
     _onSectionClick: function(event) {
-        var section = $(Event.element(event).up('.section'));
-        if (section.hasClassName('allow')) {
-            Event.stop(event);
-            this.gotoSection(section.readAttribute('id').replace('opc-', ''), false);
+        const section = event.target.closest('.section');
+        if (section && section.classList.contains('allow')) {
+            event.preventDefault();
+            event.stopPropagation();
+            this.gotoSection(section.getAttribute('id').replace('opc-', ''), false);
             return false;
         }
     },
 
-    ajaxFailure: function(){
+    ajaxFailure: function() {
         location.href = encodeURI(this.failureUrl);
     },
 
@@ -56,197 +216,187 @@ Checkout.prototype = {
     },
 
     reloadStep: function(prevStep) {
-        var updater = new Ajax.Updater(prevStep + '-progress-opcheckout', this.progressUrl, {
-            method:'get',
-            onFailure:this.ajaxFailure.bind(this),
-            onComplete: function(){
-                this.checkout.resetPreviousSteps();
+        const self = this;
+        _opcAjaxUpdate(prevStep + '-progress-opcheckout', this.progressUrl, {
+            method: 'get',
+            onFailure: this.ajaxFailure.bind(this),
+            onComplete: function() {
+                self.resetPreviousSteps();
             },
-            parameters:prevStep ? { prevStep:prevStep } : null
+            parameters: prevStep ? { prevStep: prevStep } : null
         });
     },
 
-    reloadReviewBlock: function(){
-        new Ajax.Updater('checkout-review-load', this.reviewUrl, {method: 'get', onFailure: this.ajaxFailure.bind(this)});
+    reloadReviewBlock: function() {
+        _opcAjaxUpdate('checkout-review-load', this.reviewUrl, { method: 'get', onFailure: this.ajaxFailure.bind(this) });
     },
 
     _disableEnableAll: function(element, isDisabled) {
-        var descendants = element.descendants();
-        descendants.each(function(descendant) {
+        const descendants = Array.from(element.querySelectorAll('*'));
+        descendants.forEach(function(descendant) {
             descendant.disabled = isDisabled;
         });
         element.disabled = isDisabled;
     },
 
     setLoadWaiting: function(step, keepDisabled) {
-        var container;
+        let container;
         if (step) {
             if (this.loadWaiting) {
                 this.setLoadWaiting(false);
             }
-            container = $(step+'-buttons-container');
-            container.addClassName('disabled');
-            container.setStyle({opacity:.5});
+            container = document.getElementById(step + '-buttons-container');
+            container.classList.add('disabled');
+            container.style.opacity = 0.5;
             this._disableEnableAll(container, true);
-            Element.show(step+'-please-wait');
+            const pleaseWait = document.getElementById(step + '-please-wait');
+            if (pleaseWait) pleaseWait.style.display = '';
         } else {
             if (this.loadWaiting) {
-                container = $(this.loadWaiting+'-buttons-container');
-                var isDisabled = (keepDisabled ? true : false);
+                container = document.getElementById(this.loadWaiting + '-buttons-container');
+                const isDisabled = (keepDisabled ? true : false);
                 if (!isDisabled) {
-                    container.removeClassName('disabled');
-                    container.setStyle({opacity:1});
+                    container.classList.remove('disabled');
+                    container.style.opacity = 1;
                 }
                 this._disableEnableAll(container, isDisabled);
-                Element.hide(this.loadWaiting+'-please-wait');
+                const pleaseWaitEl = document.getElementById(this.loadWaiting + '-please-wait');
+                if (pleaseWaitEl) pleaseWaitEl.style.display = 'none';
             }
         }
         this.loadWaiting = step;
     },
 
-    gotoSection: function (section, reloadProgressBlock) {
-
+    gotoSection: function(section, reloadProgressBlock) {
         if (reloadProgressBlock) {
             this.reloadProgressBlock(this.currentStep);
         }
         this.currentStep = section;
-        var sectionElement = $('opc-' + section);
-        sectionElement.addClassName('allow');
+        const sectionElement = document.getElementById('opc-' + section);
+        sectionElement.classList.add('allow');
         this.accordion.openSection('opc-' + section);
-        if(!reloadProgressBlock) {
+        if (!reloadProgressBlock) {
             this.resetPreviousSteps();
         }
     },
 
-    resetPreviousSteps: function () {
-        var stepIndex = this.steps.indexOf(this.currentStep);
+    resetPreviousSteps: function() {
+        const stepIndex = this.steps.indexOf(this.currentStep);
 
         //Clear other steps if already populated through javascript
-        for (var i = stepIndex; i < this.steps.length; i++) {
-            var nextStep = this.steps[i];
-            var progressDiv = nextStep + '-progress-opcheckout';
-            if ($(progressDiv)) {
+        for (let i = stepIndex; i < this.steps.length; i++) {
+            const nextStep = this.steps[i];
+            const progressDiv = document.getElementById(nextStep + '-progress-opcheckout');
+            if (progressDiv) {
                 //Remove the link
-                $(progressDiv).select('.changelink').invoke('remove');
-                $(progressDiv).select('dt').invoke('removeClassName','complete');
+                Array.from(progressDiv.querySelectorAll('.changelink')).forEach(function(el) { el.remove(); });
+                Array.from(progressDiv.querySelectorAll('dt')).forEach(function(el) { el.classList.remove('complete'); });
                 //Remove the content
-                $(progressDiv).select('dd.complete').invoke('remove');
+                Array.from(progressDiv.querySelectorAll('dd.complete')).forEach(function(el) { el.remove(); });
             }
         }
     },
 
-    changeSection: function (section) {
-        var changeStep = section.replace('opc-', '');
+    changeSection: function(section) {
+        const changeStep = section.replace('opc-', '');
         this.gotoSection(changeStep, false);
     },
 
-    setMethod: function(){
-        if ($('login:guest') && $('login:guest').checked) {
+    setMethod: function() {
+        const loginGuest = document.getElementById('login:guest');
+        const loginRegister = document.getElementById('login:register');
+        if (loginGuest && loginGuest.checked) {
             this.method = 'guest';
-            new Ajax.Request(
+            _opcAjax(
                 this.saveMethodUrl,
-                {method: 'post', onFailure: this.ajaxFailure.bind(this), parameters: {method:'guest'}}
+                { method: 'post', onFailure: this.ajaxFailure.bind(this), parameters: { method: 'guest' } }
             );
-            Element.hide('register-customer-password');
+            const regPassword = document.getElementById('register-customer-password');
+            if (regPassword) regPassword.style.display = 'none';
             this.gotoSection('billing', true);
         }
-        else if($('login:register') && ($('login:register').checked || $('login:register').type == 'hidden')) {
+        else if (loginRegister && (loginRegister.checked || loginRegister.type == 'hidden')) {
             this.method = 'register';
-            new Ajax.Request(
+            _opcAjax(
                 this.saveMethodUrl,
-                {method: 'post', onFailure: this.ajaxFailure.bind(this), parameters: {method:'register'}}
+                { method: 'post', onFailure: this.ajaxFailure.bind(this), parameters: { method: 'register' } }
             );
-            Element.show('register-customer-password');
+            const regPasswordEl = document.getElementById('register-customer-password');
+            if (regPasswordEl) regPasswordEl.style.display = '';
             this.gotoSection('billing', true);
         }
-        else{
-            alert(Translator.translate('Please choose to register or to checkout as a guest').stripTags());
+        else {
+            alert(_opcStripTags(Translator.translate('Please choose to register or to checkout as a guest')));
             return false;
         }
-        document.body.fire('login:setMethod', {method : this.method});
+        _opcFireEvent(document.body, 'login:setMethod', { method: this.method });
     },
 
     setBilling: function() {
-        if (($('billing:use_for_shipping_yes')) && ($('billing:use_for_shipping_yes').checked)) {
+        const useYes = document.getElementById('billing:use_for_shipping_yes');
+        const useNo = document.getElementById('billing:use_for_shipping_no');
+        const sameAsBilling = document.getElementById('shipping:same_as_billing');
+        if (useYes && useYes.checked) {
             shipping.syncWithBilling();
-            $('opc-shipping').addClassName('allow');
+            document.getElementById('opc-shipping').classList.add('allow');
             this.gotoSection('shipping_method', true);
-        } else if (($('billing:use_for_shipping_no')) && ($('billing:use_for_shipping_no').checked)) {
-            $('shipping:same_as_billing').checked = false;
+        } else if (useNo && useNo.checked) {
+            sameAsBilling.checked = false;
             this.gotoSection('shipping', true);
         } else {
-            $('shipping:same_as_billing').checked = true;
+            sameAsBilling.checked = true;
             this.gotoSection('shipping', true);
         }
-
-        // this refreshes the checkout progress column
-
-//        if ($('billing:use_for_shipping') && $('billing:use_for_shipping').checked){
-//            shipping.syncWithBilling();
-//            //this.setShipping();
-//            //shipping.save();
-//            $('opc-shipping').addClassName('allow');
-//            this.gotoSection('shipping_method');
-//        } else {
-//            $('shipping:same_as_billing').checked = false;
-//            this.gotoSection('shipping');
-//        }
-//        this.reloadProgressBlock();
-//        //this.accordion.openNextSection(true);
     },
 
     setShipping: function() {
-        //this.nextStep();
         this.gotoSection('shipping_method', true);
-        //this.accordion.openNextSection(true);
     },
 
     setShippingMethod: function() {
-        //this.nextStep();
         this.gotoSection('payment', true);
-        //this.accordion.openNextSection(true);
     },
 
     setPayment: function() {
-        //this.nextStep();
         this.gotoSection('review', true);
-        //this.accordion.openNextSection(true);
     },
 
     setReview: function() {
         this.reloadProgressBlock();
-        //this.nextStep();
-        //this.accordion.openNextSection(true);
     },
 
-    back: function(){
+    back: function() {
         if (this.loadWaiting) return;
         //Navigate back to the previous available step
-        var stepIndex = this.steps.indexOf(this.currentStep);
-        var section = this.steps[--stepIndex];
-        var sectionElement = $('opc-' + section);
+        let stepIndex = this.steps.indexOf(this.currentStep);
+        let section = this.steps[--stepIndex];
+        let sectionElement = document.getElementById('opc-' + section);
 
         //Traverse back to find the available section. Ex Virtual product does not have shipping section
         while (sectionElement === null && stepIndex > 0) {
             --stepIndex;
             section = this.steps[stepIndex];
-            sectionElement = $('opc-' + section);
+            sectionElement = document.getElementById('opc-' + section);
         }
         this.changeSection('opc-' + section);
     },
 
-    setStepResponse: function(response){
+    setStepResponse: function(response) {
         if (response.update_section) {
-            $('checkout-'+response.update_section.name+'-load').update(response.update_section.html);
+            const updateEl = document.getElementById('checkout-' + response.update_section.name + '-load');
+            if (updateEl) {
+                updateEl.innerHTML = response.update_section.html;
+                Varien.evalScripts(updateEl);
+            }
         }
         if (response.allow_sections) {
-            response.allow_sections.each(function(e){
-                $('opc-'+e).addClassName('allow');
+            response.allow_sections.forEach(function(e) {
+                const el = document.getElementById('opc-' + e);
+                if (el) el.classList.add('allow');
             });
         }
 
-        if(response.duplicateBillingInfo)
-        {
+        if (response.duplicateBillingInfo) {
             this.syncBillingShipping = true;
             shipping.setSameAsBilling(true);
         }
@@ -262,27 +412,34 @@ Checkout.prototype = {
         return false;
     }
 };
+Varien.classCompat(Checkout);
 
-// billing
-var Billing = Class.create();
+// =====================================================================
+// Billing
+// =====================================================================
+
+var Billing = function(form, addressUrl, saveUrl) {
+    this.initialize(form, addressUrl, saveUrl);
+};
 Billing.prototype = {
-    initialize: function(form, addressUrl, saveUrl){
+    initialize: function(form, addressUrl, saveUrl) {
         this.form = form;
-        if ($(this.form)) {
-            $(this.form).observe('submit', function(event){this.save();Event.stop(event);}.bind(this));
+        const formEl = document.getElementById(this.form);
+        if (formEl) {
+            formEl.addEventListener('submit', function(event) { this.save(); event.preventDefault(); event.stopPropagation(); }.bind(this));
         }
         this.addressUrl = addressUrl;
         this.saveUrl = saveUrl;
-        this.onAddressLoad = this.fillForm.bindAsEventListener(this);
-        this.onSave = this.nextStep.bindAsEventListener(this);
-        this.onComplete = this.resetLoadWaiting.bindAsEventListener(this);
+        this.onAddressLoad = this.fillForm.bind(this);
+        this.onSave = this.nextStep.bind(this);
+        this.onComplete = this.resetLoadWaiting.bind(this);
     },
 
-    setAddress: function(addressId){
+    setAddress: function(addressId) {
         if (addressId) {
-            new Ajax.Request(
-                this.addressUrl+addressId,
-                {method:'get', onSuccess: this.onAddressLoad, onFailure: checkout.ajaxFailure.bind(checkout)}
+            _opcAjax(
+                this.addressUrl + addressId,
+                { method: 'get', onSuccess: this.onAddressLoad, onFailure: checkout.ajaxFailure.bind(checkout) }
             );
         }
         else {
@@ -290,132 +447,136 @@ Billing.prototype = {
         }
     },
 
-    newAddress: function(isNew){
+    newAddress: function(isNew) {
+        const newForm = document.getElementById('billing-new-address-form');
         if (isNew) {
             this.resetSelectedAddress();
-            Element.show('billing-new-address-form');
+            if (newForm) newForm.style.display = '';
         } else {
-            Element.hide('billing-new-address-form');
+            if (newForm) newForm.style.display = 'none';
         }
     },
 
-    resetSelectedAddress: function(){
-        var selectElement = $('billing-address-select');
+    resetSelectedAddress: function() {
+        const selectElement = document.getElementById('billing-address-select');
         if (selectElement) {
-            selectElement.value='';
+            selectElement.value = '';
         }
     },
 
-    fillForm: function(transport){
-        var elementValues = transport.responseJSON || transport.responseText.evalJSON(true) || {};
-        if (!transport && !Object.keys(elementValues).length){
+    fillForm: function(transport) {
+        let elementValues = {};
+        if (transport) {
+            elementValues = _opcParseResponse(transport);
+        }
+        if (!transport && !Object.keys(elementValues).length) {
             this.resetSelectedAddress();
         }
-        var arrElements = Form.getElements(this.form);
-        for (var elemIndex in arrElements) {
-            if(arrElements.hasOwnProperty(elemIndex)) {
-                if (arrElements[elemIndex].id) {
-                    var fieldName = arrElements[elemIndex].id.replace(/^billing:/, '');
-                    arrElements[elemIndex].value = elementValues[fieldName] ? elementValues[fieldName] : '';
-                    if (fieldName == 'country_id' && billingForm){
-                        billingForm.elementChildLoad(arrElements[elemIndex]);
-                    }
+        const arrElements = _opcFormElements(this.form);
+        for (let i = 0; i < arrElements.length; i++) {
+            if (arrElements[i].id) {
+                const fieldName = arrElements[i].id.replace(/^billing:/, '');
+                arrElements[i].value = elementValues[fieldName] ? elementValues[fieldName] : '';
+                if (fieldName == 'country_id' && billingForm) {
+                    billingForm.elementChildLoad(arrElements[i]);
                 }
             }
         }
     },
 
     setUseForShipping: function(flag) {
-        $('shipping:same_as_billing').checked = flag;
+        document.getElementById('shipping:same_as_billing').checked = flag;
     },
 
-    save: function(){
-        if (checkout.loadWaiting!=false) return;
+    save: function() {
+        if (checkout.loadWaiting != false) return;
 
-        var validator = new Validation(this.form);
+        const validator = new Validation(this.form);
         if (validator.validate()) {
             checkout.setLoadWaiting('billing');
 
-//            if ($('billing:use_for_shipping') && $('billing:use_for_shipping').checked) {
-//                $('billing:use_for_shipping').value=1;
-//            }
-
-            new Ajax.Request(
+            _opcAjax(
                 this.saveUrl,
                 {
                     method: 'post',
                     onComplete: this.onComplete,
                     onSuccess: this.onSave,
                     onFailure: checkout.ajaxFailure.bind(checkout),
-                    parameters: Form.serialize(this.form)
+                    parameters: _opcSerializeForm(this.form)
                 }
             );
         }
     },
 
-    resetLoadWaiting: function(transport){
+    resetLoadWaiting: function(transport) {
         checkout.setLoadWaiting(false);
-        document.body.fire('billing-request:completed', {transport: transport});
+        _opcFireEvent(document.body, 'billing-request:completed', { transport: transport });
     },
 
     /**
-     This method recieves the AJAX response on success.
+     This method receives the AJAX response on success.
      There are 3 options: error, redirect or html with shipping options.
      */
-    nextStep: function(transport){
-        var response = transport.responseJSON || transport.responseText.evalJSON(true) || {};
+    nextStep: function(transport) {
+        const response = _opcParseResponse(transport);
 
-        if (response.error){
-            if (Object.isString(response.message)) {
-                alert(response.message.stripTags().toString());
+        if (response.error) {
+            if (typeof response.message === 'string') {
+                alert(_opcStripTags(response.message));
             } else {
                 if (window.billingRegionUpdater) {
                     billingRegionUpdater.update();
                 }
 
-                var msg = response.message;
-                if(Object.isArray(msg)) {
+                const msg = response.message;
+                if (Array.isArray(msg)) {
                     alert(msg.join("\n"));
                 }
-                alert(msg.stripTags().toString());
+                alert(_opcStripTags(String(msg)));
             }
 
             return false;
         }
 
         checkout.setStepResponse(response);
-        if(payment) {
+        if (payment) {
             payment.initWhatIsCvvListeners();
         }
-        // DELETE
-        //alert('error: ' + response.error + ' / redirect: ' + response.redirect + ' / shipping_methods_html: ' + response.shipping_methods_html);
-        // This moves the accordion panels of one page checkout and updates the checkout progress
-        //checkout.setBilling();
     }
 };
+Varien.classCompat(Billing);
 
-// shipping
-var Shipping = Class.create();
+// =====================================================================
+// Shipping
+// =====================================================================
+
+var Shipping = function(form, addressUrl, saveUrl, methodsUrl) {
+    this.initialize(form, addressUrl, saveUrl, methodsUrl);
+};
 Shipping.prototype = {
-    initialize: function(form, addressUrl, saveUrl, methodsUrl){
+    initialize: function(form, addressUrl, saveUrl, methodsUrl) {
         this.form = form;
-        if ($(this.form)) {
-            $(this.form).observe('submit', function(event){this.save();Event.stop(event);}.bind(this));
-            $(this.form).select('#shipping\\:country_id').first()?.addEventListener('change', () => { if (window.shipping) shipping.setSameAsBilling(false) });
+        const formEl = document.getElementById(this.form);
+        if (formEl) {
+            formEl.addEventListener('submit', function(event) { this.save(); event.preventDefault(); event.stopPropagation(); }.bind(this));
+            const countrySelect = formEl.querySelector('#shipping\\:country_id');
+            if (countrySelect) {
+                countrySelect.addEventListener('change', function() { if (window.shipping) shipping.setSameAsBilling(false); });
+            }
         }
         this.addressUrl = addressUrl;
         this.saveUrl = saveUrl;
         this.methodsUrl = methodsUrl;
-        this.onAddressLoad = this.fillForm.bindAsEventListener(this);
-        this.onSave = this.nextStep.bindAsEventListener(this);
-        this.onComplete = this.resetLoadWaiting.bindAsEventListener(this);
+        this.onAddressLoad = this.fillForm.bind(this);
+        this.onSave = this.nextStep.bind(this);
+        this.onComplete = this.resetLoadWaiting.bind(this);
     },
 
-    setAddress: function(addressId){
+    setAddress: function(addressId) {
         if (addressId) {
-            new Ajax.Request(
-                this.addressUrl+addressId,
-                {method:'get', onSuccess: this.onAddressLoad, onFailure: checkout.ajaxFailure.bind(checkout)}
+            _opcAjax(
+                this.addressUrl + addressId,
+                { method: 'get', onSuccess: this.onAddressLoad, onFailure: checkout.ajaxFailure.bind(checkout) }
             );
         }
         else {
@@ -423,199 +584,199 @@ Shipping.prototype = {
         }
     },
 
-    newAddress: function(isNew){
+    newAddress: function(isNew) {
+        const newForm = document.getElementById('shipping-new-address-form');
         if (isNew) {
             this.resetSelectedAddress();
-            Element.show('shipping-new-address-form');
+            if (newForm) newForm.style.display = '';
         } else {
-            Element.hide('shipping-new-address-form');
+            if (newForm) newForm.style.display = 'none';
         }
         shipping.setSameAsBilling(false);
     },
 
-    resetSelectedAddress: function(){
-        var selectElement = $('shipping-address-select');
+    resetSelectedAddress: function() {
+        const selectElement = document.getElementById('shipping-address-select');
         if (selectElement) {
-            selectElement.value='';
+            selectElement.value = '';
         }
     },
 
-    fillForm: function(transport){
-        var elementValues = transport.responseJSON || transport.responseText.evalJSON(true) || {};
+    fillForm: function(transport) {
+        let elementValues = {};
+        if (transport) {
+            elementValues = _opcParseResponse(transport);
+        }
         if (!transport && !Object.keys(elementValues).length) {
             this.resetSelectedAddress();
         }
-        var arrElements = Form.getElements(this.form);
-        for (var elemIndex in arrElements) {
-            if(arrElements.hasOwnProperty(elemIndex)) {
-                if (arrElements[elemIndex].id) {
-                    var fieldName = arrElements[elemIndex].id.replace(/^shipping:/, '');
-                    arrElements[elemIndex].value = elementValues[fieldName] ? elementValues[fieldName] : '';
-                    if (fieldName == 'country_id' && shippingForm){
-                        shippingForm.elementChildLoad(arrElements[elemIndex]);
-                    }
+        const arrElements = _opcFormElements(this.form);
+        for (let i = 0; i < arrElements.length; i++) {
+            if (arrElements[i].id) {
+                const fieldName = arrElements[i].id.replace(/^shipping:/, '');
+                arrElements[i].value = elementValues[fieldName] ? elementValues[fieldName] : '';
+                if (fieldName == 'country_id' && shippingForm) {
+                    shippingForm.elementChildLoad(arrElements[i]);
                 }
             }
         }
     },
 
     setSameAsBilling: function(flag) {
-        $('shipping:same_as_billing').checked = flag;
-// #5599. Also it hangs up, if the flag is not false
-//        $('billing:use_for_shipping_yes').checked = flag;
+        document.getElementById('shipping:same_as_billing').checked = flag;
         if (flag) {
             this.syncWithBilling();
         }
     },
 
-    syncWithBilling: function () {
-        $('billing-address-select') && this.newAddress(!$('billing-address-select').value);
-        $('shipping:same_as_billing').checked = true;
-        if (!$('billing-address-select') || !$('billing-address-select').value) {
-            arrElements = Form.getElements(this.form);
-            for (var elemIndex in arrElements) {
-                if (arrElements[elemIndex].id) {
-                    var sourceField = $(arrElements[elemIndex].id.replace(/^shipping:/, 'billing:'));
-                    if (sourceField){
-                        arrElements[elemIndex].value = sourceField.value;
+    syncWithBilling: function() {
+        const billingSelect = document.getElementById('billing-address-select');
+        if (billingSelect) this.newAddress(!billingSelect.value);
+        document.getElementById('shipping:same_as_billing').checked = true;
+        if (!billingSelect || !billingSelect.value) {
+            const arrElements = _opcFormElements(this.form);
+            for (let i = 0; i < arrElements.length; i++) {
+                if (arrElements[i].id) {
+                    const sourceField = document.getElementById(arrElements[i].id.replace(/^shipping:/, 'billing:'));
+                    if (sourceField) {
+                        arrElements[i].value = sourceField.value;
                     }
                 }
             }
-            //$('shipping:country_id').value = $('billing:country_id').value;
             shippingRegionUpdater.update();
-            $('shipping:region_id').value = $('billing:region_id').value;
-            $('shipping:region').value = $('billing:region').value;
-            //shippingForm.elementChildLoad($('shipping:country_id'), this.setRegionValue.bind(this));
+            document.getElementById('shipping:region_id').value = document.getElementById('billing:region_id').value;
+            document.getElementById('shipping:region').value = document.getElementById('billing:region').value;
         } else {
-            $('shipping-address-select').value = $('billing-address-select').value;
+            document.getElementById('shipping-address-select').value = billingSelect.value;
         }
     },
 
-    setRegionValue: function(){
-        $('shipping:region').value = $('billing:region').value;
+    setRegionValue: function() {
+        document.getElementById('shipping:region').value = document.getElementById('billing:region').value;
     },
 
-    save: function(){
-        if (checkout.loadWaiting!=false) return;
-        var validator = new Validation(this.form);
+    save: function() {
+        if (checkout.loadWaiting != false) return;
+        const validator = new Validation(this.form);
         if (validator.validate()) {
             checkout.setLoadWaiting('shipping');
-            new Ajax.Request(
+            _opcAjax(
                 this.saveUrl,
                 {
-                    method:'post',
+                    method: 'post',
                     onComplete: this.onComplete,
                     onSuccess: this.onSave,
                     onFailure: checkout.ajaxFailure.bind(checkout),
-                    parameters: Form.serialize(this.form)
+                    parameters: _opcSerializeForm(this.form)
                 }
             );
         }
     },
 
-    resetLoadWaiting: function(){
+    resetLoadWaiting: function() {
         checkout.setLoadWaiting(false);
     },
 
-    nextStep: function(transport){
-        var response = transport.responseJSON || transport.responseText.evalJSON(true) || {};
+    nextStep: function(transport) {
+        const response = _opcParseResponse(transport);
 
-        if (response.error){
-            if (Object.isString(response.message)) {
-                alert(response.message.stripTags().toString());
+        if (response.error) {
+            if (typeof response.message === 'string') {
+                alert(_opcStripTags(response.message));
             } else {
                 if (window.shippingRegionUpdater) {
                     shippingRegionUpdater.update();
                 }
-                var msg = response.message;
-                if(Object.isArray(msg)) {
+                const msg = response.message;
+                if (Array.isArray(msg)) {
                     alert(msg.join("\n"));
                 }
-                alert(msg.stripTags().toString());
+                alert(_opcStripTags(String(msg)));
             }
 
             return false;
         }
 
         checkout.setStepResponse(response);
-
-        /*
-         var updater = new Ajax.Updater(
-         'checkout-shipping-method-load',
-         this.methodsUrl,
-         {method:'get', onSuccess: checkout.setShipping.bind(checkout)}
-         );
-         */
-        //checkout.setShipping();
     }
 };
+Varien.classCompat(Shipping);
 
-// shipping method
-var ShippingMethod = Class.create();
+// =====================================================================
+// ShippingMethod
+// =====================================================================
+
+var ShippingMethod = function(form, saveUrl) {
+    this.initialize(form, saveUrl);
+};
 ShippingMethod.prototype = {
-    initialize: function(form, saveUrl){
+    initialize: function(form, saveUrl) {
         this.form = form;
-        if ($(this.form)) {
-            $(this.form).observe('submit', function(event){this.save();Event.stop(event);}.bind(this));
+        const formEl = document.getElementById(this.form);
+        if (formEl) {
+            formEl.addEventListener('submit', function(event) { this.save(); event.preventDefault(); event.stopPropagation(); }.bind(this));
         }
         this.saveUrl = saveUrl;
         this.validator = new Validation(this.form);
-        this.onSave = this.nextStep.bindAsEventListener(this);
-        this.onComplete = this.resetLoadWaiting.bindAsEventListener(this);
+        this.onSave = this.nextStep.bind(this);
+        this.onComplete = this.resetLoadWaiting.bind(this);
     },
 
     validate: function() {
-        var methods = document.getElementsByName('shipping_method');
-        if (methods.length==0) {
-            alert(Translator.translate('Your order cannot be completed at this time as there is no shipping methods available for it. Please make necessary changes in your shipping address.').stripTags());
+        const methods = document.getElementsByName('shipping_method');
+        if (methods.length == 0) {
+            alert(_opcStripTags(Translator.translate('Your order cannot be completed at this time as there is no shipping methods available for it. Please make necessary changes in your shipping address.')));
             return false;
         }
 
-        if(!this.validator.validate()) {
+        if (!this.validator.validate()) {
             return false;
         }
 
-        for (var i=0; i<methods.length; i++) {
+        for (let i = 0; i < methods.length; i++) {
             if (methods[i].checked) {
                 return true;
             }
         }
-        alert(Translator.translate('Please specify shipping method.').stripTags());
+        alert(_opcStripTags(Translator.translate('Please specify shipping method.')));
         return false;
     },
 
-    save: function(){
-
-        if (checkout.loadWaiting!=false) return;
+    save: function() {
+        if (checkout.loadWaiting != false) return;
         if (this.validate()) {
             checkout.setLoadWaiting('shipping-method');
-            new Ajax.Request(
+            _opcAjax(
                 this.saveUrl,
                 {
-                    method:'post',
+                    method: 'post',
                     onComplete: this.onComplete,
                     onSuccess: this.onSave,
                     onFailure: checkout.ajaxFailure.bind(checkout),
-                    parameters: Form.serialize(this.form)
+                    parameters: _opcSerializeForm(this.form)
                 }
             );
         }
     },
 
-    resetLoadWaiting: function(transport){
+    resetLoadWaiting: function(transport) {
         checkout.setLoadWaiting(false);
     },
 
-    nextStep: function(transport){
-        var response = transport.responseJSON || transport.responseText.evalJSON(true) || {};
+    nextStep: function(transport) {
+        const response = _opcParseResponse(transport);
 
         if (response.error) {
-            alert(response.message.stripTags().toString());
+            alert(_opcStripTags(String(response.message)));
             return false;
         }
 
         if (response.update_section) {
-            $('checkout-'+response.update_section.name+'-load').update(response.update_section.html);
+            const updateEl = document.getElementById('checkout-' + response.update_section.name + '-load');
+            if (updateEl) {
+                updateEl.innerHTML = response.update_section.html;
+                Varien.evalScripts(updateEl);
+            }
         }
 
         payment.initWhatIsCvvListeners();
@@ -627,91 +788,106 @@ ShippingMethod.prototype = {
         }
 
         if (response.payment_methods_html) {
-            $('checkout-payment-method-load').update(response.payment_methods_html);
+            const paymentLoad = document.getElementById('checkout-payment-method-load');
+            if (paymentLoad) {
+                paymentLoad.innerHTML = response.payment_methods_html;
+                Varien.evalScripts(paymentLoad);
+            }
         }
 
         checkout.setShippingMethod();
     }
 };
+Varien.classCompat(ShippingMethod);
 
+// =====================================================================
+// Payment
+// =====================================================================
 
-// payment
-var Payment = Class.create();
+var Payment = function(form, saveUrl) {
+    this.initialize(form, saveUrl);
+};
 Payment.prototype = {
-    beforeInitFunc:$H({}),
-    afterInitFunc:$H({}),
-    beforeValidateFunc:$H({}),
-    afterValidateFunc:$H({}),
-    initialize: function(form, saveUrl){
+    beforeInitFunc: {},
+    afterInitFunc: {},
+    beforeValidateFunc: {},
+    afterValidateFunc: {},
+
+    initialize: function(form, saveUrl) {
         this.form = form;
         this.saveUrl = saveUrl;
-        this.onSave = this.nextStep.bindAsEventListener(this);
-        this.onComplete = this.resetLoadWaiting.bindAsEventListener(this);
+        this.onSave = this.nextStep.bind(this);
+        this.onComplete = this.resetLoadWaiting.bind(this);
     },
 
-    addBeforeInitFunction : function(code, func) {
-        this.beforeInitFunc.set(code, func);
+    addBeforeInitFunction: function(code, func) {
+        this.beforeInitFunc[code] = func;
     },
 
-    beforeInit : function() {
-        (this.beforeInitFunc).each(function(init){
-            (init.value)();;
+    beforeInit: function() {
+        const self = this;
+        _opcEachEntry(this.beforeInitFunc, function(init) {
+            (init.value)();
         });
     },
 
-    init : function () {
+    init: function() {
         this.beforeInit();
-        var elements = Form.getElements(this.form);
-        if ($(this.form)) {
-            $(this.form).observe('submit', function(event){this.save();Event.stop(event);}.bind(this));
+        const elements = _opcFormElements(this.form);
+        const formEl = document.getElementById(this.form);
+        if (formEl) {
+            formEl.addEventListener('submit', function(event) { this.save(); event.preventDefault(); event.stopPropagation(); }.bind(this));
         }
-        var method = null;
-        for (var i=0; i<elements.length; i++) {
-            if (elements[i].name=='payment[method]' || elements[i].name == 'form_key') {
+        let method = null;
+        for (let i = 0; i < elements.length; i++) {
+            if (elements[i].name == 'payment[method]' || elements[i].name == 'form_key') {
                 if (elements[i].checked) {
                     method = elements[i].value;
                 }
             } else {
                 elements[i].disabled = true;
             }
-            elements[i].setAttribute('autocomplete','off');
+            elements[i].setAttribute('autocomplete', 'off');
         }
         if (method) this.switchMethod(method);
         this.afterInit();
     },
 
-    addAfterInitFunction : function(code, func) {
-        this.afterInitFunc.set(code, func);
+    addAfterInitFunction: function(code, func) {
+        this.afterInitFunc[code] = func;
     },
 
-    afterInit : function() {
-        (this.afterInitFunc).each(function(init){
+    afterInit: function() {
+        _opcEachEntry(this.afterInitFunc, function(init) {
             (init.value)();
         });
     },
 
-    switchMethod: function(method){
-        if (this.currentMethod && $('payment_form_'+this.currentMethod)) {
+    switchMethod: function(method) {
+        if (this.currentMethod && document.getElementById('payment_form_' + this.currentMethod)) {
             this.changeVisible(this.currentMethod, true);
-            $('payment_form_'+this.currentMethod).fire('payment-method:switched-off', {method_code : this.currentMethod});
+            _opcFireEvent(document.getElementById('payment_form_' + this.currentMethod), 'payment-method:switched-off', { method_code: this.currentMethod });
         }
-        if ($('payment_form_'+method)){
+        if (document.getElementById('payment_form_' + method)) {
             this.changeVisible(method, false);
-            $('payment_form_'+method).fire('payment-method:switched', {method_code : method});
+            _opcFireEvent(document.getElementById('payment_form_' + method), 'payment-method:switched', { method_code: method });
         } else {
             //Event fix for payment methods without form like "Check / Money order"
-            document.body.fire('payment-method:switched', {method_code : method});
+            _opcFireEvent(document.body, 'payment-method:switched', { method_code: method });
         }
         if (method == 'free' && quoteBaseGrandTotal > 0.0001
-            && !(($('use_reward_points') && $('use_reward_points').checked) || ($('use_customer_balance') && $('use_customer_balance').checked))
+            && !((document.getElementById('use_reward_points') && document.getElementById('use_reward_points').checked) || (document.getElementById('use_customer_balance') && document.getElementById('use_customer_balance').checked))
         ) {
-            if ($('p_method_' + method)) {
-                $('p_method_' + method).checked = false;
-                if ($('dt_method_' + method)) {
-                    $('dt_method_' + method).hide();
+            const pMethod = document.getElementById('p_method_' + method);
+            if (pMethod) {
+                pMethod.checked = false;
+                const dtMethod = document.getElementById('dt_method_' + method);
+                if (dtMethod) {
+                    dtMethod.style.display = 'none';
                 }
-                if ($('dd_method_' + method)) {
-                    $('dd_method_' + method).hide();
+                const ddMethod = document.getElementById('dd_method_' + method);
+                if (ddMethod) {
+                    ddMethod.style.display = 'none';
                 }
             }
             method == '';
@@ -723,31 +899,31 @@ Payment.prototype = {
     },
 
     changeVisible: function(method, mode) {
-        var block = 'payment_form_' + method;
-        [block + '_before', block, block + '_after'].each(function(el) {
-            var element = $(el);
+        const block = 'payment_form_' + method;
+        [block + '_before', block, block + '_after'].forEach(function(elId) {
+            const element = document.getElementById(elId);
             if (element) {
                 element.style.display = (mode) ? 'none' : '';
-                element.select('input', 'select', 'textarea', 'button').each(function(field) {
+                Array.from(element.querySelectorAll('input, select, textarea, button')).forEach(function(field) {
                     field.disabled = mode;
                 });
             }
         });
     },
 
-    addBeforeValidateFunction : function(code, func) {
-        this.beforeValidateFunc.set(code, func);
+    addBeforeValidateFunction: function(code, func) {
+        this.beforeValidateFunc[code] = func;
     },
 
-    beforeValidate : function() {
-        var validateResult = true;
-        var hasValidation = false;
-        (this.beforeValidateFunc).each(function(validate){
+    beforeValidate: function() {
+        let validateResult = true;
+        let hasValidation = false;
+        _opcEachEntry(this.beforeValidateFunc, function(validate) {
             hasValidation = true;
             if ((validate.value)() == false) {
                 validateResult = false;
             }
-        }.bind(this));
+        });
         if (!hasValidation) {
             validateResult = false;
         }
@@ -755,16 +931,16 @@ Payment.prototype = {
     },
 
     validate: function() {
-        var result = this.beforeValidate();
+        let result = this.beforeValidate();
         if (result) {
             return true;
         }
-        var methods = document.getElementsByName('payment[method]');
-        if (methods.length==0) {
-            alert(Translator.translate('Your order cannot be completed at this time as there is no payment methods available for it.').stripTags());
+        const methods = document.getElementsByName('payment[method]');
+        if (methods.length == 0) {
+            alert(_opcStripTags(Translator.translate('Your order cannot be completed at this time as there is no payment methods available for it.')));
             return false;
         }
-        for (var i=0; i<methods.length; i++) {
+        for (let i = 0; i < methods.length; i++) {
             if (methods[i].checked) {
                 return true;
             }
@@ -773,111 +949,116 @@ Payment.prototype = {
         if (result) {
             return true;
         }
-        alert(Translator.translate('Please specify payment method.').stripTags());
+        alert(_opcStripTags(Translator.translate('Please specify payment method.')));
         return false;
     },
 
-    addAfterValidateFunction : function(code, func) {
-        this.afterValidateFunc.set(code, func);
+    addAfterValidateFunction: function(code, func) {
+        this.afterValidateFunc[code] = func;
     },
 
-    afterValidate : function() {
-        var validateResult = true;
-        var hasValidation = false;
-        (this.afterValidateFunc).each(function(validate){
+    afterValidate: function() {
+        let validateResult = true;
+        let hasValidation = false;
+        _opcEachEntry(this.afterValidateFunc, function(validate) {
             hasValidation = true;
             if ((validate.value)() == false) {
                 validateResult = false;
             }
-        }.bind(this));
+        });
         if (!hasValidation) {
             validateResult = false;
         }
         return validateResult;
     },
 
-    save: function(){
-        if (checkout.loadWaiting!=false) return;
-        var validator = new Validation(this.form);
+    save: function() {
+        if (checkout.loadWaiting != false) return;
+        const validator = new Validation(this.form);
         if (this.validate() && validator.validate()) {
             checkout.setLoadWaiting('payment');
-            new Ajax.Request(
+            _opcAjax(
                 this.saveUrl,
                 {
-                    method:'post',
+                    method: 'post',
                     onComplete: this.onComplete,
                     onSuccess: this.onSave,
                     onFailure: checkout.ajaxFailure.bind(checkout),
-                    parameters: Form.serialize(this.form)
+                    parameters: _opcSerializeForm(this.form)
                 }
             );
         }
     },
 
-    resetLoadWaiting: function(){
+    resetLoadWaiting: function() {
         checkout.setLoadWaiting(false);
     },
 
-    nextStep: function(transport){
-        var response = transport.responseJSON || transport.responseText.evalJSON(true) || {};
+    nextStep: function(transport) {
+        const response = _opcParseResponse(transport);
 
         /*
          * if there is an error in payment, need to show error message
          */
         if (response.error) {
             if (response.fields) {
-                var fields = response.fields.split(',');
-                for (var i=0;i<fields.length;i++) {
-                    var field = null;
-                    if (field = $(fields[i])) {
+                const fields = response.fields.split(',');
+                for (let i = 0; i < fields.length; i++) {
+                    const field = document.getElementById(fields[i]);
+                    if (field) {
                         Validation.ajaxError(field, response.error);
                     }
                 }
                 return;
             }
-            if (Object.isString(response.message)) {
-                alert(response.message.stripTags().toString());
+            if (typeof response.message === 'string') {
+                alert(_opcStripTags(response.message));
             } else {
-                alert(response.error.stripTags().toString());
+                alert(_opcStripTags(String(response.error)));
             }
             return;
         }
 
         checkout.setStepResponse(response);
-
-        //checkout.setPayment();
     },
 
-    initWhatIsCvvListeners: function(){
-        $$('.cvv-what-is-this').each(function(element){
-            Event.observe(element, 'click', toggleToolTip);
+    initWhatIsCvvListeners: function() {
+        Array.from(document.querySelectorAll('.cvv-what-is-this')).forEach(function(element) {
+            element.addEventListener('click', toggleToolTip);
         });
     }
 };
+Varien.classCompat(Payment);
 
-var Review = Class.create();
+// =====================================================================
+// Review
+// =====================================================================
+
+var Review = function(saveUrl, successUrl, agreementsForm) {
+    this.initialize(saveUrl, successUrl, agreementsForm);
+};
 Review.prototype = {
-    initialize: function(saveUrl, successUrl, agreementsForm){
+    initialize: function(saveUrl, successUrl, agreementsForm) {
         this.saveUrl = saveUrl;
         this.successUrl = successUrl;
         this.agreementsForm = agreementsForm;
-        this.onSave = this.nextStep.bindAsEventListener(this);
-        this.onComplete = this.resetLoadWaiting.bindAsEventListener(this);
+        this.onSave = this.nextStep.bind(this);
+        this.onComplete = this.resetLoadWaiting.bind(this);
     },
 
-    save: function(){
-        if (checkout.loadWaiting!=false) return;
+    save: function() {
+        if (checkout.loadWaiting != false) return;
         checkout.setLoadWaiting('review');
-        var params = Form.serialize(payment.form);
+        let params = _opcSerializeForm(payment.form);
         if (this.agreementsForm) {
-            params += '&'+Form.serialize(this.agreementsForm);
+            params += '&' + _opcSerializeForm(this.agreementsForm);
         }
         params.save = true;
-        new Ajax.Request(
+        _opcAjax(
             this.saveUrl,
             {
-                method:'post',
-                parameters:params,
+                method: 'post',
+                parameters: params,
                 onComplete: this.onComplete,
                 onSuccess: this.onSave,
                 onFailure: checkout.ajaxFailure.bind(checkout)
@@ -885,13 +1066,13 @@ Review.prototype = {
         );
     },
 
-    resetLoadWaiting: function(transport){
+    resetLoadWaiting: function(transport) {
         checkout.setLoadWaiting(false, this.isSuccess);
     },
 
-    nextStep: function(transport){
+    nextStep: function(transport) {
         if (transport) {
-            var response = transport.responseJSON || transport.responseText.evalJSON(true) || {};
+            const response = _opcParseResponse(transport);
 
             if (response.redirect) {
                 this.isSuccess = true;
@@ -902,10 +1083,10 @@ Review.prototype = {
                 this.isSuccess = true;
                 location.href = encodeURI(this.successUrl);
             }
-            else{
-                var msg = response.error_messages;
-                if (Object.isArray(msg)) {
-                    msg = msg.join("\n").stripTags().toString();
+            else {
+                let msg = response.error_messages;
+                if (Array.isArray(msg)) {
+                    msg = _opcStripTags(msg.join("\n"));
                 }
                 if (msg) {
                     alert(msg);
@@ -913,7 +1094,11 @@ Review.prototype = {
             }
 
             if (response.update_section) {
-                $('checkout-'+response.update_section.name+'-load').update(response.update_section.html);
+                const updateEl = document.getElementById('checkout-' + response.update_section.name + '-load');
+                if (updateEl) {
+                    updateEl.innerHTML = response.update_section.html;
+                    Varien.evalScripts(updateEl);
+                }
             }
 
             if (response.goto_section) {
@@ -924,3 +1109,4 @@ Review.prototype = {
 
     isSuccess: false
 };
+Varien.classCompat(Review);

--- a/skin/frontend/rwd/default/js/app.js
+++ b/skin/frontend/rwd/default/js/app.js
@@ -30,21 +30,22 @@ var bp = {
  * class gets added to the input, but the "This is a required field." text does not display
  */
 Varien.searchForm.prototype.initialize = function (form, field, emptyText) {
-    this.form = $(form);
-    this.field = $(field);
+    this.form = typeof form === 'string' ? document.getElementById(form) : form;
+    this.field = typeof field === 'string' ? document.getElementById(field) : field;
     this.emptyText = emptyText;
 
-    Event.observe(this.form, 'submit', this.submit.bind(this));
-    Event.observe(this.field, 'change', this.change.bind(this));
-    Event.observe(this.field, 'focus', this.focus.bind(this));
-    Event.observe(this.field, 'blur', this.blur.bind(this));
+    this.form.addEventListener('submit', this.submit.bind(this));
+    this.field.addEventListener('change', this.change.bind(this));
+    this.field.addEventListener('focus', this.focus.bind(this));
+    this.field.addEventListener('blur', this.blur.bind(this));
     this.blur();
 };
 
 Varien.searchForm.prototype.submit = function (event) {
     if (this.field.value == this.emptyText || this.field.value == ''){
-        Event.stop(event);
-        this.field.addClassName('validation-failed');
+        event.preventDefault();
+        event.stopPropagation();
+        this.field.classList.add('validation-failed');
         this.field.focus();
         return false;
     }
@@ -55,15 +56,15 @@ Varien.searchForm.prototype.change = function (event) {
     if (
         this.field.value != this.emptyText
         && this.field.value != ''
-        && this.field.hasClassName('validation-failed')
+        && this.field.classList.contains('validation-failed')
     ) {
-        this.field.removeClassName('validation-failed');
+        this.field.classList.remove('validation-failed');
     }
 };
 
 Varien.searchForm.prototype.blur = function (event) {
-    if (this.field.hasClassName('validation-failed')) {
-        this.field.removeClassName('validation-failed');
+    if (this.field.classList.contains('validation-failed')) {
+        this.field.classList.remove('validation-failed');
     }
 };
 
@@ -153,7 +154,7 @@ var PointerManager = {
         this.pointerEventLock = false;
     },
     setPointerEventLockTimeout: function() {
-        var that = this;
+        const that = this;
 
         if(this.pointerTimeout) {
             clearTimeout(this.pointerTimeout);
@@ -193,7 +194,7 @@ var PointerManager = {
     },
 
     wirePointerDetection: function() {
-        var that = this;
+        const that = this;
 
         if(this.standardTouch) { //standard-based touch events. Wire only one event.
             //detect pointer event
@@ -289,7 +290,7 @@ var MenuManager = {
                 return false;
             }
 
-            var scroll = $j(window).scrollTop() - this.touchStartPosition;
+            const scroll = $j(window).scrollTop() - this.touchStartPosition;
             return Math.abs(scroll) > this.TOUCH_SCROLL_THRESHOLD;
         }
     },
@@ -310,8 +311,8 @@ var MenuManager = {
      * @param target
      */
     toggleMenuVisibility: function(target) {
-        var link = $j(target);
-        var li = link.closest('li');
+        const link = $j(target);
+        const li = link.closest('li');
 
         if(!this.useSmallScreenBehavior()) {
             // remove menu-active from siblings and children of siblings
@@ -358,16 +359,16 @@ var MenuManager = {
      * along with mouseenter / mouseleave to emulate pointer events.
      */
     wirePointerEvents: function() {
-        var that = this;
-        var pointerTarget = $j('#nav a.has-children');
-        var hoverTarget = $j('#nav li');
+        const that = this;
+        const pointerTarget = $j('#nav a.has-children');
+        const hoverTarget = $j('#nav li');
 
         if(PointerManager.getPointerEventsSupported()) {
             // pointer events supported, so observe those type of events
 
-            var enterEvent = window.navigator.pointerEnabled ? 'pointerenter' : 'mouseenter';
-            var leaveEvent = window.navigator.pointerEnabled ? 'pointerleave' : 'mouseleave';
-            var fullPointerSupport = window.navigator.pointerEnabled;
+            const enterEvent = window.navigator.pointerEnabled ? 'pointerenter' : 'mouseenter';
+            const leaveEvent = window.navigator.pointerEnabled ? 'pointerleave' : 'mouseleave';
+            const fullPointerSupport = window.navigator.pointerEnabled;
 
             hoverTarget.on(enterEvent, function(e) {
                 if(e.originalEvent.pointerType === undefined // Browsers with partial PointerEvent support don't provide pointer type
@@ -401,7 +402,7 @@ var MenuManager = {
             }
 
             pointerTarget.on('click', function(e) {
-                var pointerType = fullPointerSupport ? e.originalEvent.pointerType : $j(this).data('pointer-type');
+                const pointerType = fullPointerSupport ? e.originalEvent.pointerType : $j(this).data('pointer-type');
 
                 if(pointerType === undefined || pointerType == PointerManager.getPointerEventsInputTypes().MOUSE) {
                     that.mouseClickAction(e, this);
@@ -506,7 +507,7 @@ var MenuManager = {
 
             event.stopPropagation();
 
-            var jtarget = $j(target);
+            const jtarget = $j(target);
             if(!jtarget.hasClass('level0')) {
                 this.mouseleaveLock = jtarget.parents('li').length + 1;
             }
@@ -651,9 +652,9 @@ $j(document).ready(function () {
     // ==============================================
 
     // Document
-    var w = $j(window);
-    var d = $j(document);
-    var body = $j('body');
+    const w = $j(window);
+    const d = $j(document);
+    const body = $j('body');
 
     Modernizr.addTest('ios', function () {
         return navigator.userAgent.match(/(iPad|iPhone|iPod)/g);
@@ -678,21 +679,21 @@ $j(document).ready(function () {
     // Skip Links
     // =============================================
 
-    var skipContents = $j('.skip-content');
-    var skipLinks = $j('.skip-link');
+    const skipContents = $j('.skip-content');
+    const skipLinks = $j('.skip-link');
 
     $j('.skip-links').on('click', '.skip-link', function (e) {
         e.preventDefault();
 
-        var self = $j(this);
+        const self = $j(this);
         // Use the data-target-element attribute, if it exists. Fall back to href.
-        var target = self.attr('data-target-element') ? self.attr('data-target-element') : self.attr('href');
+        const target = self.attr('data-target-element') ? self.attr('data-target-element') : self.attr('href');
 
         // Get target element
-        var elem = $j(target);
+        const elem = $j(target);
 
         // Check if stub is open
-        var isSkipContentOpen = elem.hasClass('skip-active') ? 1 : 0;
+        const isSkipContentOpen = elem.hasClass('skip-active') ? 1 : 0;
 
         // Hide all stubs
         skipLinks.removeClass('skip-active');
@@ -716,8 +717,8 @@ $j(document).ready(function () {
     });
 
     $j('.skip-links').on('click', '#header-cart .skip-link-close', function(e) {
-        var parent = $j(this).parents('.skip-content');
-        var link = parent.siblings('.skip-link');
+        const parent = $j(this).parents('.skip-content');
+        const link = parent.siblings('.skip-link');
 
         parent.removeClass('skip-active');
         link.removeClass('skip-active');
@@ -735,14 +736,14 @@ $j(document).ready(function () {
 
     // Prevent sub menus from spilling out of the window.
     function preventMenuSpill() {
-        var windowWidth = $j(window).width();
+        const windowWidth = $j(window).width();
         $j('ul.level0').each(function(){
-            var ul = $j(this);
+            const ul = $j(this);
             //Show it long enough to get info, then hide it.
             ul.addClass('position-test');
             ul.removeClass('spill');
-            var width = ul.outerWidth();
-            var offset = ul.offset().left;
+            const width = ul.outerWidth();
+            const offset = ul.offset().left;
             ul.removeClass('position-test');
             //Add the spill class if it will spill off the page.
             if ((offset + width) > windowWidth) {
@@ -792,14 +793,14 @@ $j(document).ready(function () {
 
     // Used to swap primary product photo from thumbnails.
 
-    var mediaListLinks = $j('.media-list').find('a');
-    var mediaPrimaryImage = $j('.primary-image').find('img');
+    const mediaListLinks = $j('.media-list').find('a');
+    const mediaPrimaryImage = $j('.primary-image').find('img');
 
     if (mediaListLinks.length) {
         mediaListLinks.on('click', function (e) {
             e.preventDefault();
 
-            var self = $j(this);
+            const self = $j(this);
 
             mediaPrimaryImage.attr('src', self.attr('href'));
         });
@@ -832,7 +833,7 @@ $j(document).ready(function () {
     $j.fn.toggleSingle = function (options) {
 
         // passing destruct: true allows
-        var settings = $j.extend({
+        const settings = $j.extend({
             destruct: false
         }, options);
 
@@ -864,23 +865,23 @@ $j(document).ready(function () {
     // ==============================================
 
     $j('.toggle-content').each(function () {
-        var wrapper = jQuery(this);
+        const wrapper = jQuery(this);
 
-        var hasTabs = wrapper.hasClass('tabs');
-        var hasAccordion = wrapper.hasClass('accordion');
-        var startOpen = wrapper.hasClass('open');
+        const hasTabs = wrapper.hasClass('tabs');
+        const hasAccordion = wrapper.hasClass('accordion');
+        const startOpen = wrapper.hasClass('open');
 
-        var dl = wrapper.children('dl:first');
-        var dts = dl.children('dt');
-        var panes = dl.children('dd');
-        var groups = new Array(dts, panes);
+        const dl = wrapper.children('dl:first');
+        const dts = dl.children('dt');
+        const panes = dl.children('dd');
+        const groups = new Array(dts, panes);
 
         //Create a ul for tabs if necessary.
         if (hasTabs) {
-            var ul = jQuery('<ul class="toggle-tabs"></ul>');
+            const ul = jQuery('<ul class="toggle-tabs"></ul>');
             dts.each(function () {
-                var dt = jQuery(this);
-                var li = jQuery('<li></li>');
+                const dt = jQuery(this);
+                const li = jQuery('<li></li>');
                 li.html(dt.html());
                 ul.append(li);
             });
@@ -890,14 +891,14 @@ $j(document).ready(function () {
         }
 
         //Add "last" classes.
-        var i;
+        let i;
         for (i = 0; i < groups.length; i++) {
             groups[i].filter(':last').addClass('last');
         }
 
         function toggleClasses(clickedItem, group) {
-            var index = group.index(clickedItem);
-            var i;
+            const index = group.index(clickedItem);
+            let i;
             for (i = 0; i < groups.length; i++) {
                 groups[i].removeClass('current');
                 groups[i].eq(index).addClass('current');
@@ -961,14 +962,14 @@ $j(document).ready(function () {
     if ($j('.main-container.col3-layout').length > 0) {
         enquire.register('screen and (max-width: 1000px)', {
             match: function () {
-                var rightColumn = $j('.col-right');
-                var colWrapper = $j('.col-wrapper');
+                const rightColumn = $j('.col-right');
+                const colWrapper = $j('.col-wrapper');
 
                 rightColumn.appendTo(colWrapper);
             },
             unmatch: function () {
-                var rightColumn = $j('.col-right');
-                var main = $j('.main');
+                const rightColumn = $j('.col-right');
+                const main = $j('.main');
 
                 rightColumn.appendTo(main);
             }
@@ -1054,12 +1055,12 @@ $j(document).ready(function () {
 
     if ($j('.products-grid').length) {
 
-        var alignProductGridActions = function () {
+        const alignProductGridActions = function () {
             // Loop through each product grid on the page
             $j('.products-grid').each(function(){
-                var gridRows = []; // This will store an array per row
-                var tempRow = [];
-                productGridElements = $j(this).children('li');
+                const gridRows = []; // This will store an array per row
+                let tempRow = [];
+                const productGridElements = $j(this).children('li');
                 productGridElements.each(function (index) {
                     // The JS ought to be agnostic of the specific CSS breakpoints, so we are dynamically checking to find
                     // each row by grouping all cells (eg, li elements) up until we find an element that is cleared.
@@ -1078,7 +1079,7 @@ $j(document).ready(function () {
                 });
 
                 $j.each(gridRows, function () {
-                    var tallestProductInfo = 0;
+                    let tallestProductInfo = 0;
                     $j.each(this, function () {
                         // Since this function is called every time the page is resized, we need to remove the min-height
                         // and bottom-padding so each cell can return to its natural size before being measured.
@@ -1089,15 +1090,15 @@ $j(document).ready(function () {
 
                         // We are checking the height of .product-info (rather than the entire li), because the images
                         // will not be loaded when this JS is run.
-                        var productInfoHeight = $j(this).find('.product-info').height();
+                        const productInfoHeight = $j(this).find('.product-info').height();
                         // Space above .actions element
-                        var actionSpacing = 10;
+                        const actionSpacing = 10;
                         // The height of the absolutely positioned .actions element
-                        var actionHeight = $j(this).find('.product-info .actions').height();
+                        const actionHeight = $j(this).find('.product-info .actions').height();
 
                         // Add height of two elements. This is necessary since .actions is absolutely positioned and won't
                         // be included in the height of .product-info
-                        var totalHeight = productInfoHeight + actionSpacing + actionHeight;
+                        const totalHeight = productInfoHeight + actionSpacing + actionHeight;
                         if (totalHeight > tallestProductInfo) {
                             tallestProductInfo = totalHeight;
                         }
@@ -1127,7 +1128,7 @@ $j(document).ready(function () {
     // ==============================================
 
     // Using setTimeout since Web-Kit and some other browsers call the resize function constantly upon window resizing.
-    var resizeTimer;
+    let resizeTimer;
     $j(window).resize(function (e) {
         clearTimeout(resizeTimer);
         resizeTimer = setTimeout(function () {
@@ -1167,8 +1168,8 @@ var ProductMediaManager = {
         }
 
         if(image[0].naturalWidth && image[0].naturalHeight) {
-            var widthDiff = image[0].naturalWidth - image.width() - ProductMediaManager.IMAGE_ZOOM_THRESHOLD;
-            var heightDiff = image[0].naturalHeight - image.height() - ProductMediaManager.IMAGE_ZOOM_THRESHOLD;
+            const widthDiff = image[0].naturalWidth - image.width() - ProductMediaManager.IMAGE_ZOOM_THRESHOLD;
+            const heightDiff = image[0].naturalHeight - image.height() - ProductMediaManager.IMAGE_ZOOM_THRESHOLD;
 
             if(widthDiff < 0 && heightDiff < 0) {
                 //image not big enough
@@ -1190,7 +1191,7 @@ var ProductMediaManager = {
 
         ProductMediaManager.destroyZoom();
 
-        var imageGallery = $j('.product-image-gallery');
+        const imageGallery = $j('.product-image-gallery');
 
         if(targetImage[0].complete) { //image already loaded -- swap immediately
 
@@ -1235,8 +1236,8 @@ var ProductMediaManager = {
         //trigger image change event on thumbnail click
         $j('.product-image-thumbs .thumb-link').click(function(e) {
             e.preventDefault();
-            var jlink = $j(this);
-            var target = $j('#image-' + jlink.data('image-index'));
+            const jlink = $j(this);
+            const target = $j('#image-' + jlink.data('image-index'));
 
             ProductMediaManager.swapImage(target);
         });

--- a/skin/frontend/rwd/default/js/configurableswatches/configurable-swatch-prices.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/configurable-swatch-prices.js
@@ -5,7 +5,9 @@
  * @package     rwd_default
  */
 
-var ConfigurableSwatchPrices = Class.create({
+function ConfigurableSwatchPrices() { this.initialize(...arguments); }
+
+ConfigurableSwatchPrices.prototype = {
     initialize: function(config) {
         this.swatchesPrices = [];
         this.generalConfig = config.generalConfig;
@@ -15,43 +17,43 @@ var ConfigurableSwatchPrices = Class.create({
     },
 
     addObservers: function() {
-        $(document).on('click', '.swatch-link', this.onSwatchClick.bind(this));
+        document.addEventListener('click', this.onSwatchClick.bind(this));
     },
 
     onSwatchClick: function(e) {
-        var element = Event.findElement(e);
-        var swatchElement = element.up('[data-product-id]');
-        var productId = parseInt(swatchElement.getAttribute('data-product-id'), 10);
-        var swatchLabel = swatchElement.getAttribute('data-option-label');
-        var optionsPrice = this.optionsPrice(productId);
-        var swatchTarget = this.getSwatchPriceInfo(productId, swatchLabel);
+        const element = e.target.closest('.swatch-link');
+        if (!element) return;
+        const swatchElement = element.closest('[data-product-id]');
+        if (!swatchElement) return;
+        const productId = parseInt(swatchElement.getAttribute('data-product-id'), 10);
+        const swatchLabel = swatchElement.getAttribute('data-option-label');
+        const optionsPrice = this.optionsPrice(productId);
+        const swatchTarget = this.getSwatchPriceInfo(productId, swatchLabel);
 
-        if(swatchTarget) {
+        if (swatchTarget) {
             optionsPrice.changePrice('config', {price: swatchTarget.price, oldPrice: swatchTarget.oldPrice});
             optionsPrice.reload();
         }
     },
 
     getSwatchPriceInfo: function(productId, swatchLabel) {
-        var productInfo = this.products[productId];
-        if(productInfo && productInfo.swatchPrices[swatchLabel]) {
+        const productInfo = this.products[productId];
+        if (productInfo && productInfo.swatchPrices[swatchLabel]) {
             return productInfo.swatchPrices[swatchLabel];
         }
         return 0;
     },
 
     optionsPrice: function(productId) {
-        if(this.swatchesPrices[productId]) {
+        if (this.swatchesPrices[productId]) {
             return this.swatchesPrices[productId];
         }
         this.swatchesPrices[productId] = new Product.OptionsPrice(this.getProductConfig(productId));
-
         return this.swatchesPrices[productId];
     },
 
     getProductConfig: function(productId) {
-        var generalConfigClone = Object.extend({}, this.generalConfig);
-
-        return Object.extend(generalConfigClone, this.products[productId]);
+        return Object.assign({}, this.generalConfig, this.products[productId]);
     }
-});
+};
+Varien.classCompat(ConfigurableSwatchPrices);

--- a/skin/frontend/rwd/default/js/configurableswatches/product-media.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/product-media.js
@@ -10,33 +10,35 @@ var ConfigurableMediaImages = {
     productImages: {},
     imageObjects: {},
 
-    // deprecated - use Array.prototype.intersect instead
     arrayIntersect: function(a, b) {
-        return a.intersect(b);
+        // Array#intersect de-duplicated the left-hand array first
+        return a.filter(function(item, idx) {
+            return a.indexOf(item) === idx && b.indexOf(item) !== -1;
+        });
     },
 
     getCompatibleProductImages: function(productFallback, selectedLabels) {
         //find compatible products
-        var compatibleProducts = [];
-        var compatibleProductSets = [];
-        selectedLabels.each(function(selectedLabel) {
+        let compatibleProducts = [];
+        const compatibleProductSets = [];
+        selectedLabels.forEach(function(selectedLabel) {
             if(typeof(productFallback['option_labels']) != 'undefined') {
                 if (!productFallback['option_labels'][selectedLabel]) {
                     return;
                 }
 
-                var optionProducts = productFallback['option_labels'][selectedLabel]['products'];
+                const optionProducts = productFallback['option_labels'][selectedLabel]['products'];
                 compatibleProductSets.push(optionProducts);
 
                 //optimistically push all products
-                optionProducts.each(function (productId) {
+                optionProducts.forEach(function(productId) {
                     compatibleProducts.push(productId);
                 });
             }
         });
 
         //intersect compatible products
-        compatibleProductSets.each(function(productSet) {
+        compatibleProductSets.forEach(function(productSet) {
             compatibleProducts = ConfigurableMediaImages.arrayIntersect(compatibleProducts, productSet);
         });
 
@@ -52,37 +54,37 @@ var ConfigurableMediaImages = {
     },
 
     getSwatchImage: function(productId, optionLabel, selectedLabels) {
-        var fallback = ConfigurableMediaImages.productImages[productId];
+        const fallback = ConfigurableMediaImages.productImages[productId];
         if(!fallback) {
             return null;
         }
 
         //first, try to get label-matching image on config product for this option's label
         if(typeof(fallback['option_labels']) != 'undefined') {
-            var currentLabelImage = fallback['option_labels'][optionLabel];
+            const currentLabelImage = fallback['option_labels'][optionLabel];
             if (currentLabelImage && fallback['option_labels'][optionLabel]['configurable_product'][ConfigurableMediaImages.imageType]) {
                 //found label image on configurable product
                 return fallback['option_labels'][optionLabel]['configurable_product'][ConfigurableMediaImages.imageType];
             }
         }
 
-        var compatibleProducts = ConfigurableMediaImages.getCompatibleProductImages(fallback, selectedLabels);
+        const compatibleProducts = ConfigurableMediaImages.getCompatibleProductImages(fallback, selectedLabels);
 
         if(compatibleProducts.length == 0) { //no compatible products
             return null; //bail
         }
 
         //second, get any product which is compatible with currently selected option(s)
-        var optionLabels = fallback['option_labels'];
-        for (var key in optionLabels) {
+        const optionLabels = fallback['option_labels'];
+        for (const key in optionLabels) {
             if (optionLabels.hasOwnProperty(key)) {
-                var value = optionLabels[key];
-                var image = value['configurable_product'][ConfigurableMediaImages.imageType];
-                var products = value['products'];
+                const value = optionLabels[key];
+                const image = value['configurable_product'][ConfigurableMediaImages.imageType];
+                const products = value['products'];
 
                 if (image) { //configurable product has image in the first place
                     //if intersection between compatible products and this label's products, we found a match
-                    var isCompatibleProduct = products.filter(function(productId) {
+                    const isCompatibleProduct = products.filter(function(productId) {
                         return compatibleProducts.includes(productId);
                     }).length > 0;
 
@@ -94,12 +96,14 @@ var ConfigurableMediaImages = {
         }
 
         //third, get image off of child product which is compatible
-        var childSwatchImage = null;
-        var childProductImages = fallback[ConfigurableMediaImages.imageType];
-        compatibleProducts.each(function(productId) {
-            if(childProductImages[productId] && ConfigurableMediaImages.isValidImage(childProductImages[productId])) {
-                childSwatchImage = childProductImages[productId];
-                return false; //break "loop"
+        // NB: the original Prototype code used `each(... return false)`, which does NOT break the
+        // loop (only `throw $break` does), so it iterated all compatible products and the LAST
+        // match won. Preserve that behaviour here — do not break on the first match.
+        let childSwatchImage = null;
+        const childProductImages = fallback[ConfigurableMediaImages.imageType];
+        compatibleProducts.forEach(function(childId) {
+            if(childProductImages[childId] && ConfigurableMediaImages.isValidImage(childProductImages[childId])) {
+                childSwatchImage = childProductImages[childId];
             }
         });
         if (childSwatchImage) {
@@ -116,9 +120,9 @@ var ConfigurableMediaImages = {
     },
 
     getImageObject: function(productId, imageUrl) {
-        var key = productId+'-'+imageUrl;
+        const key = productId+'-'+imageUrl;
         if(!ConfigurableMediaImages.imageObjects[key]) {
-            var image = document.createElement('img');
+            const image = document.createElement('img');
             image.src = imageUrl;
             ConfigurableMediaImages.imageObjects[key] = image;
         }
@@ -126,27 +130,27 @@ var ConfigurableMediaImages = {
     },
 
     updateImage(el) {
-        var select = el;
-        var label = select.options[select.selectedIndex].getAttribute('data-label');
-        var productId = optionsPrice.productId; //get product ID from options price object
+        const select = el;
+        const label = select.options[select.selectedIndex].getAttribute('data-label');
+        const productId = optionsPrice.productId; //get product ID from options price object
 
         //find all selected labels
-        var selectedLabels = [];
+        const selectedLabels = [];
 
-        var superAttributeSelects = document.querySelectorAll('.product-options .super-attribute-select');
+        const superAttributeSelects = document.querySelectorAll('.product-options .super-attribute-select');
         superAttributeSelects.forEach(function(option) {
             if (option.value !== '') {
                 selectedLabels.push(option.options[option.selectedIndex].getAttribute('data-label'));
             }
         });
 
-        var swatchImageUrl = ConfigurableMediaImages.getSwatchImage(productId, label, selectedLabels);
+        const swatchImageUrl = ConfigurableMediaImages.getSwatchImage(productId, label, selectedLabels);
         if (!ConfigurableMediaImages.isValidImage(swatchImageUrl)) {
             console.log('no image found');
             return;
         }
 
-        var swatchImage = ConfigurableMediaImages.getImageObject(productId, swatchImageUrl);
+        const swatchImage = ConfigurableMediaImages.getImageObject(productId, swatchImageUrl);
 
         this.swapImage(swatchImage);
     },
@@ -154,10 +158,12 @@ var ConfigurableMediaImages = {
     swapImage: function(targetImage) {
         targetImage.classList.add('gallery-image');
 
-        var imageGallery = document.querySelector('.product-image-gallery');
+        ProductMediaManager.destroyZoom();
+
+        const imageGallery = document.querySelector('.product-image-gallery');
 
         if (targetImage.complete) { // image already loaded -- swap immediately
-            var galleryImages = imageGallery.querySelectorAll('.gallery-image');
+            const galleryImages = imageGallery.querySelectorAll('.gallery-image');
             galleryImages.forEach(function(image) {
                 image.classList.remove('visible');
             });
@@ -167,6 +173,8 @@ var ConfigurableMediaImages = {
 
             // reveal new image
             targetImage.classList.add('visible');
+
+            ProductMediaManager.createZoom($j(targetImage));
         } else { // need to wait for image to load
             // add spinner
             imageGallery.classList.add('loading');
@@ -180,19 +188,21 @@ var ConfigurableMediaImages = {
                 imageGallery.classList.remove('loading');
 
                 // hide old image
-                var galleryImages = imageGallery.querySelectorAll('.gallery-image');
+                const galleryImages = imageGallery.querySelectorAll('.gallery-image');
                 galleryImages.forEach(function(image) {
                     image.classList.remove('visible');
                 });
 
                 // reveal new image
                 targetImage.classList.add('visible');
+
+                ProductMediaManager.createZoom($j(targetImage));
             });
         }
     },
 
     wireOptions: function() {
-        var selectElements = document.querySelectorAll('.product-options .super-attribute-select');
+        const selectElements = document.querySelectorAll('.product-options .super-attribute-select');
         selectElements.forEach(function(selectElement) {
             selectElement.addEventListener('change', function(e) {
                 ConfigurableMediaImages.updateImage(this);
@@ -201,7 +211,7 @@ var ConfigurableMediaImages = {
     },
 
     swapListImage: function(productId, imageObject) {
-        var originalImage = document.querySelector('#product-collection-image-' + productId);
+        const originalImage = document.querySelector('#product-collection-image-' + productId);
 
         if (imageObject.complete) { // swap image immediately
 
@@ -216,7 +226,7 @@ var ConfigurableMediaImages = {
 
         } else { // need to load image
 
-            var wrapper = originalImage.parentNode;
+            const wrapper = originalImage.parentNode;
 
             // add spinner
             wrapper.classList.add('loading');
@@ -240,12 +250,12 @@ var ConfigurableMediaImages = {
     },
 
     swapListImageByOption: function(productId, optionLabel) {
-        var swatchImageUrl = ConfigurableMediaImages.getSwatchImage(productId, optionLabel, [optionLabel]);
+        const swatchImageUrl = ConfigurableMediaImages.getSwatchImage(productId, optionLabel, [optionLabel]);
         if(!swatchImageUrl) {
             return;
         }
 
-        var newImage = ConfigurableMediaImages.getImageObject(productId, swatchImageUrl);
+        const newImage = ConfigurableMediaImages.getImageObject(productId, swatchImageUrl);
         newImage.classList.add('product-collection-image-' + productId);
 
         ConfigurableMediaImages.swapListImage(productId, newImage);

--- a/skin/frontend/rwd/default/js/configurableswatches/swatches-product.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/swatches-product.js
@@ -6,7 +6,7 @@
  */
 
 var windowLoaded = false;
-Event.observe(window, 'load', function() { windowLoaded = true; });
+window.addEventListener('load', function() { windowLoaded = true; });
 
 // rewrite the fillselect method from /js/varien/configurable.js
 Product.Config.prototype.fillSelect = function (element) {
@@ -23,16 +23,15 @@ Product.Config.prototype.configureForValues = function(){
 };
 
 Product.Config.prototype.origInitialize = Product.Config.prototype.initialize;
-Product.Config.prototype.initialize = function(config)
-{
-    this.origInitialize(config);
+Product.Config.prototype.initialize = function(config) {
     this.configureObservers = [];
+    this.origInitialize(config);
     this.loadOptions();
 };
 
 Product.Config.prototype.handleSelectChange = function(element) {
     this.configureElement(element);
-    this.configureObservers.each(function(funct) {
+    this.configureObservers.forEach(function(funct) {
         funct(element);
     });
 };
@@ -40,8 +39,8 @@ Product.Config.prototype.handleSelectChange = function(element) {
 Product.Config.prototype.origConfigure = Product.Config.prototype.configure;
 Product.Config.prototype.configure = function(event) {
     this.origConfigure(event);
-    var element = Event.element(event);
-    this.configureObservers.each(function(funct) {
+    const element = event.target;
+    this.configureObservers.forEach(function(funct) {
         funct(element);
     });
 };
@@ -57,16 +56,17 @@ Product.Config.prototype.configureSubscribe = function(funct)
  * Uses global var spConfig declared in template/configurableswatches/catalog/product/view/type/configurable.phtml
  **/
 Product.Config.prototype.loadOptions = function() {
-    this.settings.each(function(element){
+    const self = this;
+    this.settings.forEach(function(element){
         element.disabled = false;
-        element.options[0] = new Option(this.config.chooseText, '');
-        var attributeId = element.id.replace(/[a-z]*/, '');
-        var options = this.getAttributeOptions(attributeId);
+        element.options[0] = new Option(self.config.chooseText, '');
+        const attributeId = element.id.replace(/[a-z]*/, '');
+        const options = self.getAttributeOptions(attributeId);
         if(options) {
-            var index = 1;
-            for(var i=0;i<options.length;i++){
-                options[i].allowedProducts = options[i].products.clone();
-                element.options[index] = new Option(this.getOptionLabel(options[i], options[i].price), options[i].id);
+            let index = 1;
+            for(let i=0;i<options.length;i++){
+                options[i].allowedProducts = options[i].products.slice(0);
+                element.options[index] = new Option(self.getOptionLabel(options[i], options[i].price), options[i].id);
                 if (typeof options[i].price != 'undefined') {
                     element.options[index].setAttribute('price', options[i].price);
                 }
@@ -75,710 +75,659 @@ Product.Config.prototype.loadOptions = function() {
                 index++;
             }
         }
-        this.reloadOptionLabels(element);
-    }.bind(this));
-},
+        self.reloadOptionLabels(element);
+    });
+};
 
 
-Product.ConfigurableSwatches = Class.create();
-Product.ConfigurableSwatches.prototype = {
-    productConfig: false,
-    configurableAttributes: {},
-    // Options
-    _O: {
-        selectFirstOption: false // select the first option of the first configurable attribute (or first custom option if no configurable attributes exist)
-    },
-    // Flags
-    _F: {
-        currentAction: false,
-        firstOptionSelected: false,
-        nativeSelectChange: true
-    },
-    // Namespaces
-    _N: {
-        resetTimeout: false
-    },
-    // Elements
-    _E: {
-        cartBtn: {
-            btn: false,
-            txt: ['Add to Cart'],
-            onclick: function() { return false; }
+Product.ConfigurableSwatches = (function() {
+    function ProductConfigurableSwatches() { this.initialize(...arguments); }
+
+    ProductConfigurableSwatches.prototype = {
+        initialize: function(productConfig, config) {
+            if (config && typeof(config) == 'object') {
+                this.setConfig(config);
+            }
+            this.productConfig = productConfig;
+            const attributes = [];
+            for (const i in productConfig.config.attributes) {
+                attributes.push(productConfig.config.attributes[i]);
+            }
+            this.configurableAttributes = attributes;
+            this.run();
+            return this;
         },
-        availability: false,
-        optionOver: false,
-        optionOut: false,
-        _last: {
-            optionOver: false
+        productConfig: false,
+        configurableAttributes: {},
+        // Options
+        _O: {
+            selectFirstOption: false
         },
-        activeConfigurableOptions: [],
-        allConfigurableOptions: []
-    },
-    /**
-     *
-     * Gather configurable or custom option data (configurableAttributes),
-     * load the selects with options, and start to run everything that needs to be done
-     *
-     * @var configurableAttributes -
-     * For configurable options: a JSON created/modified in template/configurableswatches/catalog/product/view/type/configurable.phtml
-     * originally from Mage_Catalog_Block_Product_View_Type_Configurable::getJsonConfig()
-     * For custom options: a JSON created/modified in template/configurableswatches/catalog/product/view/options.phtml
-     * which comes from Mage_ConfigurableSwatches_Block_Catalog_Product_View_Options::getOptionJsonConfig()
-     **/
-    initialize: function(productConfig, config) {
-        // redefine some default options if configured
-        if (config && typeof(config) == 'object') {
-            this.setConfig(config);
-        }
-        this.productConfig = productConfig;
-        // Store configurable attribute data
-        var attributes = [];
-        for (var i in productConfig.config.attributes) {
-            attributes.push(productConfig.config.attributes[i]);
-        }
-        this.configurableAttributes = attributes;
-        // Run it
-        this.run();
-        return this;
-    },
-    /**
-     *
-     * redefine some default options if configured
-     **/
-    setConfig: function(config) {
-        this._O = Object.extend( this._O, config );
-    },
-    /**
-     *
-     * Sets the stage for configurable swatches, including attaching all the data and events needed in the process to all attributes and options
-     **/
-    run: function() {
-        // Set some dom dependent flags
-        this._F.hasPresetValues = (typeof spConfig != "undefined" && typeof spConfig.values != "undefined");
-
-        // Store stock status related items
-        this.setStockData();
-
-        // Set and store additional data on attributes and options and attach events to them
-        this.configurableAttributes.each(function(attr, i){
-            // set attribute data
-            this.setAttrData(attr, i);
-            attr.options.each(function(opt, j){
-                // set option data
-                this.setOptData(opt, attr, j);
-                // add option to allConfigurableOptions
-                this._E.allConfigurableOptions.push( opt );
-                // attach option events
-                this.attachOptEvents(opt);
-            }.bind(this));
-        }.bind(this));
-
-        this.productConfig.configureSubscribe(this.onSelectChange.bind(this));
-
-        if (this._F.hasPresetValues) {
-            // store values
-            this.values = spConfig.values;
-            // find the options
-            this.configurableAttributes.each(function(attr){
-                var optId = this.values[attr.id];
-                // Make new break so I don't break both loops using prototypes $break; This is so I don't have to loop through ALL options
-                var $break2 = {};
-                try {
-                    attr.options.each(function(opt){
-                        if (optId == opt.id) {
-                            this.selectOption(opt);
-                            throw $break2;
-                        };
-                    }.bind(this));
-                } catch(e) {};
-            }.bind(this));
-            this._F.presetValuesSelected = true;
-        } else if (this._O.selectFirstOption) {
-            this.selectFirstOption();
-        }
-        return this;
-    },
-    /**
-     *
-     * Enables/Disables the add to cart button to prevent the user from selecting an out of stock item.
-     * This also makes the necessary visual cues to show in stock/out of stock.
-     **/
-    setStockData: function() {
-        var cartBtn = $$('.add-to-cart button.button');
-        this._E.cartBtn = {
-            btn: cartBtn,
-            txt: cartBtn.invoke('readAttribute', 'title'),
-            onclick: cartBtn.length ? cartBtn[0].getAttribute('onclick') : ''
-        };
-        this._E.availability = $$('p.availability');
-        // Set cart button event
-        this._E.cartBtn.btn.invoke('up').invoke('observe','mouseenter',function(){
-            clearTimeout(this._N.resetTimeout);
-            this.resetAvailableOptions();
-        }.bind(this));
-    },
-    /**
-     *
-     * Sets the necessary flags on the attribute and stores the DOM elements related to the attribute
-     *
-     * @var attr - an object with options
-     * @var i - index of attr in `configurableAttributes`
-     **/
-    setAttrData: function(attr, i) {
-        var optionSelect = $('attribute' + attr.id);
         // Flags
-        attr._f = {};
-        // FIXME for Custom Option Support
-        attr._f.isCustomOption = false;
-        attr._f.isSwatch = optionSelect.hasClassName('swatch-select');
+        _F: {
+            currentAction: false,
+            firstOptionSelected: false,
+            nativeSelectChange: true
+        },
+        // Namespaces
+        _N: {
+            resetTimeout: false
+        },
         // Elements
-        attr._e = {
-            optionSelect: optionSelect,
-            attrLabel: this._u.getAttrLabelElement( attr.code ),
-            selectedOption: false,
+        _E: {
+            cartBtn: {
+                btn: false,
+                txt: ['Add to Cart'],
+                onclick: function() { return false; }
+            },
+            availability: false,
+            optionOver: false,
+            optionOut: false,
             _last: {
-                selectedOption: false
-            }
-        };
-        attr._e.optionSelect.attr = attr;
-        if (attr._f.isSwatch) {
-            attr._e.ul = $('configurable_swatch_' + attr.code);
-        };
-        return attr;
-    },
-    /**
-     *
-     * Set necessary flags and related DOM elements at an option level
-     *
-     * @var opt - object being looped through
-     * @var attr - the object from which the `opt` came from
-     * @var j - index of `opt` in `attr`
-     **/
-    setOptData: function(opt, attr, j) {
-        // Store Attribute on option
-        opt.attr = attr;
-        // Flags
-        opt._f = {
-            isSwatch: attr._f.isSwatch,
-            enabled: true,
-            active: false
-        };
-        // Elements
-        opt._e = {
-            option: this._u.getOptionElement(opt, attr, j)
-        };
-        opt._e.option.opt = opt;
-        if (attr._f.isSwatch) {
-            opt._e.a = $('swatch'+opt.id);
-            opt._e.li = $('option'+opt.id);
-            opt._e.ul = attr._e.ul;
-        }
-        return opt;
-    },
-    /**
-     *
-     * Attach click, mouseenter, and mouseleave events for each option/swatch
-     **/
-    attachOptEvents: function(opt) {
-        var attr = opt.attr;
-        // Swatch Events
-        if (opt._f.isSwatch) {
-            opt._e.a.observe('click', function(event) {
-                Event.stop(event);
-                this._F.currentAction = "click";
-                // set new last option
-                attr._e._last.selectedOption = attr._e.selectedOption;
-                // Store selected option
-                attr._e.selectedOption = opt;
+                optionOver: false
+            },
+            activeConfigurableOptions: [],
+            allConfigurableOptions: []
+        },
 
-                // Run the event
-                this.onOptionClick( attr );
-                return false;
-            }.bind(this)).observe('mouseenter', function(){
-                this._F.currentAction = "over-swatch";
-                // set active over option to this option
-                this._E.optionOver = opt;
-                this.onOptionOver();
-                // set the new last option
-                this._E._last.optionOver = this._E.optionOver;
-            }.bind(this)).observe('mouseleave', function(){
-                this._F.currentAction = "out-swatch";
-                this._E.optionOut = opt;
-                this.onOptionOut();
-            }.bind(this));
-        };
-    },
-    /**
-     *
-     * An optional method to select the first option on page load
-     **/
-    selectFirstOption: function() {
-        if (this.configurableAttributes.length) {
-            var attr = this.configurableAttributes[0];
-            if (attr.options.length) {
-                var opt = attr.options[0];
-                this.selectOption(opt);
-            };
-        };
-    },
-    /**
-     *
-     * Initialize the selecting of an option: set necessary flags,
-     * store active options, and remove last active options
-     * Send to onOptionClick method
-     **/
-    selectOption: function(opt) {
-        var attr = opt.attr;
+        setConfig: function(config) {
+            Object.assign(this._O, config);
+        },
 
-        this._F.currentAction = "click";
-        // set new last option
-        attr._e._last.selectedOption = attr._e.selectedOption;
-        // Store selected option
-        attr._e.selectedOption = opt;
+        /**
+         *
+         * Sets the stage for configurable swatches, including attaching all the data and events needed in the process to all attributes and options
+         **/
+        run: function() {
+            const self = this;
+            this._F.hasPresetValues = (typeof spConfig != "undefined" && typeof spConfig.values != "undefined");
 
-        // Run the event
-        this.onOptionClick( attr );
-    },
-    onSelectChange: function(select)
-    {
-        var attr = select.attr;
+            this.setStockData();
 
-        if (this._F.nativeSelectChange) {
-            this._F.currentAction = 'change';
-            var option = select.options[select.selectedIndex];
-            if (option.opt) {
-                attr._e._last.selectedOption = attr._e.selectedOption;
-                attr._e.selectedOption = option.opt;
+            this.configurableAttributes.forEach(function(attr, i){
+                self.setAttrData(attr, i);
+                attr.options.forEach(function(opt, j){
+                    self.setOptData(opt, attr, j);
+                    self._E.allConfigurableOptions.push( opt );
+                    self.attachOptEvents(opt);
+                });
+            });
 
-                // Mark last option as no longer active
-                if (attr._e._last.selectedOption) attr._e._last.selectedOption._f.active = false;
-                // Mark this option as active
-                option.opt._f.active = true;
+            this.productConfig.configureSubscribe(this.onSelectChange.bind(this));
 
-                // remove last active option from activeConfigurableOptions
-                var pos = this._E.activeConfigurableOptions.indexOf( attr._e._last.selectedOption );
-                if (pos !== -1) this._E.activeConfigurableOptions.splice(pos, 1);
-
-                // add active option to activeConfigurableOptions
-                this._E.activeConfigurableOptions.push( option.opt );
-
-            } else { // opt is null (e.g. the first option in a select "--Please Select--")
-                // remove last active option from activeConfigurableOptions
-                var pos = this._E.activeConfigurableOptions.indexOf( attr._e._last.selectedOption );
-                if (pos !== -1) this._E.activeConfigurableOptions.splice(pos, 1);
-                // Make last option no longer active
-                if (attr._e._last.selectedOption) attr._e._last.selectedOption._f.active = false;
-            }
-            this.setAvailableOptions();
-            this.checkStockStatus();
-        }
-    },
-    /**
-     *
-     * Run everything that needs to happen (visually and functionally) when an option is clicked
-     **/
-    onOptionClick: function(attr) {
-        var opt = attr._e.selectedOption;
-        if (opt) {
-            if (opt != attr._e._last.selectedOption) {
-                // Set the attribute's label
-                attr._e.attrLabel.innerHTML = this.getOptionLabel(opt);
-
-                if (opt._f.isSwatch) {
-                    // Clear .selected from any other li for this attr
-                    opt._e.ul.select('li').invoke('removeClassName','selected');
-                    // Add selected class to swatch's li
-                    opt._e.li.addClassName('selected');
-                    // Add validation styling to label
-                    var inputBox = attr._e.optionSelect.up();
-                    if (inputBox.hasClassName('validation-error')) {
-                        inputBox.removeClassName('validation-error');
-                        inputBox.down('.validation-advice').remove();
+            if (this._F.hasPresetValues) {
+                this.values = spConfig.values;
+                this.configurableAttributes.forEach(function(attr){
+                    const optId = self.values[attr.id];
+                    const matched = attr.options.find(function(opt) {
+                        return optId == opt.id;
+                    });
+                    if (matched) {
+                        self.selectOption(matched);
                     }
-                };
-
-                // Mark last option as no longer active
-                if (attr._e._last.selectedOption) attr._e._last.selectedOption._f.active = false;
-                // Mark this option as active
-                opt._f.active = true;
-
-                // remove last active option from activeConfigurableOptions
-                var pos = this._E.activeConfigurableOptions.indexOf( attr._e._last.selectedOption );
-                if (pos !== -1) this._E.activeConfigurableOptions.splice(pos, 1);
-
-                // add active option to activeConfigurableOptions
-                this._E.activeConfigurableOptions.push( opt );
-
-                // Set what other configurable options are available now this option was selected
-                this.setAvailableOptions();
-                // preview available after clicking to show the mouseover state
-                if (opt._f.isSwatch && !attr._f.isCustomOption && this._F.firstOptionSelected) {
-                    this.previewAvailableOptions();
-                };
-            };
-        } else { // opt is null (e.g. the first option in a select "--Please Select--")
-            // remove last active option from activeConfigurableOptions
-            var pos = this._E.activeConfigurableOptions.indexOf( attr._e._last.selectedOption );
-            if (pos !== -1) this._E.activeConfigurableOptions.splice(pos, 1);
-            // Make last option no longer active
-            if (attr._e._last.selectedOption) attr._e._last.selectedOption._f.active = false;
-            // loop through all options and set available
-            this.setAvailableOptions();
-        }
-        // check and set stock status
-        this.checkStockStatus();
-
-        // Make sure all the selected options are actually selected in their hidden select elements
-        this._E.activeConfigurableOptions.each(function(selectedOpt){
-            var oldDisabledValue = selectedOpt._e.option.disabled;
-            selectedOpt._e.option.disabled = false;
-            selectedOpt._e.option.selected = true;
-            selectedOpt._e.option.disabled = oldDisabledValue;
-        });
-
-        // update select
-        if ((this._O.selectFirstOption && !this._F.firstOptionSelected) ||
-            (this._F.hasPresetValues && !this._F.presetValuesSelected) ||
-            (!windowLoaded)) {
-            Event.observe(window, 'load', function() {
-                window.setTimeout(function() {
-                    this.updateSelect( attr );
-                    this._F.firstOptionSelected = true;
-                }.bind(this), 200);
-            }.bind(this));
-        } else {
-            this.updateSelect(attr);
-            this._F.firstOptionSelected = true;
-        }
-    },
-    /**
-     *
-     * Visual cues if you were to click on the option/swatch you're hovering over
-     * - Show enabled/disabled state of other options/swatches
-     * - Preview label of hovered swatch
-     * - Preview the stock status
-     **/
-    onOptionOver: function() {
-        // Since browsers like Safari on iOS will emulate a hover event, use custom event detection to determine
-        // whether if input is touch. If event *is* touch, then don't run this code so that the onOptionClick
-        // method will be triggered.
-        if(PointerManager.getPointer() == PointerManager.TOUCH_POINTER_TYPE) {
-            return;
-        }
-
-        var opt = this._E.optionOver;
-        var attr = opt.attr;
-        var lastOpt = this._E._last.optionOver;
-
-        // clear mouseout timeout
-        clearTimeout(this._N.resetTimeout);
-
-        // Remove last hover class
-        if (lastOpt && lastOpt._f.isSwatch) {
-            lastOpt._e.li.removeClassName('hover');
-        }
-        // Set new hover class
-        if (opt._f.isSwatch) {
-            opt._e.li.addClassName('hover');
-        }
-
-        // Change label
-        attr._e.attrLabel.innerHTML = this.getOptionLabel(opt);
-
-        // run setAvailable before previewAvailable and reset last label if
-        // 1) the timeout has not been run (which means lastOpt != false) and
-        // 2) the last hover swatch's attribute is different than this hover swatch's
-        this.setAvailableOptions();
-        if(lastOpt && lastOpt.attr.id != opt.attr.id) {
-            // reset last hover swatch's attribute
-            lastOpt.attr._e.attrLabel.innerHTML = lastOpt.attr._e.selectedOption ? this.getOptionLabel(lastOpt.attr._e.selectedOption) : '';
-        }
-
-        // Preview available
-        if (!attr._f.isCustomOption) {
-            this.previewAvailableOptions();
-
-            // Set Stock Status
-            // start with all active options, minus the one from the attribute currently being hovered
-            var stockCheckOptions = this._E.activeConfigurableOptions;
-            if (!opt._f.active) {
-                // Remove the attribute's selected option (if applicable)
-                stockCheckOptions = stockCheckOptions.without( attr._e.selectedOption );
-                // Add the currently hovered option
-                stockCheckOptions.push(opt);
-            };
-            this.checkStockStatus( stockCheckOptions );
-        };
-    },
-    /**
-     *
-     * Reset all visual cues from onOptionOver
-     **/
-    onOptionOut: function() {
-        // Since browsers like Safari on iOS will emulate a hover event, use custom event detection to determine
-        // whether if input is touch. If event *is* touch, then don't run this code so that the onOptionClick
-        // method will be triggered.
-        if (PointerManager.getPointer() == PointerManager.TOUCH_POINTER_TYPE) {
-            return;
-        }
-
-        var opt = this._E.optionOver;
-
-        // Set timeout
-        this._N.resetTimeout = setTimeout(function(){
-            this.resetAvailableOptions();
-        }.bind(this), 300);
-
-        if (opt && opt._f.isSwatch) {
-            opt._e.li.removeClassName('hover');
-        };
-    },
-    /**
-     *
-     * Loop through each option across all attributes to set them as available or not
-     * and set necessary flags as such
-     **/
-    setAvailableOptions: function() {
-        var args = arguments;
-        // Allows to check one specific option instead of having to loop through all of them
-        var loopThroughOptions = args.length ? args[0] : this._E.allConfigurableOptions;
-        loopThroughOptions.each( function(loopingOption) {
-            var productArrays = [ loopingOption.products ];
-            // If the attr of the looping swatch has a selection
-            if (loopingOption.attr._e.selectedOption) {
-                this._E.activeConfigurableOptions.without( loopingOption.attr._e.selectedOption ).each(function(selectedOpt) {
-                    productArrays.push( selectedOpt.products );
                 });
-            } else {
-                this._E.activeConfigurableOptions.each(function(selectedOpt){
-                    productArrays.push( selectedOpt.products );
-                });
+                this._F.presetValuesSelected = true;
+            } else if (this._O.selectFirstOption) {
+                this.selectFirstOption();
             }
-            var result = this._u.intersectAll( productArrays );
-            this.setOptionStatus(loopingOption, result.length);
-        }.bind(this));
-    },
-    /**
-     *
-     * Loop though each option across all attributes to preview their availability if the
-     * option being hovered were to be selected
-     **/
-    previewAvailableOptions: function() {
-        var opt = this._E.optionOver;
-        if (!opt) {
-            return; // Exit if there is no option currently being hovered
-        }
+            return this;
+        },
 
-        var attr = opt.attr;
-
-        this._E.allConfigurableOptions.each( function(loopingOption, i) {
-            var productArrays = [ loopingOption.products, opt.products ];
-
-            // keep all swatches in the same attribute as they were
-            if (attr.id == loopingOption.attr.id) {
-                return;
-            }
-            // if loop attribute has no selection, then add selected swatches that are not in the hover swatch's attribute
-            if (!loopingOption.attr._e.selectedOption) {
-                this._E.activeConfigurableOptions.each(function(selectedOpt){
-                    if (selectedOpt.attr.id != opt.attr.id) {
-                        productArrays.push( selectedOpt.products );
-                    };
-                });
+        /**
+         *
+         * Enables/Disables the add to cart button to prevent the user from selecting an out of stock item.
+         * This also makes the necessary visual cues to show in stock/out of stock.
+         **/
+        setStockData: function() {
+            const self = this;
+            const cartBtn = Array.from(document.querySelectorAll('.add-to-cart button.button'));
+            this._E.cartBtn = {
+                btn: cartBtn,
+                txt: cartBtn.map(function(el) { return el.getAttribute('title'); }),
+                onclick: cartBtn.length ? cartBtn[0].getAttribute('onclick') : ''
             };
-            var result = this._u.intersectAll( productArrays );
-            this.setOptionStatus(loopingOption, result.length);
-        }.bind(this));
-    },
-    /**
-     *
-     * Reset all the options and their availability, the attribute labels, and the stock status
-     **/
-    resetAvailableOptions: function() {
-        var opt = this._E.optionOver;
-
-        if (opt) {
-            var attr = opt.attr;
-
-            // Reset last label
-            attr._e.attrLabel.innerHTML = attr._e.selectedOption ? this.getOptionLabel(attr._e.selectedOption) : '';
-
-            // Reset current action
-            this._F.currentAction = false;
-
-            // process
-            if (!attr._f.isCustomOption) {
-                // Reset the availability of all options
-                this.setAvailableOptions();
-                // Set stock status
-                this.checkStockStatus();
-            }
-
-            // reset the last optionOver
-            this._E._last.optionOver = false;
-        };
-    },
-    /**
-     *
-     * Run a check though all the selected options and set the stock status if any are disabled
-     **/
-    checkStockStatus: function() {
-        var inStock = true;
-        var checkOptions = arguments.length ? arguments[0] : this._E.activeConfigurableOptions;
-        // Set out of stock if any selected item is not enabled
-        checkOptions.each( function(selectedOpt) {
-            if (!selectedOpt._f.enabled) {
-                inStock = false;
-                throw $break;
-            }
-        });
-        this.setStockStatus( inStock );
-    },
-    /**
-     *
-     * Do all the visual changes and enable/disable add to cart button depending on the stock status
-     *
-     * @var inStock - boolean
-     **/
-    setStockStatus: function(inStock) {
-        if (inStock) {
-            this._E.availability.each(function(el) {
-                var el = $(el);
-                el.addClassName('in-stock').removeClassName('out-of-stock');
-                el.select('span').invoke('update', Translator.translate('In Stock'));
+            this._E.availability = Array.from(document.querySelectorAll('p.availability'));
+            cartBtn.forEach(function(el) {
+                el.parentElement.addEventListener('mouseenter', function() {
+                    clearTimeout(self._N.resetTimeout);
+                    self.resetAvailableOptions();
+                });
             });
+        },
 
-            this._E.cartBtn.btn.each(function(el, index) {
-                var el = $(el);
-                el.disabled = false;
-                el.removeClassName('out-of-stock');
-                el.writeAttribute('onclick', this._E.cartBtn.onclick);
-                el.title = '' + Translator.translate(this._E.cartBtn.txt[index]);
-                el.select('span span').invoke('update', Translator.translate(this._E.cartBtn.txt[index]));
-            }.bind(this));
-        } else {
-            this._E.availability.each(function(el) {
-                var el = $(el);
-                el.addClassName('out-of-stock').removeClassName('in-stock');
-                el.select('span').invoke('update', Translator.translate('Out of Stock'));
-            });
-            this._E.cartBtn.btn.each(function(el) {
-                var el = $(el);
-                el.addClassName('out-of-stock');
-                el.disabled = true;
-                el.removeAttribute('onclick');
-                el.observe('click', function(event) {
-                    Event.stop(event);
+        /**
+         *
+         * Sets the necessary flags on the attribute and stores the DOM elements related to the attribute
+         *
+         * @var attr - an object with options
+         * @var i - index of attr in `configurableAttributes`
+         **/
+        setAttrData: function(attr, i) {
+            const optionSelect = document.getElementById('attribute' + attr.id);
+            attr._f = {};
+            attr._f.isCustomOption = false;
+            attr._f.isSwatch = optionSelect.classList.contains('swatch-select');
+            attr._e = {
+                optionSelect: optionSelect,
+                attrLabel: this._u.getAttrLabelElement( attr.code ),
+                selectedOption: false,
+                _last: {
+                    selectedOption: false
+                }
+            };
+            attr._e.optionSelect.attr = attr;
+            if (attr._f.isSwatch) {
+                attr._e.ul = document.getElementById('configurable_swatch_' + attr.code);
+            }
+            return attr;
+        },
+
+        /**
+         *
+         * Set necessary flags and related DOM elements at an option level
+         *
+         * @var opt - object being looped through
+         * @var attr - the object from which the `opt` came from
+         * @var j - index of `opt` in `attr`
+         **/
+        setOptData: function(opt, attr, j) {
+            opt.attr = attr;
+            opt._f = {
+                isSwatch: attr._f.isSwatch,
+                enabled: true,
+                active: false
+            };
+            opt._e = {
+                option: this._u.getOptionElement(opt, attr, j)
+            };
+            opt._e.option.opt = opt;
+            if (attr._f.isSwatch) {
+                opt._e.a = document.getElementById('swatch'+opt.id);
+                opt._e.li = document.getElementById('option'+opt.id);
+                opt._e.ul = attr._e.ul;
+            }
+            return opt;
+        },
+
+        /**
+         *
+         * Attach click, mouseenter, and mouseleave events for each option/swatch
+         **/
+        attachOptEvents: function(opt) {
+            const self = this;
+            const attr = opt.attr;
+            if (opt._f.isSwatch) {
+                opt._e.a.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    self._F.currentAction = "click";
+                    attr._e._last.selectedOption = attr._e.selectedOption;
+                    attr._e.selectedOption = opt;
+                    self.onOptionClick( attr );
                     return false;
                 });
-                el.writeAttribute('title', Translator.translate('Out of Stock'));
-                el.select('span span').invoke('update', Translator.translate('Out of Stock'));
-            });
-        }
-    },
-    /**
-     *
-     * Enable/disable a specific option
-     **/
-    setOptionStatus: function(opt, enabled) {
-        var attr = opt.attr;
-        var enabled = enabled > 0;
+                opt._e.a.addEventListener('mouseenter', function(){
+                    self._F.currentAction = "over-swatch";
+                    self._E.optionOver = opt;
+                    self.onOptionOver();
+                    self._E._last.optionOver = self._E.optionOver;
+                });
+                opt._e.a.addEventListener('mouseleave', function(){
+                    self._F.currentAction = "out-swatch";
+                    self._E.optionOut = opt;
+                    self.onOptionOut();
+                });
+            }
+        },
 
-        // Set enabled flag on option
-        opt._f.enabled = enabled;
-        if (opt._f.isSwatch) {
-            var method = enabled ? 'removeClassName' : 'addClassName';
-            opt._e.li[method]('not-available');
-        } else if (this._F.currentAction == "click" || this._F.currentAction == "change") {
-            // Set disabled and selected if action is permanent, ONLY for non-swatch selects
-            var attrDisable = enabled ? 'removeAttribute' : 'writeAttribute';
-            $(opt._e.option)[attrDisable]('disabled');
-        }
-        return enabled;
-    },
-    /**
-     *
-     * Make sure all events related to the select being updated are fired appropriately
-     **/
-    updateSelect: function(attr) {
-        // fire select change event
-        // this will trigger the validation of the select
-        // only fire if this attribute has had a selected option at one time
-        if (attr._e.selectedOption !== false && attr._e.optionSelect) {
-            this._F.nativeSelectChange = false;
-            ConfigurableMediaImages.updateImage(attr._e.optionSelect);
-            this.productConfig.handleSelectChange(attr._e.optionSelect);
-            this._F.nativeSelectChange = true;
-        };
-    },
-    /**
-     * Return text that should be displayed in attribute label for a certain option
-     *
-     * @param {object} option
-     * return {string}
-     */
-    getOptionLabel: function(option) {
-        return this.productConfig.getOptionLabel(option, option.price);
-    },
-
-    /**
-     * Utility methods - none of these require more information than what is sent to them in the params or any outside methods
-     */
-    _u: {
         /**
          *
-         * Find (or else, make) the attribute's label
+         * An optional method to select the first option on page load
          **/
-        getAttrLabelElement: function(attrCode) {
-            var spanLabel = $$('#select_label_'+attrCode);
-            if (spanLabel.length) {
-                return spanLabel[0];
+        selectFirstOption: function() {
+            if (this.configurableAttributes.length) {
+                const attr = this.configurableAttributes[0];
+                if (attr.options.length) {
+                    const opt = attr.options[0];
+                    this.selectOption(opt);
+                }
+            }
+        },
+
+        /**
+         *
+         * Initialize the selecting of an option: set necessary flags,
+         * store active options, and remove last active options
+         * Send to onOptionClick method
+         **/
+        selectOption: function(opt) {
+            const attr = opt.attr;
+            this._F.currentAction = "click";
+            attr._e._last.selectedOption = attr._e.selectedOption;
+            attr._e.selectedOption = opt;
+            this.onOptionClick( attr );
+        },
+
+        onSelectChange: function(select)
+        {
+            const attr = select.attr;
+
+            if (this._F.nativeSelectChange) {
+                this._F.currentAction = 'change';
+                const option = select.options[select.selectedIndex];
+                if (option.opt) {
+                    attr._e._last.selectedOption = attr._e.selectedOption;
+                    attr._e.selectedOption = option.opt;
+
+                    if (attr._e._last.selectedOption) attr._e._last.selectedOption._f.active = false;
+                    option.opt._f.active = true;
+
+                    var pos = this._E.activeConfigurableOptions.indexOf( attr._e._last.selectedOption );
+                    if (pos !== -1) this._E.activeConfigurableOptions.splice(pos, 1);
+
+                    this._E.activeConfigurableOptions.push( option.opt );
+
+                } else {
+                    var pos = this._E.activeConfigurableOptions.indexOf( attr._e._last.selectedOption );
+                    if (pos !== -1) this._E.activeConfigurableOptions.splice(pos, 1);
+                    if (attr._e._last.selectedOption) attr._e._last.selectedOption._f.active = false;
+                }
+                this.setAvailableOptions();
+                this.checkStockStatus();
+            }
+        },
+
+        /**
+         *
+         * Run everything that needs to happen (visually and functionally) when an option is clicked
+         **/
+        onOptionClick: function(attr) {
+            const self = this;
+            const opt = attr._e.selectedOption;
+            if (opt) {
+                if (opt != attr._e._last.selectedOption) {
+                    attr._e.attrLabel.innerHTML = this.getOptionLabel(opt);
+
+                    if (opt._f.isSwatch) {
+                        opt._e.ul.querySelectorAll('li').forEach(function(li) {
+                            li.classList.remove('selected');
+                        });
+                        opt._e.li.classList.add('selected');
+                        const inputBox = attr._e.optionSelect.parentElement;
+                        if (inputBox.classList.contains('validation-error')) {
+                            inputBox.classList.remove('validation-error');
+                            const advice = inputBox.querySelector('.validation-advice');
+                            if (advice) advice.remove();
+                        }
+                    }
+
+                    if (attr._e._last.selectedOption) attr._e._last.selectedOption._f.active = false;
+                    opt._f.active = true;
+
+                    var pos = this._E.activeConfigurableOptions.indexOf( attr._e._last.selectedOption );
+                    if (pos !== -1) this._E.activeConfigurableOptions.splice(pos, 1);
+
+                    this._E.activeConfigurableOptions.push( opt );
+
+                    this.setAvailableOptions();
+                    if (opt._f.isSwatch && !attr._f.isCustomOption && this._F.firstOptionSelected) {
+                        this.previewAvailableOptions();
+                    }
+                }
             } else {
-                var label = $$('#'+attrCode+'_label');
-                if (label.length) {
-                    return label[0].insert({ 'bottom': ' <span id="select_label_'+attrCode+'" class="select-label"></span>'}).select('span.select-label')[0];
-                };
-            };
-            return false;
-        },
-        /**
-         *
-         * Find the DOM element option relating to the option object in configurableAttributes
-         **/
-        getOptionElement: function(opt, attr, idx) {
-            var indexedOption = attr._e.optionSelect.options[idx+1];
-            if (indexedOption && indexedOption.value == opt.id) {
-                return indexedOption;
-            };
-            var optionElement = false;
-            var optionsLen = attr._e.optionSelect.options.length;
-            var option;
-            for (var i=0; i<optionsLen; i++) {
-                option = attr._e.optionSelect.options[i];
-                if (option.value == opt.id) {
-                    optionElement = option;
-                    throw $break;
-                };
+                var pos = this._E.activeConfigurableOptions.indexOf( attr._e._last.selectedOption );
+                if (pos !== -1) this._E.activeConfigurableOptions.splice(pos, 1);
+                if (attr._e._last.selectedOption) attr._e._last.selectedOption._f.active = false;
+                this.setAvailableOptions();
             }
-            return optionElement;
-        },
-        /**
-         *
-         * Find intersecting items from an array of arrays
-         *
-         * @var lists - array
-         * Example: intersectAll([ [1,2,3], [2,3,4] ]); returns [2,3]
-         **/
-        intersectAll: function(lists) {
-            if (lists.length == 0) return [];
-            else if (lists.length == 1) return lists[0];
+            this.checkStockStatus();
 
-            var result = lists[0];
-            for (var i = 1; i < lists.length; i++) {
-                if (!result.length) break;
-                result = result.intersect(lists[i]);
+            this._E.activeConfigurableOptions.forEach(function(selectedOpt){
+                const oldDisabledValue = selectedOpt._e.option.disabled;
+                selectedOpt._e.option.disabled = false;
+                selectedOpt._e.option.selected = true;
+                selectedOpt._e.option.disabled = oldDisabledValue;
+            });
+
+            if ((this._O.selectFirstOption && !this._F.firstOptionSelected) ||
+                (this._F.hasPresetValues && !this._F.presetValuesSelected) ||
+                (!windowLoaded)) {
+                window.addEventListener('load', function() {
+                    window.setTimeout(function() {
+                        self.updateSelect( attr );
+                        self._F.firstOptionSelected = true;
+                    }, 200);
+                });
+            } else {
+                this.updateSelect(attr);
+                this._F.firstOptionSelected = true;
             }
-            return result;
+        },
+
+        /**
+         *
+         * Visual cues if you were to click on the option/swatch you're hovering over
+         * - Show enabled/disabled state of other options/swatches
+         * - Preview label of hovered swatch
+         * - Preview the stock status
+         **/
+        onOptionOver: function() {
+            if(PointerManager.getPointer() == PointerManager.TOUCH_POINTER_TYPE) {
+                return;
+            }
+
+            const opt = this._E.optionOver;
+            const attr = opt.attr;
+            const lastOpt = this._E._last.optionOver;
+
+            clearTimeout(this._N.resetTimeout);
+
+            if (lastOpt && lastOpt._f.isSwatch) {
+                lastOpt._e.li.classList.remove('hover');
+            }
+            if (opt._f.isSwatch) {
+                opt._e.li.classList.add('hover');
+            }
+
+            attr._e.attrLabel.innerHTML = this.getOptionLabel(opt);
+
+            this.setAvailableOptions();
+            if(lastOpt && lastOpt.attr.id != opt.attr.id) {
+                lastOpt.attr._e.attrLabel.innerHTML = lastOpt.attr._e.selectedOption ? this.getOptionLabel(lastOpt.attr._e.selectedOption) : '';
+            }
+
+            if (!attr._f.isCustomOption) {
+                this.previewAvailableOptions();
+
+                let stockCheckOptions = this._E.activeConfigurableOptions;
+                if (!opt._f.active) {
+                    stockCheckOptions = stockCheckOptions.filter(function(o) { return o !== attr._e.selectedOption; });
+                    stockCheckOptions.push(opt);
+                }
+                this.checkStockStatus( stockCheckOptions );
+            }
+        },
+
+        /**
+         *
+         * Reset all visual cues from onOptionOver
+         **/
+        onOptionOut: function() {
+            if (PointerManager.getPointer() == PointerManager.TOUCH_POINTER_TYPE) {
+                return;
+            }
+
+            const self = this;
+            const opt = this._E.optionOver;
+
+            this._N.resetTimeout = setTimeout(function(){
+                self.resetAvailableOptions();
+            }, 300);
+
+            if (opt && opt._f.isSwatch) {
+                opt._e.li.classList.remove('hover');
+            }
+        },
+
+        /**
+         *
+         * Loop through each option across all attributes to set them as available or not
+         * and set necessary flags as such
+         **/
+        setAvailableOptions: function() {
+            const self = this;
+            const args = arguments;
+            const loopThroughOptions = args.length ? args[0] : this._E.allConfigurableOptions;
+            loopThroughOptions.forEach( function(loopingOption) {
+                const productArrays = [ loopingOption.products ];
+                if (loopingOption.attr._e.selectedOption) {
+                    self._E.activeConfigurableOptions
+                        .filter(function(o) { return o !== loopingOption.attr._e.selectedOption; })
+                        .forEach(function(selectedOpt) {
+                            productArrays.push( selectedOpt.products );
+                        });
+                } else {
+                    self._E.activeConfigurableOptions.forEach(function(selectedOpt){
+                        productArrays.push( selectedOpt.products );
+                    });
+                }
+                const result = self._u.intersectAll( productArrays );
+                self.setOptionStatus(loopingOption, result.length);
+            });
+        },
+
+        /**
+         *
+         * Loop though each option across all attributes to preview their availability if the
+         * option being hovered were to be selected
+         **/
+        previewAvailableOptions: function() {
+            const self = this;
+            const opt = this._E.optionOver;
+            if (!opt) {
+                return;
+            }
+
+            const attr = opt.attr;
+
+            this._E.allConfigurableOptions.forEach( function(loopingOption, i) {
+                const productArrays = [ loopingOption.products, opt.products ];
+
+                if (attr.id == loopingOption.attr.id) {
+                    return;
+                }
+                if (!loopingOption.attr._e.selectedOption) {
+                    self._E.activeConfigurableOptions.forEach(function(selectedOpt){
+                        if (selectedOpt.attr.id != opt.attr.id) {
+                            productArrays.push( selectedOpt.products );
+                        }
+                    });
+                }
+                const result = self._u.intersectAll( productArrays );
+                self.setOptionStatus(loopingOption, result.length);
+            });
+        },
+
+        /**
+         *
+         * Reset all the options and their availability, the attribute labels, and the stock status
+         **/
+        resetAvailableOptions: function() {
+            const opt = this._E.optionOver;
+
+            if (opt) {
+                const attr = opt.attr;
+
+                attr._e.attrLabel.innerHTML = attr._e.selectedOption ? this.getOptionLabel(attr._e.selectedOption) : '';
+                this._F.currentAction = false;
+
+                if (!attr._f.isCustomOption) {
+                    this.setAvailableOptions();
+                    this.checkStockStatus();
+                }
+
+                this._E._last.optionOver = false;
+            }
+        },
+
+        /**
+         *
+         * Run a check though all the selected options and set the stock status if any are disabled
+         **/
+        checkStockStatus: function() {
+            const checkOptions = arguments.length ? arguments[0] : this._E.activeConfigurableOptions;
+            const inStock = !checkOptions.some(function(selectedOpt) {
+                return !selectedOpt._f.enabled;
+            });
+            this.setStockStatus( inStock );
+        },
+
+        /**
+         *
+         * Do all the visual changes and enable/disable add to cart button depending on the stock status
+         *
+         * @var inStock - boolean
+         **/
+        setStockStatus: function(inStock) {
+            const self = this;
+            if (inStock) {
+                this._E.availability.forEach(function(el) {
+                    el.classList.add('in-stock');
+                    el.classList.remove('out-of-stock');
+                    el.querySelectorAll('span').forEach(function(span) {
+                        span.innerHTML = Translator.translate('In Stock');
+                    });
+                });
+
+                this._E.cartBtn.btn.forEach(function(el, index) {
+                    el.disabled = false;
+                    el.classList.remove('out-of-stock');
+                    if (self._E.cartBtn.onclick) {
+                        el.setAttribute('onclick', self._E.cartBtn.onclick);
+                    } else {
+                        el.removeAttribute('onclick');
+                    }
+                    el.title = '' + Translator.translate(self._E.cartBtn.txt[index]);
+                    el.querySelectorAll('span span').forEach(function(span) {
+                        span.innerHTML = Translator.translate(self._E.cartBtn.txt[index]);
+                    });
+                });
+            } else {
+                this._E.availability.forEach(function(el) {
+                    el.classList.add('out-of-stock');
+                    el.classList.remove('in-stock');
+                    el.querySelectorAll('span').forEach(function(span) {
+                        span.innerHTML = Translator.translate('Out of Stock');
+                    });
+                });
+                this._E.cartBtn.btn.forEach(function(el) {
+                    el.classList.add('out-of-stock');
+                    el.disabled = true;
+                    el.removeAttribute('onclick');
+                    el.addEventListener('click', function(event) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        return false;
+                    });
+                    el.setAttribute('title', Translator.translate('Out of Stock'));
+                    el.querySelectorAll('span span').forEach(function(span) {
+                        span.innerHTML = Translator.translate('Out of Stock');
+                    });
+                });
+            }
+        },
+
+        /**
+         *
+         * Enable/disable a specific option
+         **/
+        setOptionStatus: function(opt, enabled) {
+            enabled = enabled > 0;
+            opt._f.enabled = enabled;
+            if (opt._f.isSwatch) {
+                if (enabled) {
+                    opt._e.li.classList.remove('not-available');
+                } else {
+                    opt._e.li.classList.add('not-available');
+                }
+            } else if (this._F.currentAction == "click" || this._F.currentAction == "change") {
+                if (enabled) {
+                    opt._e.option.removeAttribute('disabled');
+                } else {
+                    opt._e.option.setAttribute('disabled', 'disabled');
+                }
+            }
+            return enabled;
+        },
+
+        /**
+         *
+         * Make sure all events related to the select being updated are fired appropriately
+         **/
+        updateSelect: function(attr) {
+            if (attr._e.selectedOption !== false && attr._e.optionSelect) {
+                this._F.nativeSelectChange = false;
+                ConfigurableMediaImages.updateImage(attr._e.optionSelect);
+                this.productConfig.handleSelectChange(attr._e.optionSelect);
+                this._F.nativeSelectChange = true;
+            }
+        },
+
+        /**
+         * Return text that should be displayed in attribute label for a certain option
+         *
+         * @param {object} option
+         * return {string}
+         */
+        getOptionLabel: function(option) {
+            return this.productConfig.getOptionLabel(option, option.price);
+        },
+
+        /**
+         * Utility methods - none of these require more information than what is sent to them in the params or any outside methods
+         */
+        _u: {
+            /**
+             *
+             * Find (or else, make) the attribute's label
+             **/
+            getAttrLabelElement: function(attrCode) {
+                const spanLabel = document.querySelectorAll('#select_label_'+attrCode);
+                if (spanLabel.length) {
+                    return spanLabel[0];
+                } else {
+                    const labels = document.querySelectorAll('#'+attrCode+'_label');
+                    if (labels.length) {
+                        labels[0].insertAdjacentHTML('beforeend', ' <span id="select_label_'+attrCode+'" class="select-label"></span>');
+                        return labels[0].querySelector('span.select-label');
+                    }
+                }
+                return false;
+            },
+
+            /**
+             *
+             * Find the DOM element option relating to the option object in configurableAttributes
+             **/
+            getOptionElement: function(opt, attr, idx) {
+                const indexedOption = attr._e.optionSelect.options[idx+1];
+                if (indexedOption && indexedOption.value == opt.id) {
+                    return indexedOption;
+                }
+                let optionElement = false;
+                const optionsLen = attr._e.optionSelect.options.length;
+                for (let i=0; i<optionsLen; i++) {
+                    const option = attr._e.optionSelect.options[i];
+                    if (option.value == opt.id) {
+                        optionElement = option;
+                        break;
+                    }
+                }
+                return optionElement;
+            },
+
+            /**
+             *
+             * Find intersecting items from an array of arrays
+             *
+             * @var lists - array
+             * Example: intersectAll([ [1,2,3], [2,3,4] ]); returns [2,3]
+             **/
+            intersectAll: function(lists) {
+                if (lists.length == 0) return [];
+                else if (lists.length == 1) return lists[0];
+
+                let result = lists[0];
+                for (let i = 1; i < lists.length; i++) {
+                    if (!result.length) break;
+                    const other = lists[i];
+                    result = result.filter(function(item) { return other.indexOf(item) !== -1; });
+                }
+                return result;
+            }
         }
-    }
-};
+    };
+    Varien.classCompat(ProductConfigurableSwatches);
+
+    return ProductConfigurableSwatches;
+})();

--- a/skin/frontend/rwd/default/js/minicart.js
+++ b/skin/frontend/rwd/default/js/minicart.js
@@ -32,7 +32,7 @@ Minicart.prototype = {
     initAfterEvents : {},
     removeItemAfterEvents : {},
     init: function() {
-        var cart = this;
+        const cart = this;
 
         // bind remove event
         $j(this.selectors.itemRemove).unbind('click.minicart').bind('click.minicart', function(e) {
@@ -58,7 +58,7 @@ Minicart.prototype = {
                 cart.processUpdateQuantity(this);
         });
 
-        for (var i in this.initAfterEvents) {
+        for (const i in this.initAfterEvents) {
             if (this.initAfterEvents.hasOwnProperty(i) && typeof(this.initAfterEvents[i]) === "function") {
                 this.initAfterEvents[i]();
             }
@@ -67,7 +67,7 @@ Minicart.prototype = {
     },
 
     removeItem: function(el) {
-        var cart = this;
+        const cart = this;
         if (confirm(el.data('confirm'))) {
             cart.hideMessage();
             cart.showOverlay();
@@ -85,12 +85,12 @@ Minicart.prototype = {
                 } else {
                     cart.showMessage(result);
                 }
-            }).error(function() {
+            }).fail(function() {
                 cart.hideOverlay();
                 cart.showError(cart.defaultErrorMessage);
             });
         }
-        for (var i in this.removeItemAfterEvents) {
+        for (const i in this.removeItemAfterEvents) {
             if (this.removeItemAfterEvents.hasOwnProperty(i) && typeof(this.removeItemAfterEvents[i]) === "function") {
                 this.removeItemAfterEvents[i]();
             }
@@ -105,17 +105,17 @@ Minicart.prototype = {
     },
 
     displayQuantityButton: function(el) {
-        var buttonId = this.selectors.quantityButtonPrefix + $j(el).data('item-id');
+        const buttonId = this.selectors.quantityButtonPrefix + $j(el).data('item-id');
         $j(buttonId).addClass('visible').attr('disabled',null);
     },
 
     hideQuantityButton: function(el) {
-        var buttonId = this.selectors.quantityButtonPrefix + $j(el).data('item-id');
+        const buttonId = this.selectors.quantityButtonPrefix + $j(el).data('item-id');
         $j(buttonId).removeClass('visible').attr('disabled','disabled');
     },
 
     processUpdateQuantity: function(el) {
-        var input = $j(this.selectors.quantityInputPrefix + $j(el).data('item-id'));
+        const input = $j(this.selectors.quantityInputPrefix + $j(el).data('item-id'));
         if (this.isValidQty(input.val()) && input.val() != this.previousVal) {
             this.updateItem(el);
         } else {
@@ -124,8 +124,8 @@ Minicart.prototype = {
     },
 
     updateItem: function(el) {
-        var cart = this;
-        var input = $j(this.selectors.quantityInputPrefix + $j(el).data('item-id'));
+        const cart = this;
+        const input = $j(this.selectors.quantityInputPrefix + $j(el).data('item-id'));
 
         if (!$j.isNumeric(input.val())) {
             cart.hideOverlay();
@@ -133,7 +133,7 @@ Minicart.prototype = {
             return false;
         }
 
-        var quantity = input.val();
+        const quantity = input.val();
         cart.hideMessage();
         cart.showOverlay();
         $j.ajax({
@@ -154,7 +154,7 @@ Minicart.prototype = {
             } else {
                 cart.showMessage(result);
             }
-        }).error(function() {
+        }).fail(function() {
             cart.hideOverlay();
             cart.showError(cart.defaultErrorMessage);
         });
@@ -162,7 +162,7 @@ Minicart.prototype = {
     },
 
     updateContentOnRemove: function(result, el) {
-        var cart = this;
+        const cart = this;
         el.hide('slow', function() {
             $j(cart.selectors.container).html(result.content);
             cart.showMessage(result);

--- a/skin/frontend/rwd/default/js/msrp_rwd.js
+++ b/skin/frontend/rwd/default/js/msrp_rwd.js
@@ -5,18 +5,26 @@
  * @package     rwd_default
  */
 
-Catalog.Map.showHelp = Catalog.Map.showHelp.wrap(function (parent, event) {
-    var helpBox = document.getElementById('map-popup');
-    var bodyNode = document.getElementsByTagName('body')[0];
-    parent(event);
-    
-    if (helpBox && this != Catalog.Map && Catalog.Map.active != this.link) {
-        helpBox.classList.remove('map-popup-right');
-        helpBox.classList.remove('map-popup-left');
-        if (Element.getWidth(bodyNode) < event.pageX + (Element.getWidth(helpBox) / 2)) {
-            helpBox.classList.add('map-popup-left');
-        } else if (event.pageX - (Element.getWidth(helpBox) / 2) < 0) {
-            helpBox.classList.add('map-popup-right');
+/**
+ * Rewritten to vanilla JS — no Prototype.js dependency.
+ * Wraps Catalog.Map.showHelp to adjust popup positioning for RWD theme.
+ */
+
+(function () {
+    const originalShowHelp = Catalog.Map.showHelp;
+    Catalog.Map.showHelp = function (event) {
+        const helpBox = document.getElementById('map-popup');
+        const bodyNode = document.body;
+        originalShowHelp.call(this, event);
+
+        if (helpBox && this != Catalog.Map && Catalog.Map.active != this.link) {
+            helpBox.classList.remove('map-popup-right');
+            helpBox.classList.remove('map-popup-left');
+            if (bodyNode.offsetWidth < event.pageX + (helpBox.offsetWidth / 2)) {
+                helpBox.classList.add('map-popup-left');
+            } else if (event.pageX - (helpBox.offsetWidth / 2) < 0) {
+                helpBox.classList.add('map-popup-right');
+            }
         }
-    }
-});
+    };
+})();

--- a/skin/frontend/rwd/default/js/opcheckout_rwd.js
+++ b/skin/frontend/rwd/default/js/opcheckout_rwd.js
@@ -5,23 +5,33 @@
  * @package     rwd_default
  */
 
+/**
+ * Rewritten to vanilla JS — no Prototype.js dependency.
+ */
+
 Checkout.prototype.gotoSection = function (section, reloadProgressBlock) {
     // Adds class so that the page can be styled to only show the "Checkout Method" step
     if ((this.currentStep == 'login' || this.currentStep == 'billing') && section == 'billing') {
-        $j('body').addClass('opc-has-progressed-from-login');
+        if (typeof $j !== 'undefined') {
+            $j('body').addClass('opc-has-progressed-from-login');
+        } else {
+            document.body.classList.add('opc-has-progressed-from-login');
+        }
     }
 
     if (reloadProgressBlock) {
         this.reloadProgressBlock(this.currentStep);
     }
     this.currentStep = section;
-    var sectionElement = $('opc-' + section);
-    sectionElement.addClassName('allow');
+    const sectionElement = document.getElementById('opc-' + section);
+    sectionElement.classList.add('allow');
     this.accordion.openSection('opc-' + section);
 
     // Scroll viewport to top of checkout steps for smaller viewports
-    if (Modernizr.mq('(max-width: ' + bp.xsmall + 'px)')) {
-        $j('html,body').animate({scrollTop: $j('#checkoutSteps').offset().top}, 800);
+    if (typeof Modernizr !== 'undefined' && typeof bp !== 'undefined' && Modernizr.mq('(max-width: ' + bp.xsmall + 'px)')) {
+        if (typeof $j !== 'undefined') {
+            $j('html,body').animate({scrollTop: $j('#checkoutSteps').offset().top}, 800);
+        }
     }
 
     if (!reloadProgressBlock) {


### PR DESCRIPTION
### Description (*)

Part 1 of 4 of the Prototype.js removal, split out of #5612 per the plan in #3645 (replace piece by piece, keep `prototype.js` loaded for extensions) and #5478.

This PR rewrites the core and storefront JavaScript from Prototype.js / Scriptaculous APIs to native browser JavaScript:

- `js/varien/*` (accordion, configurable, form, js, menu, payment, product, product_options, telephone, weee)
- `js/mage/captcha.js`, `centinel.js`, `translate.js`, `translate_inline.js`
- `js/prototype/validation.js`
- `skin/frontend/base/default/js/*` and `skin/frontend/rwd/default/js/*`
- New `js/varien/autocomplete.js` replaces `Ajax.Autocompleter` for the search form. It is registered in the frontend `page.xml` and removed in `oauth.xml`, next to `varien/js.js`.

**Prototype.js and Scriptaculous still load on every page.** No layout change removes them. Public function and object names are unchanged.

### Extension compatibility

Third-party modules hook core JS through Prototype patterns. This PR keeps the common ones:

- Every class that `Class.create()` built keeps its constructor body in `prototype.initialize`; the constructor only applies it. Wrapping `X.prototype.initialize` still works.
- `Varien.classCompat(ctor, parent)` sets `subclasses`, `superclass` and `Class.Methods` (`addMethods`) on each constructor, so `Class.create(X, {...})` and `X.addMethods({...})` still work. Files that can load without `varien/js.js` (`validation.js`, `captcha.js`, `translate.js`, `translate_inline.js`, `form.js`) inline the same lines.
- Custom events (`payment-method:switched`, `billing-request:completed`, `login:setMethod`, `bundle:reload-price`) fire through `dispatchEvent()` and `Event.fire()`. Prototype observers listen on `dataavailable`, which a native `CustomEvent` never reaches. `bundle:reload-price` exposes the payload as `event.memo` and `event.detail`.
- `Payment` keeps its before/after registries on the prototype. `Validation.creditCartTypes` has `get()` and `set()`. `priceTemplate` exposes `evaluate()`.
- Public entry points that accepted an id or an element through `$()` still do.
- Ajax semantics match `Ajax.Request`/`Ajax.Updater`: POST by default, `X-Requested-With` header, callbacks run outside the fetch chain (an exception in `onSuccess` does not route to `onFailure`, `onComplete` still runs), `evalScripts` off by default. `$F()`, `Form.serialize`, `Form.findFirstElement` and `visible()` semantics are kept.

**Not preserved:** Hash methods (`each`, `keys`, `get`) on plain objects that were `$H()` instances, `Ajax.Responders` for the rewritten requests, Scriptaculous `Autocompleter` options and `Effect` calls, and `$()` on private internal arguments. Extensions that rely on those need Part 1 of their own migration.

Planned follow-ups, each independent and behavior-neutral:
2. Admin JS (`js/mage/adminhtml`, ExtJS tree)
3. Storefront templates and blocks
4. Admin templates and blocks

After all four, OpenMage core no longer calls Prototype. Removal of the library itself is a separate, future major-release decision.

### Related Pull Requests
- see OpenMage/magento-lts#5612 (closed, superseded by this split)

### Fixed Issues (if relevant)
- relates to OpenMage/magento-lts#5478
- relates to OpenMage/magento-lts#3645

### Manual testing scenarios (*)
1. Storefront: open a configurable product with swatches, change options, confirm price updates and add to cart.
2. Storefront: open a bundle product, change options, confirm price updates and add to cart.
3. Storefront: use the header search box, confirm autocomplete suggestions appear and select one.
4. Storefront: run guest onepage checkout through order placement, confirm no console errors.
5. Storefront: submit a form with validation errors (e.g. register with empty fields), confirm inline messages appear.
6. Storefront: with `dev/translate_inline` enabled, open the inline translate popup and save a translation.

### Questions or comments
**Style:** rewritten code uses `const` and `let` per the ES6+ guideline in `.github/copilot-instructions.md`. Top-level globals stay `var` on purpose: a top-level `let`/`const` is not a `window` property, and a second script that redeclares the same name throws. Same-scope redeclarations (loop counters, if/else branches) also stay `var` to avoid restructuring logic in this PR.

**Intentional behavior change:** `Product.Config.reloadOldPrice` in `js/varien/configurable.js` sums `oldPrice` of the selected options. The original summed `price`, which put the new-price delta on the old-price line.

The full Cypress suite runs in CI on this PR with Prototype still loaded. The same code passed the suite on #5612 under `full`, `shim`, and `none` modes.

